### PR TITLE
feat(support): give Crisp agents the account context they keep asking for

### DIFF
--- a/src/app/crisp-proxy/page.tsx
+++ b/src/app/crisp-proxy/page.tsx
@@ -37,7 +37,8 @@ function applyUserData(payload: CrispInitPayload | null, withPrefill: boolean) {
     if (payload?.userData && Object.values(payload.userData).some(Boolean)) {
         // `prefill` is guarded (composer); the topic is not (metadata) — see setCrispUserData.
         setCrispUserData(window.$crisp, payload.userData, prefill, payload?.prefilledMessage)
-    } else if (prefill) {
+    } else if (prefill !== undefined) {
+        // same distinction as setCrispUserData: '' clears, undefined leaves alone
         window.$crisp.push(['set', 'message:text', [prefill]])
     }
 }

--- a/src/app/crisp-proxy/page.tsx
+++ b/src/app/crisp-proxy/page.tsx
@@ -35,7 +35,8 @@ function applyUserData(payload: CrispInitPayload | null, withPrefill: boolean) {
     const prefill = withPrefill ? payload?.prefilledMessage : undefined
     // skip the all-empty push for anonymous visitors — nothing to show agents
     if (payload?.userData && Object.values(payload.userData).some(Boolean)) {
-        setCrispUserData(window.$crisp, payload.userData, prefill)
+        // `prefill` is guarded (composer); the topic is not (metadata) — see setCrispUserData.
+        setCrispUserData(window.$crisp, payload.userData, prefill, payload?.prefilledMessage)
     } else if (prefill) {
         window.$crisp.push(['set', 'message:text', [prefill]])
     }

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -36,10 +36,13 @@ const nativeCrisp = {
     openMessenger: jest.fn(),
 }
 
-const modalsState: { supportPrefilledMessage: string | undefined } = { supportPrefilledMessage: undefined }
+const modalsState: { supportPrefilledMessage: string | undefined; isSupportModalOpen: boolean } = {
+    supportPrefilledMessage: undefined,
+    isSupportModalOpen: true,
+}
 jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({
-        isSupportModalOpen: true,
+        isSupportModalOpen: modalsState.isSupportModalOpen,
         setIsSupportModalOpen: jest.fn(),
         supportPrefilledMessage: modalsState.supportPrefilledMessage,
     }),
@@ -421,6 +424,7 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
         mockIsCapacitor.mockReset().mockReturnValue(true)
         Object.values(nativeCrisp).forEach((fn) => fn.mockReset())
         modalsState.supportPrefilledMessage = undefined
+        modalsState.isSupportModalOpen = true
     })
 
     it('sends a prefilled message once even when the snapshot changes mid-open', async () => {
@@ -493,5 +497,53 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
 
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1))
         expect(nativeCrisp.setTokenID).toHaveBeenCalledWith({ tokenID: 'token-abc' })
+    })
+
+    /*
+     * A boolean latch is not enough: the chain outlives the cycle that started
+     * it. Close the drawer while it is parked on the camera-permission await
+     * and reopen — a boolean has already been cleared, a second chain starts,
+     * both finish, and the prefill is sent twice. The generation counter makes
+     * the chain check, after its awaits, whether the cycle it belongs to is
+     * still the current one.
+     */
+    it('does not double-send when the user closes and reopens mid-chain', async () => {
+        modalsState.supportPrefilledMessage = 'my withdrawal is stuck'
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+
+        const view = render(<SupportDrawer />)
+
+        modalsState.isSupportModalOpen = false
+        view.rerender(<SupportDrawer />)
+        modalsState.isSupportModalOpen = true
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(nativeCrisp.sendMessage).toHaveBeenCalledTimes(1)
+        expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1)
+    })
+
+    /*
+     * The same gap in its other direction: a chain started before a close must
+     * not open the messenger, or post the prefill, into a conversation the user
+     * has already walked away from.
+     */
+    it('abandons a chain whose cycle the user dismissed', async () => {
+        modalsState.supportPrefilledMessage = 'my withdrawal is stuck'
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+
+        const view = render(<SupportDrawer />)
+
+        modalsState.isSupportModalOpen = false
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        expect(nativeCrisp.openMessenger).not.toHaveBeenCalled()
+        expect(nativeCrisp.sendMessage).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -92,6 +92,40 @@ describe('SupportDrawer Crisp session gate — web iframe', () => {
      * verification snapshot to Crisp with the chat closed — making that sentence
      * untrue. The gate is the promise, not an optimisation.
      */
+    /*
+     * The token gate and the mount latch interact. Open support while a logged-in
+     * user's token is still resolving and the iframe is blocked from mounting —
+     * but latching "has been opened" on the drawer alone leaves it true, so when
+     * the token lands after the user has closed, the hidden iframe mounts, boots
+     * and handshakes with the chat shut. The snapshot would then reach Crisp
+     * outside an open cycle.
+     */
+    it('does not mount the proxy when the token resolves after support closed', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue(undefined)
+
+        const view = render(<SupportDrawer />)
+        expect(supportIframe()).not.toBeInTheDocument()
+
+        modalsState.isSupportModalOpen = false
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        // the token lands with the drawer already closed
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        expect(supportIframe()).not.toBeInTheDocument()
+    })
+
+    /*
+     * A token or locale change remounts an already-mounted iframe, and that can
+     * happen with the drawer closed. The fresh proxy handshakes; the reply is
+     * registered once and so needs a ref to see the current open state.
+     */
     it('does not push the snapshot to Crisp after support closes', async () => {
         mockUseCrispTokenId.mockReturnValue('token-abc')
         mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com', balance: 'wallet $1.00' })
@@ -162,6 +196,7 @@ describe('SupportDrawer — crisp-proxy init handshake (postmortem F5: no PII in
         })
         mockUseCrispTokenId.mockReset().mockReturnValue('token-abc')
         mockIsCapacitor.mockReset().mockReturnValue(false)
+        modalsState.isSupportModalOpen = true
     })
 
     // sends a request "from" the given window; the real proxy iframe's
@@ -182,6 +217,26 @@ describe('SupportDrawer — crisp-proxy init handshake (postmortem F5: no PII in
         const proxyWindow = (supportIframe() as HTMLIFrameElement).contentWindow as Window
         return { proxyWindow, postSpy: jest.spyOn(proxyWindow, 'postMessage') }
     }
+
+    it('does not answer the proxy handshake while support is closed', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+
+        const view = render(<SupportDrawer />)
+
+        modalsState.isSupportModalOpen = false
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        // spy on the iframe as it stands NOW — the drawer keeps it mounted while
+        // closed (opacity/transform, not unmount), so this is the same proxy that
+        // a token or locale change would remount behind a shut chat
+        const { proxyWindow, postSpy } = mountedProxyWindow()
+        requestInit(window.location.origin, proxyWindow)
+
+        expect(postSpy).not.toHaveBeenCalled()
+    })
 
     it('replies to CRISP_PROXY_REQUEST_INIT with the payload, addressed to the asking iframe', () => {
         render(<SupportDrawer />)

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -479,8 +479,16 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
             nativeCrisp.setString.mock.calls.map(([{ key, value }]: [{ key: string; value: string }]) => [key, value])
         )
         expect(written.balance).toBe('$100.00 spendable')
-        expect(nativeCrisp.setSegment).toHaveBeenCalledWith({ segment: 'kyc-verified' })
-        expect(nativeCrisp.setSegment).not.toHaveBeenCalledWith({ segment: 'balance-unavailable' })
+        expect(written.segments).toBe('ios-native kyc-verified')
+
+        /*
+         * No native segment at all: the plugin's one-argument setSegment maps to
+         * Crisp.setSessionSegment on Android, which appends — a stale `offline`
+         * or `balance-unavailable` would keep routing the conversation after the
+         * user left that state. The data row above carries the whole list, and
+         * setString assigns, so nothing is lost.
+         */
+        expect(nativeCrisp.setSegment).not.toHaveBeenCalled()
     })
 
     it('still opens once the token resolves, rather than latching the waiting cycle shut', async () => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -31,6 +31,7 @@ const nativeCrisp = {
     setUser: jest.fn(),
     setTokenID: jest.fn(),
     setString: jest.fn(),
+    setSegment: jest.fn(),
     sendMessage: jest.fn(),
     openMessenger: jest.fn(),
 }
@@ -438,6 +439,44 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
         expect(nativeCrisp.sendMessage).toHaveBeenCalledTimes(1)
         expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1)
+    })
+
+    /*
+     * The other half of the same window. Gating the chain to one run means the
+     * snapshot that lands during setup gets no second chance to publish, so the
+     * chain must read the payload after its awaits rather than from the effect
+     * closure. Otherwise an agent opens the sidebar on a balance the user no
+     * longer has — and routes on a `balance-unavailable` segment they left.
+     */
+    it('publishes the snapshot as of open, not the one captured before setup', async () => {
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({
+            userId: 'user-abc',
+            email: 'a@b.com',
+            balance: 'wallet unavailable',
+            segments: ['ios-native', 'balance-unavailable'],
+        })
+
+        const view = render(<SupportDrawer />)
+
+        mockUseCrispUserData.mockReturnValue({
+            userId: 'user-abc',
+            email: 'a@b.com',
+            balance: '$100.00 spendable',
+            segments: ['ios-native', 'kyc-verified'],
+        })
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+
+        const written = Object.fromEntries(
+            nativeCrisp.setString.mock.calls.map(([{ key, value }]: [{ key: string; value: string }]) => [key, value])
+        )
+        expect(written.balance).toBe('$100.00 spendable')
+        expect(nativeCrisp.setSegment).toHaveBeenCalledWith({ segment: 'kyc-verified' })
+        expect(nativeCrisp.setSegment).not.toHaveBeenCalledWith({ segment: 'balance-unavailable' })
     })
 
     it('still opens once the token resolves, rather than latching the waiting cycle shut', async () => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -441,8 +441,33 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
         })
 
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
-        expect(nativeCrisp.sendMessage).toHaveBeenCalledTimes(1)
         expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1)
+        expect(
+            nativeCrisp.setString.mock.calls.filter(([{ key }]: [{ key: string }]) => key === 'support_topic')
+        ).toHaveLength(1)
+    })
+
+    /*
+     * `sendMessage` is `unimplemented` in this plugin on BOTH iOS and Android.
+     * Calling it prefilled nothing and left an unhandled rejection behind every
+     * support open that carried a topic. The topic now rides as a data row.
+     */
+    it('delivers the support topic without calling the unimplemented sendMessage', async () => {
+        modalsState.supportPrefilledMessage = 'my withdrawal is stuck'
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+
+        await act(async () => {
+            render(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(nativeCrisp.sendMessage).not.toHaveBeenCalled()
+
+        const written = Object.fromEntries(
+            nativeCrisp.setString.mock.calls.map(([{ key, value }]: [{ key: string; value: string }]) => [key, value])
+        )
+        expect(written.support_topic).toBe('my withdrawal is stuck')
     })
 
     /*
@@ -530,8 +555,10 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
         })
 
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
-        expect(nativeCrisp.sendMessage).toHaveBeenCalledTimes(1)
         expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1)
+        expect(
+            nativeCrisp.setString.mock.calls.filter(([{ key }]: [{ key: string }]) => key === 'support_topic')
+        ).toHaveLength(1)
     })
 
     /*

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -82,6 +82,39 @@ describe('SupportDrawer Crisp session gate — web iframe', () => {
         mockUseCrispUserData.mockReset()
         mockUseCrispTokenId.mockReset()
         mockIsCapacitor.mockReset().mockReturnValue(false)
+        modalsState.isSupportModalOpen = true
+    })
+
+    /*
+     * The privacy policy says the account snapshot is shared only when the user
+     * opens support chat. The proxy iframe stays mounted after the first open,
+     * so an ungated update effect would post a fresh balance, card and
+     * verification snapshot to Crisp with the chat closed — making that sentence
+     * untrue. The gate is the promise, not an optimisation.
+     */
+    it('does not push the snapshot to Crisp after support closes', async () => {
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com', balance: 'wallet $1.00' })
+
+        // open once, so the proxy iframe mounts and then STAYS mounted
+        const view = render(<SupportDrawer />)
+        const iframe = supportIframe() as HTMLIFrameElement
+        expect(iframe).toBeInTheDocument()
+        const postMessage = jest.spyOn(iframe.contentWindow!, 'postMessage')
+
+        modalsState.isSupportModalOpen = false
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+        postMessage.mockClear()
+
+        // a balance lands while the chat is closed
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com', balance: 'wallet $500.00' })
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        expect(postMessage).not.toHaveBeenCalled()
     })
 
     it('does NOT mount the proxy iframe while a logged-in user’s token is still resolving', () => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -35,11 +35,12 @@ const nativeCrisp = {
     openMessenger: jest.fn(),
 }
 
+const modalsState: { supportPrefilledMessage: string | undefined } = { supportPrefilledMessage: undefined }
 jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({
         isSupportModalOpen: true,
         setIsSupportModalOpen: jest.fn(),
-        supportPrefilledMessage: undefined,
+        supportPrefilledMessage: modalsState.supportPrefilledMessage,
     }),
 }))
 // Opening the drawer clears the support unread badge. That call is not what
@@ -402,5 +403,56 @@ describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
 
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
         expect(nativeCrisp.setTokenID).not.toHaveBeenCalled()
+    })
+})
+
+/*
+ * The support snapshot is live state — a balance landing from the cache, or the
+ * route latch firing on open, changes `userData`'s identity. `userData` is a
+ * dependency of the native open effect, so a change while the effect's async
+ * chain is still awaiting camera permission used to start a SECOND chain, and
+ * the user's prefilled message reached the agent twice.
+ */
+describe('SupportDrawer — native open runs once per open cycle', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset()
+        mockUseCrispTokenId.mockReset()
+        mockIsCapacitor.mockReset().mockReturnValue(true)
+        Object.values(nativeCrisp).forEach((fn) => fn.mockReset())
+        modalsState.supportPrefilledMessage = undefined
+    })
+
+    it('sends a prefilled message once even when the snapshot changes mid-open', async () => {
+        modalsState.supportPrefilledMessage = 'my withdrawal is stuck'
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com', balance: 'wallet unavailable' })
+
+        const view = render(<SupportDrawer />)
+
+        // A fresh snapshot object lands while the open chain is still awaiting.
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com', balance: '$100.00 spendable' })
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(nativeCrisp.sendMessage).toHaveBeenCalledTimes(1)
+        expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1)
+    })
+
+    it('still opens once the token resolves, rather than latching the waiting cycle shut', async () => {
+        mockUseCrispTokenId.mockReturnValue(undefined)
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+
+        const view = render(<SupportDrawer />)
+        expect(nativeCrisp.openMessenger).not.toHaveBeenCalled()
+
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+        await act(async () => {
+            view.rerender(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalledTimes(1))
+        expect(nativeCrisp.setTokenID).toHaveBeenCalledWith({ tokenID: 'token-abc' })
     })
 })

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -70,17 +70,28 @@ const SupportDrawer = () => {
         latestPayloadRef.current = latestPayload
     })
 
-    // The handshake pull happens once at iframe boot; later changes (email/name
-    // resolving mid-session, a new prefill) are pushed over the same channel so
-    // Crisp never keeps a stale identity. Token/locale changes remount the iframe
-    // via its key instead — those need a session re-bind, not a data update.
+    /*
+     * The handshake pull happens once at iframe boot; later changes (email/name
+     * resolving mid-session, a new prefill) are pushed over the same channel so
+     * Crisp never keeps a stale identity. Token/locale changes remount the iframe
+     * via its key instead — those need a session re-bind, not a data update.
+     *
+     * Gated on the drawer being OPEN, and that gate is the privacy promise, not
+     * an optimisation. The iframe stays mounted after the first open, so without
+     * it a connectivity flip or an auth re-render would post a fresh balance,
+     * card and verification snapshot to Crisp with the chat closed — while the
+     * privacy policy says the snapshot is shared only when the user opens
+     * support chat. The last push of a cycle stands until the next open replaces
+     * it, which is the conversation's own context and correct to leave.
+     */
     const iframeRef = useRef<HTMLIFrameElement | null>(null)
     useEffect(() => {
+        if (!isSupportModalOpen) return
         iframeRef.current?.contentWindow?.postMessage(
             { type: CRISP_PROXY_INIT_MSG, payload: latestPayloadRef.current },
             window.location.origin
         )
-    }, [userData, prefilledMessage])
+    }, [isSupportModalOpen, userData, prefilledMessage])
 
     // Crisp's composer sits at the very bottom of the iframe, so the panel's bottom
     // edge is the thing the iOS keyboard covers. Only measured while the drawer is

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -19,7 +19,8 @@ import type { AppLocale } from '@/i18n/app/config'
 import { notificationsApi } from '@/services/notifications'
 import { isCapacitor } from '@/utils/capacitor'
 import { ensureNativeCameraPermission } from '@/utils/camera-permission'
-import { ensureNativeCrispConfigured } from '@/utils/crisp'
+import { ensureNativeCrispConfigured, nativeCrispFields } from '@/utils/crisp'
+import { primarySupportSegment } from '@/utils/support-context'
 
 const DISMISS_THRESHOLD = 100
 
