### PR TITLE
fix(send-link): classify offline fetch failures and stop Sentry dropping them (TASK-21956)

### DIFF
--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -14,6 +14,7 @@ import { sendLinksApi } from '@/services/sendLinks'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import { isAmountWithinBalance } from '@/utils/balance.utils'
 import { captureException } from '@sentry/nextjs'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
@@ -129,18 +130,32 @@ const LinkSendInitialView = () => {
                 } catch (error) {
                     // we want to capture any errors here because we are already in the background
                     console.error(error)
-                    captureException(error)
+                    captureException(error, {
+                        tags: { ...criticalFlowTags('send-link'), send_link_step: 'persist' },
+                    })
                 }
             }, 0)
         } catch (error) {
             // handle errors
             const errorString = toFriendlyError(error)
             setErrorState({ showError: true, errorMessage: errorString })
+            // `error_message` is the LOCALIZED copy the user saw, so it can't be
+            // grouped on — carry the raw class/message alongside it, which is what
+            // actually identifies the failing substep (TASK-21956).
             posthog.capture(ANALYTICS_EVENTS.SEND_LINK_FAILED, {
                 amount: tokenValue,
                 error_message: errorString,
+                error_name: error instanceof Error ? error.name : 'unknown',
+                error_raw: error instanceof Error ? error.message : String(error),
             })
-            captureException(error)
+            // Tagged, or the noise filters drop it: a send link that dies on a
+            // failed fetch matched `networkIssues` in sentry.utils.ts and was
+            // silently discarded, leaving the user on "contact support" and us
+            // with nothing to look at — the exact gap in TASK-21956.
+            captureException(error, {
+                tags: { ...criticalFlowTags('send-link'), send_link_step: 'create' },
+                extra: { amount: tokenValue, hasAttachment: !!attachmentOptions?.rawFile },
+            })
         } finally {
             setLoadingState('Idle')
         }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3127,6 +3127,7 @@
         "notDeployedOnChain": "Bulk is not able on this chain, please try another chain.",
         "userRejectedRequest": "Please confirm the request in your wallet.",
         "networkError": "A network error occured. Please refresh and try again.",
+        "connectionLost": "Connection lost. Check your internet connection and try again.",
         "nonceExpired": "Nonce expired, please try again.",
         "walletNotConnected": "Please make sure your wallet is connected.",
         "gasExceedsAllowance": "Gas required exceeds balance. Please confirm you have enough funds.",

--- a/src/i18n/app/messages/en.marketing.json
+++ b/src/i18n/app/messages/en.marketing.json
@@ -64,6 +64,7 @@
         "notDeployedOnChain": "Bulk is not able on this chain, please try another chain.",
         "userRejectedRequest": "Please confirm the request in your wallet.",
         "networkError": "A network error occured. Please refresh and try again.",
+        "connectionLost": "Connection lost. Check your internet connection and try again.",
         "nonceExpired": "Nonce expired, please try again.",
         "walletNotConnected": "Please make sure your wallet is connected.",
         "gasExceedsAllowance": "Gas required exceeds balance. Please confirm you have enough funds.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3127,6 +3127,7 @@
         "notDeployedOnChain": "Bulk no está disponible en esta red, prueba con otra red.",
         "userRejectedRequest": "Confirma la solicitud en tu billetera.",
         "networkError": "Ocurrió un error de red. Actualiza la página e inténtalo de nuevo.",
+        "connectionLost": "Se perdió la conexión. Revisa tu conexión a internet e inténtalo de nuevo.",
         "nonceExpired": "El nonce expiró, inténtalo de nuevo.",
         "walletNotConnected": "Asegúrate de que tu billetera esté conectada.",
         "gasExceedsAllowance": "El gas requerido supera tu saldo. Confirma que tienes fondos suficientes.",

--- a/src/i18n/app/messages/es-419.marketing.json
+++ b/src/i18n/app/messages/es-419.marketing.json
@@ -64,6 +64,7 @@
         "notDeployedOnChain": "Bulk no está disponible en esta red, prueba con otra red.",
         "userRejectedRequest": "Confirma la solicitud en tu billetera.",
         "networkError": "Ocurrió un error de red. Actualiza la página e inténtalo de nuevo.",
