### PR TITLE
ci: forward /chip quiet and /chip loud to the review bridge

### DIFF
--- a/.github/workflows/chip-pr-review.yml
+++ b/.github/workflows/chip-pr-review.yml
@@ -67,7 +67,9 @@ jobs:
         if: >-
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
-            (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review'))
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association) &&
+            (contains(github.event.comment.body, '/chip review') || contains(github.event.comment.body, '@chip-peanut-bot review')
+            || contains(github.event.comment.body, '/chip quiet') || contains(github.event.comment.body, '/chip loud'))
         runs-on: ubuntu-latest
         timeout-minutes: 2
         steps:


### PR DESCRIPTION
## Summary

Adds `/chip quiet` and `/chip loud` to the comment commands the bridge forwards, so each person can turn their own review pings off and on.

Loud stays the default — a review nobody sees is worse than a ping nobody needed. Quiet still mentions the person so the thread stays searchable; it only drops the notification.

The preference is stored per person on the box, so changing it is a comment rather than a PR against config.

https://claude.ai/code/session_01TYXiBavHf8unVNbn2pbhg6