### PR TITLE
i18n(limits): stage copy for the Manteca cap-nudge under-review state

### DIFF
--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -479,6 +479,11 @@
             "yearly": "Yearly",
             "selectAriaLabel": "Select period"
         },
+        "capNudge": {
+            "description": "You've hit your monthly limit. Verify your income to request a higher one.",
+            "cta": "Verify income",
+            "underReview": "Income verification received — our team is reviewing your limit."
+        },
         "increase": {
             "cta": "Increase my limits",
             "submitted": "Document submitted! Your limits will be updated shortly."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -479,6 +479,11 @@
             "yearly": "Anual",
             "selectAriaLabel": "Seleccionar período"
         },
+        "capNudge": {
+            "description": "Alcanzaste tu límite mensual. Verifica tus ingresos para solicitar uno más alto.",
+            "cta": "Verificar ingresos",
+            "underReview": "Recibimos la verificación de tus ingresos: nuestro equipo está revisando tu límite."
+        },
         "increase": {
             "cta": "Aumentar mis límites",
             "submitted": "¡Documento enviado! Tus límites se actualizarán pronto."

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -230,6 +230,9 @@
         }
     },
     "limits": {
+        "capNudge": {
+            "description": "Alcanzaste tu límite mensual. Verificá tus ingresos para solicitar uno más alto."
+        },
         "pageDescription": "Los límites de pago controlan cuánto podés enviar y recibir. Varían según la región y se reinician cada mes o cada año.",
         "fiatLocked": {
             "title": "Desbloqueá pagos fiat",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -479,6 +479,11 @@
             "yearly": "Anual",
             "selectAriaLabel": "Selecionar período"
         },
+        "capNudge": {
+            "description": "Você atingiu seu limite mensal. Verifique sua renda para solicitar um limite maior.",
+            "cta": "Verificar renda",
+            "underReview": "Recebemos a verificação da sua renda: nossa equipe está revisando seu limite."
+        },
         "increase": {
             "cta": "Aumentar meus limites",
             "submitted": "Documento enviado! Seus limites serão atualizados em breve."


### PR DESCRIPTION
Companion to peanut-api-ts [#1423](https://github.com/peanutprotocol/peanut-api-ts/pull/1423). **Strings only — no UI wiring.**

## Why

`#1423` stops the Manteca source-of-funds cap-nudge from being deleted when Sumsub accepts the document. Sumsub going GREEN means *Sumsub* accepted it, not that Manteca raised the cap — there's no vendor endpoint for that, so the raise is a manual, support-driven step. Deleting the marker asserted more than we know: the user's only limit hint vanished while the cap was unchanged.

The BE now retires the marker to a `submittedAt` state and the resolver swaps the actionable CTA for a non-actionable `wait`:

| marker | `hintActions` | `NextAction` |
| --- | --- | --- |
| fresh block | `sumsub:source_of_funds` | `kind: 'sumsub'`, `purpose: 'raise-manteca-limit'` |
| after the RFI completes | `manteca:limit-review` | `kind: 'wait'`, `purpose: 'manteca-limit-under-review'` |

A genuinely new cap block re-seeds the marker without `submittedAt`, which restores the actionable CTA on its own.

## Why no UI in this PR

**The cap-nudge has no renderer today.** `firstAdvisory` ([capability-gate.ts:232](https://github.com/peanutprotocol/peanut-ui/blob/dev/src/utils/capability-gate.ts#L232)) skips any hint without an `effectiveDate`, and that field is Bridge-advisory-only — so an enabled Manteca rail's hint reaches `verdict.nextAction` and then stops. Nothing downstream reads it. The only limit-raising UI we ship is the limits page's `IncreaseLimitsButton`, which drives a *different* endpoint (`POST /users/increase-limits`, BR legacy-user document migration).

So "add the copy" isn't a copy change — it needs a placement decision (limits page vs. a payment-time pre-empt) and design input. Staging the strings here keeps that PR copy-complete on arrival, and leaves today's behaviour untouched.

## Copy

Added under `limits.capNudge` in `en` / `es-419` / `pt-BR`:

- `description` — "You've hit your monthly limit. Verify your income to request a higher one."
- `cta` — "Verify income"
- `underReview` — "Income verification received — our team is reviewing your limit."

`underReview` deliberately does **not** promise a raise (unlike the neighbouring `limits.increase.submitted`, "Your limits will be updated shortly"), because on this path nothing has confirmed one.

`es-AR` is omitted on purpose — it's a deltas-only overlay on `es-419` and neither string needs an Argentine variant.

## Tests

`jest src/i18n` — 15 suites / 196 tests green, covering key parity across the full locales, the `es-AR` subset rule, duplicate-value drift, the glossary, and ICU compilation. `prettier --check` clean.