+        "connectionLost": "Se perdió la conexión. Revisa tu conexión a internet e inténtalo de nuevo.",
         "nonceExpired": "El nonce expiró, inténtalo de nuevo.",
         "walletNotConnected": "Asegúrate de que tu billetera esté conectada.",
         "gasExceedsAllowance": "El gas requerido supera tu saldo. Confirma que tienes fondos suficientes.",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1231,6 +1231,7 @@
         "notDeployedOnChain": "Bulk no está disponible en esta red, probá con otra red.",
         "userRejectedRequest": "Confirmá la solicitud en tu billetera.",
         "networkError": "Ocurrió un error de red. Actualizá la página e intentalo de nuevo.",
+        "connectionLost": "Se perdió la conexión. Revisá tu conexión a internet e intentá de nuevo.",
         "nonceExpired": "El nonce expiró, intentalo de nuevo.",
         "walletNotConnected": "Asegurate de que tu billetera esté conectada.",
         "gasExceedsAllowance": "El gas requerido supera tu saldo. Confirmá que tenés fondos suficientes.",

--- a/src/i18n/app/messages/es-AR.marketing.json
+++ b/src/i18n/app/messages/es-AR.marketing.json
@@ -11,6 +11,7 @@
         "notDeployedOnChain": "Bulk no está disponible en esta red, probá con otra red.",
         "userRejectedRequest": "Confirmá la solicitud en tu billetera.",
         "networkError": "Ocurrió un error de red. Actualizá la página e intentalo de nuevo.",
+        "connectionLost": "Se perdió la conexión. Revisá tu conexión a internet e intentá de nuevo.",
         "nonceExpired": "El nonce expiró, intentalo de nuevo.",
         "walletNotConnected": "Asegurate de que tu billetera esté conectada.",
         "gasExceedsAllowance": "El gas requerido supera tu saldo. Confirmá que tenés fondos suficientes.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3127,6 +3127,7 @@
         "notDeployedOnChain": "O Bulk não está disponível nesta rede, tente outra rede.",
         "userRejectedRequest": "Confirme a solicitação na sua carteira.",
         "networkError": "Ocorreu um erro de rede. Atualize a página e tente novamente.",
+        "connectionLost": "Conexão perdida. Verifique sua conexão com a internet e tente novamente.",
         "nonceExpired": "O nonce expirou, tente novamente.",
         "walletNotConnected": "Verifique se a sua carteira está conectada.",
         "gasExceedsAllowance": "O gas necessário excede o seu saldo. Confirme se você tem fundos suficientes.",

--- a/src/i18n/app/messages/pt-BR.marketing.json
+++ b/src/i18n/app/messages/pt-BR.marketing.json
@@ -64,6 +64,7 @@
         "notDeployedOnChain": "O Bulk não está disponível nesta rede, tente outra rede.",
         "userRejectedRequest": "Confirme a solicitação na sua carteira.",
         "networkError": "Ocorreu um erro de rede. Atualize a página e tente novamente.",
+        "connectionLost": "Conexão perdida. Verifique sua conexão com a internet e tente novamente.",
         "nonceExpired": "O nonce expirou, tente novamente.",
         "walletNotConnected": "Verifique se a sua carteira está conectada.",
         "gasExceedsAllowance": "O gas necessário excede o seu saldo. Confirme se você tem fundos suficientes.",

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -309,4 +309,22 @@ describe('browser-native fetch rejection (TASK-21956)', () => {
         const wrapped = Object.assign(new Error('Failed to fetch'), { name: 'ServiceUnavailableError' })
         expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'networkBusyTimeout' })
     })
