### PR TITLE
security: require a human code owner so a bot approval cannot count

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Chip must never be able to satisfy a review requirement.
+#
+# main requires code-owner review. Without this file that rule has no owners
+# to require, so any approval counted -- including one from a bot holding a
+# write token. Listing humans here means a human has to approve, whatever else
+# happens to appear on the pull request.
+#
+# Keep this list to people. Never add an app or a bot.
+
+* @Hugo0 @jjramirezn @kushagrasarathe @0xkkonrad @innolope-dev @abalinda


### PR DESCRIPTION
## Summary

`main` already sets `require_code_owner_review: true`, but neither repo has a CODEOWNERS file — so the rule has no owners to require and is vacuous. Today a bot approval would count toward the one required approval.

Chip has never approved a PR (checked across 50 recent PRs in both repos) and the publisher now refuses to submit anything but `COMMENT`/`REQUEST_CHANGES`. But Chip holds a token with `pull_requests: write`, and until now the only thing preventing an approval was an instruction in a skill — policy, not structure.

With this file, a human has to approve `main`, whatever else appears on the PR. That is enforced by GitHub, not by us.

Reconciliation also now dismisses any approval wearing Chip's name and alerts in Discord.

https://claude.ai/code/session_01TYXiBavHf8unVNbn2pbhg6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules requiring review from designated maintainers.
  * Clarified that automated accounts and apps are not eligible as code owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->