### PR TITLE
copy(i18n): use 'Recibir' for the Spanish request action

### DIFF
--- a/src/i18n/app/__tests__/messages.test.ts
+++ b/src/i18n/app/__tests__/messages.test.ts
@@ -21,7 +21,7 @@ const FULL_LOCALES = APP_LOCALES.filter((locale) => !DELTA_LOCALES.includes(loca
  */
 const CONTEXT_DIVERGENT: Record<string, string> = {
     Send: 'nav/action verb vs. transaction-type noun (Enviar / Envío)',
-    Request: 'nav/action verb vs. transaction-type noun (Solicitar / Solicitud)',
+    Request: 'nav/action verb vs. transaction-type noun (Recibir / Solicitud)',
     Add: 'nav verb vs. transaction-type noun (Agregar / Ingreso)',
     Withdraw: 'nav verb vs. transaction-type noun (Retirar / Retiro)',
     Pay: 'nav/action verb vs. transaction-type noun (Pagar / Pago)',

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -59,7 +59,7 @@
     "navigation": {
         "home": "Inicio",
         "send": "Enviar",
-        "request": "Solicitar",
+        "request": "Recibir",
         "add": "Agregar",
         "withdraw": "Retirar",
         "history": "Historial",


### PR DESCRIPTION
## What

Spanish request action now reads **Recibir** instead of **Solicitar**, in both `es-419` and `es-AR`.

## Why

"Solicitar" reads as filing a formal application, not asking a friend for money. "Recibir" matches how people describe the action and keeps the nav verb in line with the rest of the wallet.

## Scope

One string: `navigation.request` in `es-419.json`.

- `es-AR.json` is a deltas-only overlay on `es-419` and carried no override for this key, so it inherits the new string. The infinitive is voseo-neutral, so no AR-specific form is needed.
- The transaction-type noun `transaction.type.request` / `transaction.name.request` stays **Solicitud**. History rows read as a noun, not an action.
- The `CONTEXT_DIVERGENT` comment in `messages.test.ts` is updated so it no longer names the old string.

## Surfaces affected

Everything that renders `tNav('request')`:

- home action button — `src/app/(mobile-ui)/home/page.tsx:245`
- public profile CTA — `src/components/Profile/components/PublicProfile.tsx:211`
- direct-request nav headers, mobile title, submit button — `src/components/Request/direct-request/views/Initial.direct.request.view.tsx`
- request-link create header — `src/components/Request/link/views/Create.request.link.view.tsx:372`

## Test

`src/i18n/app/__tests__/messages.test.ts` — 14/14 pass (key parity, duplicate-value drift, ICU compilation for all four locales).