+
+    // 21 services throw `Failed to fetch <thing>: <status>` for a response that
+    // DID arrive and carry no `status` for the ApiError branch to catch. A
+    // substring match would tell those users their connection is down.
+    test.each([
+        ['chargesApi.get on a 500', new Error('Failed to fetch charge: Internal Server Error')],
+        ['useLimits on a 503', new Error('Failed to fetch limits: Service Unavailable')],
+        ['quests leaderboard', new Error('Failed to fetch leaderboards')],
+    ])('%s is a server error, not lost connectivity', (_case, error) => {
+        expect(friendlyError(error)).toEqual({ kind: 'code', code: 'genericSupport' })
+    })
+
+    test('a TypeError whose message merely CONTAINS the engine copy is not claimed', () => {
+        expect(friendlyError(new TypeError('Failed to fetch charge: Internal Server Error'))).toEqual({
+            kind: 'code',
+            code: 'genericSupport',
+        })
+    })
 })

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -141,6 +141,7 @@ describe('friendly error copy catalog', () => {
         'sendLinkAlreadyClaimed',
         'lowLiquidity',
         'networkBusyTimeout',
+        'connectionLost',
         'sessionExpired',
         'genericSupport',
         'staleCardApproval',
@@ -286,5 +287,26 @@ describe('chain-infrastructure outage on claim', () => {
         // genuinely unclassified 500, must not start advertising a retry
         const unclassified = new Error('An unexpected error occurred. Please try again or contact support.')
         expect(friendlyError(unclassified)).toEqual({ kind: 'code', code: 'genericSupport' })
+    })
+})
+
+describe('browser-native fetch rejection (TASK-21956)', () => {
+    // Hugo lost connectivity mid-send on Android 1.0.53 (OTA ota-1.0.56) and was
+    // told to contact support. `TypeError: Failed to fetch` matched none of the
+    // classifiers — only the ethers-style uppercase `NETWORK_ERROR` was mapped —
+    // so the one error whose real advice is "you're offline" got the fallback.
+    test.each([
+        ['Chromium / Android WebView', new TypeError('Failed to fetch')],
+        ['WebKit', new TypeError('Load failed')],
+        ['Gecko', new TypeError('NetworkError when attempting to fetch resource.')],
+    ])('%s fetch rejection maps to connectionLost, not the support fallback', (_engine, error) => {
+        expect(friendlyError(error)).toEqual({ kind: 'code', code: 'connectionLost' })
+    })
+
+    test('a wrapped fetch failure still prefers the more specific wrapper code', () => {
+        // fetchWithSentry already classifies its own failures; the new matcher
+        // sits last so it can never steal one of those.
+        const wrapped = Object.assign(new Error('Failed to fetch'), { name: 'ServiceUnavailableError' })
+        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'networkBusyTimeout' })
     })
 })

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -79,6 +79,7 @@ export type FriendlyErrorCode =
     | 'sendLinkAlreadyClaimed'
     | 'lowLiquidity'
     | 'networkBusyTimeout'
+    | 'connectionLost'
     | 'sessionExpired'
     | 'connectionTimeout'
     | 'genericSupport'
@@ -276,5 +277,20 @@ export const friendlyError = (error: unknown): FriendlyError => {
         text.includes('timed out after')
     )
         return code('networkBusyTimeout')