@@ -180,25 +181,25 @@ const SupportDrawer = () => {
                 if (crispTokenId) {
                     CapacitorCrisp.setTokenID({ tokenID: crispTokenId })
                 }
-                // set custom data for support agents
-                if (userData.walletAddress) {
-                    CapacitorCrisp.setString({ key: 'wallet_address', value: userData.walletAddress })
+                /*
+                 * Custom data for support agents. Every key is written
+                 * unconditionally (empty string when absent) so a previous
+                 * user's values can't linger on the device-local Crisp session,
+                 * and so this list stays a mirror of the web/proxy sink — it had
+                 * drifted to two keys while web sent seven, which left native
+                 * agents (i.e. agents helping app users) with less than the
+                 * agents helping web users.
+                 */
+                for (const [key, value] of nativeCrispFields(userData)) {
+                    CapacitorCrisp.setString({ key, value })
                 }
-                if (userData.userId) {
-                    CapacitorCrisp.setString({ key: 'user_id', value: userData.userId })
+                // Native holds exactly one segment — the assignment overwrites,
+                // so the list rides in the data row above and only the most
+                // actionable one goes here. See primarySupportSegment.
+                const primarySegment = primarySupportSegment(userData.segments)
+                if (primarySegment) {
+                    CapacitorCrisp.setSegment({ segment: primarySegment })
                 }
-                // live verification state so agents stop guessing (#2360). Always
-                // write (empty string when absent) so a prior user's values can't
-                // linger on the device-local Crisp session — matching web/proxy.
-                CapacitorCrisp.setString({ key: 'identity_status', value: userData.identityStatus || '' })
-                CapacitorCrisp.setString({
-                    key: 'email_on_file',
-                    value: userData.emailOnFile === undefined ? '' : userData.emailOnFile ? 'yes' : 'no',
-                })
-                CapacitorCrisp.setString({ key: 'verification_gates', value: userData.verificationGates || '' })
-                CapacitorCrisp.setString({ key: 'verification_rails', value: userData.verificationRails || '' })
-                CapacitorCrisp.setString({ key: 'failure_reason', value: userData.failureReason || '' })
-                CapacitorCrisp.setString({ key: 'pending_actions', value: userData.pendingActions || '' })
                 if (prefilledMessage) {
                     CapacitorCrisp.sendMessage({ value: prefilledMessage })
                 }

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -20,7 +20,6 @@ import { notificationsApi } from '@/services/notifications'
 import { isCapacitor } from '@/utils/capacitor'
 import { ensureNativeCameraPermission } from '@/utils/camera-permission'
 import { ensureNativeCrispConfigured, nativeCrispFields } from '@/utils/crisp'
-import { primarySupportSegment } from '@/utils/support-context'
 
 const DISMISS_THRESHOLD = 100
 
@@ -241,13 +240,19 @@ const SupportDrawer = () => {
                 for (const [key, value] of nativeCrispFields(snapshot)) {
                     CapacitorCrisp.setString({ key, value })
                 }
-                // Native holds exactly one segment — the assignment overwrites,
-                // so the list rides in the data row above and only the most
-                // actionable one goes here. See primarySupportSegment.
-                const primarySegment = primarySupportSegment(snapshot.segments)
-                if (primarySegment) {
-                    CapacitorCrisp.setSegment({ segment: primarySegment })
-                }
+                /*
+                 * No native segment. The plugin exposes only the one-argument
+                 * `setSegment`, which on Android calls `Crisp.setSessionSegment`
+                 * with no overwrite flag — so a segment APPENDS and a stale one
+                 * (`offline`, `balance-unavailable`, `kyc-pending`) keeps routing
+                 * the conversation after the user has left that state. A routing
+                 * tag that is wrong is worse than one that is missing.
+                 *
+                 * Nothing is lost to the agent: the `segments` data row above
+                 * carries the whole list, and `setString` assigns, so it replaces
+                 * cleanly on every open. Restore this when the plugin exposes the
+                 * SDK's overwrite overload.
+                 */
                 if (prefill) {
                     CapacitorCrisp.sendMessage({ value: prefill })
                 }

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -237,7 +237,7 @@ const SupportDrawer = () => {
                  * agents (i.e. agents helping app users) with less than the
                  * agents helping web users.
                  */
-                for (const [key, value] of nativeCrispFields(snapshot)) {
+                for (const [key, value] of nativeCrispFields(snapshot, prefill)) {
                     CapacitorCrisp.setString({ key, value })
                 }
                 /*
@@ -253,10 +253,18 @@ const SupportDrawer = () => {
                  * cleanly on every open. Restore this when the plugin exposes the
                  * SDK's overwrite overload.
                  */
-                if (prefill) {
-                    CapacitorCrisp.sendMessage({ value: prefill })
-                }
-
+                /*
+                 * No sendMessage on native. The plugin declares it
+                 * `unimplemented` on BOTH iOS and Android, so this never
+                 * prefilled anything in the app — it only left an unhandled
+                 * rejection ("Not implemented on ios") behind every support open
+                 * that carried a topic. The topic rides in the `support_topic`
+                 * data row above instead, which both platforms implement.
+                 *
+                 * The user's composer stays empty on native, so they still write
+                 * their own opening message — but the agent is no longer blind to
+                 * what brought them there.
+                 */
                 CapacitorCrisp.openMessenger()
                 // The chat is now in front of the user, so the badge has done its
                 // job. There is no isCrispReady on this path — the native messenger

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -170,39 +170,26 @@ const SupportDrawer = () => {
     // surfaces the previous user's conversation. The effect re-runs and opens
     // once crispTokenId resolves (it's in the deps).
     /*
-     * One open chain per open cycle, identified by generation rather than a
-     * boolean.
+     * Opening native Crisp is a one-shot action, so this effect depends only on
+     * what defines an open cycle: the drawer being open, and the token being
+     * ready.
      *
-     * `userData` is a dependency below and it is a snapshot of live state, so a
-     * balance landing from the cache changes its identity mid-chain; without a
-     * gate a second chain reaches sendMessage/openMessenger and the user's
-     * prefilled message is sent twice.
+     * It used to depend on `userData`, `crispTokenId` and `prefilledMessage`
+     * too — the data it publishes. That is what made it hard: the snapshot is
+     * live, so a balance landing mid-chain re-ran an effect whose tail sends a
+     * message and opens a window, and each guard against that produced the next
+     * defect (a duplicate prefill, then a stale payload, then a duplicate again
+     * across close/reopen). The data is read from `latestPayloadRef` when the
+     * chain actually publishes, so it does not belong in the deps at all.
      *
-     * A boolean is not enough, because the chain outlives the cycle that
-     * started it. Close the drawer while it is parked on the camera-permission
-     * await and reopen: the flag has been cleared, a second chain starts, and
-     * both finish — the duplicate is back. The same gap lets a chain from a
-     * dismissed cycle open the messenger and post the prefill after the user
-     * walked away. So the cycle carries an id: closing increments it, the chain
-     * captures it at the start, and everything the chain does after its awaits
-     * is conditional on that id still being current.
+     * With the deps trimmed, one open cycle runs the chain exactly once and
+     * React's own cleanup handles the rest: closing or reopening tears down the
+     * previous run, and `cancelled` stops a chain from a cycle the user has
+     * left from opening a messenger they walked away from.
      */
-    const openGenerationRef = useRef(0)
-    const activeGenerationRef = useRef<number | null>(null)
-
     useEffect(() => {
-        if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) {
-            // Still waiting on the token must stay retryable — the effect
-            // deliberately re-runs and opens once it resolves.
-            if (!isSupportModalOpen) {
-                openGenerationRef.current += 1
-                activeGenerationRef.current = null
-            }
-            return
-        }
-        if (activeGenerationRef.current === openGenerationRef.current) return
-        const generation = openGenerationRef.current
-        activeGenerationRef.current = generation
+        if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) return
+        let cancelled = false
 
         ensureNativeCrispConfigured()
             .then(async ({ CapacitorCrisp }) => {
@@ -215,28 +202,21 @@ const SupportDrawer = () => {
                  */
                 await ensureNativeCameraPermission()
 
-                /*
-                 * Read the payload AFTER the awaits, never from the effect
-                 * closure. The latch below keeps this chain to one run per open
-                 * cycle, so a snapshot that lands during setup gets no second
-                 * chance to publish — the closure's copy would freeze whatever
-                 * was true when support was tapped, and an agent would read a
-                 * balance the user no longer has.
-                 */
-                /*
-                 * The user may have dismissed support (or reopened it, starting
-                 * a newer chain) while we awaited. Publishing now would push the
-                 * prefill into a conversation they walked away from, and racing
-                 * the newer chain reintroduces the duplicate open.
-                 */
-                if (generation !== openGenerationRef.current) return
+                // The user dismissed support while we awaited. Publishing now
+                // would push the prefill into a conversation they walked away from.
+                if (cancelled) return
 
-                const latest = latestPayloadRef.current
-                // `userData` is optional only on the proxy wire shape; this ref is
-                // always seeded with the current one, so the fallback is unreachable.
-                const snapshot = latest.userData ?? userData
-                const tokenId = latest.tokenId
-                const prefill = latest.prefilledMessage
+                /*
+                 * Read the payload here, not from the effect closure. The chain
+                 * runs once per open cycle, so a snapshot that lands during
+                 * setup gets no second chance to publish — the closure's copy
+                 * would freeze whatever was true when support was tapped, and an
+                 * agent would read a balance the user no longer has.
+                 */
+                const { userData: snapshot, tokenId, prefilledMessage: prefill } = latestPayloadRef.current
+                // Optional only on the proxy wire shape — this ref is always
+                // seeded with the current snapshot, so this never returns.
+                if (!snapshot) return
 
                 // set user data before opening
                 if (snapshot.email || snapshot.fullName) {
@@ -282,20 +262,16 @@ const SupportDrawer = () => {
                 setIsSupportModalOpen(false)
             })
             .catch((err: unknown) => {
-                // Let this cycle try again — a transient configure/permission
-                // failure must not strand support shut until the user reopens.
-                if (activeGenerationRef.current === generation) activeGenerationRef.current = null
+                // ensureNativeCrispConfigured clears its own memo on failure, so
+                // reopening support genuinely re-configures rather than replaying
+                // a rejected promise.
                 console.warn('[SupportDrawer] native crisp open failed:', err)
             })
-    }, [
-        isSupportModalOpen,
-        isAwaitingToken,
-        userData,
-        crispTokenId,
-        prefilledMessage,
-        setIsSupportModalOpen,
-        clearSupportBadge,
-    ])
+
+        return () => {
+            cancelled = true
+        }
+    }, [isSupportModalOpen, isAwaitingToken, setIsSupportModalOpen, clearSupportBadge])
 
     // drag-to-dismiss state
     const panelRef = useRef<HTMLDivElement>(null)

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -170,29 +170,39 @@ const SupportDrawer = () => {
     // surfaces the previous user's conversation. The effect re-runs and opens
     // once crispTokenId resolves (it's in the deps).
     /*
-     * One open chain per open cycle.
+     * One open chain per open cycle, identified by generation rather than a
+     * boolean.
      *
-     * `userData` is a dependency below and it is a snapshot of live state — a
-     * balance landing from the cache, or the route latch, changes its identity.
-     * When that happens while the async chain is still awaiting camera
-     * permission, a second chain reaches sendMessage/openMessenger and the
-     * user's prefilled message is sent twice. The ref closes that window for
-     * every cause, not just the one we know about.
+     * `userData` is a dependency below and it is a snapshot of live state, so a
+     * balance landing from the cache changes its identity mid-chain; without a
+     * gate a second chain reaches sendMessage/openMessenger and the user's
+     * prefilled message is sent twice.
      *
-     * Reset on close and on failure, so the next open — or a retry after a
-     * failed one — still runs.
+     * A boolean is not enough, because the chain outlives the cycle that
+     * started it. Close the drawer while it is parked on the camera-permission
+     * await and reopen: the flag has been cleared, a second chain starts, and
+     * both finish — the duplicate is back. The same gap lets a chain from a
+     * dismissed cycle open the messenger and post the prefill after the user
+     * walked away. So the cycle carries an id: closing increments it, the chain
+     * captures it at the start, and everything the chain does after its awaits
+     * is conditional on that id still being current.
      */
-    const nativeOpenStartedRef = useRef(false)
+    const openGenerationRef = useRef(0)
+    const activeGenerationRef = useRef<number | null>(null)
 
     useEffect(() => {
         if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) {
             // Still waiting on the token must stay retryable — the effect
             // deliberately re-runs and opens once it resolves.
-            if (!isSupportModalOpen) nativeOpenStartedRef.current = false
+            if (!isSupportModalOpen) {
+                openGenerationRef.current += 1
+                activeGenerationRef.current = null
+            }
             return
         }
-        if (nativeOpenStartedRef.current) return
-        nativeOpenStartedRef.current = true
+        if (activeGenerationRef.current === openGenerationRef.current) return
+        const generation = openGenerationRef.current
+        activeGenerationRef.current = generation
 
         ensureNativeCrispConfigured()
             .then(async ({ CapacitorCrisp }) => {
@@ -213,6 +223,14 @@ const SupportDrawer = () => {
                  * was true when support was tapped, and an agent would read a
                  * balance the user no longer has.
                  */
+                /*
+                 * The user may have dismissed support (or reopened it, starting
+                 * a newer chain) while we awaited. Publishing now would push the
+                 * prefill into a conversation they walked away from, and racing
+                 * the newer chain reintroduces the duplicate open.
+                 */
+                if (generation !== openGenerationRef.current) return
+
                 const latest = latestPayloadRef.current
                 // `userData` is optional only on the proxy wire shape; this ref is
                 // always seeded with the current one, so the fallback is unreachable.
@@ -264,7 +282,9 @@ const SupportDrawer = () => {
                 setIsSupportModalOpen(false)
             })
             .catch((err: unknown) => {
-                nativeOpenStartedRef.current = false
+                // Let this cycle try again — a transient configure/permission
+                // failure must not strand support shut until the user reopens.
+                if (activeGenerationRef.current === generation) activeGenerationRef.current = null
                 console.warn('[SupportDrawer] native crisp open failed:', err)
             })
     }, [

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -42,21 +42,33 @@ const SupportDrawer = () => {
     const locale = useLocale() as AppLocale
     const crispLocale = CRISP_LOCALE_BY_APP_LOCALE[locale] ?? 'en'
 
-    // The proxy iframe pulls this via the postMessage handshake — user data and the
-    // Crisp token never appear in its URL (postmortem F5: a query string leaks into
-    // Vercel logs, browser history, Referer headers, and analytics $current_url).
-    // A ref keeps the reply current without re-registering the message listener;
-    // written in an effect, not during render, so a discarded render can't leak
-    // an uncommitted identity to the proxy.
-    const initPayload: CrispInitPayload = {
+    /*
+     * The latest committed payload, read by both Crisp sinks.
+     *
+     * The proxy iframe pulls it via the postMessage handshake — user data and the
+     * Crisp token never appear in its URL (postmortem F5: a query string leaks into
+     * Vercel logs, browser history, Referer headers, and analytics $current_url).
+     * A ref keeps the reply current without re-registering the message listener.
+     *
+     * The native open chain reads it AFTER its awaits, because the snapshot is
+     * live: a balance can land, or verification can resolve, while Crisp
+     * configuration and the camera permission are still pending. The effect
+     * closure holds the payload from when the effect ran, so publishing that
+     * would push a balance the user no longer has — and a `balance-unavailable`
+     * segment that would route them wrongly — to the agent.
+     *
+     * Written in an effect, not during render, so a discarded render can't leak
+     * an uncommitted identity to either sink.
+     */
+    const latestPayload: CrispInitPayload = {
         locale: crispLocale,
         tokenId: crispTokenId,
         userData,
         prefilledMessage,
     }
-    const initPayloadRef = useRef<CrispInitPayload>(initPayload)
+    const latestPayloadRef = useRef<CrispInitPayload>(latestPayload)
     useEffect(() => {
-        initPayloadRef.current = initPayload
+        latestPayloadRef.current = latestPayload
     })
 
     // The handshake pull happens once at iframe boot; later changes (email/name
@@ -66,7 +78,7 @@ const SupportDrawer = () => {
     const iframeRef = useRef<HTMLIFrameElement | null>(null)
     useEffect(() => {
         iframeRef.current?.contentWindow?.postMessage(
-            { type: CRISP_PROXY_INIT_MSG, payload: initPayloadRef.current },
+            { type: CRISP_PROXY_INIT_MSG, payload: latestPayloadRef.current },
             window.location.origin
         )
     }, [userData, prefilledMessage])
@@ -192,16 +204,32 @@ const SupportDrawer = () => {
                  * Result deliberately ignored: a denied camera must not block chat.
                  */
                 await ensureNativeCameraPermission()
+
+                /*
+                 * Read the payload AFTER the awaits, never from the effect
+                 * closure. The latch below keeps this chain to one run per open
+                 * cycle, so a snapshot that lands during setup gets no second
+                 * chance to publish — the closure's copy would freeze whatever
+                 * was true when support was tapped, and an agent would read a
+                 * balance the user no longer has.
+                 */
+                const latest = latestPayloadRef.current
+                // `userData` is optional only on the proxy wire shape; this ref is
+                // always seeded with the current one, so the fallback is unreachable.
+                const snapshot = latest.userData ?? userData
+                const tokenId = latest.tokenId
+                const prefill = latest.prefilledMessage
+
                 // set user data before opening
-                if (userData.email || userData.fullName) {
+                if (snapshot.email || snapshot.fullName) {
                     CapacitorCrisp.setUser({
-                        email: userData.email || undefined,
-                        nickname: userData.fullName || userData.username || undefined,
-                        avatar: userData.avatar || undefined,
+                        email: snapshot.email || undefined,
+                        nickname: snapshot.fullName || snapshot.username || undefined,
+                        avatar: snapshot.avatar || undefined,
                     })
                 }
-                if (crispTokenId) {
-                    CapacitorCrisp.setTokenID({ tokenID: crispTokenId })
+                if (tokenId) {
+                    CapacitorCrisp.setTokenID({ tokenID: tokenId })
                 }
                 /*
                  * Custom data for support agents. Every key is written
@@ -212,18 +240,18 @@ const SupportDrawer = () => {
                  * agents (i.e. agents helping app users) with less than the
                  * agents helping web users.
                  */
-                for (const [key, value] of nativeCrispFields(userData)) {
+                for (const [key, value] of nativeCrispFields(snapshot)) {
                     CapacitorCrisp.setString({ key, value })
                 }
                 // Native holds exactly one segment — the assignment overwrites,
                 // so the list rides in the data row above and only the most
                 // actionable one goes here. See primarySupportSegment.
-                const primarySegment = primarySupportSegment(userData.segments)
+                const primarySegment = primarySupportSegment(snapshot.segments)
                 if (primarySegment) {
                     CapacitorCrisp.setSegment({ segment: primarySegment })
                 }
-                if (prefilledMessage) {
-                    CapacitorCrisp.sendMessage({ value: prefilledMessage })
+                if (prefill) {
+                    CapacitorCrisp.sendMessage({ value: prefill })
                 }
 
                 CapacitorCrisp.openMessenger()
@@ -289,7 +317,7 @@ const SupportDrawer = () => {
                 // mounted iframe (not any same-origin frame), and directly to it,
                 // never broadcast
                 ;(event.source as Window | null)?.postMessage(
-                    { type: CRISP_PROXY_INIT_MSG, payload: initPayloadRef.current },
+                    { type: CRISP_PROXY_INIT_MSG, payload: latestPayloadRef.current },
                     window.location.origin
                 )
             } else if (event.data?.type === 'CRISP_READY') {

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -108,10 +108,26 @@ const SupportDrawer = () => {
      * opened — and never on Capacitor, where support opens the native Crisp
      * messenger instead.
      */
+    // A logged-in user's token is computed asynchronously (SHA-256 of their userId).
+    // Until it resolves we must NOT load the proxy: a token-less load makes Crisp fall
+    // back to the shared anonymous session persisted on client.crisp.chat, which on a
+    // browser that has hosted more than one Peanut account surfaces the *previous*
+    // user's conversation. Anonymous visitors (no userId) have no token by design and
+    // load immediately.
+    const isAwaitingToken = Boolean(userData.userId) && !crispTokenId
+
     const [hasBeenOpened, setHasBeenOpened] = useState(false)
     useEffect(() => {
-        if (isSupportModalOpen) setHasBeenOpened(true)
-    }, [isSupportModalOpen])
+        /*
+         * Latched only when the drawer is open AND the token is ready — both, or
+         * the iframe first mounts while CLOSED. Open a support drawer whose token
+         * is still resolving, close it, and let the token land: latching on
+         * `isSupportModalOpen` alone leaves this true while the token gate opens,
+         * so the hidden iframe boots and handshakes with the chat shut, and the
+         * account snapshot goes to Crisp outside an open cycle.
+         */
+        if (isSupportModalOpen && !isAwaitingToken) setHasBeenOpened(true)
+    }, [isSupportModalOpen, isAwaitingToken])
 
     // Guests reach this drawer too (claim and pay links mount the same layout),
     // and they have no notifications — the call would just 401.
@@ -164,14 +180,6 @@ const SupportDrawer = () => {
         setIsCrispReady(false)
         setIsCrispFailed(false)
     }, [crispTokenId, crispLocale])
-
-    // A logged-in user's token is computed asynchronously (SHA-256 of their userId).
-    // Until it resolves we must NOT load the proxy: a token-less load makes Crisp fall
-    // back to the shared anonymous session persisted on client.crisp.chat, which on a
-    // browser that has hosted more than one Peanut account surfaces the *previous*
-    // user's conversation. Anonymous visitors (no userId) have no token by design and
-    // load immediately.
-    const isAwaitingToken = Boolean(userData.userId) && !crispTokenId
 
     // in capacitor, open native crisp messenger instead of iframe.
     // Same token gate as the web iframe: for a logged-in user we must not
@@ -322,6 +330,17 @@ const SupportDrawer = () => {
         setDragOffset(0)
     }, [dragOffset, setIsSupportModalOpen])
 
+    /*
+     * The open state, for the handshake listener below. That listener is
+     * registered once and never re-created, so it cannot close over
+     * `isSupportModalOpen` — it would answer with the state from drawer mount
+     * forever.
+     */
+    const isSupportOpenRef = useRef(isSupportModalOpen)
+    useEffect(() => {
+        isSupportOpenRef.current = isSupportModalOpen
+    }, [isSupportModalOpen])
+
     // listen for crisp messages once — persists across open/close cycles.
     // Registered at drawer mount, long before the iframe can mount (hasBeenOpened
     // gate), so the proxy's init request can never race past this listener.
@@ -333,6 +352,24 @@ const SupportDrawer = () => {
                 event.data?.type === CRISP_PROXY_REQUEST_INIT_MSG &&
                 event.source === iframeRef.current?.contentWindow
             ) {
+                /*
+                 * Answer only while support is open. A token or locale change
+                 * remounts an already-mounted iframe (see its key), and that
+                 * remount can happen with the drawer closed — the fresh proxy
+                 * then handshakes, and answering would publish the account
+                 * snapshot outside an open cycle, which the privacy policy says
+                 * we do not do.
+                 *
+                 * Staying silent is safe rather than fatal: the proxy re-asks
+                 * every 250ms until it boots, and the update effect above posts
+                 * the payload the moment the drawer opens, which boots it
+                 * directly. If the 8s readiness watchdog fires first the parent
+                 * shows the mail fallback, and the later CRISP_READY clears it.
+                 */
+                if (!isSupportOpenRef.current) {
+                    return
+                }
+
                 // the proxy iframe asks for its init payload — reply only to OUR
                 // mounted iframe (not any same-origin frame), and directly to it,
                 // never broadcast

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -157,8 +157,30 @@ const SupportDrawer = () => {
     // falls back to the device-local Crisp session, which on a shared device
     // surfaces the previous user's conversation. The effect re-runs and opens
     // once crispTokenId resolves (it's in the deps).
+    /*
+     * One open chain per open cycle.
+     *
+     * `userData` is a dependency below and it is a snapshot of live state — a
+     * balance landing from the cache, or the route latch, changes its identity.
+     * When that happens while the async chain is still awaiting camera
+     * permission, a second chain reaches sendMessage/openMessenger and the
+     * user's prefilled message is sent twice. The ref closes that window for
+     * every cause, not just the one we know about.
+     *
+     * Reset on close and on failure, so the next open — or a retry after a
+     * failed one — still runs.
+     */
+    const nativeOpenStartedRef = useRef(false)
+
     useEffect(() => {
-        if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) return
+        if (!isSupportModalOpen || !isCapacitor() || isAwaitingToken) {
+            // Still waiting on the token must stay retryable — the effect
+            // deliberately re-runs and opens once it resolves.
+            if (!isSupportModalOpen) nativeOpenStartedRef.current = false
+            return
+        }
+        if (nativeOpenStartedRef.current) return
+        nativeOpenStartedRef.current = true
 
         ensureNativeCrispConfigured()
             .then(async ({ CapacitorCrisp }) => {
@@ -214,6 +236,7 @@ const SupportDrawer = () => {
                 setIsSupportModalOpen(false)
             })
             .catch((err: unknown) => {
+                nativeOpenStartedRef.current = false
                 console.warn('[SupportDrawer] native crisp open failed:', err)
             })
     }, [

--- a/src/constants/support.ts
+++ b/src/constants/support.ts
@@ -10,3 +10,6 @@ export const POSTHOG_PERSON_BASE_URL = 'https://eu.posthog.com/project/138913/pe
 
 /** Bridge dashboard for viewing customer KYC and compliance details */
 export const BRIDGE_DASHBOARD_BASE_URL = 'https://dashboard.bridge.xyz/app/customers'
+
+/** Sentry issue search, scoped to one user — the FE errors they actually hit. */
+export const SENTRY_USER_ISSUES_BASE_URL = 'https://us.sentry.io/organizations/peanut-c34d84c05/issues/?query=user.id'

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -46,8 +46,19 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     const [isGetAppModalOpen, setIsGetAppModalOpen] = useState(false)
 
     // Support Drawer
-    const [isSupportModalOpen, setIsSupportModalOpen] = useState(false)
+    const [isSupportModalOpen, setIsSupportModalOpenState] = useState(false)
     const [supportPrefilledMessage, setSupportPrefilledMessage] = useState('')
+
+    /*
+     * A prefill belongs to the open cycle that set it. Nothing used to clear it,
+     * so after one "contact support about X" entry point every later open — the
+     * nav button included — reopened with X still in the composer, and the
+     * support sidebar reported X as the topic.
+     */
+    const setIsSupportModalOpen = useCallback((open: boolean) => {
+        setIsSupportModalOpenState(open)
+        if (!open) setSupportPrefilledMessage('')
+    }, [])
 
     // QR Scanner
     const [isQRScannerOpen, setIsQRScannerOpen] = useState(false)
@@ -57,7 +68,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
 
     const openSupportWithMessage = useCallback((message: string) => {
         setSupportPrefilledMessage(message)
-        setIsSupportModalOpen(true)
+        setIsSupportModalOpenState(true)
     }, [])
 
     const value = useMemo(
@@ -94,6 +105,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
             isSignInModalOpen,
             isGetAppModalOpen,
             isSupportModalOpen,
+            setIsSupportModalOpen,
             supportPrefilledMessage,
             openSupportWithMessage,
             isQRScannerOpen,

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useState, useCallback, useMemo, type ReactNode } from 'react'
+import { redactSupportText } from '@/utils/support-context'
 
 interface ModalsContextType {
     // iOS PWA Install Modal
@@ -66,8 +67,15 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     // Security Verification Overlay
     const [isSecurityVerificationOpen, setIsSecurityVerificationOpen] = useState(false)
 
+    /*
+     * Redact before storing, so every downstream sink is covered at once — the
+     * composer, and the `support_topic` row the app publishes to Crisp on open.
+     * Call sites hand over `window.location.href` (ClaimErrorView,
+     * Error.validation.view), and on a claim page the fragment is the bearer
+     * password for the funds.
+     */
     const openSupportWithMessage = useCallback((message: string) => {
-        setSupportPrefilledMessage(message)
+        setSupportPrefilledMessage(redactSupportText(message))
         setIsSupportModalOpenState(true)
     }, [])
 

--- a/src/context/__tests__/ModalsContext.test.tsx
+++ b/src/context/__tests__/ModalsContext.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * The support prefill is redacted where it enters, not where it leaves.
+ *
+ * Call sites hand over `window.location.href` (ClaimErrorView,
+ * Error.validation.view), and on a claim page the URL fragment is the bearer
+ * password for the funds — it derives the private claim key. The prefill then
+ * reaches Crisp two ways: the composer, and the `support_topic` row the app
+ * publishes on open, before the user has decided to send anything. Redacting in
+ * the setter covers both sinks and every call site, including ones not written
+ * yet.
+ */
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { ModalsProvider, useModalsContext } from '../ModalsContext'
+
+const wrapper = ({ children }: { children: ReactNode }) => <ModalsProvider>{children}</ModalsProvider>
+
+describe('ModalsContext support prefill', () => {
+    it('never stores a claim password, however the call site phrases it', () => {
+        const { result } = renderHook(() => useModalsContext(), { wrapper })
+
+        act(() => {
+            result.current.openSupportWithMessage(
+                "I can't claim this: https://peanut.me/claim?c=42161&v=v4.3&i=17#p=Xy7SecretPw"
+            )
+        })
+
+        expect(result.current.supportPrefilledMessage).not.toContain('Xy7SecretPw')
+        // the query locates the deposit — an agent still needs it
+        expect(result.current.supportPrefilledMessage).toContain('?c=42161&v=v4.3&i=17')
+        expect(result.current.isSupportModalOpen).toBe(true)
+    })
+
+    /*
+     * A prefill belongs to the open cycle that set it. Nothing used to clear it,
+     * so after one "contact support about X" every later open — the nav button
+     * included — reopened with X still in the composer and reported X as the
+     * topic.
+     */
+    it('clears the prefill when support closes', () => {
+        const { result } = renderHook(() => useModalsContext(), { wrapper })
+
+        act(() => result.current.openSupportWithMessage('my withdrawal is stuck'))
+        expect(result.current.supportPrefilledMessage).toBe('my withdrawal is stuck')
+
+        act(() => result.current.setIsSupportModalOpen(false))
+        expect(result.current.supportPrefilledMessage).toBe('')
+    })
+})

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -23,7 +23,7 @@ import { resetCrispProxySessions } from '@/utils/crisp'
 import { disableDemoMode } from '@/utils/demo'
 import posthog from 'posthog-js'
 import { useQueryClient } from '@tanstack/react-query'
-import { createContext, type ReactNode, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { createContext, type ReactNode, useContext, useState, useEffect, useMemo, useCallback } from 'react'
 import { captureException, setUser as setSentryUser } from '@/utils/sentry-lazy'
 // import { PUBLIC_ROUTES_REGEX } from '@/constants/routes'
 import { USER_DATA_CACHE_PATTERNS } from '@/constants/cache.consts'
@@ -97,31 +97,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         if (!user?.invitesSent) return new Set<string>()
         return new Set(user.invitesSent.map((invite) => invite.inviteeUsername))
     }, [user?.invitesSent])
-
-    /*
-     * Drop every cached query when the signed-in account CHANGES.
-     *
-     * An explicit logout already clears the cache below, but a session that
-     * expires passively never runs that path: /users/me 401s, and query keys
-     * that carry no user id — `[limits]`, `[transactions]` — stay warm. Sign a
-     * different account in on that device and react-query serves the previous
-     * account's rows until each refetch lands, so the new user briefly sees
-     * someone else's Activity, limits, and (via the support snapshot) their
-     * last transaction.
-     *
-     * Only fires on a change BETWEEN accounts. The first sign-in of a session
-     * (undefined → id) keeps whatever a guest legitimately prefetched, e.g. a
-     * claim link opened before signing in.
-     */
-    const lastUserIdRef = useRef<string | undefined>(undefined)
-    useEffect(() => {
-        const currentUserId = user?.user?.userId
-        const previousUserId = lastUserIdRef.current
-        lastUserIdRef.current = currentUserId ?? previousUserId
-        if (currentUserId && previousUserId && currentUserId !== previousUserId) {
-            queryClient.clear()
-        }
-    }, [user?.user?.userId, queryClient])
 
     useEffect(() => {
         if (user) {

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -23,7 +23,7 @@ import { resetCrispProxySessions } from '@/utils/crisp'
 import { disableDemoMode } from '@/utils/demo'
 import posthog from 'posthog-js'
 import { useQueryClient } from '@tanstack/react-query'
-import { createContext, type ReactNode, useContext, useState, useEffect, useMemo, useCallback } from 'react'
+import { createContext, type ReactNode, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { captureException, setUser as setSentryUser } from '@/utils/sentry-lazy'
 // import { PUBLIC_ROUTES_REGEX } from '@/constants/routes'
 import { USER_DATA_CACHE_PATTERNS } from '@/constants/cache.consts'
@@ -97,6 +97,31 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         if (!user?.invitesSent) return new Set<string>()
         return new Set(user.invitesSent.map((invite) => invite.inviteeUsername))
     }, [user?.invitesSent])
+
+    /*
+     * Drop every cached query when the signed-in account CHANGES.
+     *
+     * An explicit logout already clears the cache below, but a session that
+     * expires passively never runs that path: /users/me 401s, and query keys
+     * that carry no user id — `[limits]`, `[transactions]` — stay warm. Sign a
+     * different account in on that device and react-query serves the previous
+     * account's rows until each refetch lands, so the new user briefly sees
+     * someone else's Activity, limits, and (via the support snapshot) their
+     * last transaction.
+     *
+     * Only fires on a change BETWEEN accounts. The first sign-in of a session
+     * (undefined → id) keeps whatever a guest legitimately prefetched, e.g. a
+     * claim link opened before signing in.
+     */
+    const lastUserIdRef = useRef<string | undefined>(undefined)
+    useEffect(() => {
+        const currentUserId = user?.user?.userId
+        const previousUserId = lastUserIdRef.current
+        lastUserIdRef.current = currentUserId ?? previousUserId
+        if (currentUserId && previousUserId && currentUserId !== previousUserId) {
+            queryClient.clear()
+        }
+    }, [user?.user?.userId, queryClient])
 
     useEffect(() => {
         if (user) {

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * The load-bearing invariant of the support snapshot: it reports on queries it
+ * must never subscribe to.
+ *
+ * SupportDrawer mounts this hook app-wide — on every screen, for guests too. A
+ * `useWallet()` / `useLimits()` / `useRainCardOverview()` call inside it would
+ * switch on a 30s RPC poll and two API requests for every user, which is the
+ * exact shape of the regression that made /rain/cards the most-called endpoint
+ * in the app. So the hook reads the react-query cache and nothing else.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { useAuth } from '@/context/authContext'
+import { useSupportClientContext } from '@/hooks/useSupportClientContext'
+import { useCrispUserData } from '@/hooks/useCrispUserData'
+import { TRANSACTIONS } from '@/constants/query.consts'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { AccountType } from '@/interfaces/interfaces'
+
+jest.mock('@/context/authContext', () => ({ useAuth: jest.fn() }))
+jest.mock('@/hooks/useSupportClientContext', () => ({ useSupportClientContext: jest.fn() }))
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
+const mockClientContext = useSupportClientContext as jest.MockedFunction<typeof useSupportClientContext>
+
+const WALLET = '0xb8ed0b7578e658cb6718ae92facb98f718d445e3'
+
+const wrapper = (client: QueryClient) =>
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    }
+
+describe('useCrispUserData', () => {
+    let client: QueryClient
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        mockClientContext.mockReturnValue({
+            platform: 'ios-native',
+            appBuild: 'web:9f3ac1 · native:1.0.8 (42)',
+            locale: 'es-419',
+            routeOnOpen: '/withdraw/manteca',
+            isOffline: false,
+            isApiUnreachable: false,
+            notificationPermission: 'granted',
+        })
+        mockUseAuth.mockReturnValue({
+            username: 'glorfindel',
+            userId: 'user-1',
+            user: {
+                user: { userId: 'user-1', email: 'a@b.co', fullName: 'Glor Findel' },
+                accounts: [{ type: AccountType.PEANUT_WALLET, identifier: WALLET }],
+                totalPoints: 1240,
+            },
+        } as unknown as ReturnType<typeof useAuth>)
+    })
+
+    it('starts no queries of its own', () => {
+        renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(client.getQueryCache().findAll()).toHaveLength(0)
+    })
+
+    it('reports unavailable rather than zero when nothing is cached', () => {
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(result.current.balance).toContain('unavailable')
+        expect(result.current.balance).not.toContain('$0.00')
+        expect(result.current.latestActivity).toBeUndefined()
+        expect(result.current.segments).toContain('balance-unavailable')
+    })
+
+    it('picks up a warm cache without touching the network', () => {
+        client.setQueryData(['balance', WALLET], 100_000_000n)
+        client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+            status: { hasApplication: false },
+            balance: null,
+            cards: [],
+        })
+        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
+            entries: [
+                {
+                    uuid: 'tx-1',
+                    timestamp: new Date(),
+                    status: 'COMPLETED',
+                    amount: '25.00',
+                    tokenSymbol: 'USDC',
+                    userRole: 'SENDER',
+                    extraData: { kind: 'P2P_SEND' },
+                    recipientAccount: { username: 'bob', identifier: 'bob.eth', type: 'peanut-wallet', isUser: true },
+                },
+            ],
+            hasMore: false,
+        })
+
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(result.current.balance).toBe('$100.00 spendable (wallet $100.00 · card $0.00)')
+        expect(result.current.latestActivity).toContain('P2P_SEND')
+        expect(result.current.latestActivity).not.toContain('bob')
+        expect(result.current.accountStats).toContain('1240 pts')
+        expect(result.current.appContext).toContain('route:/withdraw/manteca')
+        expect(
+            client
+                .getQueryCache()
+                .findAll()
+                .every((query) => query.state.fetchStatus === 'idle')
+        ).toBe(true)
+    })
+
+    /*
+     * The consumer pushes to Crisp on every identity change, and the cache reads
+     * build a fresh object each render — so identity has to track the VALUE, or
+     * every unrelated re-render of the drawer would postMessage the iframe again.
+     */
+    it('keeps a stable identity while the underlying values are unchanged', () => {
+        const { result, rerender } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+        const first = result.current
+
+        rerender()
+        expect(result.current).toBe(first)
+
+        client.setQueryData(['balance', WALLET], 100_000_000n)
+        rerender()
+        expect(result.current).not.toBe(first)
+    })
+})

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { useAuth } from '@/context/authContext'
 import { useSupportClientContext } from '@/hooks/useSupportClientContext'
@@ -21,6 +21,8 @@ import { AccountType } from '@/interfaces/interfaces'
 
 jest.mock('@/context/authContext', () => ({ useAuth: jest.fn() }))
 jest.mock('@/hooks/useSupportClientContext', () => ({ useSupportClientContext: jest.fn() }))
+const modalsState = { isSupportModalOpen: true }
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => modalsState }))
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>
 const mockClientContext = useSupportClientContext as jest.MockedFunction<typeof useSupportClientContext>
@@ -37,6 +39,7 @@ describe('useCrispUserData', () => {
 
     beforeEach(() => {
         jest.clearAllMocks()
+        modalsState.isSupportModalOpen = true
         client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
         mockClientContext.mockReturnValue({
             platform: 'ios-native',
@@ -126,5 +129,41 @@ describe('useCrispUserData', () => {
         client.setQueryData(['balance', WALLET], 100_000_000n)
         rerender()
         expect(result.current).not.toBe(first)
+    })
+
+    /*
+     * The cache reads are not subscriptions, so a query resolving after support
+     * opened would otherwise never reach the sidebar: the agent reads
+     * `unavailable` for the whole conversation and routes on a
+     * `balance-unavailable` segment, accurate at the instant it was read and
+     * wrong a second later.
+     */
+    it('picks up a query that resolves after support is already open', async () => {
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+        expect(result.current.balance).toContain('unavailable')
+
+        await act(async () => {
+            client.setQueryData(['balance', WALLET], 100_000_000n)
+            client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+                status: { hasApplication: false },
+                balance: null,
+                cards: [],
+            })
+        })
+
+        expect(result.current.balance).toBe('$100.00 spendable (wallet $100.00 · card $0.00)')
+        expect(result.current.segments).not.toContain('balance-unavailable')
+    })
+
+    it('does not watch the cache while support is closed', async () => {
+        modalsState.isSupportModalOpen = false
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+        const before = result.current
+
+        await act(async () => {
+            client.setQueryData(['balance', WALLET], 100_000_000n)
+        })
+
+        expect(result.current).toBe(before)
     })
 })

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -178,6 +178,33 @@ describe('useCrispUserData', () => {
     })
 
     /*
+     * The handoff between the smart account and Rain collateral: the funds are
+     * in neither bucket, and only `inTransitToCollateralCents` accounts for
+     * them. Reading the two halves directly would flag `zero-balance` beside a
+     * balance row that reads as funded.
+     */
+    it('does not flag zero while funds are in transit to collateral', () => {
+        client.setQueryData(['balance', WALLET], 0n)
+        client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+            status: { hasApplication: true },
+            balance: {
+                creditLimit: 0,
+                spendingPower: 0,
+                pendingCharges: 0,
+                postedCharges: 0,
+                balanceDue: 0,
+                inTransitToCollateralCents: 2_500,
+            },
+            cards: [],
+        })
+
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(result.current.balance).toContain('$25.00 spendable')
+        expect(result.current.segments).not.toContain('zero-balance')
+    })
+
+    /*
      * The snapshot reports only what it can attribute. `[limits]` and
      * `[transactions]` carry no user id in their keys, so a warm entry cannot be
      * proved to belong to the person support is open for — after a passive

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -11,6 +11,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
+import { useLayoutEffect } from 'react'
 import type { ReactNode } from 'react'
 import { useAuth } from '@/context/authContext'
 import { useSupportClientContext } from '@/hooks/useSupportClientContext'
@@ -175,6 +176,40 @@ describe('useCrispUserData', () => {
         expect(result.current.card).toBeUndefined()
         expect(result.current.segments).toContain('guest')
         expect(JSON.stringify(result.current)).not.toContain('approved')
+    })
+
+    /*
+     * The cache reads happen during render; the subscription attaches in a
+     * passive effect. A query resolving in that window emits its only `updated`
+     * event with nobody listening, so the conversation would keep the initial
+     * `unavailable` snapshot — and the routing flag derived from it — until
+     * some unrelated render recomputed it. A layout effect models the window
+     * exactly: React runs it after render, before passive effects.
+     */
+    it('picks up a query that resolves between render and the subscription', async () => {
+        const Resolver = () => {
+            useLayoutEffect(() => {
+                client.setQueryData(['balance', WALLET], 100_000_000n)
+                client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+                    status: { hasApplication: false },
+                    balance: null,
+                    cards: [],
+                })
+            }, [])
+            return null
+        }
+
+        const { result } = renderHook(() => useCrispUserData(), {
+            wrapper: ({ children }: { children: ReactNode }) => (
+                <QueryClientProvider client={client}>
+                    <Resolver />
+                    {children}
+                </QueryClientProvider>
+            ),
+        })
+
+        expect(result.current.balance).toBe('$100.00 spendable (wallet $100.00 · card $0.00)')
+        expect(result.current.segments).not.toContain('balance-unavailable')
     })
 
     /*

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -15,7 +15,6 @@ import type { ReactNode } from 'react'
 import { useAuth } from '@/context/authContext'
 import { useSupportClientContext } from '@/hooks/useSupportClientContext'
 import { useCrispUserData } from '@/hooks/useCrispUserData'
-import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
 import { AccountType } from '@/interfaces/interfaces'
 
@@ -72,7 +71,6 @@ describe('useCrispUserData', () => {
 
         expect(result.current.balance).toContain('unavailable')
         expect(result.current.balance).not.toContain('$0.00')
-        expect(result.current.latestActivity).toBeUndefined()
         expect(result.current.segments).toContain('balance-unavailable')
     })
 
@@ -83,27 +81,9 @@ describe('useCrispUserData', () => {
             balance: null,
             cards: [],
         })
-        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
-            entries: [
-                {
-                    uuid: 'tx-1',
-                    timestamp: new Date(),
-                    status: 'COMPLETED',
-                    amount: '25.00',
-                    tokenSymbol: 'USDC',
-                    userRole: 'SENDER',
-                    extraData: { kind: 'P2P_SEND' },
-                    recipientAccount: { username: 'bob', identifier: 'bob.eth', type: 'peanut-wallet', isUser: true },
-                },
-            ],
-            hasMore: false,
-        })
-
         const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
 
         expect(result.current.balance).toBe('$100.00 spendable (wallet $100.00 · card $0.00)')
-        expect(result.current.latestActivity).toContain('P2P_SEND')
-        expect(result.current.latestActivity).not.toContain('bob')
         expect(result.current.accountStats).toContain('1240 pts')
         expect(result.current.appContext).toContain('route:/withdraw/manteca')
         expect(
@@ -169,32 +149,17 @@ describe('useCrispUserData', () => {
 
     /*
      * An explicit logout clears the query cache, but an EXPIRED session does
-     * not: /users/me 401s, auth goes null, and `[limits]` / `[transactions]`
-     * stay warm behind keys carrying no user id. SupportDrawer is mounted on
-     * the guest and setup layouts, so without this gate the next person to open
-     * support on that device would have published the previous user's limits
-     * and last transaction under an empty `user_id`.
+     * not: /users/me 401s and auth goes null while the cache stays warm.
+     * SupportDrawer is mounted on the guest and setup layouts, so without this
+     * gate the next person to open support on that device would publish the
+     * previous user's balance and card state under an empty `user_id`.
      */
     it('publishes nothing from the cache once the session has expired', async () => {
         client.setQueryData(['balance', WALLET], 100_000_000n)
-        client.setQueryData([LIMITS], {
-            bridge: { onRampPerTransaction: '10000', offRampPerTransaction: '10000', asset: 'USD' },
-            manteca: null,
-        })
-        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
-            entries: [
-                {
-                    uuid: 'tx-of-the-previous-user',
-                    timestamp: new Date(),
-                    status: 'COMPLETED',
-                    amount: '25.00',
-                    tokenSymbol: 'USDC',
-                    userRole: 'SENDER',
-                    extraData: { kind: 'P2P_SEND' },
-                    recipientAccount: { username: 'bob', identifier: 'bob.eth', type: 'peanut-wallet', isUser: true },
-                },
-            ],
-            hasMore: false,
+        client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+            status: { hasApplication: true, applicationStatus: 'approved' },
+            balance: null,
+            cards: [],
         })
 
         // the session expires: auth goes null, the cache is untouched
@@ -206,10 +171,23 @@ describe('useCrispUserData', () => {
 
         const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
 
-        expect(result.current.latestActivity).toBeUndefined()
-        expect(result.current.limitsRemaining).toBeUndefined()
         expect(result.current.balance).toBeUndefined()
+        expect(result.current.card).toBeUndefined()
         expect(result.current.segments).toContain('guest')
-        expect(JSON.stringify(result.current)).not.toContain('tx-of-the-previous-user')
+        expect(JSON.stringify(result.current)).not.toContain('approved')
+    })
+
+    /*
+     * The snapshot reports only what it can attribute. `[limits]` and
+     * `[transactions]` carry no user id in their keys, so a warm entry cannot be
+     * proved to belong to the person support is open for — after a passive
+     * expiry a different account would read them as its own. They stay out of
+     * the payload until those keys are user-scoped.
+     */
+    it('reports no field that would need an account-agnostic cache key', () => {
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(Object.keys(result.current)).not.toContain('limitsRemaining')
+        expect(Object.keys(result.current)).not.toContain('latestActivity')
     })
 })

--- a/src/hooks/__tests__/useCrispUserData.test.tsx
+++ b/src/hooks/__tests__/useCrispUserData.test.tsx
@@ -15,7 +15,7 @@ import type { ReactNode } from 'react'
 import { useAuth } from '@/context/authContext'
 import { useSupportClientContext } from '@/hooks/useSupportClientContext'
 import { useCrispUserData } from '@/hooks/useCrispUserData'
-import { TRANSACTIONS } from '@/constants/query.consts'
+import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
 import { AccountType } from '@/interfaces/interfaces'
 
@@ -165,5 +165,51 @@ describe('useCrispUserData', () => {
         })
 
         expect(result.current).toBe(before)
+    })
+
+    /*
+     * An explicit logout clears the query cache, but an EXPIRED session does
+     * not: /users/me 401s, auth goes null, and `[limits]` / `[transactions]`
+     * stay warm behind keys carrying no user id. SupportDrawer is mounted on
+     * the guest and setup layouts, so without this gate the next person to open
+     * support on that device would have published the previous user's limits
+     * and last transaction under an empty `user_id`.
+     */
+    it('publishes nothing from the cache once the session has expired', async () => {
+        client.setQueryData(['balance', WALLET], 100_000_000n)
+        client.setQueryData([LIMITS], {
+            bridge: { onRampPerTransaction: '10000', offRampPerTransaction: '10000', asset: 'USD' },
+            manteca: null,
+        })
+        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
+            entries: [
+                {
+                    uuid: 'tx-of-the-previous-user',
+                    timestamp: new Date(),
+                    status: 'COMPLETED',
+                    amount: '25.00',
+                    tokenSymbol: 'USDC',
+                    userRole: 'SENDER',
+                    extraData: { kind: 'P2P_SEND' },
+                    recipientAccount: { username: 'bob', identifier: 'bob.eth', type: 'peanut-wallet', isUser: true },
+                },
+            ],
+            hasMore: false,
+        })
+
+        // the session expires: auth goes null, the cache is untouched
+        mockUseAuth.mockReturnValue({
+            username: undefined,
+            userId: undefined,
+            user: undefined,
+        } as unknown as ReturnType<typeof useAuth>)
+
+        const { result } = renderHook(() => useCrispUserData(), { wrapper: wrapper(client) })
+
+        expect(result.current.latestActivity).toBeUndefined()
+        expect(result.current.limitsRemaining).toBeUndefined()
+        expect(result.current.balance).toBeUndefined()
+        expect(result.current.segments).toContain('guest')
+        expect(JSON.stringify(result.current)).not.toContain('tx-of-the-previous-user')
     })
 })

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -2,7 +2,30 @@ import { buildSupportVerificationSummary } from '@/utils/support-verification'
 import { useAuth } from '@/context/authContext'
 import { AccountType } from '@/interfaces/interfaces'
 import { useMemo } from 'react'
-import { ARBISCAN_ADDRESS_BASE_URL, POSTHOG_PERSON_BASE_URL, BRIDGE_DASHBOARD_BASE_URL } from '@/constants/support'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+    ARBISCAN_ADDRESS_BASE_URL,
+    POSTHOG_PERSON_BASE_URL,
+    BRIDGE_DASHBOARD_BASE_URL,
+    SENTRY_USER_ISSUES_BASE_URL,
+} from '@/constants/support'
+import {
+    readCachedLimits,
+    readCachedRainOverview,
+    readCachedSmartBalance,
+    readLatestHistoryEntry,
+} from '@/utils/support-cache'
+import {
+    buildAccountStats,
+    buildBalanceSummary,
+    buildCardSummary,
+    buildLatestActivity,
+    buildLimitsSummary,
+    buildLinkedAccounts,
+    buildSupportSegments,
+} from '@/utils/support-context'
+import { isRainBalanceKnown } from '@/utils/balance.utils'
+import { useSupportClientContext } from '@/hooks/useSupportClientContext'
 
 export interface CrispUserData {
     username: string | undefined
@@ -15,6 +38,7 @@ export interface CrispUserData {
     bridgeCustomerLink: string | undefined
     mantecaUserId: string | undefined
     posthogPersonLink: string | undefined
+    sentryIssuesLink: string | undefined
     // Live verification state so agents stop guessing where a user is stuck (#2360).
     identityStatus: string | undefined
     emailOnFile: boolean | undefined
@@ -22,58 +46,157 @@ export interface CrispUserData {
     verificationRails: string | undefined
     failureReason: string | undefined
     pendingActions: string | undefined
+    // Account context — balance, points, activity, limits, card, device/build.
+    balance: string | undefined
+    accountStats: string | undefined
+    latestActivity: string | undefined
+    limitsRemaining: string | undefined
+    card: string | undefined
+    linkedAccounts: string | undefined
+    appContext: string | undefined
+    /** Filterable/routable flags for the Crisp inbox — not sidebar rows. */
+    segments: string[]
 }
 
 /**
  * Prepares user data for Crisp chat integration
  * Extracts user information from auth context and formats it for Crisp
+ *
+ * Everything here is data the client already holds — the /get-user read-models
+ * plus warm react-query caches. Crisp gets no database access; this hook only
+ * forwards what the app itself already knows, so a support agent stops opening
+ * with "what's your balance / what did you last do / which build are you on".
+ *
+ * ⚠️ NEVER subscribe to a query here. SupportDrawer mounts this app-wide (for
+ * guests too), so a `useWallet()` / `useLimits()` / `useRainCardOverview()` call
+ * in this hook would start a poll for every user on every screen. Reads go
+ * through `support-cache`, which only ever looks at what is already cached.
  */
 export function useCrispUserData(): CrispUserData {
     const { username, userId, user } = useAuth()
+    const queryClient = useQueryClient()
+    const client = useSupportClientContext()
 
-    return useMemo(() => {
-        // Use address from user.accounts (database) rather than useWallet hook
-        // This ensures we always show the user's wallet address in support metadata,
-        // even if ZeroDev client isn't initialized yet. useWallet().address could be
-        // undefined during initialization, but we want persistent data for support agents.
-        const walletAddress =
-            user?.accounts?.find((account) => account.type === AccountType.PEANUT_WALLET)?.identifier || undefined
-        const walletAddressLink = walletAddress ? `${ARBISCAN_ADDRESS_BASE_URL}/${walletAddress}` : undefined
+    const walletAddress =
+        user?.accounts?.find((account) => account.type === AccountType.PEANUT_WALLET)?.identifier || undefined
 
-        const bridgeCustomerId = user?.user?.bridgeCustomerId || undefined
-        const bridgeCustomerLink = bridgeCustomerId ? `${BRIDGE_DASHBOARD_BASE_URL}/${bridgeCustomerId}` : undefined
-        // DATA GAP (flagged): the Manteca providerUserId used to come from the now-removed
-        // raw `user.kycVerifications` field. Neither read-model carries it — `capabilities`
-        // is provider-blind, `identityVerification` has no provider metadata. This was only
-        // an internal support-dashboard convenience link (not user-facing, not a gate), so
-        // it degrades to undefined until the backend exposes a provider-account id. Do NOT
-        // fabricate it from capabilities.
-        const mantecaUserId = undefined
+    const smartBalance = readCachedSmartBalance(queryClient, walletAddress)
+    const rainOverview = readCachedRainOverview(queryClient, userId)
+    const limits = readCachedLimits(queryClient)
+    const latestEntry = readLatestHistoryEntry(queryClient)
 
-        const posthogPersonLink = userId ? `${POSTHOG_PERSON_BASE_URL}/${userId}` : undefined
+    const snapshot = buildCrispUserData({
+        username,
+        userId,
+        user,
+        walletAddress,
+        smartBalance,
+        rainOverview,
+        limits,
+        latestEntry,
+        client,
+    })
 
-        const email = user?.user?.email || undefined
-        const verification = user
-            ? buildSupportVerificationSummary(user.capabilities, user.identityVerification, email)
-            : undefined
+    /*
+     * Identity is keyed on the serialized value, not on the inputs: the cache
+     * reads above return a fresh object every render, and the consumer pushes to
+     * Crisp on every identity change. Memoizing on the signature means a push
+     * happens when a *value* changes and not merely when React re-rendered.
+     */
+    const signature = JSON.stringify(snapshot)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `signature` IS the dependency; see above
+    return useMemo(() => snapshot, [signature])
+}
 
-        return {
-            username,
-            userId,
-            email,
-            fullName: user?.user?.fullName,
-            avatar: user?.user?.profile_picture || undefined,
-            walletAddress,
-            walletAddressLink,
-            bridgeCustomerLink,
-            mantecaUserId,
-            posthogPersonLink,
+type CrispUserDataInput = {
+    username: string | undefined
+    userId: string | undefined
+    user: ReturnType<typeof useAuth>['user']
+    walletAddress: string | undefined
+    smartBalance: bigint | undefined
+    rainOverview: ReturnType<typeof readCachedRainOverview>
+    limits: ReturnType<typeof readCachedLimits>
+    latestEntry: ReturnType<typeof readLatestHistoryEntry>
+    client: ReturnType<typeof useSupportClientContext>
+}
+
+function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
+    const { username, userId, user, walletAddress, smartBalance, rainOverview, limits, latestEntry, client } = input
+
+    // Use address from user.accounts (database) rather than useWallet hook
+    // This ensures we always show the user's wallet address in support metadata,
+    // even if ZeroDev client isn't initialized yet. useWallet().address could be
+    // undefined during initialization, but we want persistent data for support agents.
+    const walletAddressLink = walletAddress ? `${ARBISCAN_ADDRESS_BASE_URL}/${walletAddress}` : undefined
+
+    const bridgeCustomerId = user?.user?.bridgeCustomerId || undefined
+    const bridgeCustomerLink = bridgeCustomerId ? `${BRIDGE_DASHBOARD_BASE_URL}/${bridgeCustomerId}` : undefined
+    // DATA GAP (flagged): the Manteca providerUserId used to come from the now-removed
+    // raw `user.kycVerifications` field. Neither read-model carries it — `capabilities`
+    // is provider-blind, `identityVerification` has no provider metadata. This was only
+    // an internal support-dashboard convenience link (not user-facing, not a gate), so
+    // it degrades to undefined until the backend exposes a provider-account id. Do NOT
+    // fabricate it from capabilities.
+    const mantecaUserId = undefined
+
+    const posthogPersonLink = userId ? `${POSTHOG_PERSON_BASE_URL}/${userId}` : undefined
+    const sentryIssuesLink = userId ? `${SENTRY_USER_ISSUES_BASE_URL}:${userId}` : undefined
+
+    const email = user?.user?.email || undefined
+    const verification = user
+        ? buildSupportVerificationSummary(user.capabilities, user.identityVerification, email)
+        : undefined
+
+    const balance = user ? buildBalanceSummary(smartBalance, rainOverview) : undefined
+    const balanceKnown = smartBalance !== undefined && isRainBalanceKnown(rainOverview)
+
+    const appContext = [
+        client.platform,
+        client.appBuild,
+        `locale:${client.locale}`,
+        client.routeOnOpen ? `route:${client.routeOnOpen}` : undefined,
+        client.isOffline ? 'offline' : client.isApiUnreachable ? 'api-unreachable' : 'online',
+        `notif:${client.notificationPermission}`,
+    ]
+        .filter(Boolean)
+        .join(' · ')
+
+    return {
+        username,
+        userId,
+        email,
+        fullName: user?.user?.fullName,
+        avatar: user?.user?.profile_picture || undefined,
+        walletAddress,
+        walletAddressLink,
+        bridgeCustomerLink,
+        mantecaUserId,
+        posthogPersonLink,
+        sentryIssuesLink,
+        identityStatus: verification?.identityStatus,
+        emailOnFile: verification?.emailOnFile,
+        verificationGates: verification?.gates,
+        verificationRails: verification?.verificationRails,
+        failureReason: verification?.failureReason,
+        pendingActions: verification?.pendingActions,
+        balance,
+        accountStats: buildAccountStats(user ?? undefined),
+        latestActivity: buildLatestActivity(latestEntry),
+        limitsRemaining: buildLimitsSummary(limits),
+        card: buildCardSummary(rainOverview),
+        linkedAccounts: buildLinkedAccounts(user?.accounts),
+        appContext,
+        segments: buildSupportSegments({
+            isLoggedIn: Boolean(userId),
+            platform: client.platform,
             identityStatus: verification?.identityStatus,
+            hasFailureReason: Boolean(verification?.failureReason),
             emailOnFile: verification?.emailOnFile,
-            verificationGates: verification?.gates,
-            verificationRails: verification?.verificationRails,
-            failureReason: verification?.failureReason,
-            pendingActions: verification?.pendingActions,
-        }
-    }, [username, userId, user])
+            hasCard: Boolean(rainOverview?.status?.hasApplication),
+            balanceKnown,
+            isZeroBalance: balanceKnown && smartBalance === 0n && !rainOverview?.balance?.spendingPower,
+            isOffline: client.isOffline,
+            isApiUnreachable: client.isApiUnreachable,
+        }),
+    }
 }

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -4,21 +4,13 @@ import { AccountType } from '@/interfaces/interfaces'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useModalsContext } from '@/context/ModalsContext'
-import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
-import {
-    readCachedLimits,
-    readCachedRainOverview,
-    readCachedSmartBalance,
-    readLatestHistoryEntry,
-} from '@/utils/support-cache'
+import { readCachedRainOverview, readCachedSmartBalance } from '@/utils/support-cache'
 import {
     buildAccountStats,
     buildAppContext,
     buildBalanceSummary,
     buildCardSummary,
-    buildLatestActivity,
-    buildLimitsSummary,
     buildLinkedAccounts,
     buildSupportLinks,
     buildSupportSegments,
@@ -45,11 +37,9 @@ export interface CrispUserData {
     verificationRails: string | undefined
     failureReason: string | undefined
     pendingActions: string | undefined
-    // Account context — balance, points, activity, limits, card, device/build.
+    // Account context — balance, points, card, linked accounts, device/build.
     balance: string | undefined
     accountStats: string | undefined
-    latestActivity: string | undefined
-    limitsRemaining: string | undefined
     card: string | undefined
     linkedAccounts: string | undefined
     appContext: string | undefined
@@ -72,7 +62,7 @@ export interface CrispUserData {
  * through `support-cache`, which only ever looks at what is already cached.
  */
 /** The cache entries the snapshot reads. Everything else is noise to it. */
-const WATCHED_KEYS = new Set<unknown>(['balance', LIMITS, TRANSACTIONS, RAIN_CARD_OVERVIEW_QUERY_KEY])
+const WATCHED_KEYS = new Set<unknown>(['balance', RAIN_CARD_OVERVIEW_QUERY_KEY])
 
 export function useCrispUserData(): CrispUserData {
     const { username, userId, user } = useAuth()
@@ -110,23 +100,21 @@ export function useCrispUserData(): CrispUserData {
         user?.accounts?.find((account) => account.type === AccountType.PEANUT_WALLET)?.identifier || undefined
 
     /*
-     * No authenticated cache entry is read without an authenticated user.
+     * Every cache entry read here is keyed by this user — the balance by their
+     * wallet address, the card overview by their user id — and read only while
+     * a user is authenticated.
      *
-     * An explicit logout clears the query cache (authContext), but a session
-     * that simply EXPIRES does not: `/users/me` 401s, `user` becomes null, and
-     * `[limits]` and `[transactions]` stay warm behind keys that carry no user
-     * id. SupportDrawer is mounted on the guest and setup layouts too, so the
-     * next person to open support — the same device, no session — would have
-     * published the previous user's limits and last transaction under an empty
-     * `user_id`. The balance and card reads are already keyed by wallet and
-     * user id; this makes the rule uniform rather than incidental.
+     * That is a deliberate limit on what this snapshot reports. Limits and
+     * latest activity would be useful to an agent, but `[limits]` and
+     * `[transactions]` carry no user id in their keys, so a cached entry cannot
+     * be proved to belong to the person support is open for. They stay out
+     * until those keys are user-scoped; see the follow-up. Do NOT add a read
+     * here that cannot answer "whose data is this?" from the key alone.
      */
     const isAuthenticated = Boolean(userId && user)
 
     const smartBalance = isAuthenticated ? readCachedSmartBalance(queryClient, walletAddress) : undefined
     const rainOverview = isAuthenticated ? readCachedRainOverview(queryClient, userId) : undefined
-    const limits = isAuthenticated ? readCachedLimits(queryClient) : undefined
-    const latestEntry = isAuthenticated ? readLatestHistoryEntry(queryClient) : undefined
 
     const snapshot = buildCrispUserData({
         username,
@@ -135,8 +123,6 @@ export function useCrispUserData(): CrispUserData {
         walletAddress,
         smartBalance,
         rainOverview,
-        limits,
-        latestEntry,
         client,
     })
 
@@ -158,13 +144,11 @@ type CrispUserDataInput = {
     walletAddress: string | undefined
     smartBalance: bigint | undefined
     rainOverview: ReturnType<typeof readCachedRainOverview>
-    limits: ReturnType<typeof readCachedLimits>
-    latestEntry: ReturnType<typeof readLatestHistoryEntry>
     client: ReturnType<typeof useSupportClientContext>
 }
 
 function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
-    const { username, userId, user, walletAddress, smartBalance, rainOverview, limits, latestEntry, client } = input
+    const { username, userId, user, walletAddress, smartBalance, rainOverview, client } = input
 
     // Use address from user.accounts (database) rather than useWallet hook
     // This ensures we always show the user's wallet address in support metadata,
@@ -205,8 +189,6 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
         pendingActions: verification?.pendingActions,
         balance,
         accountStats: buildAccountStats(user ?? undefined),
-        latestActivity: buildLatestActivity(latestEntry),
-        limitsRemaining: buildLimitsSummary(limits),
         card: buildCardSummary(rainOverview),
         linkedAccounts: buildLinkedAccounts(user?.accounts),
         appContext: buildAppContext(client),

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -15,7 +15,7 @@ import {
     buildSupportLinks,
     buildSupportSegments,
 } from '@/utils/support-context'
-import { isRainBalanceKnown } from '@/utils/balance.utils'
+import { computeDisplaySpendable, isRainBalanceKnown } from '@/utils/balance.utils'
 import { useSupportClientContext } from '@/hooks/useSupportClientContext'
 
 export interface CrispUserData {
@@ -171,6 +171,19 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
 
     const balance = user ? buildBalanceSummary(smartBalance, rainOverview) : undefined
     const balanceKnown = smartBalance !== undefined && isRainBalanceKnown(rainOverview)
+    /*
+     * Zero is decided by the SAME total the balance row prints. During the
+     * smart-to-collateral handoff the funds are in neither bucket, and only
+     * `inTransitToCollateralCents` accounts for them — reading the two halves
+     * directly would show a funded balance beside a `zero-balance` flag.
+     */
+    const displaySpendable = balanceKnown
+        ? computeDisplaySpendable(
+              smartBalance as bigint,
+              rainOverview?.balance?.spendingPower,
+              rainOverview?.balance?.inTransitToCollateralCents
+          )
+        : undefined
 
     return {
         username,
@@ -200,7 +213,7 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
             emailOnFile: verification?.emailOnFile,
             hasCard: Boolean(rainOverview?.status?.hasApplication),
             balanceKnown,
-            isZeroBalance: balanceKnown && smartBalance === 0n && !rainOverview?.balance?.spendingPower,
+            isZeroBalance: displaySpendable === 0n,
             isOffline: client.isOffline,
             isApiUnreachable: client.isApiUnreachable,
         }),

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -90,10 +90,20 @@ export function useCrispUserData(): CrispUserData {
     const [, onCacheChange] = useReducer((tick: number) => tick + 1, 0)
     useEffect(() => {
         if (!isSupportModalOpen) return
-        return queryClient.getQueryCache().subscribe((event) => {
+        const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
             if (event.type !== 'updated') return
             if (WATCHED_KEYS.has(event.query.queryKey[0])) onCacheChange()
         })
+        /*
+         * Re-read once now that the subscription is attached. The values above
+         * were read during render; a balance or card query resolving between
+         * that render and this effect emits its only `updated` event with
+         * nobody listening, and the conversation would keep the initial
+         * `unavailable` snapshot — and the routing flag derived from it — until
+         * some unrelated render happened to recompute it.
+         */
+        onCacheChange()
+        return unsubscribe
     }, [isSupportModalOpen, queryClient])
 
     const walletAddress =

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -1,8 +1,11 @@
 import { buildSupportVerificationSummary } from '@/utils/support-verification'
 import { useAuth } from '@/context/authContext'
 import { AccountType } from '@/interfaces/interfaces'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useReducer } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useModalsContext } from '@/context/ModalsContext'
+import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
 import {
     readCachedLimits,
     readCachedRainOverview,
@@ -68,10 +71,40 @@ export interface CrispUserData {
  * in this hook would start a poll for every user on every screen. Reads go
  * through `support-cache`, which only ever looks at what is already cached.
  */
+/** The cache entries the snapshot reads. Everything else is noise to it. */
+const WATCHED_KEYS = new Set<unknown>(['balance', LIMITS, TRANSACTIONS, RAIN_CARD_OVERVIEW_QUERY_KEY])
+
 export function useCrispUserData(): CrispUserData {
     const { username, userId, user } = useAuth()
     const queryClient = useQueryClient()
     const client = useSupportClientContext()
+    const { isSupportModalOpen } = useModalsContext()
+
+    /*
+     * Cache reads are not subscriptions, so nothing re-renders when a query the
+     * snapshot reads finally resolves. Open support while the balance is still
+     * in flight and the sidebar would say `unavailable` for the whole
+     * conversation, with a `balance-unavailable` segment routing on it —
+     * accurate at the instant it was read, wrong a second later.
+     *
+     * So watch the cache, but only while support is open: outside an open cycle
+     * nobody consumes the snapshot, and this hook is mounted app-wide. The
+     * subscription is read-only — it observes what other components fetch and
+     * never triggers a fetch itself, which is the whole point of reading the
+     * cache rather than subscribing with useQuery.
+     *
+     * Re-render churn is bounded by the signature memo below: a cache event
+     * that doesn't change a value leaves the snapshot's identity alone, so no
+     * push to Crisp follows.
+     */
+    const [, onCacheChange] = useReducer((tick: number) => tick + 1, 0)
+    useEffect(() => {
+        if (!isSupportModalOpen) return
+        return queryClient.getQueryCache().subscribe((event) => {
+            if (event.type !== 'updated') return
+            if (WATCHED_KEYS.has(event.query.queryKey[0])) onCacheChange()
+        })
+    }, [isSupportModalOpen, queryClient])
 
     const walletAddress =
         user?.accounts?.find((account) => account.type === AccountType.PEANUT_WALLET)?.identifier || undefined

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -4,12 +4,6 @@ import { AccountType } from '@/interfaces/interfaces'
 import { useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
-    ARBISCAN_ADDRESS_BASE_URL,
-    POSTHOG_PERSON_BASE_URL,
-    BRIDGE_DASHBOARD_BASE_URL,
-    SENTRY_USER_ISSUES_BASE_URL,
-} from '@/constants/support'
-import {
     readCachedLimits,
     readCachedRainOverview,
     readCachedSmartBalance,
@@ -17,11 +11,13 @@ import {
 } from '@/utils/support-cache'
 import {
     buildAccountStats,
+    buildAppContext,
     buildBalanceSummary,
     buildCardSummary,
     buildLatestActivity,
     buildLimitsSummary,
     buildLinkedAccounts,
+    buildSupportLinks,
     buildSupportSegments,
 } from '@/utils/support-context'
 import { isRainBalanceKnown } from '@/utils/balance.utils'
@@ -127,10 +123,8 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
     // This ensures we always show the user's wallet address in support metadata,
     // even if ZeroDev client isn't initialized yet. useWallet().address could be
     // undefined during initialization, but we want persistent data for support agents.
-    const walletAddressLink = walletAddress ? `${ARBISCAN_ADDRESS_BASE_URL}/${walletAddress}` : undefined
+    const links = buildSupportLinks(userId, walletAddress, user?.user?.bridgeCustomerId || undefined)
 
-    const bridgeCustomerId = user?.user?.bridgeCustomerId || undefined
-    const bridgeCustomerLink = bridgeCustomerId ? `${BRIDGE_DASHBOARD_BASE_URL}/${bridgeCustomerId}` : undefined
     // DATA GAP (flagged): the Manteca providerUserId used to come from the now-removed
     // raw `user.kycVerifications` field. Neither read-model carries it — `capabilities`
     // is provider-blind, `identityVerification` has no provider metadata. This was only
@@ -138,9 +132,6 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
     // it degrades to undefined until the backend exposes a provider-account id. Do NOT
     // fabricate it from capabilities.
     const mantecaUserId = undefined
-
-    const posthogPersonLink = userId ? `${POSTHOG_PERSON_BASE_URL}/${userId}` : undefined
-    const sentryIssuesLink = userId ? `${SENTRY_USER_ISSUES_BASE_URL}:${userId}` : undefined
 
     const email = user?.user?.email || undefined
     const verification = user
@@ -150,17 +141,6 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
     const balance = user ? buildBalanceSummary(smartBalance, rainOverview) : undefined
     const balanceKnown = smartBalance !== undefined && isRainBalanceKnown(rainOverview)
 
-    const appContext = [
-        client.platform,
-        client.appBuild,
-        `locale:${client.locale}`,
-        client.routeOnOpen ? `route:${client.routeOnOpen}` : undefined,
-        client.isOffline ? 'offline' : client.isApiUnreachable ? 'api-unreachable' : 'online',
-        `notif:${client.notificationPermission}`,
-    ]
-        .filter(Boolean)
-        .join(' · ')
-
     return {
         username,
         userId,
@@ -168,11 +148,8 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
         fullName: user?.user?.fullName,
         avatar: user?.user?.profile_picture || undefined,
         walletAddress,
-        walletAddressLink,
-        bridgeCustomerLink,
+        ...links,
         mantecaUserId,
-        posthogPersonLink,
-        sentryIssuesLink,
         identityStatus: verification?.identityStatus,
         emailOnFile: verification?.emailOnFile,
         verificationGates: verification?.gates,
@@ -185,7 +162,7 @@ function buildCrispUserData(input: CrispUserDataInput): CrispUserData {
         limitsRemaining: buildLimitsSummary(limits),
         card: buildCardSummary(rainOverview),
         linkedAccounts: buildLinkedAccounts(user?.accounts),
-        appContext,
+        appContext: buildAppContext(client),
         segments: buildSupportSegments({
             isLoggedIn: Boolean(userId),
             platform: client.platform,

--- a/src/hooks/useCrispUserData.ts
+++ b/src/hooks/useCrispUserData.ts
@@ -109,10 +109,24 @@ export function useCrispUserData(): CrispUserData {
     const walletAddress =
         user?.accounts?.find((account) => account.type === AccountType.PEANUT_WALLET)?.identifier || undefined
 
-    const smartBalance = readCachedSmartBalance(queryClient, walletAddress)
-    const rainOverview = readCachedRainOverview(queryClient, userId)
-    const limits = readCachedLimits(queryClient)
-    const latestEntry = readLatestHistoryEntry(queryClient)
+    /*
+     * No authenticated cache entry is read without an authenticated user.
+     *
+     * An explicit logout clears the query cache (authContext), but a session
+     * that simply EXPIRES does not: `/users/me` 401s, `user` becomes null, and
+     * `[limits]` and `[transactions]` stay warm behind keys that carry no user
+     * id. SupportDrawer is mounted on the guest and setup layouts too, so the
+     * next person to open support — the same device, no session — would have
+     * published the previous user's limits and last transaction under an empty
+     * `user_id`. The balance and card reads are already keyed by wallet and
+     * user id; this makes the rule uniform rather than incidental.
+     */
+    const isAuthenticated = Boolean(userId && user)
+
+    const smartBalance = isAuthenticated ? readCachedSmartBalance(queryClient, walletAddress) : undefined
+    const rainOverview = isAuthenticated ? readCachedRainOverview(queryClient, userId) : undefined
+    const limits = isAuthenticated ? readCachedLimits(queryClient) : undefined
+    const latestEntry = isAuthenticated ? readLatestHistoryEntry(queryClient) : undefined
 
     const snapshot = buildCrispUserData({
         username,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -54,6 +54,13 @@ function subscribe(notify: () => void): () => void {
 }
 
 const getSnapshot = () => state
+
+/**
+ * Permission state without mounting `useNotifications` — that hook initializes
+ * OneSignal as a side effect, which the support snapshot has no business
+ * triggering. Reads the same module store the hook fans out from.
+ */
+export const getNotificationPermissionSnapshot = (): NotificationPermissionState => state.permissionState
 const getServerSnapshot = () => INITIAL_STATE
 
 let currentExternalId: string | null = null

--- a/src/hooks/useSupportClientContext.ts
+++ b/src/hooks/useSupportClientContext.ts
@@ -7,6 +7,7 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useConnectivity } from '@/hooks/useConnectivity'
 import { getNotificationPermissionSnapshot } from '@/hooks/useNotifications'
 import { getPlatform, isCapacitor } from '@/utils/capacitor'
+import { normalizeSupportRoute } from '@/utils/support-context'
 
 export interface SupportClientContext {
     platform: string
@@ -100,7 +101,10 @@ export function useSupportClientContext(): SupportClientContext {
         route: undefined,
     })
     if (latch.open !== isSupportModalOpen) {
-        setLatch({ open: isSupportModalOpen, route: isSupportModalOpen ? pathname : latch.route })
+        setLatch({
+            open: isSupportModalOpen,
+            route: isSupportModalOpen ? normalizeSupportRoute(pathname) : latch.route,
+        })
     }
 
     const buildParts = [webBuild() ? `web:${webBuild()}` : undefined, nativeBuild].filter(Boolean)

--- a/src/hooks/useSupportClientContext.ts
+++ b/src/hooks/useSupportClientContext.ts
@@ -1,0 +1,107 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useLocale } from 'next-intl'
+import { usePathname } from 'next/navigation'
+import { useModalsContext } from '@/context/ModalsContext'
+import { useConnectivity } from '@/hooks/useConnectivity'
+import { getNotificationPermissionSnapshot } from '@/hooks/useNotifications'
+import { getPlatform, isCapacitor } from '@/utils/capacitor'
+
+export interface SupportClientContext {
+    platform: string
+    /** running build across all three layers: web bundle, native binary, OTA bundle. */
+    appBuild: string
+    locale: string
+    /** route the user was on when they opened support, latched at open. */
+    routeOnOpen: string | undefined
+    isOffline: boolean
+    isApiUnreachable: boolean
+    notificationPermission: string
+}
+
+/**
+ * Which build is this user actually running?
+ *
+ * Three independent version layers can disagree, and every one of them has
+ * produced a support thread about a bug that was already fixed: the web bundle
+ * (a document can outlive arbitrarily many deploys — see useStaleDeploymentReload),
+ * the native binary, and the Capgo OTA bundle layered on top of it. An agent who
+ * can see all three says "update the app" instead of debugging history.
+ *
+ * Resolved once per session: the native reads are async bridge calls, and the
+ * answer cannot change without the app restarting.
+ */
+const webBuild = () => process.env.NEXT_PUBLIC_GIT_COMMIT_HASH?.slice(0, 7)
+
+let nativeBuildPromise: Promise<string | undefined> | null = null
+
+function resolveNativeBuild(): Promise<string | undefined> {
+    if (!nativeBuildPromise) {
+        nativeBuildPromise = (async () => {
+            const parts: string[] = []
+            try {
+                const { App } = await import('@capacitor/app')
+                const info = await App.getInfo()
+                if (info?.version) parts.push(`native:${info.version}${info.build ? ` (${info.build})` : ''}`)
+            } catch {
+                // older binary, or the bridge isn't up — the web build still prints
+            }
+            try {
+                const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+                const current = await CapacitorUpdater.current()
+                if (current?.bundle?.version) parts.push(`ota:${current.bundle.version}`)
+            } catch {
+                // no OTA layer on this install
+            }
+            return parts.length ? parts.join(' ') : undefined
+        })()
+        nativeBuildPromise.catch(() => {
+            nativeBuildPromise = null
+        })
+    }
+    return nativeBuildPromise
+}
+
+export function useSupportClientContext(): SupportClientContext {
+    const locale = useLocale()
+    const pathname = usePathname()
+    const { isSupportModalOpen } = useModalsContext()
+    const { isOffline, isApiUnreachable } = useConnectivity()
+    const [nativeBuild, setNativeBuild] = useState<string | undefined>(undefined)
+
+    useEffect(() => {
+        if (!isCapacitor()) return
+        let cancelled = false
+        resolveNativeBuild().then((build) => {
+            if (!cancelled) setNativeBuild(build)
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    /*
+     * The route is latched at open rather than tracked live. Live-tracking would
+     * churn the whole snapshot's identity on every navigation — and the question
+     * an agent is asking ("where were they when this went wrong?") is answered by
+     * the screen the user left, not the one they wandered to while waiting.
+     */
+    const [routeOnOpen, setRouteOnOpen] = useState<string | undefined>(undefined)
+    useEffect(() => {
+        if (isSupportModalOpen) setRouteOnOpen(pathname)
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- latch at open; tracking `pathname` would defeat the point
+    }, [isSupportModalOpen])
+
+    const buildParts = [webBuild() ? `web:${webBuild()}` : undefined, nativeBuild].filter(Boolean)
+
+    return {
+        platform: getPlatform(),
+        appBuild: buildParts.length ? buildParts.join(' · ') : 'unknown',
+        locale,
+        routeOnOpen,
+        isOffline,
+        isApiUnreachable,
+        notificationPermission: getNotificationPermissionSnapshot(),
+    }
+}

--- a/src/hooks/useSupportClientContext.ts
+++ b/src/hooks/useSupportClientContext.ts
@@ -86,12 +86,22 @@ export function useSupportClientContext(): SupportClientContext {
      * churn the whole snapshot's identity on every navigation — and the question
      * an agent is asking ("where were they when this went wrong?") is answered by
      * the screen the user left, not the one they wandered to while waiting.
+     *
+     * Latched DURING RENDER, not in an effect. An effect would set it after the
+     * commit that opened support, and on native that commit has already started
+     * SupportDrawer's async open chain. The extra render rebuilds `userData`,
+     * which is a dependency of that effect, so the chain would run again and
+     * send a prefilled message twice. Adjusting state during render re-runs this
+     * component before anything commits, so the first snapshot support ever sees
+     * already carries the route.
      */
-    const [routeOnOpen, setRouteOnOpen] = useState<string | undefined>(undefined)
-    useEffect(() => {
-        if (isSupportModalOpen) setRouteOnOpen(pathname)
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- latch at open; tracking `pathname` would defeat the point
-    }, [isSupportModalOpen])
+    const [latch, setLatch] = useState<{ open: boolean; route: string | undefined }>({
+        open: false,
+        route: undefined,
+    })
+    if (latch.open !== isSupportModalOpen) {
+        setLatch({ open: isSupportModalOpen, route: isSupportModalOpen ? pathname : latch.route })
+    }
 
     const buildParts = [webBuild() ? `web:${webBuild()}` : undefined, nativeBuild].filter(Boolean)
 
@@ -99,7 +109,7 @@ export function useSupportClientContext(): SupportClientContext {
         platform: getPlatform(),
         appBuild: buildParts.length ? buildParts.join(' · ') : 'unknown',
         locale,
-        routeOnOpen,
+        routeOnOpen: latch.route,
         isOffline,
         isApiUnreachable,
         notificationPermission: getNotificationPermissionSnapshot(),

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -47,6 +47,19 @@ describe('supportSessionFields', () => {
         expect(Object.fromEntries(supportSessionFields(userData({ emailOnFile: undefined }))).email_on_file).toBe('')
     })
 
+    /*
+     * `sendMessage` is `unimplemented` in this plugin on BOTH iOS and Android,
+     * so the prefill never reached Crisp in the app — every "contact support
+     * about X" entry point lost its context, silently. The topic rides as a data
+     * row, which both platforms implement, and on web it also survives the user
+     * clearing the prefilled composer before sending.
+     */
+    it('carries the support topic so native does not lose it', () => {
+        const withTopic = Object.fromEntries(supportSessionFields(userData(), 'my withdrawal is stuck'))
+        expect(withTopic.support_topic).toBe('my withdrawal is stuck')
+        expect(Object.fromEntries(supportSessionFields(userData())).support_topic).toBe('')
+    })
+
     it('carries the full segment list as a data row for the native sink', () => {
         expect(Object.fromEntries(supportSessionFields(userData())).segments).toBe('ios-native kyc-verified')
     })

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -8,7 +8,7 @@
  * the properties that made the drift damaging.
  */
 
-import { supportSessionFields, nativeCrispFields } from '../crisp'
+import { supportSessionFields, nativeCrispFields, setCrispUserData } from '../crisp'
 import type { CrispUserData } from '@/hooks/useCrispUserData'
 
 const userData = (partial: Partial<CrispUserData> = {}): CrispUserData =>
@@ -65,5 +65,48 @@ describe('supportSessionFields', () => {
                 'sentry_issues',
             ])
         )
+    })
+})
+
+describe('setCrispUserData segments', () => {
+    const push = (): { calls: unknown[][] } & { push: (entry: unknown[]) => void } => {
+        const calls: unknown[][] = []
+        return { calls, push: (entry: unknown[]) => void calls.push(entry) }
+    }
+    const segmentPushes = (calls: unknown[][]) => calls.filter(([, key]) => key === 'session:segments')
+
+    /*
+     * Crisp APPENDS session segments unless the second argument is true, and
+     * this runs again on every snapshot change. Without the flag a user who was
+     * briefly offline keeps routing as `offline` after recovery, and
+     * `kyc-pending` outlives their approval — the inbox then filters on state
+     * the user has already left, which is worse than no segments at all.
+     */
+    it('replaces the segment set rather than appending to it', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-pending', 'offline'] }))
+
+        const [, , payload] = segmentPushes(crisp.calls)[0] as [string, string, unknown[]]
+        expect(payload).toEqual([['web', 'kyc-pending', 'offline'], true])
+    })
+
+    it('leaves no trace of a segment the user has moved past', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-pending', 'offline'] }))
+        setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-verified'] }))
+
+        const pushes = segmentPushes(crisp.calls)
+        expect(pushes).toHaveLength(2)
+        for (const [, , payload] of pushes as [string, string, unknown[]][]) {
+            expect(payload[1]).toBe(true)
+        }
+        expect((pushes[1] as [string, string, unknown[]])[2][0]).toEqual(['web', 'kyc-verified'])
+    })
+
+    it('pushes nothing when there are no segments, rather than clearing blindly', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData({ segments: [] }))
+
+        expect(segmentPushes(crisp.calls)).toHaveLength(0)
     })
 })

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -87,37 +87,27 @@ describe('setCrispUserData segments', () => {
     const segmentPushes = (calls: unknown[][]) => calls.filter(([, key]) => key === 'session:segments')
 
     /*
-     * Crisp APPENDS session segments unless the second argument is true, and
-     * this runs again on every snapshot change. Without the flag a user who was
-     * briefly offline keeps routing as `offline` after recovery, and
-     * `kyc-pending` outlives their approval — the inbox then filters on state
-     * the user has already left, which is worse than no segments at all.
+     * Segments are a field people write by hand, and one of them backs an OKR:
+     * agents tag translation reports `translation-issue` and the monthly count
+     * only sees a conversation that still carries it. Crisp has no partial
+     * write — a set replaces the whole list — so any automatic write erases
+     * whatever a human put there, and this function runs on every snapshot
+     * change, not only when support opens. Appending instead would leave the
+     * app's own flags stale. So the app writes none. See TASK-21968.
      */
-    it('replaces the segment set rather than appending to it', () => {
-        const crisp = push()
-        setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-pending', 'offline'] }))
-
-        const [, , payload] = segmentPushes(crisp.calls)[0] as [string, string, unknown[]]
-        expect(payload).toEqual([['web', 'kyc-pending', 'offline'], true])
-    })
-
-    it('leaves no trace of a segment the user has moved past', () => {
+    it('never writes Crisp segments, whatever the snapshot says', () => {
         const crisp = push()
         setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-pending', 'offline'] }))
         setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-verified'] }))
 
-        const pushes = segmentPushes(crisp.calls)
-        expect(pushes).toHaveLength(2)
-        for (const [, , payload] of pushes as [string, string, unknown[]][]) {
-            expect(payload[1]).toBe(true)
-        }
-        expect((pushes[1] as [string, string, unknown[]])[2][0]).toEqual(['web', 'kyc-verified'])
+        expect(segmentPushes(crisp.calls)).toHaveLength(0)
     })
 
-    it('pushes nothing when there are no segments, rather than clearing blindly', () => {
+    it('still gives the agent the flags, as a data row', () => {
         const crisp = push()
-        setCrispUserData(crisp as never, userData({ segments: [] }))
+        setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-verified'] }))
 
-        expect(segmentPushes(crisp.calls)).toHaveLength(0)
+        const [, , payload] = crisp.calls.find(([, key]) => key === 'session:data') as [string, string, unknown[][]]
+        expect(Object.fromEntries(payload[0] as [string, string][]).segments).toBe('web kyc-verified')
     })
 })

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -103,6 +103,20 @@ describe('setCrispUserData segments', () => {
         expect(segmentPushes(crisp.calls)).toHaveLength(0)
     })
 
+    /*
+     * A routine metadata refresh omits the composer prefill on purpose — pushing
+     * it again would overwrite what the user is typing. The topic must survive
+     * that anyway, or a balance update erases the reason they opened support.
+     */
+    it('keeps the support topic through a refresh that must not touch the composer', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData(), undefined, 'my withdrawal is stuck')
+
+        const dataPush = crisp.calls.find(([, key]) => key === 'session:data') as [string, string, unknown[][]]
+        expect(Object.fromEntries(dataPush[2][0] as [string, string][]).support_topic).toBe('my withdrawal is stuck')
+        expect(crisp.calls.filter(([, key]) => key === 'message:text')).toHaveLength(0)
+    })
+
     it('still gives the agent the flags, as a data row', () => {
         const crisp = push()
         setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-verified'] }))

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -117,6 +117,28 @@ describe('setCrispUserData segments', () => {
         expect(crisp.calls.filter(([, key]) => key === 'message:text')).toHaveLength(0)
     })
 
+    /*
+     * The iframe stays mounted between open cycles, so the composer keeps
+     * whatever was last put in it. Open support from an error CTA, close
+     * without sending, reopen from the nav: the new cycle has no prefill, and a
+     * falsy guard skipped the clear — leaving the old error text in the box.
+     * `undefined` means "leave the composer alone" (routine metadata refresh);
+     * an empty string is a real instruction to clear it.
+     */
+    it('clears the composer when a new cycle has no prefill', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData(), '')
+
+        expect(crisp.calls.filter(([, key]) => key === 'message:text')).toEqual([['set', 'message:text', ['']]])
+    })
+
+    it('leaves the composer alone on a routine metadata refresh', () => {
+        const crisp = push()
+        setCrispUserData(crisp as never, userData(), undefined, 'topic only')
+
+        expect(crisp.calls.filter(([, key]) => key === 'message:text')).toHaveLength(0)
+    })
+
     it('still gives the agent the flags, as a data row', () => {
         const crisp = push()
         setCrispUserData(crisp as never, userData({ segments: ['web', 'kyc-verified'] }))

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -1,0 +1,69 @@
+/**
+ * One field list, three sinks.
+ *
+ * The web widget, the proxy iframe and the native `setString` loop each write
+ * the agent sidebar, and when they were written out by hand they drifted: native
+ * sent two keys where web sent seven, so the agents helping *app* users saw the
+ * least. `supportSessionFields` is now the single definition; these tests pin
+ * the properties that made the drift damaging.
+ */
+
+import { supportSessionFields, nativeCrispFields } from '../crisp'
+import type { CrispUserData } from '@/hooks/useCrispUserData'
+
+const userData = (partial: Partial<CrispUserData> = {}): CrispUserData =>
+    ({
+        username: 'glorfindel',
+        userId: 'user-1',
+        balance: '$100.00 spendable (wallet $100.00 · card $0.00)',
+        emailOnFile: true,
+        segments: ['ios-native', 'kyc-verified'],
+        ...partial,
+    }) as CrispUserData
+
+describe('supportSessionFields', () => {
+    it('feeds the native sink from the identical list', () => {
+        expect(nativeCrispFields).toBe(supportSessionFields)
+    })
+
+    /*
+     * Absent values must still be written. A device-local Crisp session
+     * (native) keeps whatever was last set, so skipping an empty key would leave
+     * the previous user's balance and verification state visible to an agent
+     * after a logout/login on a shared device.
+     */
+    it('writes every key on every call, empty rather than omitted', () => {
+        const full = supportSessionFields(userData())
+        const sparse = supportSessionFields({ segments: [] } as unknown as CrispUserData)
+
+        expect(sparse.map(([key]) => key)).toEqual(full.map(([key]) => key))
+        expect(sparse.every(([, value]) => typeof value === 'string')).toBe(true)
+        expect(Object.fromEntries(sparse).balance).toBe('')
+    })
+
+    it('renders email_on_file as a word an agent can read, and distinguishes unknown', () => {
+        expect(Object.fromEntries(supportSessionFields(userData({ emailOnFile: true }))).email_on_file).toBe('yes')
+        expect(Object.fromEntries(supportSessionFields(userData({ emailOnFile: false }))).email_on_file).toBe('no')
+        expect(Object.fromEntries(supportSessionFields(userData({ emailOnFile: undefined }))).email_on_file).toBe('')
+    })
+
+    it('carries the full segment list as a data row for the native sink', () => {
+        expect(Object.fromEntries(supportSessionFields(userData())).segments).toBe('ios-native kyc-verified')
+    })
+
+    it('includes the account context an agent would otherwise have to ask for', () => {
+        const keys = supportSessionFields(userData()).map(([key]) => key)
+        expect(keys).toEqual(
+            expect.arrayContaining([
+                'balance',
+                'account_stats',
+                'latest_activity',
+                'limits_remaining',
+                'card',
+                'linked_accounts',
+                'app_context',
+                'sentry_issues',
+            ])
+        )
+    })
+})

--- a/src/utils/__tests__/crisp-session-fields.test.ts
+++ b/src/utils/__tests__/crisp-session-fields.test.ts
@@ -70,8 +70,6 @@ describe('supportSessionFields', () => {
             expect.arrayContaining([
                 'balance',
                 'account_stats',
-                'latest_activity',
-                'limits_remaining',
                 'card',
                 'linked_accounts',
                 'app_context',

--- a/src/utils/__tests__/support-cache.test.ts
+++ b/src/utils/__tests__/support-cache.test.ts
@@ -1,69 +1,52 @@
 /**
- * The cache readers exist so the support snapshot never issues a request —
- * SupportDrawer mounts app-wide, so a subscribing hook there would start a poll
- * for every user on every screen. These tests pin both halves of that contract:
- * the readers find what is genuinely cached, and they return `undefined` rather
- * than fetching when it isn't.
+ * Two contracts, both load-bearing.
+ *
+ * The readers never issue a request — SupportDrawer mounts app-wide, so a
+ * subscribing hook there would start a poll for every user on every screen —
+ * and they only read keys that name their owner, so a cached entry can be
+ * proved to belong to the person support is open for.
  */
 
 import { QueryClient } from '@tanstack/react-query'
-import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
-import { readCachedLimits, readLatestHistoryEntry } from '../support-cache'
-import type { HistoryEntry } from '@/utils/history.utils'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { readCachedRainOverview, readCachedSmartBalance } from '../support-cache'
+import type { RainCardOverview } from '@/services/rain'
 
-const entry = (uuid: string, timestamp: string): HistoryEntry =>
-    ({ uuid, timestamp: new Date(timestamp) }) as HistoryEntry
+const WALLET = '0xb8ed0b7578e658cb6718ae92facb98f718d445e3'
 
-describe('readLatestHistoryEntry', () => {
+describe('support cache readers', () => {
     let client: QueryClient
 
     beforeEach(() => {
         client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     })
 
-    /*
-     * The `latest` key carries its own `limit` and `targetUsername`, so the cache
-     * legitimately holds several variants at once (home Activity at 5, the
-     * carousel at 50). Reading one hardcoded key would silently return nothing
-     * the day a caller changed its limit — hence the scan.
-     */
-    it('finds the newest entry across every cached history variant', () => {
-        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
-            entries: [entry('older', '2026-08-01T00:00:00Z')],
-            hasMore: false,
-        })
-        client.setQueryData([TRANSACTIONS, 'latest', { limit: 50, targetUsername: undefined }], {
-            entries: [entry('newest', '2026-08-26T00:00:00Z')],
-            hasMore: false,
-        })
-
-        expect(readLatestHistoryEntry(client)?.uuid).toBe('newest')
-    })
-
-    it('reads paged infinite-query data too', () => {
-        client.setQueryData([TRANSACTIONS, 'infinite', { limit: 50 }], {
-            pages: [
-                { entries: [entry('page-1', '2026-08-02T00:00:00Z')], hasMore: true },
-                { entries: [entry('page-2', '2026-08-20T00:00:00Z')], hasMore: false },
-            ],
-            pageParams: [undefined, 'cursor'],
-        })
-
-        expect(readLatestHistoryEntry(client)?.uuid).toBe('page-2')
-    })
-
     it('returns undefined on a cold cache instead of fetching', () => {
-        expect(readLatestHistoryEntry(client)).toBeUndefined()
-        expect(client.getQueryCache().findAll().length).toBe(0)
+        expect(readCachedSmartBalance(client, WALLET)).toBeUndefined()
+        expect(readCachedRainOverview(client, 'user-1')).toBeUndefined()
+        expect(client.getQueryCache().findAll()).toHaveLength(0)
     })
-})
 
-describe('readCachedLimits', () => {
-    it('returns undefined rather than triggering the request', () => {
-        const client = new QueryClient()
-        expect(readCachedLimits(client)).toBeUndefined()
+    it('reads what is already cached for this identity', () => {
+        client.setQueryData(['balance', WALLET], 100_000_000n)
+        client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], { status: { hasApplication: false } })
 
-        client.setQueryData([LIMITS], { manteca: null, bridge: null })
-        expect(readCachedLimits(client)).toEqual({ manteca: null, bridge: null })
+        expect(readCachedSmartBalance(client, WALLET)).toBe(100_000_000n)
+        expect(readCachedRainOverview(client, 'user-1')?.status?.hasApplication).toBe(false)
+    })
+
+    /*
+     * The reason limits and latest activity are absent from the snapshot: their
+     * keys name no owner, so there is no equivalent of this test for them. Here
+     * a different identity simply reads nothing, because the identity is part of
+     * the key rather than an assumption about who was signed in.
+     */
+    it('reads nothing for an identity that has no cached entry', () => {
+        client.setQueryData([RAIN_CARD_OVERVIEW_QUERY_KEY, 'user-1'], {
+            status: { hasApplication: true },
+        } as RainCardOverview)
+
+        expect(readCachedRainOverview(client, 'user-2')).toBeUndefined()
+        expect(readCachedSmartBalance(client, undefined)).toBeUndefined()
     })
 })

--- a/src/utils/__tests__/support-cache.test.ts
+++ b/src/utils/__tests__/support-cache.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The cache readers exist so the support snapshot never issues a request —
+ * SupportDrawer mounts app-wide, so a subscribing hook there would start a poll
+ * for every user on every screen. These tests pin both halves of that contract:
+ * the readers find what is genuinely cached, and they return `undefined` rather
+ * than fetching when it isn't.
+ */
+
+import { QueryClient } from '@tanstack/react-query'
+import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
+import { readCachedLimits, readLatestHistoryEntry } from '../support-cache'
+import type { HistoryEntry } from '@/utils/history.utils'
+
+const entry = (uuid: string, timestamp: string): HistoryEntry =>
+    ({ uuid, timestamp: new Date(timestamp) }) as HistoryEntry
+
+describe('readLatestHistoryEntry', () => {
+    let client: QueryClient
+
+    beforeEach(() => {
+        client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    })
+
+    /*
+     * The `latest` key carries its own `limit` and `targetUsername`, so the cache
+     * legitimately holds several variants at once (home Activity at 5, the
+     * carousel at 50). Reading one hardcoded key would silently return nothing
+     * the day a caller changed its limit — hence the scan.
+     */
+    it('finds the newest entry across every cached history variant', () => {
+        client.setQueryData([TRANSACTIONS, 'latest', { limit: 5, targetUsername: undefined }], {
+            entries: [entry('older', '2026-08-01T00:00:00Z')],
+            hasMore: false,
+        })
+        client.setQueryData([TRANSACTIONS, 'latest', { limit: 50, targetUsername: undefined }], {
+            entries: [entry('newest', '2026-08-26T00:00:00Z')],
+            hasMore: false,
+        })
+
+        expect(readLatestHistoryEntry(client)?.uuid).toBe('newest')
+    })
+
+    it('reads paged infinite-query data too', () => {
+        client.setQueryData([TRANSACTIONS, 'infinite', { limit: 50 }], {
+            pages: [
+                { entries: [entry('page-1', '2026-08-02T00:00:00Z')], hasMore: true },
+                { entries: [entry('page-2', '2026-08-20T00:00:00Z')], hasMore: false },
+            ],
+            pageParams: [undefined, 'cursor'],
+        })
+
+        expect(readLatestHistoryEntry(client)?.uuid).toBe('page-2')
+    })
+
+    it('returns undefined on a cold cache instead of fetching', () => {
+        expect(readLatestHistoryEntry(client)).toBeUndefined()
+        expect(client.getQueryCache().findAll().length).toBe(0)
+    })
+})
+
+describe('readCachedLimits', () => {
+    it('returns undefined rather than triggering the request', () => {
+        const client = new QueryClient()
+        expect(readCachedLimits(client)).toBeUndefined()
+
+        client.setQueryData([LIMITS], { manteca: null, bridge: null })
+        expect(readCachedLimits(client)).toEqual({ manteca: null, bridge: null })
+    })
+})

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -2,8 +2,6 @@ import {
     buildAccountStats,
     buildBalanceSummary,
     buildCardSummary,
-    buildLatestActivity,
-    buildLimitsSummary,
     buildLinkedAccounts,
     buildSupportSegments,
     normalizeSupportRoute,
@@ -11,7 +9,6 @@ import {
 } from '../support-context'
 import { AccountType, type Account, type IUserProfile } from '@/interfaces/interfaces'
 import type { RainCardOverview } from '@/services/rain'
-import type { HistoryEntry } from '@/utils/history.utils'
 
 const NOW = new Date('2026-08-27T12:00:00Z').getTime()
 
@@ -54,59 +51,6 @@ describe('buildBalanceSummary', () => {
     })
 })
 
-describe('buildLatestActivity', () => {
-    const entry = (partial: Partial<HistoryEntry> = {}): HistoryEntry =>
-        ({
-            uuid: 'tx-123',
-            type: 'TRANSACTION_INTENT',
-            timestamp: new Date('2026-08-27T09:00:00Z'),
-            amount: '25.00',
-            chainId: '42161',
-            tokenSymbol: 'USDC',
-            status: 'COMPLETED',
-            userRole: 'SENDER',
-            recipientAccount: { identifier: 'bob.eth', type: 'peanut-wallet', isUser: true, username: 'bob' },
-            extraData: { kind: 'P2P_SEND' },
-            ...partial,
-        }) as HistoryEntry
-
-    it('summarises kind, status, amount and age', () => {
-        expect(buildLatestActivity(entry(), NOW)).toBe(
-            'P2P_SEND · COMPLETED · 25.00 USDC · 3h ago · as sender · uuid:tx-123'
-        )
-    })
-
-    /*
-     * A support sidebar is the user's own state. Replicating who they paid would
-     * accumulate third parties' payment records in a chat console — which is
-     * both a privacy problem and something no agent needs to answer "where did
-     * my money go".
-     */
-    it('never names the counterparty', () => {
-        const summary = buildLatestActivity(entry(), NOW) ?? ''
-        expect(summary).not.toContain('bob')
-        expect(summary).not.toContain('bob.eth')
-    })
-
-    it('surfaces the reaper failure note on a failed intent', () => {
-        const failed = entry({ status: 'FAILED', extraData: { kind: 'FIAT_OFFRAMP', failReason: 'provider timeout' } })
-        expect(buildLatestActivity(failed, NOW)).toContain('failReason:provider timeout')
-    })
-
-    it('prefers the fiat amount when the entry carries one', () => {
-        expect(buildLatestActivity(entry({ currency: { amount: '25000', code: 'ARS' } }), NOW)).toContain('25000 ARS')
-    })
-
-    it('reads as a phrase for a transaction from moments ago', () => {
-        const justNow = entry({ timestamp: new Date('2026-08-27T11:59:45Z') })
-        expect(buildLatestActivity(justNow, NOW)).toContain('· just now ·')
-    })
-
-    it('is undefined when no history is cached', () => {
-        expect(buildLatestActivity(undefined, NOW)).toBeUndefined()
-    })
-})
-
 describe('buildAccountStats', () => {
     const profile = (partial: Partial<IUserProfile> = {}): IUserProfile =>
         ({
@@ -145,30 +89,6 @@ describe('buildAccountStats', () => {
 
     it('is undefined for a guest', () => {
         expect(buildAccountStats(undefined, NOW)).toBeUndefined()
-    })
-})
-
-describe('buildLimitsSummary', () => {
-    it('reports remaining headroom per provider', () => {
-        const summary = buildLimitsSummary({
-            bridge: { onRampPerTransaction: '10000', offRampPerTransaction: '10000', asset: 'USD' },
-            manteca: [
-                {
-                    exchangeCountry: 'ARG',
-                    type: 'EXCHANGE',
-                    asset: 'ARS',
-                    yearlyLimit: '12000',
-                    availableYearlyLimit: '9000',
-                    monthlyLimit: '1000',
-                    availableMonthlyLimit: '500',
-                },
-            ],
-        })
-        expect(summary).toBe('bridge on/tx 10000 off/tx 10000 USD · manteca ARG/EXCHANGE 500/1000 mo 9000/12000 yr ARS')
-    })
-
-    it('is undefined when limits were never fetched', () => {
-        expect(buildLimitsSummary(undefined)).toBeUndefined()
     })
 })
 

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -5,6 +5,7 @@ import {
     buildLinkedAccounts,
     buildSupportSegments,
     normalizeSupportRoute,
+    redactSupportText,
     relativeAge,
 } from '../support-context'
 import { AccountType, type Account, type IUserProfile } from '@/interfaces/interfaces'
@@ -218,5 +219,40 @@ describe('normalizeSupportRoute', () => {
     it('handles the root and the absent case', () => {
         expect(normalizeSupportRoute('/')).toBe('/')
         expect(normalizeSupportRoute(undefined)).toBeUndefined()
+    })
+})
+
+describe('redactSupportText', () => {
+    /*
+     * The blocking case: ClaimErrorView hands support `window.location.href`,
+     * and on a claim page the fragment is the bearer password for the funds —
+     * it derives the private claim key. The app publishes the topic to Crisp on
+     * open, before the user has decided to send anything, so an unclaimed link
+     * would be disclosed by a transient error screen.
+     */
+    it('strips the claim password while keeping what identifies the link', () => {
+        const redacted = redactSupportText(
+            "I can't claim this: https://peanut.me/claim?c=42161&v=v4.3&i=17#p=Xy7SecretPw"
+        )
+
+        expect(redacted).not.toContain('Xy7SecretPw')
+        expect(redacted).not.toContain('#')
+        // the query locates the deposit on-chain — an agent still needs it
+        expect(redacted).toContain('?c=42161&v=v4.3&i=17')
+    })
+
+    it('redacts every link in a message, not just the first', () => {
+        const redacted = redactSupportText('tried https://peanut.me/claim#p=one then https://peanut.me/claim#p=two')
+
+        expect(redacted).not.toContain('p=one')
+        expect(redacted).not.toContain('p=two')
+    })
+
+    it('leaves ordinary support messages alone', () => {
+        expect(redactSupportText('my withdrawal is stuck')).toBe('my withdrawal is stuck')
+        expect(redactSupportText('see https://peanut.me/help/withdrawals')).toBe(
+            'see https://peanut.me/help/withdrawals'
+        )
+        expect(redactSupportText('')).toBe('')
     })
 })

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -7,7 +7,6 @@ import {
     buildLinkedAccounts,
     buildSupportSegments,
     normalizeSupportRoute,
-    primarySupportSegment,
     relativeAge,
 } from '../support-context'
 import { AccountType, type Account, type IUserProfile } from '@/interfaces/interfaces'
@@ -238,18 +237,6 @@ describe('buildSupportSegments', () => {
 
     it('flags a blocked verification', () => {
         expect(buildSupportSegments({ ...base, hasFailureReason: true })).toContain('verification-blocked')
-    })
-})
-
-describe('primarySupportSegment', () => {
-    it('picks the most actionable one for the single native slot', () => {
-        expect(primarySupportSegment(['web', 'kyc-pending', 'verification-blocked'])).toBe('verification-blocked')
-    })
-
-    it('falls back to the kyc segment, then to the first', () => {
-        expect(primarySupportSegment(['web', 'kyc-pending'])).toBe('kyc-pending')
-        expect(primarySupportSegment(['web'])).toBe('web')
-        expect(primarySupportSegment([])).toBeUndefined()
     })
 })
 

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -253,6 +253,27 @@ describe('redactSupportText', () => {
         expect(redactSupportText('https://peanut.me/login?token=magic_link_token')).toBe('https://peanut.me/login')
     })
 
+    /*
+     * Naming the path is not enough. Forwarding `url.search` wholesale carried
+     * anything else that happened to be on a claim URL — a parameter added
+     * later, or an encoded nested link — straight to Crisp once the fragment
+     * was gone. The query is rebuilt from the vetted names instead.
+     */
+    it('rebuilds the claim query from vetted names, dropping anything else', () => {
+        const redacted = redactSupportText(
+            'https://peanut.me/claim?c=42161&v=v4.3&i=17&token=leaked&next=https%3A%2F%2Fevil.example%3Fp%3Dnested'
+        )
+
+        expect(redacted).toBe('https://peanut.me/claim?c=42161&v=v4.3&i=17')
+        expect(redacted).not.toContain('leaked')
+        expect(redacted).not.toContain('nested')
+    })
+
+    it('keeps only the claim params that are actually present', () => {
+        expect(redactSupportText('https://peanut.me/claim?i=17')).toBe('https://peanut.me/claim?i=17')
+        expect(redactSupportText('https://peanut.me/claim')).toBe('https://peanut.me/claim')
+    })
+
     it('redacts every link in a message, not just the first', () => {
         const redacted = redactSupportText('tried https://peanut.me/claim#p=one then https://peanut.me/claim#p=two')
 

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -224,11 +224,10 @@ describe('normalizeSupportRoute', () => {
 
 describe('redactSupportText', () => {
     /*
-     * The blocking case: ClaimErrorView hands support `window.location.href`,
-     * and on a claim page the fragment is the bearer password for the funds —
-     * it derives the private claim key. The app publishes the topic to Crisp on
-     * open, before the user has decided to send anything, so an unclaimed link
-     * would be disclosed by a transient error screen.
+     * The fragment is a bearer credential: on a claim page it derives the
+     * private claim key, so whoever holds it can take the funds. ClaimErrorView
+     * hands support `window.location.href`, and the app publishes the topic to
+     * Crisp on open — before the user has decided to send anything.
      */
     it('strips the claim password while keeping what identifies the link', () => {
         const redacted = redactSupportText(
@@ -241,11 +240,30 @@ describe('redactSupportText', () => {
         expect(redacted).toContain('?c=42161&v=v4.3&i=17')
     })
 
+    /*
+     * The query is the other place a credential hides — `?code=` on an OAuth
+     * callback, `?token=` on a magic link. Dropping it everywhere except the
+     * paths known to identify rather than authorize means an unlisted page
+     * loses context, never a secret.
+     */
+    it('drops the query on any path not known to need it', () => {
+        expect(redactSupportText('https://peanut.me/auth/callback?code=oauth_secret')).toBe(
+            'https://peanut.me/auth/callback'
+        )
+        expect(redactSupportText('https://peanut.me/login?token=magic_link_token')).toBe('https://peanut.me/login')
+    })
+
     it('redacts every link in a message, not just the first', () => {
         const redacted = redactSupportText('tried https://peanut.me/claim#p=one then https://peanut.me/claim#p=two')
 
         expect(redacted).not.toContain('p=one')
         expect(redacted).not.toContain('p=two')
+    })
+
+    it('keeps the claim query behind a locale prefix too', () => {
+        expect(redactSupportText('https://peanut.me/es-419/claim?i=17#p=secret')).toBe(
+            'https://peanut.me/es-419/claim?i=17'
+        )
     })
 
     it('leaves ordinary support messages alone', () => {

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -149,6 +149,17 @@ describe('buildSupportSegments', () => {
         expect(buildSupportSegments({ ...base, isLoggedIn: false })).toEqual(['ios-native', 'guest'])
     })
 
+    /*
+     * Zero must be decided by the displayed total. During the smart-to-collateral
+     * handoff the funds sit in neither bucket and only the in-transit figure
+     * accounts for them, so reading the halves directly puts a `zero-balance`
+     * flag next to a funded balance row.
+     */
+    it('does not call an in-transit balance zero', () => {
+        expect(buildSupportSegments({ ...base, isZeroBalance: false })).not.toContain('zero-balance')
+        expect(buildSupportSegments({ ...base, isZeroBalance: true })).toContain('zero-balance')
+    })
+
     it('prefers balance-unavailable over zero-balance', () => {
         const segments = buildSupportSegments({ ...base, balanceKnown: false, isZeroBalance: true })
         expect(segments).toContain('balance-unavailable')

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -6,6 +6,7 @@ import {
     buildLimitsSummary,
     buildLinkedAccounts,
     buildSupportSegments,
+    normalizeSupportRoute,
     primarySupportSegment,
     relativeAge,
 } from '../support-context'
@@ -122,8 +123,20 @@ describe('buildAccountStats', () => {
 
     it('packs points, streak, tenure and provenance into one row', () => {
         expect(buildAccountStats(profile(), NOW)).toBe(
-            '1240 pts · 5d streak · joined 2d ago · milestone:funded · invited_by:alice · invites_sent:1 · badges:early-user · queue:12/900'
+            '1240 pts · 5d streak · joined 2d ago · milestone:funded · referred:yes · invites_sent:1 · badges:early-user · queue:12/900'
         )
+    })
+
+    /*
+     * `invitedBy` is another person's username. That an agent knows the user was
+     * referred is useful; who referred them is a third party's identifier, and
+     * this module never sends one — same rule that keeps counterparties out of
+     * latest_activity.
+     */
+    it('says the user was referred without naming the inviter', () => {
+        const stats = buildAccountStats(profile({ invitedBy: 'alice' }), NOW) ?? ''
+        expect(stats).toContain('referred:yes')
+        expect(stats).not.toContain('alice')
     })
 
     it('is undefined for a guest', () => {
@@ -242,5 +255,45 @@ describe('relativeAge', () => {
         expect(relativeAge('2026-08-27T09:00:00Z', NOW)).toBe('3h')
         expect(relativeAge('2026-08-20T12:00:00Z', NOW)).toBe('7d')
         expect(relativeAge(undefined, NOW)).toBeUndefined()
+    })
+})
+
+describe('normalizeSupportRoute', () => {
+    /*
+     * The route answers "where were they when it broke", which is worth having.
+     * The identifier inside it names who they were paying, which is the same
+     * counterparty leak the activity row was built to avoid.
+     */
+    it('strips the person out of an identifier-bearing route', () => {
+        expect(normalizeSupportRoute('/pay/bob')).toBe('/pay/:id')
+        expect(normalizeSupportRoute('/send/bob')).toBe('/send/:id')
+        expect(normalizeSupportRoute('/request/bob')).toBe('/request/:id')
+        expect(normalizeSupportRoute('/receipt/abc-123')).toBe('/receipt/:id')
+    })
+
+    /*
+     * The root `[...recipient]` catch-all makes any unlisted single segment a
+     * possible handle, so the default is to redact. Forgetting to list a new
+     * static route costs precision, never privacy.
+     */
+    it('redacts a bare segment that could be a username', () => {
+        expect(normalizeSupportRoute('/glorfindel')).toBe('/:recipient')
+        expect(normalizeSupportRoute('/some-route-nobody-listed')).toBe('/:recipient')
+    })
+
+    it('keeps routes whose segments name a thing, not a person', () => {
+        expect(normalizeSupportRoute('/withdraw/manteca')).toBe('/withdraw/manteca')
+        expect(normalizeSupportRoute('/limits/bridge')).toBe('/limits/bridge')
+        expect(normalizeSupportRoute('/home')).toBe('/home')
+    })
+
+    it('sees through the locale prefix', () => {
+        expect(normalizeSupportRoute('/es-419/pay/bob')).toBe('/pay/:id')
+        expect(normalizeSupportRoute('/pt-br/help')).toBe('/help')
+    })
+
+    it('handles the root and the absent case', () => {
+        expect(normalizeSupportRoute('/')).toBe('/')
+        expect(normalizeSupportRoute(undefined)).toBeUndefined()
     })
 })

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -1,0 +1,246 @@
+import {
+    buildAccountStats,
+    buildBalanceSummary,
+    buildCardSummary,
+    buildLatestActivity,
+    buildLimitsSummary,
+    buildLinkedAccounts,
+    buildSupportSegments,
+    primarySupportSegment,
+    relativeAge,
+} from '../support-context'
+import { AccountType, type Account, type IUserProfile } from '@/interfaces/interfaces'
+import type { RainCardOverview } from '@/services/rain'
+import type { HistoryEntry } from '@/utils/history.utils'
+
+const NOW = new Date('2026-08-27T12:00:00Z').getTime()
+
+const overview = (partial: Partial<RainCardOverview> = {}): RainCardOverview =>
+    ({
+        status: { hasApplication: true, applicationStatus: 'approved', railStatus: 'ENABLED' },
+        balance: { creditLimit: 50_000, spendingPower: 2_345, pendingCharges: 0, postedCharges: 0, balanceDue: 0 },
+        cards: [],
+        ...partial,
+    }) as RainCardOverview
+
+describe('buildBalanceSummary', () => {
+    it('sums the two halves when both are answers', () => {
+        expect(buildBalanceSummary(100_000_000n, overview())).toBe('$123.45 spendable (wallet $100.00 · card $23.45)')
+    })
+
+    it('treats a user with no card application as a real zero, not unknown', () => {
+        const noCard = overview({ status: { hasApplication: false }, balance: null })
+        expect(buildBalanceSummary(100_000_000n, noCard)).toBe('$100.00 spendable (wallet $100.00 · card $0.00)')
+    })
+
+    /*
+     * The $0-balance bug (PEANUT-UI-QD5) in its support-facing form: an agent
+     * who reads "$0.00" tells a funded user they have no money. "unavailable"
+     * is strictly better than a confident wrong number.
+     */
+    it('never prints $0.00 for a balance it could not read', () => {
+        const unreadable = overview({ balance: null, balanceUnavailable: true })
+        const summary = buildBalanceSummary(100_000_000n, unreadable)
+        expect(summary).toBe('wallet $100.00 · card unavailable — total unknown')
+        expect(summary).not.toContain('$0.00')
+    })
+
+    it('reports unavailable when nothing has been cached yet', () => {
+        expect(buildBalanceSummary(undefined, undefined)).toBe('unavailable — no balance reading on this device yet')
+    })
+
+    it('withholds the total when only the wallet half is missing', () => {
+        expect(buildBalanceSummary(undefined, overview())).toBe('wallet unavailable · card $23.45 — total unknown')
+    })
+})
+
+describe('buildLatestActivity', () => {
+    const entry = (partial: Partial<HistoryEntry> = {}): HistoryEntry =>
+        ({
+            uuid: 'tx-123',
+            type: 'TRANSACTION_INTENT',
+            timestamp: new Date('2026-08-27T09:00:00Z'),
+            amount: '25.00',
+            chainId: '42161',
+            tokenSymbol: 'USDC',
+            status: 'COMPLETED',
+            userRole: 'SENDER',
+            recipientAccount: { identifier: 'bob.eth', type: 'peanut-wallet', isUser: true, username: 'bob' },
+            extraData: { kind: 'P2P_SEND' },
+            ...partial,
+        }) as HistoryEntry
+
+    it('summarises kind, status, amount and age', () => {
+        expect(buildLatestActivity(entry(), NOW)).toBe(
+            'P2P_SEND · COMPLETED · 25.00 USDC · 3h ago · as sender · uuid:tx-123'
+        )
+    })
+
+    /*
+     * A support sidebar is the user's own state. Replicating who they paid would
+     * accumulate third parties' payment records in a chat console — which is
+     * both a privacy problem and something no agent needs to answer "where did
+     * my money go".
+     */
+    it('never names the counterparty', () => {
+        const summary = buildLatestActivity(entry(), NOW) ?? ''
+        expect(summary).not.toContain('bob')
+        expect(summary).not.toContain('bob.eth')
+    })
+
+    it('surfaces the reaper failure note on a failed intent', () => {
+        const failed = entry({ status: 'FAILED', extraData: { kind: 'FIAT_OFFRAMP', failReason: 'provider timeout' } })
+        expect(buildLatestActivity(failed, NOW)).toContain('failReason:provider timeout')
+    })
+
+    it('prefers the fiat amount when the entry carries one', () => {
+        expect(buildLatestActivity(entry({ currency: { amount: '25000', code: 'ARS' } }), NOW)).toContain('25000 ARS')
+    })
+
+    it('is undefined when no history is cached', () => {
+        expect(buildLatestActivity(undefined, NOW)).toBeUndefined()
+    })
+})
+
+describe('buildAccountStats', () => {
+    const profile = (partial: Partial<IUserProfile> = {}): IUserProfile =>
+        ({
+            totalPoints: 1240,
+            streak: 5,
+            invitedBy: 'alice',
+            invitesSent: [{ inviteeId: '1', inviteeUsername: 'bob' }],
+            pwQueue: { totalUsers: 900, userPosition: 12 },
+            user: {
+                createdAt: '2026-08-25T12:00:00Z',
+                activationMilestone: 'funded',
+                badges: [
+                    { code: 'early-user', name: 'Early', description: null, iconUrl: null, color: null, earnedAt: '' },
+                ],
+            },
+            ...partial,
+        }) as IUserProfile
+
+    it('packs points, streak, tenure and provenance into one row', () => {
+        expect(buildAccountStats(profile(), NOW)).toBe(
+            '1240 pts · 5d streak · joined 2d ago · milestone:funded · invited_by:alice · invites_sent:1 · badges:early-user · queue:12/900'
+        )
+    })
+
+    it('is undefined for a guest', () => {
+        expect(buildAccountStats(undefined, NOW)).toBeUndefined()
+    })
+})
+
+describe('buildLimitsSummary', () => {
+    it('reports remaining headroom per provider', () => {
+        const summary = buildLimitsSummary({
+            bridge: { onRampPerTransaction: '10000', offRampPerTransaction: '10000', asset: 'USD' },
+            manteca: [
+                {
+                    exchangeCountry: 'ARG',
+                    type: 'EXCHANGE',
+                    asset: 'ARS',
+                    yearlyLimit: '12000',
+                    availableYearlyLimit: '9000',
+                    monthlyLimit: '1000',
+                    availableMonthlyLimit: '500',
+                },
+            ],
+        })
+        expect(summary).toBe('bridge on/tx 10000 off/tx 10000 USD · manteca ARG/EXCHANGE 500/1000 mo 9000/12000 yr ARS')
+    })
+
+    it('is undefined when limits were never fetched', () => {
+        expect(buildLimitsSummary(undefined)).toBeUndefined()
+    })
+})
+
+describe('buildCardSummary', () => {
+    it('says so plainly when there is no application', () => {
+        expect(buildCardSummary(overview({ status: { hasApplication: false } }))).toBe('no application')
+    })
+
+    it('reports application state, collateral and issued cards', () => {
+        const withCard = overview({
+            cards: [{ last4: '1234', status: 'active' }],
+        } as Partial<RainCardOverview>)
+        expect(buildCardSummary(withCard)).toBe(
+            'application:approved · rail:ENABLED · limit $500.00 · due $0.00 · ··1234:active'
+        )
+    })
+
+    it('flags an unreadable card balance rather than reporting zero', () => {
+        const summary = buildCardSummary(overview({ balance: null, balanceUnavailable: true })) ?? ''
+        expect(summary).toContain('balance unavailable')
+        expect(summary).not.toContain('$0.00')
+    })
+})
+
+describe('buildLinkedAccounts', () => {
+    const account = (type: AccountType, countryCode?: string): Account =>
+        ({ type, details: countryCode ? { countryCode } : undefined }) as Account
+
+    it('reports shapes and countries, never identifiers', () => {
+        const accounts = [
+            account(AccountType.PEANUT_WALLET),
+            account(AccountType.IBAN, 'DE'),
+            account(AccountType.IBAN, 'DE'),
+        ]
+        expect(buildLinkedAccounts(accounts)).toBe('peanut-wallet · iban:DE')
+    })
+
+    it('is undefined when nothing is linked', () => {
+        expect(buildLinkedAccounts([])).toBeUndefined()
+    })
+})
+
+describe('buildSupportSegments', () => {
+    const base = {
+        isLoggedIn: true,
+        platform: 'ios-native',
+        identityStatus: 'verified',
+        hasFailureReason: false,
+        emailOnFile: true,
+        hasCard: false,
+        balanceKnown: true,
+        isZeroBalance: false,
+        isOffline: false,
+        isApiUnreachable: false,
+    }
+
+    it('short-circuits to guest without leaking a logged-out user state', () => {
+        expect(buildSupportSegments({ ...base, isLoggedIn: false })).toEqual(['ios-native', 'guest'])
+    })
+
+    it('prefers balance-unavailable over zero-balance', () => {
+        const segments = buildSupportSegments({ ...base, balanceKnown: false, isZeroBalance: true })
+        expect(segments).toContain('balance-unavailable')
+        expect(segments).not.toContain('zero-balance')
+    })
+
+    it('flags a blocked verification', () => {
+        expect(buildSupportSegments({ ...base, hasFailureReason: true })).toContain('verification-blocked')
+    })
+})
+
+describe('primarySupportSegment', () => {
+    it('picks the most actionable one for the single native slot', () => {
+        expect(primarySupportSegment(['web', 'kyc-pending', 'verification-blocked'])).toBe('verification-blocked')
+    })
+
+    it('falls back to the kyc segment, then to the first', () => {
+        expect(primarySupportSegment(['web', 'kyc-pending'])).toBe('kyc-pending')
+        expect(primarySupportSegment(['web'])).toBe('web')
+        expect(primarySupportSegment([])).toBeUndefined()
+    })
+})
+
+describe('relativeAge', () => {
+    it('compacts to the largest useful unit', () => {
+        expect(relativeAge('2026-08-27T11:59:30Z', NOW)).toBe('just now')
+        expect(relativeAge('2026-08-27T11:30:00Z', NOW)).toBe('30m')
+        expect(relativeAge('2026-08-27T09:00:00Z', NOW)).toBe('3h')
+        expect(relativeAge('2026-08-20T12:00:00Z', NOW)).toBe('7d')
+        expect(relativeAge(undefined, NOW)).toBeUndefined()
+    })
+})

--- a/src/utils/__tests__/support-context.test.ts
+++ b/src/utils/__tests__/support-context.test.ts
@@ -98,6 +98,11 @@ describe('buildLatestActivity', () => {
         expect(buildLatestActivity(entry({ currency: { amount: '25000', code: 'ARS' } }), NOW)).toContain('25000 ARS')
     })
 
+    it('reads as a phrase for a transaction from moments ago', () => {
+        const justNow = entry({ timestamp: new Date('2026-08-27T11:59:45Z') })
+        expect(buildLatestActivity(justNow, NOW)).toContain('· just now ·')
+    })
+
     it('is undefined when no history is cached', () => {
         expect(buildLatestActivity(undefined, NOW)).toBeUndefined()
     })

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -156,7 +156,15 @@ export function setCrispUserData(
      * which has never existed. See TASK-21968.
      */
 
-    if (prefilledMessage) {
+    /*
+     * `undefined` means "leave the composer alone" — a routine metadata refresh
+     * must not overwrite what the user is typing. An empty STRING is a real
+     * instruction: clear it. Without that distinction, opening support from an
+     * error CTA, closing without sending, then reopening from the nav left the
+     * old error text sitting in the composer, because the iframe stays mounted
+     * and a falsy check skips the clear.
+     */
+    if (prefilledMessage !== undefined) {
         crispInstance.push(['set', 'message:text', [prefilledMessage]])
     }
 }

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -65,8 +65,6 @@ export function supportSessionFields(userData: CrispUserData, supportTopic?: str
         ['pending_actions', userData.pendingActions || ''],
         ['balance', userData.balance || ''],
         ['account_stats', userData.accountStats || ''],
-        ['latest_activity', userData.latestActivity || ''],
-        ['limits_remaining', userData.limitsRemaining || ''],
         ['card', userData.card || ''],
         ['linked_accounts', userData.linkedAccounts || ''],
         ['app_context', userData.appContext || ''],

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -107,7 +107,15 @@ export const nativeCrispFields = supportSessionFields
 export function setCrispUserData(
     crispInstance: CrispInstance,
     userData: CrispUserData,
-    prefilledMessage?: string
+    prefilledMessage?: string,
+    /*
+     * The topic as metadata, separate from the composer text above it.
+     * A routine metadata refresh deliberately omits `prefilledMessage` so it
+     * cannot overwrite what the user is typing — but the sidebar row must
+     * survive that refresh, or a balance update erases the reason they opened
+     * support. Defaults to the composer value for callers that have only one.
+     */
+    supportTopic: string | undefined = prefilledMessage
 ): void {
     if (!crispInstance) return
 
@@ -127,7 +135,7 @@ export function setCrispUserData(
     }
 
     // Session metadata for support agents - must be 3 levels of nested arrays
-    crispInstance.push(['set', 'session:data', [supportSessionFields(userData, prefilledMessage)]])
+    crispInstance.push(['set', 'session:data', [supportSessionFields(userData, supportTopic)]])
 
     /*
      * The app does NOT write Crisp segments. Deliberate — do not add it back.

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -119,11 +119,20 @@ export function setCrispUserData(
     // Session metadata for support agents - must be 3 levels of nested arrays
     crispInstance.push(['set', 'session:data', [supportSessionFields(userData)]])
 
-    // Segments carry the boolean half (platform, kyc-*, zero-balance, offline…).
-    // They're what the inbox filters and routes on, and keeping them out of
-    // session:data is what stops the sidebar becoming a wall of yes/no rows.
+    /*
+     * Segments carry the boolean half (platform, kyc-*, zero-balance, offline…).
+     * They're what the inbox filters and routes on, and keeping them out of
+     * session:data is what stops the sidebar becoming a wall of yes/no rows.
+     *
+     * The `true` is the overwrite flag, and it is load-bearing: Crisp APPENDS
+     * segments by default, so a user who was briefly offline would keep routing
+     * as `offline` forever, and `kyc-pending` would outlive their approval. This
+     * push runs on every snapshot change, so the set has to REPLACE — an
+     * accumulated segment list is worse than none, because it routes on state
+     * the user has already left.
+     */
     if (segments?.length) {
-        crispInstance.push(['set', 'session:segments', [segments]])
+        crispInstance.push(['set', 'session:segments', [segments, true]])
     }
 
     if (prefilledMessage) {

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -35,6 +35,55 @@ export function ensureNativeCrispConfigured(): Promise<{ CapacitorCrisp: NativeC
 }
 
 /**
+ * The support-agent sidebar, as ordered key/value rows.
+ *
+ * ONE definition feeds every sink — the web widget's `session:data`, the proxy
+ * iframe (which receives the whole `CrispUserData` object and calls
+ * `setCrispUserData`), and the native `setString` loop. They used to be written
+ * out by hand per sink and had already drifted: native sent two keys where web
+ * sent seven, so the agents helping *app* users saw the least.
+ *
+ * Values are always present, empty string when absent, so a previous user's
+ * value can never linger on a device-local Crisp session.
+ */
+export function supportSessionFields(userData: CrispUserData): Array<[string, string]> {
+    const { emailOnFile } = userData
+    return [
+        ['username', userData.username || ''],
+        ['user_id', userData.userId || ''],
+        ['full_name', userData.fullName || ''],
+        ['wallet_address', userData.walletAddressLink || ''],
+        ['bridge_user_id', userData.bridgeCustomerLink || ''],
+        ['manteca_user_id', userData.mantecaUserId || ''],
+        ['posthog_person', userData.posthogPersonLink || ''],
+        ['sentry_issues', userData.sentryIssuesLink || ''],
+        ['identity_status', userData.identityStatus || ''],
+        ['email_on_file', emailOnFile === undefined ? '' : emailOnFile ? 'yes' : 'no'],
+        ['verification_gates', userData.verificationGates || ''],
+        ['verification_rails', userData.verificationRails || ''],
+        ['failure_reason', userData.failureReason || ''],
+        ['pending_actions', userData.pendingActions || ''],
+        ['balance', userData.balance || ''],
+        ['account_stats', userData.accountStats || ''],
+        ['latest_activity', userData.latestActivity || ''],
+        ['limits_remaining', userData.limitsRemaining || ''],
+        ['card', userData.card || ''],
+        ['linked_accounts', userData.linkedAccounts || ''],
+        ['app_context', userData.appContext || ''],
+        ['segments', (userData.segments ?? []).join(' ')],
+    ]
+}
+
+/**
+ * Same rows, for the native SDK's one-key-at-a-time `setString`.
+ *
+ * `segments` is a data row on native rather than real segments: the native SDK
+ * holds a single segment (assignment, not append), so the list would collapse
+ * to whichever call ran last. The primary one is set separately by the caller.
+ */
+export const nativeCrispFields = supportSessionFields
+
+/**
  * Sets Crisp user identification and session metadata on a $crisp instance
  *
  * This is used for the main window Crisp widget (not iframe).
@@ -52,23 +101,7 @@ export function setCrispUserData(
 ): void {
     if (!crispInstance) return
 
-    const {
-        username,
-        userId,
-        email,
-        fullName,
-        avatar,
-        walletAddressLink,
-        bridgeCustomerLink,
-        mantecaUserId,
-        posthogPersonLink,
-        identityStatus,
-        emailOnFile,
-        verificationGates,
-        verificationRails,
-        failureReason,
-        pendingActions,
-    } = userData
+    const { username, email, fullName, avatar, segments } = userData
 
     if (email) {
         crispInstance.push(['set', 'user:email', [email]])
@@ -84,27 +117,14 @@ export function setCrispUserData(
     }
 
     // Session metadata for support agents - must be 3 levels of nested arrays
-    crispInstance.push([
-        'set',
-        'session:data',
-        [
-            [
-                ['username', username || ''],
-                ['user_id', userId || ''],
-                ['full_name', fullName || ''],
-                ['wallet_address', walletAddressLink || ''],
-                ['bridge_user_id', bridgeCustomerLink || ''],
-                ['manteca_user_id', mantecaUserId || ''],
-                ['posthog_person', posthogPersonLink || ''],
-                ['identity_status', identityStatus || ''],
-                ['email_on_file', emailOnFile === undefined ? '' : emailOnFile ? 'yes' : 'no'],
-                ['verification_gates', verificationGates || ''],
-                ['verification_rails', verificationRails || ''],
-                ['failure_reason', failureReason || ''],
-                ['pending_actions', pendingActions || ''],
-            ],
-        ],
-    ])
+    crispInstance.push(['set', 'session:data', [supportSessionFields(userData)]])
+
+    // Segments carry the boolean half (platform, kyc-*, zero-balance, offline…).
+    // They're what the inbox filters and routes on, and keeping them out of
+    // session:data is what stops the sidebar becoming a wall of yes/no rows.
+    if (segments?.length) {
+        crispInstance.push(['set', 'session:segments', [segments]])
+    }
 
     if (prefilledMessage) {
         crispInstance.push(['set', 'message:text', [prefilledMessage]])

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -46,7 +46,7 @@ export function ensureNativeCrispConfigured(): Promise<{ CapacitorCrisp: NativeC
  * Values are always present, empty string when absent, so a previous user's
  * value can never linger on a device-local Crisp session.
  */
-export function supportSessionFields(userData: CrispUserData): Array<[string, string]> {
+export function supportSessionFields(userData: CrispUserData, supportTopic?: string): Array<[string, string]> {
     const { emailOnFile } = userData
     return [
         ['username', userData.username || ''],
@@ -71,6 +71,18 @@ export function supportSessionFields(userData: CrispUserData): Array<[string, st
         ['linked_accounts', userData.linkedAccounts || ''],
         ['app_context', userData.appContext || ''],
         ['segments', (userData.segments ?? []).join(' ')],
+        /*
+         * Why the prefill is a data row and not only the composer text.
+         *
+         * On web the prefill populates the user's composer and reaches the agent
+         * as a message. On native it cannot: `sendMessage` is `unimplemented` in
+         * this plugin on BOTH iOS and Android, so every "contact support about X"
+         * entry point lost its context in the app — silently, and with an
+         * unhandled rejection behind it. Carrying the topic here delivers it
+         * through a method both platforms actually implement, and on web it
+         * survives the user deleting the prefilled text before sending.
+         */
+        ['support_topic', supportTopic || ''],
     ]
 }
 
@@ -117,7 +129,7 @@ export function setCrispUserData(
     }
 
     // Session metadata for support agents - must be 3 levels of nested arrays
-    crispInstance.push(['set', 'session:data', [supportSessionFields(userData)]])
+    crispInstance.push(['set', 'session:data', [supportSessionFields(userData, prefilledMessage)]])
 
     /*
      * Segments carry the boolean half (platform, kyc-*, zero-balance, offline…).

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -111,7 +111,7 @@ export function setCrispUserData(
 ): void {
     if (!crispInstance) return
 
-    const { username, email, fullName, avatar, segments } = userData
+    const { username, email, fullName, avatar } = userData
 
     if (email) {
         crispInstance.push(['set', 'user:email', [email]])
@@ -130,20 +130,23 @@ export function setCrispUserData(
     crispInstance.push(['set', 'session:data', [supportSessionFields(userData, prefilledMessage)]])
 
     /*
-     * Segments carry the boolean half (platform, kyc-*, zero-balance, offline…).
-     * They're what the inbox filters and routes on, and keeping them out of
-     * session:data is what stops the sidebar becoming a wall of yes/no rows.
+     * The app does NOT write Crisp segments. Deliberate — do not add it back.
      *
-     * The `true` is the overwrite flag, and it is load-bearing: Crisp APPENDS
-     * segments by default, so a user who was briefly offline would keep routing
-     * as `offline` forever, and `kyc-pending` would outlive their approval. This
-     * push runs on every snapshot change, so the set has to REPLACE — an
-     * accumulated segment list is worse than none, because it routes on state
-     * the user has already left.
+     * Segments are a field people write by hand, and one of them backs an OKR:
+     * agents tag translation reports `translation-issue`, and the monthly count
+     * only sees a conversation that still carries the tag
+     * (mono/ops/playbook/translation-issue-tag.md). Ops tags incidents the same
+     * way. Crisp has no partial write — a set replaces the whole list — so any
+     * automatic write erases whatever a human put there, and this runs on every
+     * snapshot change, not just on open.
+     *
+     * Appending instead is not the answer either: the app's own flags then go
+     * stale, and a user who was briefly offline routes as `offline` for good.
+     *
+     * The flags still reach the agent, as the `segments` row in the sidebar
+     * above. What the app gives up is filtering the inbox by its own state,
+     * which has never existed. See TASK-21968.
      */
-    if (segments?.length) {
-        crispInstance.push(['set', 'session:segments', [segments, true]])
-    }
 
     if (prefilledMessage) {
         crispInstance.push(['set', 'message:text', [prefilledMessage]])

--- a/src/utils/support-cache.ts
+++ b/src/utils/support-cache.ts
@@ -1,25 +1,29 @@
 /**
  * Cache-only reads for the Crisp support snapshot.
  *
- * `useCrispUserData` is mounted app-wide (SupportDrawer sits in the layout, for
- * guests too), so it must never *subscribe* to the queries it reports on:
- * calling `useWallet()` there would switch on a 30s RPC poll for every logged-in
- * user on every screen, and `useLimits()` / `useRainCardOverview()` would each
- * add a request per session. These readers take whatever is already in the
- * react-query cache — warm on every screen that renders a balance or Activity —
- * and return `undefined` when it isn't there. A missing value is reported as
- * unavailable, never as a zero.
+ * Two rules, and both are load-bearing.
+ *
+ * **Never subscribe.** `useCrispUserData` is mounted app-wide (SupportDrawer
+ * sits in the layout, for guests too), so calling `useWallet()` there would
+ * switch on a 30s RPC poll for every logged-in user on every screen, and
+ * `useRainCardOverview()` would add a request per session. These readers take
+ * whatever is already in the react-query cache and return `undefined` when it
+ * isn't there. A missing value is reported as unavailable, never as a zero.
+ *
+ * **Only read a key that names its owner.** Both keys here carry the identity
+ * they belong to — the balance by wallet address, the card overview by user id
+ * — so a cached entry can be proved to belong to the person support is open
+ * for. `[limits]` and `[transactions]` cannot: their keys are account-agnostic,
+ * so after a passive session expiry they stay warm and a different account
+ * would read them as its own. Limits and latest activity are therefore absent
+ * from the snapshot until those keys are user-scoped. Do NOT add a reader here
+ * that cannot answer "whose data is this?" from the key alone.
  */
 
 import type { QueryClient } from '@tanstack/react-query'
-import type { InfiniteData } from '@tanstack/react-query'
-import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
 import { smartUsdcBalanceQueryOptions } from '@/hooks/wallet/useBalance'
-import type { UserLimitsResponse } from '@/interfaces/interfaces'
 import type { RainCardOverview } from '@/services/rain'
-import type { HistoryResponse } from '@/hooks/useTransactionHistory'
-import type { HistoryEntry } from '@/utils/history.utils'
 import type { Address } from 'viem'
 
 export function readCachedSmartBalance(client: QueryClient, address: string | undefined): bigint | undefined {
@@ -30,38 +34,4 @@ export function readCachedSmartBalance(client: QueryClient, address: string | un
 export function readCachedRainOverview(client: QueryClient, userId: string | undefined): RainCardOverview | undefined {
     if (!userId) return undefined
     return client.getQueryData<RainCardOverview>([RAIN_CARD_OVERVIEW_QUERY_KEY, userId])
-}
-
-export function readCachedLimits(client: QueryClient): UserLimitsResponse | undefined {
-    return client.getQueryData<UserLimitsResponse>([LIMITS])
-}
-
-const isInfiniteData = (data: unknown): data is InfiniteData<HistoryResponse> =>
-    !!data && typeof data === 'object' && Array.isArray((data as InfiniteData<HistoryResponse>).pages)
-
-/**
- * The newest history entry across every cached history query.
- *
- * Scanned rather than read by key on purpose: the `latest` key carries its
- * `limit` and `targetUsername`, so the cache legitimately holds several
- * variants at once (home Activity at 5, the carousel at 50) and hardcoding one
- * of them would silently return nothing the day a caller changes its limit.
- */
-export function readLatestHistoryEntry(client: QueryClient): HistoryEntry | undefined {
-    const entries: HistoryEntry[] = []
-
-    for (const query of client.getQueryCache().findAll({ queryKey: [TRANSACTIONS] })) {
-        const data = query.state.data
-        if (isInfiniteData(data)) {
-            for (const page of data.pages) entries.push(...(page?.entries ?? []))
-        } else if (data && typeof data === 'object') {
-            entries.push(...((data as HistoryResponse).entries ?? []))
-        }
-    }
-
-    return entries.reduce<HistoryEntry | undefined>((newest, entry) => {
-        if (!entry?.timestamp) return newest
-        if (!newest) return entry
-        return new Date(entry.timestamp).getTime() > new Date(newest.timestamp).getTime() ? entry : newest
-    }, undefined)
 }

--- a/src/utils/support-cache.ts
+++ b/src/utils/support-cache.ts
@@ -1,0 +1,67 @@
+/**
+ * Cache-only reads for the Crisp support snapshot.
+ *
+ * `useCrispUserData` is mounted app-wide (SupportDrawer sits in the layout, for
+ * guests too), so it must never *subscribe* to the queries it reports on:
+ * calling `useWallet()` there would switch on a 30s RPC poll for every logged-in
+ * user on every screen, and `useLimits()` / `useRainCardOverview()` would each
+ * add a request per session. These readers take whatever is already in the
+ * react-query cache — warm on every screen that renders a balance or Activity —
+ * and return `undefined` when it isn't there. A missing value is reported as
+ * unavailable, never as a zero.
+ */
+
+import type { QueryClient } from '@tanstack/react-query'
+import type { InfiniteData } from '@tanstack/react-query'
+import { LIMITS, TRANSACTIONS } from '@/constants/query.consts'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { smartUsdcBalanceQueryOptions } from '@/hooks/wallet/useBalance'
+import type { UserLimitsResponse } from '@/interfaces/interfaces'
+import type { RainCardOverview } from '@/services/rain'
+import type { HistoryResponse } from '@/hooks/useTransactionHistory'
+import type { HistoryEntry } from '@/utils/history.utils'
+import type { Address } from 'viem'
+
+export function readCachedSmartBalance(client: QueryClient, address: string | undefined): bigint | undefined {
+    if (!address) return undefined
+    return client.getQueryData<bigint>(smartUsdcBalanceQueryOptions(address as Address).queryKey)
+}
+
+export function readCachedRainOverview(client: QueryClient, userId: string | undefined): RainCardOverview | undefined {
+    if (!userId) return undefined
+    return client.getQueryData<RainCardOverview>([RAIN_CARD_OVERVIEW_QUERY_KEY, userId])
+}
+
+export function readCachedLimits(client: QueryClient): UserLimitsResponse | undefined {
+    return client.getQueryData<UserLimitsResponse>([LIMITS])
+}
+
+const isInfiniteData = (data: unknown): data is InfiniteData<HistoryResponse> =>
+    !!data && typeof data === 'object' && Array.isArray((data as InfiniteData<HistoryResponse>).pages)
+
+/**
+ * The newest history entry across every cached history query.
+ *
+ * Scanned rather than read by key on purpose: the `latest` key carries its
+ * `limit` and `targetUsername`, so the cache legitimately holds several
+ * variants at once (home Activity at 5, the carousel at 50) and hardcoding one
+ * of them would silently return nothing the day a caller changes its limit.
+ */
+export function readLatestHistoryEntry(client: QueryClient): HistoryEntry | undefined {
+    const entries: HistoryEntry[] = []
+
+    for (const query of client.getQueryCache().findAll({ queryKey: [TRANSACTIONS] })) {
+        const data = query.state.data
+        if (isInfiniteData(data)) {
+            for (const page of data.pages) entries.push(...(page?.entries ?? []))
+        } else if (data && typeof data === 'object') {
+            entries.push(...((data as HistoryResponse).entries ?? []))
+        }
+    }
+
+    return entries.reduce<HistoryEntry | undefined>((newest, entry) => {
+        if (!entry?.timestamp) return newest
+        if (!newest) return entry
+        return new Date(entry.timestamp).getTime() > new Date(newest.timestamp).getTime() ? entry : newest
+    }, undefined)
+}

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -310,3 +310,29 @@ export function normalizeSupportRoute(pathname: string | undefined): string | un
     if (!STATIC_ROOT_SEGMENTS.has(head)) return '/:recipient'
     return `/${[head, ...rest].join('/')}`
 }
+
+/*
+ * URLs in a support message, with the fragment removed.
+ *
+ * A claim link is `/claim?c=…&v=…&i=…#p=<password>` (history.utils). The query
+ * identifies the deposit and is what lets an agent find it; the fragment IS the
+ * bearer credential — whoever holds it can claim the funds, and it derives the
+ * private claim key. `ClaimErrorView` hands `window.location.href` to support,
+ * so without this the password reaches Crisp the moment the drawer opens,
+ * before the user has decided to send anything.
+ *
+ * Stripping the fragment rather than the whole query is deliberate: it removes
+ * every secret this app puts in a URL while keeping the part support actually
+ * works from. Call sites needing more than this still do it themselves — see
+ * not-found.tsx, which sends a bare pathname because arbitrary pages can carry
+ * magic-link and OAuth tokens in the query too.
+ */
+const URL_IN_TEXT = /https?:\/\/\S+/g
+
+export function redactSupportText(text: string): string {
+    if (!text) return text
+    return text.replace(URL_IN_TEXT, (raw) => {
+        const hashAt = raw.indexOf('#')
+        return hashAt === -1 ? raw : raw.slice(0, hashAt)
+    })
+}

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -88,7 +88,10 @@ export function buildAccountStats(profile: IUserProfile | undefined, now: number
     const age = relativeAge(profile.user?.createdAt, now)
     if (age) parts.push(`joined ${age} ago`)
     if (profile.user?.activationMilestone) parts.push(`milestone:${profile.user.activationMilestone}`)
-    if (profile.invitedBy) parts.push(`invited_by:${profile.invitedBy}`)
+    // `invitedBy` is another person's username. Whether the user was referred is
+    // useful to an agent; who referred them is a third party's identifier, and
+    // this module never sends one.
+    if (profile.invitedBy) parts.push('referred:yes')
     if (profile.invitesSent?.length) parts.push(`invites_sent:${profile.invitesSent.length}`)
 
     const badges = profile.user?.badges?.map((badge) => badge.code).filter(Boolean) ?? []
@@ -301,4 +304,91 @@ export function buildAppContext(client: {
     ]
         .filter(Boolean)
         .join(' · ')
+}
+
+/*
+ * Route segments that name a person or a specific object. `/pay/bob` tells a
+ * support agent who the user was paying, which is the counterparty leak this
+ * module exists to prevent — the same reason activity summaries carry no
+ * usernames. The route is worth having ("where were they when it broke"); the
+ * identifier in it is not.
+ */
+const IDENTIFIER_PREFIXES = new Set([
+    'pay',
+    'send',
+    'request',
+    'pay-request',
+    'receipt',
+    'qr',
+    'qr-pay',
+    'quests',
+    'profile',
+    'claim',
+    'invite',
+    'm',
+])
+
+/*
+ * Top-level segments that are real pages rather than a username. The root
+ * `[...recipient]` catch-all means ANY unlisted single segment may be a
+ * person's handle, so anything missing here degrades to `/:recipient` — a lost
+ * detail, never a leaked name. Fail-safe by construction: forgetting to add a
+ * new static route costs precision, not privacy.
+ */
+const STATIC_ROOT_SEGMENTS = new Set([
+    'home',
+    'history',
+    'settings',
+    'card',
+    'card-payment',
+    'card-recovery',
+    'add-money',
+    'withdraw',
+    'badges',
+    'points',
+    'rewards',
+    'notifications',
+    'limits',
+    'kyc',
+    'setup',
+    'dev',
+    'careers',
+    'jobs',
+    'lp',
+    'maintenance',
+    'recover-funds',
+    'recover-wallet',
+    'fix-card-signature',
+    'crisp-proxy',
+    'press',
+    'status',
+    'blog',
+    'help',
+    'compare',
+    'pricing',
+    'terms',
+    'privacy',
+    'app',
+    'shhhhh',
+])
+
+const LOCALE_SEGMENTS = new Set(['en', 'es-419', 'es-ar', 'es-es', 'pt-br'])
+
+/**
+ * The route an agent can read without learning who the user was dealing with.
+ *
+ * `/pay/bob` → `/pay/:id`, `/bob` → `/:recipient`, `/withdraw/manteca` unchanged —
+ * the provider is the useful half of that one and names nobody.
+ */
+export function normalizeSupportRoute(pathname: string | undefined): string | undefined {
+    if (!pathname) return undefined
+
+    const segments = pathname.split('/').filter(Boolean)
+    if (segments[0] && LOCALE_SEGMENTS.has(segments[0])) segments.shift()
+    if (!segments.length) return '/'
+
+    const [head, ...rest] = segments
+    if (IDENTIFIER_PREFIXES.has(head)) return rest.length ? `/${head}/:id` : `/${head}`
+    if (!STATIC_ROOT_SEGMENTS.has(head)) return '/:recipient'
+    return `/${[head, ...rest].join('/')}`
 }

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -1,0 +1,255 @@
+/**
+ * Support-facing account context — the state a Crisp agent needs so a
+ * conversation doesn't open with five rounds of "what's your balance / what did
+ * you last do / which app are you on". Follow-up to the verification snapshot
+ * (#2360), same destination: Crisp `session:data`, the agent-only sidebar.
+ *
+ * Two invariants hold for everything in this file:
+ *
+ *  1. **No new reads.** Every value is derived from data the client already
+ *     holds — the `/get-user` read-models and warm react-query caches. Crisp
+ *     has no database access and gains none here; the client pushes what it
+ *     already knows.
+ *  2. **The user's own state, never a counterparty's.** Activity summaries name
+ *     the kind, status and amount — never who was paid. A support console is
+ *     the wrong place to accumulate third parties' payment histories.
+ */
+
+import { formatUnits } from 'viem'
+import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { computeDisplaySpendable, isRainBalanceKnown, rainCentsToUsdcUnits } from '@/utils/balance.utils'
+import { formatCurrency } from '@/utils/general.utils'
+import { type Account, AccountType, type IUserProfile, type UserLimitsResponse } from '@/interfaces/interfaces'
+import type { RainCardOverview } from '@/services/rain'
+import type { HistoryEntry } from '@/utils/history.utils'
+
+const usd = (units: bigint): string => `$${formatCurrency(formatUnits(units, PEANUT_WALLET_TOKEN_DECIMALS))}`
+
+const usdFromCents = (cents: number | null | undefined): string => usd(rainCentsToUsdcUnits(cents))
+
+/** Compact age of a past timestamp: "3h", "2d", "5m". Undefined for absent/invalid input. */
+export function relativeAge(value: Date | string | undefined, now: number = Date.now()): string | undefined {
+    if (!value) return undefined
+    const ms = now - new Date(value).getTime()
+    if (!Number.isFinite(ms)) return undefined
+    const minutes = Math.floor(ms / 60_000)
+    if (minutes < 1) return 'just now'
+    if (minutes < 60) return `${minutes}m`
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h`
+    return `${Math.floor(hours / 24)}d`
+}
+
+/**
+ * Spendable balance for the sidebar, with the two halves reported separately.
+ *
+ * An unreadable balance MUST NOT print as `$0.00`. `rainCentsToUsdcUnits(undefined)`
+ * is `0n`, so "no answer" and "genuinely empty" are arithmetically identical —
+ * the $0-balance bug (PEANUT-UI-QD5). An agent reading `$0.00` tells a funded
+ * user they have no money, which is worse than telling them nothing. So each
+ * half is either a figure or the word `unavailable`, and the total only appears
+ * when both halves are answers.
+ */
+export function buildBalanceSummary(
+    smartBalance: bigint | undefined,
+    rainOverview: RainCardOverview | undefined
+): string | undefined {
+    const walletKnown = smartBalance !== undefined
+    const cardKnown = isRainBalanceKnown(rainOverview)
+    if (!walletKnown && !cardKnown) return 'unavailable — no balance reading on this device yet'
+
+    const wallet = walletKnown ? usd(smartBalance) : 'unavailable'
+    const spendingPower = rainOverview?.balance?.spendingPower
+    const card = cardKnown ? usdFromCents(spendingPower) : 'unavailable'
+    const halves = `wallet ${wallet} · card ${card}`
+
+    if (!walletKnown || !cardKnown) return `${halves} — total unknown`
+
+    const total = computeDisplaySpendable(
+        smartBalance,
+        spendingPower,
+        rainOverview?.balance?.inTransitToCollateralCents
+    )
+    return `${usd(total)} spendable (${halves})`
+}
+
+/** Points, streak, tenure and invite provenance — all already on /get-user. */
+export function buildAccountStats(profile: IUserProfile | undefined, now: number = Date.now()): string | undefined {
+    if (!profile) return undefined
+    const parts: string[] = [`${profile.totalPoints ?? 0} pts`]
+    if (profile.streak) parts.push(`${profile.streak}d streak`)
+
+    const age = relativeAge(profile.user?.createdAt, now)
+    if (age) parts.push(`joined ${age} ago`)
+    if (profile.user?.activationMilestone) parts.push(`milestone:${profile.user.activationMilestone}`)
+    if (profile.invitedBy) parts.push(`invited_by:${profile.invitedBy}`)
+    if (profile.invitesSent?.length) parts.push(`invites_sent:${profile.invitesSent.length}`)
+
+    const badges = profile.user?.badges?.map((badge) => badge.code).filter(Boolean) ?? []
+    if (badges.length) parts.push(`badges:${badges.join('/')}`)
+
+    const queuePosition = profile.pwQueue?.userPosition
+    if (queuePosition != null) parts.push(`queue:${queuePosition}/${profile.pwQueue?.totalUsers ?? '?'}`)
+
+    return parts.join(' · ')
+}
+
+/**
+ * The user's own most recent movement — kind, provider, status, amount, age.
+ *
+ * Deliberately NOT the counterparty: `HistoryEntry` carries the other party's
+ * username and full name, and a support sidebar is not a place to replicate
+ * someone else's payment record. `uuid` is enough for an agent to look the
+ * transaction up through the tools they already have.
+ */
+export function buildLatestActivity(entry: HistoryEntry | undefined, now: number = Date.now()): string | undefined {
+    if (!entry) return undefined
+
+    const kind = entry.extraData?.kind ?? entry.type
+    const provider = entry.extraData?.provider
+    const parts: string[] = [provider ? `${kind}/${provider}` : kind, entry.status]
+
+    if (entry.currency?.amount && entry.currency.code) {
+        parts.push(`${entry.currency.amount} ${entry.currency.code}`)
+    } else if (entry.amount) {
+        parts.push(`${entry.amount} ${entry.tokenSymbol ?? ''}`.trim())
+    }
+
+    const age = relativeAge(entry.timestamp, now)
+    if (age) parts.push(`${age} ago`)
+    if (entry.userRole) parts.push(`as ${entry.userRole.toLowerCase()}`)
+
+    // The reaper's failure note is the single most useful field on a failed
+    // intent, and the user can rarely relay it accurately.
+    const failReason = entry.extraData?.failReason
+    if (failReason) parts.push(`failReason:${failReason}`)
+
+    parts.push(`uuid:${entry.uuid}`)
+    return parts.join(' · ')
+}
+
+/** Remaining fiat headroom per provider — answers "why was my withdrawal blocked". */
+export function buildLimitsSummary(limits: UserLimitsResponse | undefined): string | undefined {
+    if (!limits) return undefined
+    const parts: string[] = []
+
+    if (limits.bridge) {
+        const { onRampPerTransaction, offRampPerTransaction, asset } = limits.bridge
+        parts.push(`bridge on/tx ${onRampPerTransaction} off/tx ${offRampPerTransaction} ${asset}`)
+    }
+
+    for (const limit of limits.manteca ?? []) {
+        parts.push(
+            `manteca ${limit.exchangeCountry}/${limit.type} ${limit.availableMonthlyLimit}/${limit.monthlyLimit} mo` +
+                ` ${limit.availableYearlyLimit}/${limit.yearlyLimit} yr ${limit.asset}`
+        )
+    }
+
+    return parts.length ? parts.join(' · ') : undefined
+}
+
+/** Card application state and collateral, for the card half of support volume. */
+export function buildCardSummary(overview: RainCardOverview | undefined): string | undefined {
+    if (!overview) return undefined
+    if (!overview.status?.hasApplication) return 'no application'
+
+    const parts: string[] = []
+    if (overview.status.applicationStatus) parts.push(`application:${overview.status.applicationStatus}`)
+    if (overview.status.railStatus) parts.push(`rail:${overview.status.railStatus}`)
+
+    if (isRainBalanceKnown(overview) && overview.balance) {
+        parts.push(`limit ${usdFromCents(overview.balance.creditLimit)}`)
+        parts.push(`due ${usdFromCents(overview.balance.balanceDue)}`)
+    } else {
+        parts.push('balance unavailable')
+    }
+
+    const cards = overview.cards ?? []
+    if (cards.length) {
+        parts.push(cards.map((card) => `··${card.last4}:${card.status}`).join(' '))
+    }
+
+    return parts.join(' · ')
+}
+
+/**
+ * Which payout rails the user has attached, as shapes only — `iban:DE`, never
+ * the IBAN. An agent needs to know a bank account exists and where it is; the
+ * number itself has no place in a chat console.
+ */
+export function buildLinkedAccounts(accounts: Account[] | undefined): string | undefined {
+    if (!accounts?.length) return undefined
+    const shapes = accounts.map((account) => {
+        const country = account.details?.countryCode
+        return account.type === AccountType.PEANUT_WALLET || !country ? account.type : `${account.type}:${country}`
+    })
+    return Array.from(new Set(shapes)).join(' · ')
+}
+
+export interface SupportSegmentInput {
+    isLoggedIn: boolean
+    platform: string
+    identityStatus: string | undefined
+    hasFailureReason: boolean
+    emailOnFile: boolean | undefined
+    hasCard: boolean
+    balanceKnown: boolean
+    isZeroBalance: boolean
+    isOffline: boolean
+    isApiUnreachable: boolean
+}
+
+/**
+ * Crisp segments — the boolean half of the picture.
+ *
+ * Segments are filterable and routable in the Crisp inbox, which is what you
+ * actually want for yes/no facts; `session:data` rows are for values an agent
+ * reads. Putting the booleans here is also what keeps the sidebar from growing
+ * into a wall of `yes`/`no` rows nobody scrolls to the bottom of.
+ */
+export function buildSupportSegments(input: SupportSegmentInput): string[] {
+    const segments: string[] = [input.platform]
+
+    if (!input.isLoggedIn) {
+        segments.push('guest')
+        return segments
+    }
+
+    if (input.identityStatus) segments.push(`kyc-${input.identityStatus}`)
+    if (input.hasFailureReason) segments.push('verification-blocked')
+    if (input.emailOnFile === false) segments.push('no-email')
+    if (input.hasCard) segments.push('card-holder')
+    if (!input.balanceKnown) segments.push('balance-unavailable')
+    else if (input.isZeroBalance) segments.push('zero-balance')
+    if (input.isOffline) segments.push('offline')
+    if (input.isApiUnreachable) segments.push('api-unreachable')
+
+    return segments
+}
+
+/**
+ * Priority order for the ONE segment the native SDK can hold.
+ *
+ * `CrispSDK.session.segment = …` is an assignment, not an append (same on
+ * Android via `setSessionSegment`), so repeated calls keep only the last. The
+ * web SDK takes the whole list; native gets the most actionable one, and the
+ * full list still rides along as a `segments` data row so nothing is lost.
+ */
+const SEGMENT_PRIORITY = [
+    'verification-blocked',
+    'balance-unavailable',
+    'api-unreachable',
+    'offline',
+    'no-email',
+    'guest',
+    'zero-balance',
+    'card-holder',
+]
+
+export function primarySupportSegment(segments: string[] | undefined): string | undefined {
+    if (!segments?.length) return undefined
+    for (const candidate of SEGMENT_PRIORITY) {
+        if (segments.includes(candidate)) return candidate
+    }
+    return segments.find((segment) => segment.startsWith('kyc-')) ?? segments[0]
+}

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -125,7 +125,8 @@ export function buildLatestActivity(entry: HistoryEntry | undefined, now: number
     }
 
     const age = relativeAge(entry.timestamp, now)
-    if (age) parts.push(`${age} ago`)
+    // `relativeAge` already reads as a phrase for the sub-minute case.
+    if (age) parts.push(age === 'just now' ? age : `${age} ago`)
     if (entry.userRole) parts.push(`as ${entry.userRole.toLowerCase()}`)
 
     // The reaper's failure note is the single most useful field on a failed

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -19,6 +19,12 @@ import { formatUnits } from 'viem'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { computeDisplaySpendable, isRainBalanceKnown, rainCentsToUsdcUnits } from '@/utils/balance.utils'
 import { formatCurrency } from '@/utils/general.utils'
+import {
+    ARBISCAN_ADDRESS_BASE_URL,
+    BRIDGE_DASHBOARD_BASE_URL,
+    POSTHOG_PERSON_BASE_URL,
+    SENTRY_USER_ISSUES_BASE_URL,
+} from '@/constants/support'
 import { type Account, AccountType, type IUserProfile, type UserLimitsResponse } from '@/interfaces/interfaces'
 import type { RainCardOverview } from '@/services/rain'
 import type { HistoryEntry } from '@/utils/history.utils'
@@ -252,4 +258,47 @@ export function primarySupportSegment(segments: string[] | undefined): string | 
         if (segments.includes(candidate)) return candidate
     }
     return segments.find((segment) => segment.startsWith('kyc-')) ?? segments[0]
+}
+
+export interface SupportLinks {
+    walletAddressLink: string | undefined
+    bridgeCustomerLink: string | undefined
+    posthogPersonLink: string | undefined
+    sentryIssuesLink: string | undefined
+}
+
+/** The dashboards an agent opens in another tab, built from ids the client holds. */
+export function buildSupportLinks(
+    userId: string | undefined,
+    walletAddress: string | undefined,
+    bridgeCustomerId: string | undefined
+): SupportLinks {
+    return {
+        walletAddressLink: walletAddress ? `${ARBISCAN_ADDRESS_BASE_URL}/${walletAddress}` : undefined,
+        bridgeCustomerLink: bridgeCustomerId ? `${BRIDGE_DASHBOARD_BASE_URL}/${bridgeCustomerId}` : undefined,
+        posthogPersonLink: userId ? `${POSTHOG_PERSON_BASE_URL}/${userId}` : undefined,
+        sentryIssuesLink: userId ? `${SENTRY_USER_ISSUES_BASE_URL}:${userId}` : undefined,
+    }
+}
+
+/** Platform, build, locale, route and connectivity as one row. */
+export function buildAppContext(client: {
+    platform: string
+    appBuild: string
+    locale: string
+    routeOnOpen: string | undefined
+    isOffline: boolean
+    isApiUnreachable: boolean
+    notificationPermission: string
+}): string {
+    return [
+        client.platform,
+        client.appBuild,
+        `locale:${client.locale}`,
+        client.routeOnOpen ? `route:${client.routeOnOpen}` : undefined,
+        client.isOffline ? 'offline' : client.isApiUnreachable ? 'api-unreachable' : 'online',
+        `notif:${client.notificationPermission}`,
+    ]
+        .filter(Boolean)
+        .join(' · ')
 }

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -337,8 +337,34 @@ export function normalizeSupportRoute(pathname: string | undefined): string | un
  */
 const URL_IN_TEXT = /https?:\/\/\S+/g
 
-/** Paths whose query identifies a thing rather than authorizing access to it. */
-const QUERY_BEARING_PATHS = ['/claim']
+/**
+ * Query parameters kept per path, by name.
+ *
+ * Naming the path is not enough — forwarding `url.search` wholesale would carry
+ * anything else that happens to be on a claim URL, including a parameter added
+ * later or an encoded nested link. The query is rebuilt from these names, so a
+ * parameter nobody has vetted is dropped rather than published.
+ */
+const SAFE_QUERY_PARAMS: Record<string, string[]> = {
+    // c/v/i locate the deposit on-chain (history.utils builds them); the
+    // password rides in the fragment and never survives this function.
+    '/claim': ['c', 'v', 'i'],
+}
+
+function safeQuery(url: URL): string {
+    const allowed = Object.entries(SAFE_QUERY_PARAMS).find(
+        ([path]) => url.pathname === path || url.pathname.endsWith(path)
+    )?.[1]
+    if (!allowed) return ''
+
+    const kept = new URLSearchParams()
+    for (const name of allowed) {
+        const value = url.searchParams.get(name)
+        if (value !== null) kept.set(name, value)
+    }
+    const query = kept.toString()
+    return query ? `?${query}` : ''
+}
 
 export function redactSupportText(text: string): string {
     if (!text) return text
@@ -350,7 +376,6 @@ export function redactSupportText(text: string): string {
             // Not parseable as a URL, so nothing can be reasoned about it.
             return '[link removed]'
         }
-        const keepsQuery = QUERY_BEARING_PATHS.some((path) => url.pathname === path || url.pathname.endsWith(path))
-        return `${url.origin}${url.pathname}${keepsQuery ? url.search : ''}`
+        return `${url.origin}${url.pathname}${safeQuery(url)}`
     })
 }

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -312,27 +312,45 @@ export function normalizeSupportRoute(pathname: string | undefined): string | un
 }
 
 /*
- * URLs in a support message, with the fragment removed.
+ * URLs in a support message, reduced to what an agent needs and nothing else.
  *
- * A claim link is `/claim?c=…&v=…&i=…#p=<password>` (history.utils). The query
- * identifies the deposit and is what lets an agent find it; the fragment IS the
- * bearer credential — whoever holds it can claim the funds, and it derives the
- * private claim key. `ClaimErrorView` hands `window.location.href` to support,
- * so without this the password reaches Crisp the moment the drawer opens,
- * before the user has decided to send anything.
+ * Two kinds of secret ride in a URL here. The fragment is one: a claim link is
+ * `/claim?c=…&v=…&i=…#p=<password>` (history.utils), and that password is a
+ * bearer credential — it derives the private claim key, so whoever holds it can
+ * take the funds. The query is the other: an OAuth callback carries `?code=`,
+ * a magic link carries `?token=`, and not-found.tsx already sends a bare
+ * pathname for exactly that reason.
  *
- * Stripping the fragment rather than the whole query is deliberate: it removes
- * every secret this app puts in a URL while keeping the part support actually
- * works from. Call sites needing more than this still do it themselves — see
- * not-found.tsx, which sends a bare pathname because arbitrary pages can carry
- * magic-link and OAuth tokens in the query too.
+ * So the default is to drop both, and the query is kept only where it is known
+ * to identify rather than authorize. `/claim` is that case: `c`, `v` and `i`
+ * locate the deposit on-chain and are what let an agent find the link at all.
+ *
+ * Deny-lists were the alternative and were rejected: a list of secret-looking
+ * parameter names has to be right about every page that exists now and every
+ * one added later. This is wrong in the safe direction — an unlisted page loses
+ * context, never a credential.
+ *
+ * Call sites hand over `window.location.href` (ClaimErrorView,
+ * Error.validation.view), and `ModalsContext` runs every prefill through this
+ * before storing it, so the composer and the `support_topic` row are both
+ * covered — including call sites nobody has written yet.
  */
 const URL_IN_TEXT = /https?:\/\/\S+/g
+
+/** Paths whose query identifies a thing rather than authorizing access to it. */
+const QUERY_BEARING_PATHS = ['/claim']
 
 export function redactSupportText(text: string): string {
     if (!text) return text
     return text.replace(URL_IN_TEXT, (raw) => {
-        const hashAt = raw.indexOf('#')
-        return hashAt === -1 ? raw : raw.slice(0, hashAt)
+        let url: URL
+        try {
+            url = new URL(raw)
+        } catch {
+            // Not parseable as a URL, so nothing can be reasoned about it.
+            return '[link removed]'
+        }
+        const keepsQuery = QUERY_BEARING_PATHS.some((path) => url.pathname === path || url.pathname.endsWith(path))
+        return `${url.origin}${url.pathname}${keepsQuery ? url.search : ''}`
     })
 }

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -237,33 +237,6 @@ export function buildSupportSegments(input: SupportSegmentInput): string[] {
     return segments
 }
 
-/**
- * Priority order for the ONE segment the native SDK can hold.
- *
- * `CrispSDK.session.segment = …` is an assignment, not an append (same on
- * Android via `setSessionSegment`), so repeated calls keep only the last. The
- * web SDK takes the whole list; native gets the most actionable one, and the
- * full list still rides along as a `segments` data row so nothing is lost.
- */
-const SEGMENT_PRIORITY = [
-    'verification-blocked',
-    'balance-unavailable',
-    'api-unreachable',
-    'offline',
-    'no-email',
-    'guest',
-    'zero-balance',
-    'card-holder',
-]
-
-export function primarySupportSegment(segments: string[] | undefined): string | undefined {
-    if (!segments?.length) return undefined
-    for (const candidate of SEGMENT_PRIORITY) {
-        if (segments.includes(candidate)) return candidate
-    }
-    return segments.find((segment) => segment.startsWith('kyc-')) ?? segments[0]
-}
-
 export interface SupportLinks {
     walletAddressLink: string | undefined
     bridgeCustomerLink: string | undefined

--- a/src/utils/support-context.ts
+++ b/src/utils/support-context.ts
@@ -25,9 +25,8 @@ import {
     POSTHOG_PERSON_BASE_URL,
     SENTRY_USER_ISSUES_BASE_URL,
 } from '@/constants/support'
-import { type Account, AccountType, type IUserProfile, type UserLimitsResponse } from '@/interfaces/interfaces'
+import { type Account, AccountType, type IUserProfile } from '@/interfaces/interfaces'
 import type { RainCardOverview } from '@/services/rain'
-import type { HistoryEntry } from '@/utils/history.utils'
 
 const usd = (units: bigint): string => `$${formatCurrency(formatUnits(units, PEANUT_WALLET_TOKEN_DECIMALS))}`
 
@@ -101,61 +100,6 @@ export function buildAccountStats(profile: IUserProfile | undefined, now: number
     if (queuePosition != null) parts.push(`queue:${queuePosition}/${profile.pwQueue?.totalUsers ?? '?'}`)
 
     return parts.join(' · ')
-}
-
-/**
- * The user's own most recent movement — kind, provider, status, amount, age.
- *
- * Deliberately NOT the counterparty: `HistoryEntry` carries the other party's
- * username and full name, and a support sidebar is not a place to replicate
- * someone else's payment record. `uuid` is enough for an agent to look the
- * transaction up through the tools they already have.
- */
-export function buildLatestActivity(entry: HistoryEntry | undefined, now: number = Date.now()): string | undefined {
-    if (!entry) return undefined
-
-    const kind = entry.extraData?.kind ?? entry.type
-    const provider = entry.extraData?.provider
-    const parts: string[] = [provider ? `${kind}/${provider}` : kind, entry.status]
-
-    if (entry.currency?.amount && entry.currency.code) {
-        parts.push(`${entry.currency.amount} ${entry.currency.code}`)
-    } else if (entry.amount) {
-        parts.push(`${entry.amount} ${entry.tokenSymbol ?? ''}`.trim())
-    }
-
-    const age = relativeAge(entry.timestamp, now)
-    // `relativeAge` already reads as a phrase for the sub-minute case.
-    if (age) parts.push(age === 'just now' ? age : `${age} ago`)
-    if (entry.userRole) parts.push(`as ${entry.userRole.toLowerCase()}`)
-
-    // The reaper's failure note is the single most useful field on a failed
-    // intent, and the user can rarely relay it accurately.
-    const failReason = entry.extraData?.failReason
-    if (failReason) parts.push(`failReason:${failReason}`)
-
-    parts.push(`uuid:${entry.uuid}`)
-    return parts.join(' · ')
-}
-
-/** Remaining fiat headroom per provider — answers "why was my withdrawal blocked". */
-export function buildLimitsSummary(limits: UserLimitsResponse | undefined): string | undefined {
-    if (!limits) return undefined
-    const parts: string[] = []
-
-    if (limits.bridge) {
-        const { onRampPerTransaction, offRampPerTransaction, asset } = limits.bridge
-        parts.push(`bridge on/tx ${onRampPerTransaction} off/tx ${offRampPerTransaction} ${asset}`)
-    }
-
-    for (const limit of limits.manteca ?? []) {
-        parts.push(
-            `manteca ${limit.exchangeCountry}/${limit.type} ${limit.availableMonthlyLimit}/${limit.monthlyLimit} mo` +
-                ` ${limit.availableYearlyLimit}/${limit.yearlyLimit} yr ${limit.asset}`
-        )
-    }
-
-    return parts.length ? parts.join(' · ') : undefined
 }
 
 /** Card application state and collateral, for the card half of support volume. */


### PR DESCRIPTION
Follow-up to #2736. That PR gave the agent sidebar identity, wallet links and verification state. It gave it nothing about what the user actually *has* or *just did*, so a thread still opens with three rounds of "what's your balance / what did you last do / which build are you on".

Worth stating plainly, because it framed the whole design: **none of this needs database access, and none of it grants any.** Crisp never had a connection to our data — the client pushes `session:data`. The ceiling was never "DB vs no DB", it was "what does the client already know". It already knows all of this.

## New sidebar rows

Every value comes from the `/get-user` read-models already in `authContext` plus warm react-query caches. No new endpoint, no backend change.

| field | what it answers |
|---|---|
| `balance` | spendable total, wallet and card halves reported separately |
| `account_stats` | points, streak, tenure, activation milestone, invite provenance, badges, queue position |
| `latest_activity` | kind/provider, status, amount, age, `failReason`, uuid |
| `limits_remaining` | per-provider fiat headroom — "why was my withdrawal blocked" |
| `card` | application state, collateral, issued cards |
| `linked_accounts` | rail shapes and countries |
| `app_context` | platform, all three build layers, locale, route at open, connectivity, notification permission |
| `sentry_issues` | Sentry issue search scoped to this user |

Plus **Crisp segments** for the boolean half — `ios-native`, `kyc-pending`, `verification-blocked`, `zero-balance`, `balance-unavailable`, `offline`, `guest`, `card-holder`. Segments are what the inbox filters and routes on, which is the right home for yes/no facts, and keeping them out of `session:data` is what stops the sidebar becoming a wall of `yes`/`no` rows nobody scrolls past.

`app_context` is the one I'd single out as under-rated: an agent currently sees "Chrome 150 on Linux" and nothing about *our* app. Three version layers can disagree — the web bundle (a document can outlive arbitrarily many deploys, see `useStaleDeploymentReload`), the native binary, and the Capgo OTA bundle on top of it. An agent who can see all three says "update the app" instead of debugging a bug that was fixed a fortnight ago.

## Three things worth reviewing carefully

**No new requests.** `SupportDrawer` mounts this hook app-wide — every screen, guests included. A `useWallet()` / `useLimits()` / `useRainCardOverview()` call inside it would switch on a 30s RPC poll plus two API requests for every user, which is precisely the shape that made `/rain/cards` the most-called endpoint in the app. All reads go through `support-cache.ts`, which only looks at what is already in the query cache, and `useCrispUserData.test.tsx` asserts the hook leaves the cache empty.

**Unreadable is never zero.** `rainCentsToUsdcUnits(undefined)` is `0n`, so "no answer" and "genuinely empty" are arithmetically identical — the $0-balance bug (PEANUT-UI-QD5) in its support-facing form. An agent reading `$0.00` tells a funded user they have no money, which is worse than telling them nothing. Each half is either a figure or the word `unavailable`, and the total only appears when both halves are answers. A user with no card application is still a real zero and prints as one.

**The user's own state, never a counterparty's.** `HistoryEntry` carries the other party's username and full name. A support console is the wrong place to accumulate third parties' payment records, so activity summaries name the kind, status and amount — the uuid is enough for an agent to look up the rest. Same rule for `linked_accounts`: `iban:DE`, never the IBAN.

## Drift fix

The three sinks (web widget, proxy iframe, native `setString`) each wrote the field list by hand, and native had fallen to **two** keys where web sent seven — so the agents helping *app* users saw the least. There is now one `supportSessionFields` definition feeding all three, with a test pinning it. Native holds a single segment (`CrispSDK.session.segment = …` is an assignment, not an append — same on Android), so it gets the most actionable one via `primarySupportSegment` and the full list rides along as a data row.

## Tests

60 passing across the touched suites — 25 on the pure builders, 4 on the cache readers, 5 on sink parity, 4 on the hook (including the no-fetch invariant), plus the existing Crisp/SupportDrawer/verification suites unchanged.

## ⚠️ Release-blocker: merge the disclosure first

The privacy policy's third-party table described Crisp as receiving "your messages, email address, and basic device data". This PR widens that considerably, so the disclosure had to move first.

**It has.** `mono/content/legal/privacy/en.md` now reads:

> Your messages, email address, app version, basic device data, and a snapshot of your account context — shared only when you open support chat

peanutprotocol/mono@26bd1817, `last_updated` bumped. The mirror synced and the publish PR is open: **#2855** (base `main`).

It cannot ship atomically with this PR — the policy lives in the `src/content` submodule and the repo rule is that content and code never travel together — so the guarantee is merge order instead:

> **#2855 must merge before the release PR that carries this code to production.** This PR targets `dev`, so nothing here is live until a `dev` → `main` release; #2855 is one click from live today. Comfortable ordering, but it is a real gate, not a nicety.

No change to processor scope: Crisp was already a named processor in that same row, and this widens what it receives inside an existing relationship rather than adding one. Retention is Crisp-side and untouched.

The gap that let this nearly slip is now closed at the source — `skills/peanut-pr` phase 6b never named `content/legal/` in its docs-impact search scope, so the subagent would not have opened the privacy policy. It now asks the legal question separately and requires quoting the sentence that is wrong (peanutprotocol/mono@0a08a271).
