### PR TITLE
fix(rewards-nav): safe-back everywhere, one Send header, honest sent-money badge

### DIFF
--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -12,16 +12,18 @@ import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import posthog from 'posthog-js'
 import ProfileHeader from './ProfileHeader'
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { invitesApi } from '@/services/invites'
 import { usersApi } from '@/services/users'
 import { useRouter } from 'next/navigation'
 import { isCapacitor } from '@/utils/capacitor'
 import { requestUrl } from '@/utils/native-routes'
 import Card from '@/components/Global/Card'
-import { checkIfInternalNavigation, saveToCookie, toInviteCode } from '@/utils/general.utils'
+import { saveToCookie, toInviteCode } from '@/utils/general.utils'
 import { useAuth } from '@/context/authContext'
 import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
+import { useSafeBack } from '@/hooks/useSafeBack'
+import { useUserInteractions } from '@/hooks/useUserInteractions'
 import ShareButton from '@/components/Global/ShareButton'
 import ActionModal from '@/components/Global/ActionModal'
 import BadgesRow from '@/components/Badges/BadgesRow'
@@ -35,11 +37,12 @@ interface PublicProfileProps {
 const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = false, onSendClick }) => {
     const t = useTranslations('profile.publicProfile')
     const tNav = useTranslations('navigation')
-    const [totalSentByLoggedInUser, setTotalSentByLoggedInUser] = useState<string>('0')
+    const [profileUserId, setProfileUserId] = useState<string | null>(null)
     const [fullName, setFullName] = useState<string>(username)
     const [showFullName, setShowFullName] = useState<boolean>(false)
     const [isKycVerified, setIsKycVerified] = useState<boolean>(false)
     const router = useRouter()
+    const goBack = useSafeBack('/home')
     const { user, isFetchingUser } = useAuth()
     const isSelfProfile = user?.user.username?.toLowerCase() === username.toLowerCase()
     const [showInviteModal, setShowInviteModal] = useState(false)
@@ -135,17 +138,16 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
             // get the profile owner's showFullName preference
             setShowFullName(apiUser?.showFullName ?? false)
             setIsKycVerified(apiUser?.isVerified ?? false)
-            // to check if the logged in user has sent money to the profile user,
-            // we check the amount that the profile user has received from the logged in user.
-            if (apiUser?.totalUsdReceivedFromCurrentUser) {
-                setTotalSentByLoggedInUser(apiUser.totalUsdReceivedFromCurrentUser)
-            }
+            setProfileUserId(apiUser?.userId ?? null)
             setProfileBadges(apiUser?.badges ?? [])
         })
     }, [username])
 
-    // this flag is true if the current user has sent money to the profile user before.
-    const haveSentMoneyToUser = useMemo(() => Number(totalSentByLoggedInUser) > 0, [totalSentByLoggedInUser])
+    // interaction-status is the complete "sent money before" source (covers send-link
+    // claims etc., unlike the profile payload's narrow received-from-you sum); stays
+    // false (neutral) until the query resolves.
+    const { interactions } = useUserInteractions(isLoggedIn && profileUserId ? [profileUserId] : [])
+    const haveSentMoneyToUser = !!profileUserId && (interactions[profileUserId] ?? false)
 
     // respect profile owner's showFullName preference: use fullName only if showFullName is true, otherwise use username
     const displayName = showFullName && fullName ? fullName : username
@@ -160,19 +162,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                         <Image src={PEANUT_LOGO_BLACK} alt={t('peanutLogoTextAlt')} height={12} />
                     </div>
                 ) : (
-                    <NavHeader
-                        onPrev={() => {
-                            // Check if the referrer is from the same domain (internal navigation)
-                            const isInternalReferrer = checkIfInternalNavigation()
-
-                            if (isInternalReferrer && window.history.length > 1) {
-                                router.back()
-                            } else {
-                                router.push('/home')
-                            }
-                        }}
-                        hideLabel
-                    />
+                    <NavHeader onPrev={goBack} hideLabel />
                 )}
             </div>
 

--- a/src/components/Profile/components/__tests__/PublicProfile.test.tsx
+++ b/src/components/Profile/components/__tests__/PublicProfile.test.tsx
@@ -4,18 +4,24 @@ import posthog from 'posthog-js'
 import PublicProfile from '../PublicProfile'
 import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import { renderWithIntl } from '@/test-utils/intl'
