### PR TITLE
feat(receipt): official public receipt + small defect sweep

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -9,7 +9,7 @@ import { useSafeBack } from '@/hooks/useSafeBack'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
 import Card from '@/components/Global/Card'
 import { Button } from '@/components/0_Bruddle/Button'
-import { Icon } from '@/components/Global/Icons/Icon'
+import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { mantecaApi } from '@/services/manteca'
 import type { QrPayment, QrPaymentLock } from '@/services/manteca'
 import NavHeader from '@/components/Global/NavHeader'
@@ -1097,7 +1097,7 @@ export default function QRPayPage() {
                                       }),
                                   variant: 'purple' as const,
                                   shadowSize: '4' as const,
-                                  icon: 'upload',
+                                  icon: 'upload-cloud' satisfies IconName,
                               }
                             : isRestartIdentity
                               ? {
@@ -1105,7 +1105,7 @@ export default function QRPayPage() {
                                     onClick: () => sumsubFlow.handleRestartIdentity(),
                                     variant: 'purple' as const,
                                     shadowSize: '4' as const,
-                                    icon: 'upload',
+                                    icon: 'upload-cloud' satisfies IconName,
                                 }
                               : {
                                     text: tCommon('contactSupport'),

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useEffect } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import NavHeader from '@/components/Global/NavHeader'
 import PeanutLoading from '@/components/Global/PeanutLoading'
 import { TransactionDetailsReceipt } from '@/components/TransactionDetails/TransactionDetailsReceipt'
+import { ReceiptUnavailable } from '@/components/TransactionDetails/ReceiptUnavailable'
 import { mapTransactionDataForDrawer } from '@/components/TransactionDetails/transactionTransformer'
 import { resolveReceiptKind } from '@/components/TransactionDetails/strategies/registry'
 import { TRANSACTIONS } from '@/constants/query.consts'
@@ -18,7 +18,6 @@ import { completeHistoryEntry, isFinalState, type HistoryEntry } from '@/utils/h
 // deep link — the most common push destination — had nothing to render natively.
 // deepLinkToNativePath maps /receipt/<id>?kind=X onto this route's query params.
 export default function NativeReceiptPage() {
-    const router = useRouter()
     const searchParams = useSearchParams()
     const entryId = searchParams.get('id')
     const kind = resolveReceiptKind(searchParams.get('kind') ?? undefined, searchParams.get('t') ?? undefined)
@@ -41,22 +40,20 @@ export default function NativeReceiptPage() {
 
     // `isError` also trips on a failed background poll, so gate the bail-out on
     // having no data at all — a flaky refetch must not yank the user off a
-    // receipt they're watching settle.
-    const isUnrecoverable = !entryId || !kind || (isError && !entry)
-
-    useEffect(() => {
-        if (isUnrecoverable) router.replace('/home')
-    }, [isUnrecoverable, router])
-
-    if (isUnrecoverable) return null
+    // receipt they're watching settle. An unresolvable link (or a fetch that
+    // never produced data) shows the branded unavailable state instead of a
+    // silent bounce to /home.
+    const unavailable = !entryId || !kind ? 'gone' : isError && !entry ? 'loadFailed' : undefined
 
     return (
-        <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">
-            <div className="md:hidden">
+        <PageContainer className="receipt-page flex min-h-[100dvh] flex-col items-center justify-center p-6">
+            <div className="md:hidden print:hidden">
                 <NavHeader titleKey="receipt" />
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
-                {isLoading || !entry ? (
+                {unavailable ? (
+                    <ReceiptUnavailable variant={unavailable} />
+                ) : isLoading || !entry ? (
                     <PeanutLoading />
                 ) : (
                     <TransactionDetailsReceipt

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -26,6 +26,7 @@ export default function NativeReceiptPage() {
         data: entry,
         isLoading,
         isError,
+        refetch,
     } = useQuery({
         queryKey: [TRANSACTIONS, 'entry', entryId, kind],
         enabled: Boolean(entryId && kind),
@@ -52,7 +53,10 @@ export default function NativeReceiptPage() {
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
                 {unavailable ? (
-                    <ReceiptUnavailable variant={unavailable} />
+                    <ReceiptUnavailable
+                        variant={unavailable}
+                        onRetry={unavailable === 'loadFailed' ? () => void refetch() : undefined}
+                    />
                 ) : isLoading || !entry ? (
                     <PeanutLoading />
                 ) : (

--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -1,6 +1,7 @@
 import { connection } from 'next/server'
 import { notFound } from 'next/navigation'
-import { isFinalState } from '@/utils/history.utils'
+import { captureException } from '@sentry/nextjs'
+import { isFinalState, type HistoryEntry } from '@/utils/history.utils'
 import { getHistoryEntry } from '@/app/actions/history'
 import {
     mapTransactionDataForDrawer,
@@ -8,6 +9,7 @@ import {
 } from '@/components/TransactionDetails/transactionTransformer'
 import { resolveReceiptKind } from '@/components/TransactionDetails/strategies/registry'
 import { TransactionDetailsReceipt } from '@/components/TransactionDetails/TransactionDetailsReceipt'
+import { ReceiptUnavailable } from '@/components/TransactionDetails/ReceiptUnavailable'
 import NavHeader from '@/components/Global/NavHeader'
 import { generateMetadata as generateBaseMetadata } from '@/app/metadata'
 import { type Metadata } from 'next'
@@ -125,13 +127,18 @@ export async function generateMetadata({
         return basicMetadata
     }
 
-    const entry = await getHistoryEntry(entryId, kind)
-    if (!entry) {
+    let transactionDetails: TransactionDetails
+    try {
+        const entry = await getHistoryEntry(entryId, kind)
+        if (!entry) {
+            return basicMetadata
+        }
+        // Transform the entry data to get readable transaction details
+        transactionDetails = mapTransactionDataForDrawer(entry).transactionDetails
+    } catch {
+        // the page body reports the failure; metadata just degrades
         return basicMetadata
     }
-
-    // Transform the entry data to get readable transaction details
-    const { transactionDetails } = mapTransactionDataForDrawer(entry)
 
     // Generate dynamic title and description
     const title = generateReceiptTitle(transactionDetails)
@@ -178,24 +185,51 @@ export default async function ReceiptPage({
     const { entryId } = await params
     const resolvedParams = await searchParams
     const kind = resolveReceiptKind(resolvedParams.kind, resolvedParams.t)
+    // No resolvable kind — most often a pre-May-2026 `?t=` link whose id no
+    // longer resolves. A hard 404 reads as breakage on a link users hold, so
+    // show a branded explanation instead.
     if (!entryId || !kind) {
-        notFound()
+        return <ReceiptShell state="gone" />
     }
-    const entry = await getHistoryEntry(entryId, kind)
+    let entry: HistoryEntry | null
+    try {
+        entry = await getHistoryEntry(entryId, kind)
+    } catch (error) {
+        // A BE hiccup was crashing the whole Server Components render
+        // (PEANUT-UI-4S9); keep the Sentry signal but render a retryable state.
+        captureException(error)
+        return <ReceiptShell state="loadFailed" />
+    }
     if (!entry) {
         notFound()
     }
     if (!isFinalState(entry)) {
         await connection()
     }
-    const { transactionDetails } = mapTransactionDataForDrawer(entry)
+    let transactionDetails: TransactionDetails | undefined
+    try {
+        transactionDetails = mapTransactionDataForDrawer(entry).transactionDetails
+    } catch (error) {
+        captureException(error)
+    }
+    if (!transactionDetails) {
+        return <ReceiptShell state="loadFailed" />
+    }
     return (
-        <PageContainer className="flex min-h-[100dvh] flex-col items-center justify-center p-6">
-            <div className="md:hidden">
+        <ReceiptShell>
+            <TransactionDetailsReceipt className="w-full" transaction={transactionDetails} isPublic />
+        </ReceiptShell>
+    )
+}
+
+function ReceiptShell({ state, children }: { state?: 'gone' | 'loadFailed'; children?: React.ReactNode }) {
+    return (
+        <PageContainer className="receipt-page flex min-h-[100dvh] flex-col items-center justify-center p-6">
+            <div className="md:hidden print:hidden">
                 <NavHeader titleKey="receipt" />
             </div>
             <div className="flex flex-1 flex-col items-center justify-center">
-                <TransactionDetailsReceipt className="w-full" transaction={transactionDetails!} isPublic />
+                {state ? <ReceiptUnavailable variant={state} /> : children}
             </div>
         </PageContainer>
     )

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -82,7 +82,7 @@ export const InitiateKycModal = ({
         return t('initiate.descriptionDefault')
     }
 
-    const getCta = () => {
+    const getCta = (): { text: string; onClick: () => void; icon?: IconName } => {
         if (error || isBlocked) {
             return {
                 text: tCommon('contactSupport'),
@@ -102,14 +102,14 @@ export const InitiateKycModal = ({
             return {
                 text: isLoading ? tCommon('loading') : t('initiate.titleRestartIdentity'),
                 onClick: onVerify,
-                icon: 'upload' as IconName,
+                icon: 'upload-cloud',
             }
         }
         if (isProviderRejection) {
             return {
                 text: isLoading ? tCommon('loading') : t('initiate.ctaUploadDocument'),
                 onClick: onVerify,
-                icon: 'upload' as IconName,
+                icon: 'upload-cloud',
             }
         }
         if (isCrossRegion) {
@@ -121,7 +121,7 @@ export const InitiateKycModal = ({
         return {
             text: isLoading ? tCommon('loading') : t('initiate.ctaUnlockNow'),
             onClick: onVerify,
-            icon: 'check-circle' as IconName,
+            icon: 'check-circle',
         }
     }
 

--- a/src/components/TransactionDetails/ReceiptUnavailable.tsx
+++ b/src/components/TransactionDetails/ReceiptUnavailable.tsx
@@ -9,10 +9,18 @@ import Card from '@/components/Global/Card'
 
 /**
  * Branded terminal state for a receipt link that cannot render: 'gone' for
- * legacy `?t=` links whose id no longer resolves (pre-May-2026 share URLs),
- * 'loadFailed' for a transient fetch/transform failure worth retrying.
+ * legacy `?t=` links whose id no longer resolves (pre-May-2026 share URLs) —
+ * permanently dead, no retry — and 'loadFailed' for a transient
+ * fetch/transform failure, which offers a Retry (the caller's refetch when
+ * provided, else a full reload of the same URL for the server route).
  */
-export function ReceiptUnavailable({ variant = 'gone' }: { variant?: 'gone' | 'loadFailed' }) {
+export function ReceiptUnavailable({
+    variant = 'gone',
+    onRetry,
+}: {
+    variant?: 'gone' | 'loadFailed'
+    onRetry?: () => void
+}) {
     const t = useTranslations('transaction.receiptUnavailable')
     const tCommon = useTranslations('common')
     const tNav = useTranslations('navigation')
@@ -28,8 +36,22 @@ export function ReceiptUnavailable({ variant = 'gone' }: { variant?: 'gone' | 'l
                     {variant === 'gone' ? t('description') : t('loadFailedDescription')}
                 </p>
             </Card>
+            {variant === 'loadFailed' && (
+                <Button
+                    variant="purple"
+                    shadowSize="4"
+                    className="w-full print:hidden"
+                    onClick={() => (onRetry ? onRetry() : window.location.reload())}
+                >
+                    {tCommon('retry')}
+                </Button>
+            )}
             <Link href="/home" className="w-full print:hidden">
-                <Button variant="purple" shadowSize="4" className="w-full">
+                <Button
+                    variant={variant === 'loadFailed' ? 'primary-soft' : 'purple'}
+                    shadowSize="4"
+                    className="w-full"
+                >
                     {tCommon('goToHome')}
                 </Button>
             </Link>

--- a/src/components/TransactionDetails/ReceiptUnavailable.tsx
+++ b/src/components/TransactionDetails/ReceiptUnavailable.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+import PEANUT_LOGO from '@/assets/logos/peanut-logo.svg'
+import { Button } from '@/components/0_Bruddle/Button'
+import Card from '@/components/Global/Card'
+
+/**
+ * Branded terminal state for a receipt link that cannot render: 'gone' for
+ * legacy `?t=` links whose id no longer resolves (pre-May-2026 share URLs),
+ * 'loadFailed' for a transient fetch/transform failure worth retrying.
+ */
+export function ReceiptUnavailable({ variant = 'gone' }: { variant?: 'gone' | 'loadFailed' }) {
+    const t = useTranslations('transaction.receiptUnavailable')
+    const tCommon = useTranslations('common')
+    const tNav = useTranslations('navigation')
+
+    return (
+        <div className="flex w-full max-w-md flex-col items-center gap-6 text-center">
+            <Image src={PEANUT_LOGO} alt={tNav('peanutLogoAlt')} className="w-28" />
+            <Card position="single" className="w-full space-y-2 px-6 py-8">
+                <h1 className="text-lg font-bold text-black">
+                    {variant === 'gone' ? t('title') : t('loadFailedTitle')}
+                </h1>
+                <p className="text-sm text-grey-1">
+                    {variant === 'gone' ? t('description') : t('loadFailedDescription')}
+                </p>
+            </Card>
+            <Link href="/home" className="w-full print:hidden">
+                <Button variant="purple" shadowSize="4" className="w-full">
+                    {tCommon('goToHome')}
+                </Button>
+            </Link>
+        </div>
+    )
+}

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -769,9 +769,10 @@ export const TransactionDetailsReceipt = ({
                             label={t('officialReceipt.reference')}
                             value={
                                 <div className="flex items-center gap-2">
-                                    <span>{shortenAddress(transaction.id.toUpperCase(), 20)}</span>
+                                    {/* uppercase is display-only: the raw id is a case-sensitive lookup key */}
+                                    <span className="uppercase">{shortenAddress(transaction.id, 20)}</span>
                                     <span className="print:hidden">
-                                        <CopyToClipboard textToCopy={transaction.id.toUpperCase()} iconSize="4" />
+                                        <CopyToClipboard textToCopy={transaction.id} iconSize="4" />
                                     </span>
                                 </div>
                             }

--- a/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsReceipt.tsx
@@ -32,6 +32,7 @@ import DisplayIcon from '../Global/DisplayIcon'
 import { Icon } from '../Global/Icons/Icon'
 import { PerkIcon } from './PerkIcon'
 import { STAR_STRAIGHT_ICON } from '@/assets/icons'
+import PEANUT_LOGO from '@/assets/logos/peanut-logo.svg'
 import QRCodeWrapper from '../Global/QRCodeWrapper'
 import ShareButton from '../Global/ShareButton'
 import { TransactionDetailsHeaderCard } from './TransactionDetailsHeaderCard'
@@ -135,6 +136,7 @@ export const TransactionDetailsReceipt = ({
     const { isActivated } = useActivationStatus()
     const t = useAppTranslations('transaction')
     const tCommon = useTranslations('common')
+    const tNav = useTranslations('navigation')
     const formatDate = useReceiptDateFormatter()
     const bankAccountLabel = (type: string) => {
         const key = bankAccountLabelKey(type)
@@ -301,6 +303,11 @@ export const TransactionDetailsReceipt = ({
 
     const feeDisplay = transaction.fee !== undefined ? formatAmount(transaction.fee as number) : 'N/A'
 
+    // Official-receipt issue date: the settlement timestamp when there is one,
+    // else creation. `formatDate` renders an em dash for anything unparsable.
+    const issuedAtSource = transaction.completedAt ?? transaction.claimedAt ?? transaction.createdAt ?? transaction.date
+    const issuedAt = issuedAtSource ? new Date(issuedAtSource) : undefined
+
     // QR + Share + Cancel block: pending, has a link, and either the sender of
     // a send-link OR the recipient of a request. Both gates route through the
     // kind-keyed predicates so adding a new flow only needs a predicate update.
@@ -372,6 +379,24 @@ export const TransactionDetailsReceipt = ({
 
     return (
         <div ref={contentRef} className={twMerge('space-y-4', className)}>
+            {/* official header — only the shared/public receipt carries branding */}
+            {isPublic && (
+                <div className="flex items-center justify-between">
+                    <Image src={PEANUT_LOGO} alt={tNav('peanutLogoAlt')} className="h-6 w-auto" />
+                    <div className="text-right text-xs text-grey-1">
+                        <p className="font-semibold">{t('officialReceipt.issuedBy')}</p>
+                        <a
+                            href="https://peanut.me"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline print:no-underline"
+                        >
+                            {'peanut.me'}
+                        </a>
+                    </div>
+                </div>
+            )}
+
             {/* show qr code at the top if applicable */}
             {shouldShowQrShare && transaction.extraDataForDrawer?.link && (
                 <QRCodeWrapper url={transaction.extraDataForDrawer.link} />
@@ -449,7 +474,7 @@ export const TransactionDetailsReceipt = ({
                     {rowVisibilityConfig.createdAt && (
                         <PaymentInfoRow
                             label={t('rows.created')}
-                            value={formatDate(new Date(transaction.createdAt!.toString()))}
+                            value={formatDate(transaction.createdAt ? new Date(transaction.createdAt) : undefined)}
                             hideBottomBorder={shouldHideBorder('createdAt')}
                         />
                     )}
@@ -735,6 +760,31 @@ export const TransactionDetailsReceipt = ({
                 </div>
             </Card>
 
+            {/* official footer — reference + issue date so the shared page
+                reads as a document, not an app screen */}
+            {isPublic && (
+                <Card position="single" className="px-4 py-0" border={true}>
+                    <div className="space-y-0 [&>*:last-child]:border-b-0">
+                        <PaymentInfoRow
+                            label={t('officialReceipt.reference')}
+                            value={
+                                <div className="flex items-center gap-2">
+                                    <span>{shortenAddress(transaction.id.toUpperCase(), 20)}</span>
+                                    <span className="print:hidden">
+                                        <CopyToClipboard textToCopy={transaction.id.toUpperCase()} iconSize="4" />
+                                    </span>
+                                </div>
+                            }
+                        />
+                        <PaymentInfoRow
+                            label={t('officialReceipt.issuedOn')}
+                            value={formatDate(issuedAt)}
+                            hideBottomBorder
+                        />
+                    </div>
+                </Card>
+            )}
+
             {/* Over-capture explainer — the words for the Initial hold /
                 Adjustment rows in the details card and the merchant-recourse
                 path. First of the notices: it explains THIS receipt's numbers;
@@ -755,7 +805,7 @@ export const TransactionDetailsReceipt = ({
 
             {/* share and cancel buttons section (only if qr is shown) */}
             {shouldShowQrShare && transaction.extraDataForDrawer?.link && (
-                <div className="space-y-2 pr-1">
+                <div className="space-y-2 pr-1 print:hidden">
                     {' '}
                     {/* added space-y for button separation */}
                     <ShareButton url={transaction.extraDataForDrawer.link} title={t('actions.shareLinkTitle')}>
@@ -910,7 +960,7 @@ export const TransactionDetailsReceipt = ({
             ) : (
                 <button
                     onClick={() => setIsSupportModalOpen(true)}
-                    className="flex w-full items-center justify-center gap-2 text-sm font-medium text-grey-1 underline transition-colors hover:text-black"
+                    className="flex w-full items-center justify-center gap-2 text-sm font-medium text-grey-1 underline transition-colors hover:text-black print:hidden"
                 >
                     <Icon name="peanut-support" size={16} className="text-grey-1" />
                     {t('actions.reportIssue')}

--- a/src/components/TransactionDetails/__tests__/ReceiptUnavailable.test.tsx
+++ b/src/components/TransactionDetails/__tests__/ReceiptUnavailable.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { ReceiptUnavailable } from '../ReceiptUnavailable'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: Record<string, unknown>) => React.createElement('img', props as Record<string, string>),
+}))
+
+jest.mock('@/assets/logos/peanut-logo.svg', () => 'peanut-logo.svg')
+
+const renderVariant = (variant?: 'gone' | 'loadFailed') =>
+    render(
+        <IntlWrapper>
+            <ReceiptUnavailable variant={variant} />
+        </IntlWrapper>
+    )
+
+describe('ReceiptUnavailable', () => {
+    test('defaults to the gone copy with branding and a home CTA', () => {
+        renderVariant()
+        expect(screen.getByText('This receipt link is no longer available')).toBeInTheDocument()
+        expect(screen.getByAltText('Peanut Logo')).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /go to home/i })).toHaveAttribute('href', '/home')
+    })
+
+    test('loadFailed shows the retryable copy', () => {
+        renderVariant('loadFailed')
+        expect(screen.getByText("We couldn't load this receipt")).toBeInTheDocument()
+        expect(screen.queryByText('This receipt link is no longer available')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/TransactionDetails/__tests__/ReceiptUnavailable.test.tsx
+++ b/src/components/TransactionDetails/__tests__/ReceiptUnavailable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
 import { ReceiptUnavailable } from '../ReceiptUnavailable'
 
@@ -10,24 +10,49 @@ jest.mock('next/image', () => ({
 
 jest.mock('@/assets/logos/peanut-logo.svg', () => 'peanut-logo.svg')
 
-const renderVariant = (variant?: 'gone' | 'loadFailed') =>
+const renderVariant = (variant?: 'gone' | 'loadFailed', onRetry?: () => void) =>
     render(
         <IntlWrapper>
-            <ReceiptUnavailable variant={variant} />
+            <ReceiptUnavailable variant={variant} onRetry={onRetry} />
         </IntlWrapper>
     )
 
 describe('ReceiptUnavailable', () => {
-    test('defaults to the gone copy with branding and a home CTA', () => {
+    test('defaults to the gone copy with branding and a home CTA — and no retry', () => {
         renderVariant()
         expect(screen.getByText('This receipt link is no longer available')).toBeInTheDocument()
         expect(screen.getByAltText('Peanut Logo')).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /go to home/i })).toHaveAttribute('href', '/home')
+        expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument()
     })
 
-    test('loadFailed shows the retryable copy', () => {
+    test('loadFailed shows the retryable copy and a Retry button', () => {
         renderVariant('loadFailed')
         expect(screen.getByText("We couldn't load this receipt")).toBeInTheDocument()
         expect(screen.queryByText('This receipt link is no longer available')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+
+    test('Retry fires the provided onRetry (native twin refetch)', () => {
+        const onRetry = jest.fn()
+        renderVariant('loadFailed', onRetry)
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+        expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    test('Retry without onRetry falls back to a full reload (server route)', () => {
+        const reload = jest.fn()
+        const originalLocation = window.location
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, reload },
+        })
+        try {
+            renderVariant('loadFailed')
+            fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+            expect(reload).toHaveBeenCalledTimes(1)
+        } finally {
+            Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+        }
     })
 })

--- a/src/hooks/useOtaUpdates.ts
+++ b/src/hooks/useOtaUpdates.ts
@@ -18,6 +18,7 @@ export function useOtaUpdates() {
     useEffect(() => {
         if (!isCapacitor()) return
 
+        let disposed = false
         let cleanup: (() => void) | undefined
 
         import('@/utils/capgo-updater')
@@ -29,13 +30,17 @@ export function useOtaUpdates() {
                 )
             )
             .then((fn) => {
-                cleanup = fn
+                // Unmounted while init was still resolving: run the cleanup now
+                // or the listeners it registered are never removed.
+                if (disposed) fn()
+                else cleanup = fn
             })
             .catch((err) => {
                 console.warn('[capgo] ota init failed:', err)
             })
 
         return () => {
+            disposed = true
             cleanup?.()
         }
     }, [])

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1732,6 +1732,17 @@
     },
     "transaction": {
         "drawerTitle": "Transaction Details",
+        "officialReceipt": {
+            "issuedBy": "Issued by Peanut",
+            "reference": "Receipt reference",
+            "issuedOn": "Issued on"
+        },
+        "receiptUnavailable": {
+            "title": "This receipt link is no longer available",
+            "description": "The transaction may still exist, but this shared link can't display it anymore.",
+            "loadFailedTitle": "We couldn't load this receipt",
+            "loadFailedDescription": "Please try again in a moment."
+        },
         "noGoalSet": "No goal set",
         "amountCollected": "${amount} collected",
         "contributors": "Contributors ({count})",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1732,6 +1732,17 @@
     },
     "transaction": {
         "drawerTitle": "Detalles de la transacción",
+        "officialReceipt": {
+            "issuedBy": "Emitido por Peanut",
+            "reference": "Referencia del recibo",
+            "issuedOn": "Fecha de emisión"
+        },
+        "receiptUnavailable": {
+            "title": "Este enlace de recibo ya no está disponible",
+            "description": "La transacción puede seguir existiendo, pero este enlace compartido ya no puede mostrarla.",
+            "loadFailedTitle": "No pudimos cargar este recibo",
+            "loadFailedDescription": "Inténtalo de nuevo en un momento."
+        },
         "noGoalSet": "Sin meta definida",
         "amountCollected": "${amount} recaudados",
         "contributors": "Contribuyentes ({count})",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1732,6 +1732,17 @@
     },
     "transaction": {
         "drawerTitle": "Detalhes da transação",
+        "officialReceipt": {
+            "issuedBy": "Emitido pela Peanut",
+            "reference": "Referência do recibo",
+            "issuedOn": "Emitido em"
+        },
+        "receiptUnavailable": {
+            "title": "Este link de recibo não está mais disponível",
+            "description": "A transação pode ainda existir, mas este link compartilhado não pode mais exibi-la.",
+            "loadFailedTitle": "Não foi possível carregar este recibo",
+            "loadFailedDescription": "Tente novamente em instantes."
+        },
         "noGoalSet": "Sem meta definida",
         "amountCollected": "${amount} arrecadados",
         "contributors": "Contribuidores ({count})",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -912,3 +912,17 @@ input::placeholder {
 .content-page tbody tr:nth-child(even) {
     @apply bg-primary-3/30;
 }
+
+/* ── Print (public receipt) ── */
+
+@media print {
+    body {
+        background: #fff !important;
+    }
+    * {
+        box-shadow: none !important;
+    }
+    .receipt-page {
+        padding: 0 !important;
+    }
+}

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -175,13 +175,73 @@ describe('ApiError HTTP status discrimination', () => {
         expect(friendlyError(apiError(503))).toEqual({ kind: 'code', code: 'networkBusyTimeout' })
     })
 
-    test('a 4xx ApiError with an unmapped message still falls through to genericSupport', () => {
-        expect(friendlyError(apiError(422))).toEqual({ kind: 'code', code: 'genericSupport' })
+    test('a 4xx ApiError with an unmapped human message surfaces the backend copy verbatim', () => {
+        expect(friendlyError(apiError(422))).toEqual({ kind: 'text', text: 'authorization required' })
     })
 
     test('a numeric status on a non-ApiError is ignored', () => {
         const ethersish = Object.assign(new Error('server error'), { status: 500 })
         expect(friendlyError(ethersish)).toEqual({ kind: 'code', code: 'genericSupport' })
+    })
+})
+
+describe('unmatched backend messages (genericSupport fallback)', () => {
+    const apiError = (message: string, status = 422) => Object.assign(new Error(message), { name: 'ApiError', status })
+
+    test('an unmapped ApiError message is surfaced instead of discarded', () => {
+        const err = apiError('Withdrawals to this bank are temporarily paused')
+        expect(friendlyError(err)).toEqual({ kind: 'text', text: 'Withdrawals to this bank are temporarily paused' })
+    })
+
+    test('an unmapped plain Error keeps the support fallback — only our ApiError passes through', () => {
+        expect(friendlyError(new Error('Withdrawals to this bank are temporarily paused'))).toEqual({
+            kind: 'code',
+            code: 'genericSupport',
+        })
+    })
+
+    test.each([
+        ['empty', '   '],
+        ['multi-line dump', 'Request failed\n    at withdraw (bank.ts:12)'],
+        ['URL dump', 'GET https://api.peanut.me/bridge/transfers failed'],
+        ['JSON body', '{"error":"boom"}'],
+        ['our own fetch fallback', 'Failed to create charge'],
+        ['over-long prose', 'x'.repeat(201)],
+    ])('a technical ApiError message (%s) still gets genericSupport', (_label, message) => {
+        expect(friendlyError(apiError(message))).toEqual({ kind: 'code', code: 'genericSupport' })
+    })
+
+    test('matched messages keep their code — the passthrough only fires on the fallback', () => {
+        expect(friendlyError(apiError('insufficient funds', 402))).toEqual({
+            kind: 'code',
+            code: 'insufficientFunds',
+        })
+    })
+})
+
+describe('one-level .cause walk on the fallback', () => {
+    test('an unmatched wrapper is classified by its cause', () => {
+        const wrapped = new Error('withdraw leg failed', { cause: new Error('insufficient funds') })
+        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'insufficientFunds' })
+    })
+
+    test('a matched wrapper is NOT reclassified by its cause', () => {
+        const wrapped = new Error('User rejected the request', { cause: new Error('insufficient funds') })
+        expect(friendlyError(wrapped)).toEqual({ kind: 'code', code: 'userRejectedRequest' })
+    })
+
+    test('the walk is one level deep, not recursive', () => {
+        const deep = new Error('outer', { cause: new Error('middle', { cause: new Error('insufficient funds') }) })
+        expect(friendlyError(deep)).toEqual({ kind: 'code', code: 'genericSupport' })
+    })
+
+    test('an unmapped ApiError hanging off .cause is surfaced verbatim', () => {
+        const backendErr = Object.assign(new Error('Amount is below the provider minimum'), {
+            name: 'ApiError',
+            status: 422,
+        })
+        const wrapped = new Error('withdraw leg failed', { cause: backendErr })
+        expect(friendlyError(wrapped)).toEqual({ kind: 'text', text: 'Amount is below the provider minimum' })
     })
 })
 

--- a/src/utils/__tests__/friendly-error.utils.test.tsx
+++ b/src/utils/__tests__/friendly-error.utils.test.tsx
@@ -193,6 +193,14 @@ describe('unmatched backend messages (genericSupport fallback)', () => {
         expect(friendlyError(err)).toEqual({ kind: 'text', text: 'Withdrawals to this bank are temporarily paused' })
     })
 
+    test('decimal amounts and abbreviations are not mistaken for domains', () => {
+        const err = apiError('Amount is below the 5.00 USD minimum, e.g. try a larger transfer')
+        expect(friendlyError(err)).toEqual({
+            kind: 'text',
+            text: 'Amount is below the 5.00 USD minimum, e.g. try a larger transfer',
+        })
+    })
+
     test('an unmapped plain Error keeps the support fallback — only our ApiError passes through', () => {
         expect(friendlyError(new Error('Withdrawals to this bank are temporarily paused'))).toEqual({
             kind: 'code',
@@ -204,6 +212,9 @@ describe('unmatched backend messages (genericSupport fallback)', () => {
         ['empty', '   '],
         ['multi-line dump', 'Request failed\n    at withdraw (bank.ts:12)'],
         ['URL dump', 'GET https://api.peanut.me/bridge/transfers failed'],
+        ['schemeless www link', 'visit www.evil.com to unlock withdrawals'],
+        ['bare domain', 'Payout paused — see status.peanut-verify.example.com'],
+        ['domain with path', 'complete verification at evil.co/kyc first'],
         ['JSON body', '{"error":"boom"}'],
         ['our own fetch fallback', 'Failed to create charge'],
         ['over-long prose', 'x'.repeat(201)],

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -53,11 +53,18 @@ export async function initCapgoUpdater(
     // The check itself is deferred past first paint so its network round-trip
     // and bundle download don't contend with app startup (notifyAppReady above
     // stays immediate — it must land within appReadyTimeout).
+    let updateCheckTimer: ReturnType<typeof setTimeout> | undefined
     if (!isDemoMode()) {
-        setTimeout(() => void checkAndStageUpdate(onUpdateAvailable, onUpdateFailed), UPDATE_CHECK_DELAY_MS)
+        updateCheckTimer = setTimeout(
+            () => void checkAndStageUpdate(onUpdateAvailable, onUpdateFailed),
+            UPDATE_CHECK_DELAY_MS
+        )
     }
 
-    return () => listeners.forEach((l) => l.remove())
+    return () => {
+        clearTimeout(updateCheckTimer)
+        listeners.forEach((l) => l.remove())
+    }
 }
 
 const UPDATE_CHECK_DELAY_MS = 5_000

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -160,7 +160,9 @@ const displayableApiErrorMessage = (error: unknown): string | null => {
     if (typeof message !== 'string') return null
     const trimmed = message.trim()
     if (!trimmed || trimmed.length > 200 || trimmed.includes('\n')) return null
+    // no links, scheme-prefixed or bare (www.evil.com / evil.com/path)
     if (/https?:\/\//i.test(trimmed)) return null
+    if (/(?:^|[\s(["'])(?:[a-z0-9][a-z0-9-]*\.)+[a-z]{2,}(?=$|[\s)\]"'.,!?:;/])/i.test(trimmed)) return null
     if (trimmed.startsWith('{') || trimmed.startsWith('<')) return null
     if (/^failed to /i.test(trimmed)) return null
     return trimmed

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -151,10 +151,47 @@ const cooldownMinutes = (error: unknown): number | null => {
     return Math.max(1, Math.ceil(sec / 60))
 }
 
+/** A backend-authored ApiError message worth showing verbatim: short single-line
+ *  prose, not a technical dump (URL, JSON/HTML body, stack) and not one of our
+ *  own "Failed to …" fetch fallbacks. */
+const displayableApiErrorMessage = (error: unknown): string | null => {
+    if (apiErrorStatus(error) === undefined) return null
+    const message = (error as { message?: unknown }).message
+    if (typeof message !== 'string') return null
+    const trimmed = message.trim()
+    if (!trimmed || trimmed.length > 200 || trimmed.includes('\n')) return null
+    if (/https?:\/\//i.test(trimmed)) return null
+    if (trimmed.startsWith('{') || trimmed.startsWith('<')) return null
+    if (/^failed to /i.test(trimmed)) return null
+    return trimmed
+}
+
+const isGenericSupport = (result: FriendlyError): boolean => result.kind === 'code' && result.code === 'genericSupport'
+
 /** UI-friendly error classifier. Matches substrings on common wallet / viem /
  *  Peanut API error messages and returns a display code (or verbatim backend
- *  text). Preserves the exact precedence of the original `ErrorHandler`. */
+ *  text). Preserves the exact precedence of the original `ErrorHandler`.
+ *
+ *  When nothing matches, before giving up on `genericSupport` it re-runs the
+ *  matchers on ONE level of `.cause` (fetch wrappers rethrow with the real
+ *  failure attached there), then surfaces a displayable backend-authored
+ *  ApiError message verbatim rather than discarding the actual reason. */
 export const friendlyError = (error: unknown): FriendlyError => {
+    const classified = classifyError(error)
+    if (!isGenericSupport(classified)) return classified
+
+    const cause = error && typeof error === 'object' ? (error as { cause?: unknown }).cause : undefined
+    if (cause !== undefined && cause !== null) {
+        const fromCause = classifyError(cause)
+        if (!isGenericSupport(fromCause)) return fromCause
+    }
+
+    const backendMessage = displayableApiErrorMessage(error) ?? displayableApiErrorMessage(cause)
+    if (backendMessage) return passthrough(backendMessage)
+    return code('genericSupport')
+}
+
+const classifyError = (error: unknown): FriendlyError => {
     const { text, message, name } = extractErrorParts(error)
 
     // Wire code first: it's locale-independent and immune to backend copy


### PR DESCRIPTION
Covers TASK-19830 (part 1 — official look; the PDF download follows in a stacked PR) and most of the TASK-21405 FE small-defect batch.

## TASK-19830 — receipts don't look official / pre-intent receipts broken
- Public receipts (`isPublic`) now carry the Peanut wordmark, an "Issued by Peanut" + peanut.me issuer line, and a footer card with the receipt reference (entry id, copyable) and issue date. In-app receipts are pixel-unchanged (render-baseline suite green).
- Print support: `@media print` drops shadows/background and hides nav/CTAs, so the receipt prints as a document.
- Pre-intent `?t=` links: evidence from the pre-migration `getReceiptUrl` shows only indices {3,9,10,11,13} were ever emitted; {3,9,10,11} are already mapped and 13 (SimpleFi) is provably unresolvable — so no new mappings exist to add. Instead, unresolvable links get a branded "this receipt is no longer available" state instead of a hard 404, and the native twin shows the same state instead of silently bouncing to /home.

## TASK-21405 (partial)
- **Receipt SSR crash (PEANUT-UI-4S9, 17 users):** Sentry showed only digest-only client pickups (no server frame); code reading pinned the unguarded throw paths — `getHistoryEntry` (BE 400/5xx/network) and the drawer transform — as the only candidates on the route. Both are now guarded (Sentry signal kept via `captureException`) and render a retryable state; the `transactionDetails!`/`createdAt!` asserts are gone; `generateMetadata` degrades to basic metadata.
- **`Icon "upload" not found` (569 users):** the four call sites (InitiateKycModal + qr-pay KYC CTAs) now use `'upload-cloud'`, and the `as IconName` casts are replaced with real typing so the next bad name is a compile error.
- **Discarded withdraw error reasons:** `friendlyError`'s genericSupport fallback now (1) re-classifies one level of `.cause`, then (2) surfaces a displayable backend `ApiError` message verbatim through the existing `passthrough` mechanism (guarded: ≤200 chars, single line, no URLs/JSON/HTML). All matched mappings and the withdraw page's `errorAlreadyDisplayed` latch are untouched. (The card-issuance half of this item was already fixed on dev.)
- **Capacitor listener leaks:** the AppLock/stale-reload leaks from the ticket turned out already fixed on dev; the real remaining one was `useOtaUpdates` (unmount mid-init left Capgo listeners registered forever) — fixed with the established disposed-handle pattern, plus the capgo update-check timer is cleared on cleanup.

### Deferred from TASK-21405 (noted on the Notion card)
- Sourcemaps: `next.config.js` is correctly configured (`widenClientFileUpload`, delete-after-upload) — if `/home` frames are still minified the cause is CI env (`SENTRY_AUTH_TOKEN`) or the native config, not this repo's code; needs a Sentry artifact check, not a code change.
- Render-loop/201-listener cluster: no smoking gun without its Sentry event; the three cheap listener leaks are fixed here, the rest stays open.

## Tests
friendly-error (12 new cases), capgo-updater, registry, i18n key parity, render-baseline, ReceiptUnavailable DOM test — 169 tests green; typecheck clean; live SSR check: `?t=13` → 200 branded state, bogus id → 404.

Notion: TASK-19830 · TASK-21405