+    // Browser-native fetch rejection — the request never reached a server, so
+    // there is no status and no wire code to key off, only the engine's own
+    // TypeError copy: `Failed to fetch` (Chromium, so every Android WebView),
+    // `Load failed` (WebKit), `NetworkError when attempting to fetch resource.`
+    // (Gecko). None of them match the ethers-style uppercase `NETWORK_ERROR`
+    // above, so a device that simply lost connectivity mid-send dead-ended on
+    // "contact support" — the one failure whose real advice is "you're offline,
+    // try again" (TASK-21956). Last before the fallback so it can never shadow
+    // a more specific classification.
+    if (
+        text.includes('Failed to fetch') ||
+        text.includes('Load failed') ||
+        text.includes('NetworkError when attempting to fetch resource')
+    )
+        return code('connectionLost')
     return code('genericSupport')
 }

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -286,10 +286,19 @@ export const friendlyError = (error: unknown): FriendlyError => {
     // "contact support" — the one failure whose real advice is "you're offline,
     // try again" (TASK-21956). Last before the fallback so it can never shadow
     // a more specific classification.
+    //
+    // Matched on the native `TypeError` name AND the engine message EXACTLY,
+    // never as a substring: 21 of our own services throw
+    // `Failed to fetch <thing>: <status>` (e.g. chargesApi.get on a 500) for a
+    // response that very much DID arrive, and those carry no `status` to be
+    // caught by the ApiError branch above. A substring match would tell a user
+    // whose connection is fine that they are offline — the same mislabelling
+    // this whole change exists to remove, pointed the other way.
     if (
-        text.includes('Failed to fetch') ||
-        text.includes('Load failed') ||
-        text.includes('NetworkError when attempting to fetch resource')
+        name === 'TypeError' &&
+        (message === 'Failed to fetch' ||
+            message === 'Load failed' ||
+            message === 'NetworkError when attempting to fetch resource.')
     )
         return code('connectionLost')
     return code('genericSupport')


### PR DESCRIPTION
Closes TASK-21956.

## What was reported

Hugo hit the generic "contact support" error creating a $9 Send link on Android, retried, and it worked ~2 minutes later. The ticket noted the telling part: **there was no `send_link_failed` event and no matching Sentry issue** — a reported, user-visible failure that left no trace anywhere.

## What actually happened

His device lost connectivity. PostHog caught it independently of Sentry:

```
2026-08-27T13:42:41Z  $exception  TypeError: Failed to fetch
```

Corroboration:

- Sentry has him as `3de931e9…`, `environment: native`, release `d4bd3ab` (= `ota-1.0.56`), on `https://localhost/send/`.
- His PostHog session starts at **13:42:26** — the failing attempts around 13:40:56 emitted *nothing*, not even a `$pageview`. posthog-js's retry queue is in-memory, so killing the app (which he did between attempts) drops it. That, not a missing code path, is why `send_link_failed` is absent.
- The successful retry routed `card_withdraw_attempted → strategy: smart-only` and succeeded 5s later. No Rain collateral, no paymaster, no deposit-index involvement — the DoD's substep list collapses.
- Same device logged 17 consecutive `/rain/cards timed out after 20000ms` that morning: same flaky-network signature.

**Not a stale app.** 1.0.53 is the current native version (`package.json` on `dev`), and the JS was an OTA bundle ~19h old at the time.

## Two bugs, both compounding

**1. `Failed to fetch` was unclassified.** The only network matcher keyed off ethers' uppercase `NETWORK_ERROR`. Browser-native fetch rejections — `Failed to fetch` (Chromium/Android WebView), `Load failed` (WebKit), `NetworkError when attempting to fetch resource.` (Gecko) — all missed it and fell through to `genericSupport`, whose es-419 string is *verbatim* the screenshot: "Hubo un problema con tu solicitud. Contacta con soporte."

**2. The same string is on Sentry's drop-list.** `IGNORED_ERRORS.networkIssues` in `sentry.utils.ts` contains `'Failed to fetch'` and `'Load failed'`, and the send-link catch called bare `captureException` — so `beforeSend` returned `null`. That is the whole explanation for the missing Sentry event.

The two interlock: the one error class that produces the misleading copy is the same one we were configured to throw away.

`criticalFlowTags` already exists to solve exactly this — its doc comment literally describes "a send that dies on a failed fetch was being dropped by the `networkIssues` filter" — but `useDirectSendFlow` was its **only** caller.

## Changes

- New `connectionLost` friendly-error code covering all three engines' copy, matched **last** so it can't shadow a more specific classification. Copy added for en / es-419 / es-AR (voseo) / pt-BR; marketing catalogs regenerated.
- Both send-link `captureException` sites tagged `criticalFlowTags('send-link')` + `send_link_step`, so create-time and background-persist failures stay distinguishable.
- `send_link_failed` now carries `error_name` / `error_raw` alongside the existing `error_message` (which is the *localized* string the user saw and can't be grouped across locales).

## Scale

Last 7 days: `Failed to fetch` 4,474 events / 270 users; `Load failed` 4,123 / 207 users. Not all in the send flow, but that's the population being told to contact support when their connection dropped.

## Tradeoff worth a reviewer's eye

Tagging critical-flow bypasses the `alreadyReported` filter for this flow, so a send-link failure caused by a wrapped fetch can now be counted at both the fetch site and here. Same tradeoff already accepted for direct-send, and the right side of it for a money-moving flow.

## Not done here

- `qr-pay` and `withdraw` have the same untagged-capture gap. Deliberately out of scope — worth a follow-up.
- No finer substep instrumentation inside `useCreateLink`. It now comes free from the stack trace, since the exception is no longer discarded.

## Verification

- `pnpm typecheck` clean
- `friendly-error.utils.test.tsx` — 32 passed (4 new, incl. an ordering guard that the wrapper codes still win)
- `Initial.link.send.view.test.tsx` — 7 passed
- i18n catalog suites (`messages`, `app/messages`, `marketing-messages`) — 35 passed
- `prettier --check` clean