+import { __testing as safeBackTesting } from '@/hooks/useSafeBack'
 import en from '@/i18n/app/messages/en.json'
 
 const mockPush = jest.fn()
+const mockBack = jest.fn()
 const mockSaveToCookie = jest.fn()
 const mockGetByUsername = jest.fn()
 const mockValidateInviteCode = jest.fn()
 const mockInterceptGuestCta = jest.fn(() => false)
+const mockUseUserInteractions = jest.fn()
 let mockAuth: { user: null | { user: { username: string; hasAppAccess: boolean } }; isFetchingUser: boolean }
 
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush, back: jest.fn() }) }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush, back: mockBack }) }))
 jest.mock('@/context/authContext', () => ({ useAuth: () => mockAuth }))
 jest.mock('@/services/users', () => ({ usersApi: { getByUsername: (u: string) => mockGetByUsername(u) } }))
+jest.mock('@/hooks/useUserInteractions', () => ({
+    useUserInteractions: (ids: string[]) => mockUseUserInteractions(ids),
+}))
 jest.mock('@/services/invites', () => ({
     invitesApi: { validateInviteCode: (c: string) => mockValidateInviteCode(c) },
 }))
@@ -31,11 +37,21 @@ jest.mock('@/utils/general.utils', () => {
 })
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 
-// Stubbed neighbours — this suite is about the guest door, not the page furniture.
-jest.mock('../ProfileHeader', () => ({ __esModule: true, default: () => null }))
+// Stubbed neighbours — this suite is about the guest door, back navigation and
+// the prior-transfer indicator, not the page furniture.
+jest.mock('../ProfileHeader', () => ({
+    __esModule: true,
+    default: ({ haveSentMoneyToUser }: { haveSentMoneyToUser?: boolean }) => (
+        <div data-testid="profile-header" data-sent-money={String(!!haveSentMoneyToUser)} />
+    ),
+}))
 jest.mock('@/components/Badges/BadgesRow', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Home/HomeHistory', () => ({ __esModule: true, default: () => null }))
-jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Global/NavHeader', () => ({
+    __esModule: true,
+    default: ({ onPrev }: { onPrev?: () => void }) =>
+        onPrev ? <button data-testid="nav-back" onClick={onPrev} /> : null,
+}))
 jest.mock('@/components/Global/ActionModal', () => ({
     __esModule: true,
     // Renders description + content when visible so the guest Request-gate
@@ -90,9 +106,11 @@ const deferValidation = () => {
 
 beforeEach(() => {
     jest.clearAllMocks()
+    safeBackTesting.reset()
     mockAuth = { user: null, isFetchingUser: false }
     mockInterceptGuestCta.mockReturnValue(false)
     mockGetByUsername.mockResolvedValue(null)
+    mockUseUserInteractions.mockReturnValue({ interactions: {}, isLoading: false, isError: false })
     // the door validates before persisting; default = resolvable inviter
     mockValidateInviteCode.mockResolvedValue({
         success: true,
@@ -219,4 +237,65 @@ describe('PublicProfile guest door', () => {
             })
         }
     )
+})
+
+// The "sent money before" badge comes from the interaction-status endpoint (the
+// complete source — send-link claims included), never from the profile payload's
+// narrow received-from-you sum (TASK-21929).
+describe('PublicProfile prior-transfer indicator', () => {
+    beforeEach(() => {
+        mockAuth = { user: { user: { username: 'hal', hasAppAccess: true } }, isFetchingUser: false }
+        mockGetByUsername.mockResolvedValue({ userId: 'user-1' })
+    })
+
+    it('shows the indicator when interaction status reports a prior transfer', async () => {
+        mockUseUserInteractions.mockReturnValue({
+            interactions: { 'user-1': true },
+            isLoading: false,
+            isError: false,
+        })
+        renderWithIntl(<PublicProfile username="satoshi" isLoggedIn />)
+
+        await waitFor(() => expect(screen.getByTestId('profile-header')).toHaveAttribute('data-sent-money', 'true'))
+        expect(mockUseUserInteractions).toHaveBeenLastCalledWith(['user-1'])
+    })
+
+    it('stays neutral while the interaction query is loading', async () => {
+        mockUseUserInteractions.mockReturnValue({ interactions: {}, isLoading: true, isError: false })
+        renderWithIntl(<PublicProfile username="satoshi" isLoggedIn />)
+
+        await waitFor(() => expect(mockUseUserInteractions).toHaveBeenLastCalledWith(['user-1']))
+        expect(screen.getByTestId('profile-header')).toHaveAttribute('data-sent-money', 'false')
+    })
+
+    it('never queries interaction status for guests', async () => {
+        mockAuth = { user: null, isFetchingUser: false }
+        renderWithIntl(<PublicProfile username="satoshi" />)
+
+        await screen.findByRole('button', { name: JOIN_CTA })
+        expect(mockUseUserInteractions).toHaveBeenLastCalledWith([])
+    })
+})
+
+describe('PublicProfile back navigation', () => {
+    beforeEach(() => {
+        mockAuth = { user: { user: { username: 'hal', hasAppAccess: true } }, isFetchingUser: false }
+    })
+
+    it('falls back to /home on a cold deep-link (no in-app history)', async () => {
+        renderWithIntl(<PublicProfile username="satoshi" isLoggedIn />)
+
+        fireEvent.click(await screen.findByTestId('nav-back'))
+        expect(mockPush).toHaveBeenCalledWith('/home')
+        expect(mockBack).not.toHaveBeenCalled()
+    })
+
+    it('returns through in-app history when it exists (Rewards → profile → back)', async () => {
+        window.history.pushState({}, '', '/satoshi')
+        renderWithIntl(<PublicProfile username="satoshi" isLoggedIn />)
+
+        fireEvent.click(await screen.findByTestId('nav-back'))
+        expect(mockBack).toHaveBeenCalledTimes(1)
+        expect(mockPush).not.toHaveBeenCalled()
+    })
 })

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -17,6 +17,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 // next/navigation
 const mockRouterPush = jest.fn()
 const mockRouterBack = jest.fn()
+const mockRouterReplace = jest.fn()
 const mockSearchParams = new Map<string, string>()
 
 jest.mock('next/navigation', () => ({
@@ -25,7 +26,7 @@ jest.mock('next/navigation', () => ({
     }),
     useRouter: () => ({
         push: mockRouterPush,
-        replace: jest.fn(),
+        replace: mockRouterReplace,
         prefetch: jest.fn(),
         back: mockRouterBack,
     }),
@@ -168,7 +169,14 @@ jest.mock('../link/LinkSendFlowManager', () => ({
 
 jest.mock('../views/Contacts.view', () => ({
     __esModule: true,
-    default: () => <div data-testid="contacts-view">Contacts View</div>,
+    default: (props: any) => (
+        <div data-testid="contacts-view">
+            <button data-testid="contacts-back" onClick={props.onPrev}>
+                Back
+            </button>
+            Contacts View
+        </div>
+    ),
 }))
 
 // withdraw-flow context — SendRouterView resets it when a click enters the withdraw flow
@@ -304,11 +312,25 @@ describe('GROUP 2: Send by Link', () => {
         expect(screen.getByTestId('link-send-flow-manager')).toBeInTheDocument()
     })
 
-    test('Back from link view navigates to /send', () => {
+    test('Back from a cold deep-link into link view replaces to /send without minting history', () => {
         renderSend({ view: 'link' })
 
         fireEvent.click(screen.getByTestId('link-back'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        // replace, not push — a pushed entry would let the base view's safe-back
+        // walk right back into the subview
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
+        expect(mockRouterBack).not.toHaveBeenCalled()
+    })
+
+    test('Back from an in-app-entered link view pops history instead of pushing', () => {
+        window.history.pushState({}, '', '/send?view=link')
+        renderSend({ view: 'link' })
+
+        fireEvent.click(screen.getByTestId('link-back'))
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 })
 
@@ -321,6 +343,39 @@ describe('GROUP 3: Contacts View', () => {
 
         expect(screen.getByTestId('contacts-view')).toBeInTheDocument()
         expect(screen.queryByText('Send money with a link')).not.toBeInTheDocument()
+    })
+
+    test('Back from a cold deep-link into contacts replaces to /send without minting history', () => {
+        renderSend({ view: 'contacts' })
+
+        fireEvent.click(screen.getByTestId('contacts-back'))
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
+        expect(mockRouterBack).not.toHaveBeenCalled()
+    })
+
+    // Regression: the subview branch used to router.push('/send'), minting a
+    // history entry that made the base view's safe-back re-open the subview —
+    // Back looped between Contacts and base Send forever.
+    test('cold /send → open contacts → back → back leaves Send, not re-enters contacts', () => {
+        // cold /send: user opens contacts (real in-app push, as the contacts card does)
+        window.history.pushState({}, '', '/send?view=contacts')
+        const contactsView = renderSend({ view: 'contacts' })
+
+        // Back from contacts pops the pushed entry instead of pushing a new one
+        fireEvent.click(screen.getByTestId('contacts-back'))
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+
+        // the browser pops the subview entry in response to router.back()
+        window.dispatchEvent(new PopStateEvent('popstate'))
+        contactsView.unmount()
+
+        // back at base /send: Back must fall back to /home, never into contacts
+        renderSend()
+        fireEvent.click(screen.getByTestId('nav-back'))
+        expect(mockRouterPush).toHaveBeenCalledWith('/home')
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/src/components/Send/__tests__/send-states.test.tsx
+++ b/src/components/Send/__tests__/send-states.test.tsx
@@ -16,6 +16,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // next/navigation
 const mockRouterPush = jest.fn()
+const mockRouterBack = jest.fn()
 const mockSearchParams = new Map<string, string>()
 
 jest.mock('next/navigation', () => ({
@@ -26,7 +27,7 @@ jest.mock('next/navigation', () => ({
         push: mockRouterPush,
         replace: jest.fn(),
         prefetch: jest.fn(),
-        back: jest.fn(),
+        back: mockRouterBack,
     }),
     usePathname: () => '/send',
 }))
@@ -178,6 +179,7 @@ jest.mock('@/context/WithdrawFlowContext', () => ({
 
 // ---------- import component under test AFTER all mocks ----------
 import { SendRouterView } from '../views/SendRouter.view'
+import { __testing as safeBackTesting } from '@/hooks/useSafeBack'
 
 // ---------- helpers ----------
 
@@ -240,6 +242,7 @@ function applyDefaults() {
 beforeEach(() => {
     jest.clearAllMocks()
     mockSearchParams.clear()
+    safeBackTesting.reset()
     applyDefaults()
 })
 
@@ -385,10 +388,21 @@ describe('GROUP 4: Method Selection', () => {
         expect(mockResetWithdrawFlow).not.toHaveBeenCalled()
     })
 
-    test('Back from main send navigates to /home', () => {
+    test('Back from main send falls back to /home on a cold deep-link', () => {
         renderSend()
 
         fireEvent.click(screen.getByTestId('nav-back'))
         expect(mockRouterPush).toHaveBeenCalledWith('/home')
+        expect(mockRouterBack).not.toHaveBeenCalled()
+    })
+
+    test('Back from main send returns through in-app history when it exists', () => {
+        // e.g. Rewards pushed this screen — back must land there, not /home
+        window.history.pushState({}, '', '/send')
+        renderSend()
+
+        fireEvent.click(screen.getByTestId('nav-back'))
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalledWith('/home')
     })
 })

--- a/src/components/Send/views/Contacts.view.tsx
+++ b/src/components/Send/views/Contacts.view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 import { sendUrl } from '@/utils/native-routes'
 import NavHeader from '@/components/Global/NavHeader'
 import { ActionListCard } from '@/components/ActionListCard'
@@ -17,14 +17,11 @@ import { useDebounce } from '@/hooks/useDebounce'
 import { ContactsListSkeleton } from '@/components/Common/ContactsListSkeleton'
 import { useTranslations } from 'next-intl'
 
-export default function ContactsView() {
+export default function ContactsView({ onPrev }: { onPrev: () => void }) {
     const t = useTranslations('send')
     const tNav = useTranslations('navigation')
     const tCommon = useTranslations('common')
     const router = useRouter()
-    const searchParams = useSearchParams()
-    const isSendingByLink = searchParams.get('view') === 'link' || searchParams.get('createLink') === 'true'
-    const isSendingToContacts = searchParams.get('view') === 'contacts'
     const [searchQuery, setSearchQuery] = useState('')
     const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
 
@@ -64,16 +61,6 @@ export default function ContactsView() {
         router.push(`${window.location.pathname}?view=link`)
     }
 
-    const handlePrev = () => {
-        // when in sub-views (link or contacts), go back to base send page
-        // otherwise, go to home
-        if (isSendingByLink || isSendingToContacts) {
-            router.push('/send')
-        } else {
-            router.push('/home')
-        }
-    }
-
     const handleLinkCtaClick = () => {
         redirectToSendByLink()
     }
@@ -92,7 +79,7 @@ export default function ContactsView() {
     if (!!isError) {
         return (
             <div className="flex min-h-[inherit] flex-col space-y-8">
-                <NavHeader title={tNav('send')} onPrev={handlePrev} />
+                <NavHeader title={tNav('send')} onPrev={onPrev} />
                 <div className="flex flex-1 items-center justify-center">
                     <EmptyState
                         title={t('contacts.errorTitle')}
@@ -122,7 +109,7 @@ export default function ContactsView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-8">
-            <NavHeader title={tNav('send')} onPrev={handlePrev} />
+            <NavHeader title={tNav('send')} onPrev={onPrev} />
 
             {hasContacts ? (
                 <div className="space-y-4">

--- a/src/components/Send/views/SendRouter.view.tsx
+++ b/src/components/Send/views/SendRouter.view.tsx
@@ -59,6 +59,9 @@ export const SendRouterView = () => {
     const recipientUsername = recipientFromQuery || recipientFromPath || null
     const { resetWithdrawFlow } = useWithdrawFlow()
     const goBack = useSafeBack('/home')
+    // replace, not push: a pushed fallback would mint a history entry that the
+    // base view's own safe-back then walks right back into the subview (loop)
+    const goBackToBase = useSafeBack('/send', { replace: true })
     // only fetch 3 contacts for avatar display
     const { contacts, isLoading: isFetchingContacts } = useContacts({ limit: 3 })
 
@@ -113,10 +116,10 @@ export const SendRouterView = () => {
     }
 
     const handlePrev = () => {
-        // when in sub-views (link or contacts), go back to base send page
-        // otherwise, back through in-app history (fallback: home)
+        // sub-views (link or contacts) go back to the base send page; the base
+        // view goes back through in-app history (fallback: home)
         if (isSendingByLink || isSendingToContacts) {
-            router.push('/send')
+            goBackToBase()
         } else {
             goBack()
         }

--- a/src/components/Send/views/SendRouter.view.tsx
+++ b/src/components/Send/views/SendRouter.view.tsx
@@ -14,6 +14,7 @@ import { ACTION_METHODS, type PaymentMethod } from '@/constants/actionlist.const
 import Image from 'next/image'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
 import { useGeoFilteredPaymentOptions } from '@/hooks/useGeoFilteredPaymentOptions'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useContacts } from '@/hooks/useContacts'
 import { getInitialsFromName } from '@/utils/general.utils'
@@ -57,6 +58,7 @@ export const SendRouterView = () => {
             : null
     const recipientUsername = recipientFromQuery || recipientFromPath || null
     const { resetWithdrawFlow } = useWithdrawFlow()
+    const goBack = useSafeBack('/home')
     // only fetch 3 contacts for avatar display
     const { contacts, isLoading: isFetchingContacts } = useContacts({ limit: 3 })
 
@@ -112,11 +114,11 @@ export const SendRouterView = () => {
 
     const handlePrev = () => {
         // when in sub-views (link or contacts), go back to base send page
-        // otherwise, go to home
+        // otherwise, back through in-app history (fallback: home)
         if (isSendingByLink || isSendingToContacts) {
             router.push('/send')
         } else {
-            router.push('/home')
+            goBack()
         }
     }
 
@@ -257,7 +259,7 @@ export const SendRouterView = () => {
 
     // contacts view
     if (isSendingToContacts) {
-        return <ContactsView />
+        return <ContactsView onPrev={handlePrev} />
     }
 
     return (

--- a/src/features/payments/flows/direct-send/views/SendInputView.tsx
+++ b/src/features/payments/flows/direct-send/views/SendInputView.tsx
@@ -26,7 +26,7 @@ import { PaymentMethodActionList } from '@/features/payments/shared/components/P
 import { useTranslations } from 'next-intl'
 
 export function SendInputView() {
-    const onBack = useSafeBack('/')
+    const onBack = useSafeBack('/home')
     const t = useTranslations('payment')
     const tCommon = useTranslations('common')
     const { isFetchingUser } = useAuth()
@@ -59,7 +59,7 @@ export function SendInputView() {
 
     return (
         <div className="flex min-h-[inherit] flex-col justify-between gap-8">
-            <NavHeader onPrev={onBack} title={t('headers.pay')} />
+            <NavHeader onPrev={onBack} title={t('headers.send')} />
 
             <div className="my-auto flex h-full flex-col justify-center space-y-4">
                 {/* recipient card */}

--- a/src/services/__tests__/points-calculate.test.ts
+++ b/src/services/__tests__/points-calculate.test.ts
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { pointsApi } from '@/services/points'
+import { PointsAction } from '@/services/services.types'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({
+    serverFetch: jest.fn(),
+    apiFetch: jest.fn(),
+}))
+
+const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+
+const response = (init: { ok: boolean; body?: unknown }) =>
+    ({
+        ok: init.ok,
+        status: init.ok ? 200 : 500,
+        statusText: init.ok ? 'OK' : 'Internal Server Error',
+        json: async () => init.body,
+    }) as Response
+
+const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+beforeEach(() => {
+    mockServerFetch.mockReset()
+    consoleError.mockClear()
+})
+
+// calculatePoints is a preview endpoint: a failure must degrade to null, never
+// reject — success screens call it and a throw would crash a completed payment.
+describe('pointsApi.calculatePoints', () => {
+    it('resolves the estimate on success', async () => {
+        mockServerFetch.mockResolvedValue(response({ ok: true, body: { estimatedPoints: 42 } }))
+
+        await expect(
+            pointsApi.calculatePoints({ actionType: PointsAction.P2P_SEND_LINK, usdAmount: 10 })
+        ).resolves.toEqual({ estimatedPoints: 42 })
+    })
+
+    it('resolves null on API failure and on network error, logging only once', async () => {
+        mockServerFetch.mockResolvedValueOnce(response({ ok: false }))
+        await expect(
+            pointsApi.calculatePoints({ actionType: PointsAction.P2P_SEND_LINK, usdAmount: 10 })
+        ).resolves.toBeNull()
+
+        mockServerFetch.mockRejectedValueOnce(new Error('network down'))
+        await expect(
+            pointsApi.calculatePoints({ actionType: PointsAction.P2P_SEND_LINK, usdAmount: 10 })
+        ).resolves.toBeNull()
+
+        // once per session — repeated previews must not storm the console/Sentry
+        expect(consoleError).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/services/points.ts
+++ b/src/services/points.ts
@@ -1,6 +1,15 @@
 import { type CalculatePointsRequest, PointsAction, type TierInfo } from './services.types'
 import { serverFetch } from '@/utils/api-fetch'
 
+// Once per session: repeated previews would otherwise flood the console (and
+// Sentry via captureConsole) with the same failure.
+let calculatePointsFailureLogged = false
+const logCalculatePointsFailureOnce = (detail: unknown) => {
+    if (calculatePointsFailureLogged) return
+    calculatePointsFailureLogged = true
+    console.error('calculatePoints: preview failed, degrading to no points estimate', detail)
+}
+
 /** Qualitative labels for anonymized data */
 export type FrequencyLabel = 'rare' | 'occasional' | 'regular' | 'frequent'
 export type VolumeLabel = 'small' | 'medium' | 'large' | 'whale'
@@ -173,7 +182,9 @@ export const pointsApi = {
         actionType,
         usdAmount,
         otherUserId,
-    }: CalculatePointsRequest): Promise<{ estimatedPoints: number }> => {
+    }: CalculatePointsRequest): Promise<{ estimatedPoints: number } | null> => {
+        // Preview-only endpoint: a failure resolves to null so points UI degrades
+        // silently and can never block a payment flow.
         try {
             const body: { actionType: PointsAction; usdAmount: number; otherUserId?: string } = {
                 actionType,
@@ -190,22 +201,16 @@ export const pointsApi = {
             })
 
             if (!response.ok) {
-                console.error(
-                    'calculatePoints: API request failed',
-                    response.status,
-                    response.statusText,
-                    'for action',
-                    actionType
-                )
-                throw new Error(`Failed to calculate points: ${response.status}`)
+                logCalculatePointsFailureOnce(`API request failed: ${response.status} for action ${actionType}`)
+                return null
             }
 
             const data = await response.json()
 
             return { estimatedPoints: data.estimatedPoints }
         } catch (error) {
-            console.error('calculatePoints: Unexpected error', error)
-            throw error instanceof Error ? error : new Error('Failed to calculate points')
+            logCalculatePointsFailureOnce(error)
+            return null
         }
     },
 

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -442,7 +442,6 @@ export enum PointsAction {
     MANTECA_QR_PAYMENT = 'MANTECA_QR_PAYMENT',
     P2P_SEND_LINK = 'P2P_SEND_LINK',
     P2P_REQUEST_PAYMENT = 'P2P_REQUEST_PAYMENT',
-    INVITE_KYC_VERIFIED = 'INVITE_KYC_VERIFIED',
 }
 
 export interface CalculatePointsRequest {


### PR DESCRIPTION
Fixes four Issue-Inbox cards in the rewards/send navigation + profile area (TASK-21673, TASK-21201, TASK-21929, TASK-21394-FE).

## TASK-21673 — Rewards navigation dumps users on Home (remainder)
The rewards page and InvitesGraph halves already landed on dev; this covers the send-flow half:
- `SendRouter.view.tsx` / `Contacts.view.tsx`: the base-view back handler used a hardcoded `router.push('/home')`. It now goes through `useSafeBack('/home')`, so Rewards → invitee → send → back lands on Rewards. The byte-identical duplicated handler in `ContactsView` is gone — the router passes its single handler down as a prop.
- `PublicProfile.tsx`: back relied on `document.referrer` (`checkIfInternalNavigation`), which is empty for SPA pushes and in the Capacitor export, so it reliably fell through to `/home`. Replaced with `useSafeBack('/home')`.
- `SendInputView.tsx`: safe-back fallback pointed at the marketing root `/`; now `/home`.

## TASK-21201 — flow flashed "Send" → "Pay" → "Send"
The direct-send input view was the only screen in the flow titled `headers.pay`. It now uses `headers.send` end to end (product call: sending to a contact reads Send, not Pay). `headers.pay` stays — qr-pay/contribute-pot/semantic-request use it legitimately. No new i18n keys.

## TASK-21929 — contact trust indicator inconsistent between Send and profile
The profile derived "you've sent money to them" from `totalUsdReceivedFromCurrentUser`, whose SQL misses send-link claims and requester-less direct sends — so the same contact showed the indicator in Send contacts but not on their profile. The profile now uses the interaction-status endpoint (`useUserInteractions` → `checkInteractions`), the most complete relationship source, staying neutral until the query resolves and never querying for guests.

## TASK-21394 (FE half) — points preview must never block a flow
- Removed the dead `INVITE_KYC_VERIFIED` member from `PointsAction` (zero call sites; the API's member is `KYC_VERIFIED`).
- `pointsApi.calculatePoints` now resolves `null` on any failure (logged once per session) instead of throwing. All consumers already optional-chain `estimatedPoints`, so a failed preview degrades to "no points card". The backend half of TASK-21394 (kind mapping) ships separately.

## Tests
- `send-states.test.tsx`: cold deep-link → `/home` fallback; in-app history → `router.back()`.
- `PublicProfile.test.tsx`: both back branches + indicator-from-interactions, neutral-while-loading, no-guest-query.
- `points-calculate.test.ts` (new): success, null-on-failure, logs-once.
- 37/37 pass via `--runTestsByPath`; `pnpm typecheck` clean.

Notion: TASK-21673 · TASK-21201 · TASK-21929 · TASK-21394