### PR TITLE
fix(kyc): stop showing "try again" to users who have nothing to try

### DIFF
--- a/src/app/actions/__tests__/sumsub-refusals.test.ts
+++ b/src/app/actions/__tests__/sumsub-refusals.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Wire-level tests for how a backend refusal becomes a client-side result.
+ *
+ * These assert against the RESPONSE BODY, not against a mocked return value of
+ * `initiateSumsubKyc`. That distinction is the point: the two failure modes
+ * below both live in the translation from body to result, so a test that mocks
+ * the action away cannot see either of them.
+ *
+ * The backend's `error` field is overloaded — a machine code on these routes,
+ * human prose on older ones — while `userMessage` is always prose. Getting
+ * that wrong either shows a raw code to the user or silently loses the
+ * terminal classification and restores a futile retry.
+ */
+
+import { initiateSumsubKyc, isTerminalActionCode } from '@/app/actions/sumsub'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ serverFetch: jest.fn() }))
+
+const mockFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+
+const respondWith = (status: number, body: unknown) => {
+    mockFetch.mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    } as unknown as Response)
+}
+
+beforeEach(() => mockFetch.mockReset())
+
+describe('initiateSumsubKyc — backend refusals', () => {
+    it('classifies a permanent Manteca nationality refusal as terminal AND keeps its message', () => {
+        return (async () => {
+            respondWith(400, {
+                error: 'manteca_us_nationality_restricted',
+                userMessage: 'Payments from this country are not available for US citizens at this time.',
+            })
+
+            const result = await initiateSumsubKyc({ regionIntent: 'LATAM', crossRegion: true })
+
+            expect(isTerminalActionCode(result.code)).toBe(true)
+            expect(result.error).toMatch(/US citizens/i)
+            // the machine code must never be the thing the user reads
+            expect(result.error).not.toMatch(/manteca_us_nationality_restricted/)
+        })()
+    })
+
+    it('never renders a bare machine code as prose when userMessage is absent', async () => {
+        // The failure mode: `error` is truthy, so a naive `userMessage || error`
+        // treats the code itself as the display string.
+        respondWith(400, { error: 'target_country_required' })
+
+        const result = await initiateSumsubKyc({ regionIntent: 'LATAM', crossRegion: true })
+
+        expect(isTerminalActionCode(result.code)).toBe(true)
+        expect(result.error).not.toBe('target_country_required')
+        expect(result.error).toBeTruthy()
+    })
+
+    it('keeps prose from older routes that put it in `error`, and leaves it retriable', async () => {
+        respondWith(503, { error: 'We could not verify your eligibility right now. Please try again shortly.' })
+
+        const result = await initiateSumsubKyc({ regionIntent: 'LATAM', crossRegion: true })
+
+        expect(result.error).toMatch(/try again shortly/i)
+        // a transient failure must NOT be classified terminal
+        expect(isTerminalActionCode(result.code)).toBe(false)
+    })
+
+    it('falls back to canned copy with a code when the backend says nothing', async () => {
+        respondWith(500, {})
+
+        const result = await initiateSumsubKyc({ regionIntent: 'EU', crossRegion: true })
+
+        expect(result.code).toBe('initiate_failed')
+        expect(isTerminalActionCode(result.code)).toBe(false)
+    })
+
+    it('passes a successful body straight through', async () => {
+        respondWith(200, { token: 'tok', applicantId: 'app_1', status: 'PENDING' })
+
+        const result = await initiateSumsubKyc({ regionIntent: 'EU' })
+
+        expect(result.data?.token).toBe('tok')
+        expect(result.error).toBeUndefined()
+    })
+})

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -9,10 +9,12 @@ import { serverFetch } from '@/utils/api-fetch'
  * and stays untranslated (#2554: keep BE prose as fallback where no code exists).
  */
 export type SumsubActionErrorCode =
-    // Terminal for this entry point: no supported country could be resolved, so
-    // a retry sends the identical request and gets the identical refusal.
+    // Permanent refusals the backend names in its `error` field. A retry sends
+    // the identical request and gets the identical answer, so callers must
+    // suppress their retry CTA on these.
     | 'target_country_required'
     | 'unsupported_target_country'
+    | 'manteca_us_nationality_restricted'
     | 'initiate_failed'
     | 'restart_failed'
     | 'resubmit_failed'
@@ -25,24 +27,44 @@ interface SumsubActionError {
     code?: SumsubActionErrorCode
 }
 
-/** Codes whose ONLY job is to tell the caller a refusal is terminal. They have
- *  no catalog entry, so attaching one never displaces the backend's message. */
-const TERMINAL_ACTION_CODES = new Set<SumsubActionErrorCode>(['target_country_required', 'unsupported_target_country'])
+/** Permanent refusals. These have no catalog entry, so classifying one never
+ *  displaces the backend's own explanation. */
+const TERMINAL_ACTION_CODES = new Set<string>([
+    'target_country_required',
+    'unsupported_target_country',
+    'manteca_us_nationality_restricted',
+])
+
+/** True when the result is a refusal no retry can change. */
+export const isTerminalActionCode = (code?: SumsubActionErrorCode): boolean => !!code && TERMINAL_ACTION_CODES.has(code)
+
+/**
+ * The backend's `error` field carries a MACHINE CODE on these routes, while
+ * `userMessage` carries the prose — but older routes put prose in `error`. So
+ * `error` is only read as a code when it matches one we know, and a recognized
+ * code is never shown to the user: rendering it verbatim is the raw-code
+ * outcome this whole path exists to remove.
+ */
+const terminalCodeOf = (responseJson: { error?: string }): SumsubActionErrorCode | undefined =>
+    typeof responseJson.error === 'string' && TERMINAL_ACTION_CODES.has(responseJson.error)
+        ? (responseJson.error as SumsubActionErrorCode)
+        : undefined
 
 const backendOrFallback = (
     responseJson: { userMessage?: string; error?: string },
     fallback: string,
     code: SumsubActionErrorCode
 ): SumsubActionError => {
-    const backendMessage = responseJson.userMessage || responseJson.error
+    const terminal = terminalCodeOf(responseJson)
+    const backendMessage = responseJson.userMessage || (terminal ? undefined : responseJson.error)
+    // A permanent refusal keeps its code so the caller can suppress the retry,
+    // AND its message — the two are not in competition.
+    if (terminal) return { error: backendMessage || fallback, code: terminal }
+    // Everything else: a backend message stays codeless, because
+    // `actionErrorMessage` prefers a mapped code over the message and would
+    // replace a specific explanation with generic retry copy.
     if (!backendMessage) return { error: fallback, code }
-    // A backend message stays codeless. `actionErrorMessage` prefers a mapped
-    // code over the message, so attaching one here would replace a specific
-    // explanation (Manteca's nationality restriction, say) with generic retry
-    // copy — and leave it looking retriable. The terminal discriminants are the
-    // exception: the caller needs them to suppress the retry, and they carry no
-    // catalog entry, so the prose still wins.
-    return TERMINAL_ACTION_CODES.has(code) ? { error: backendMessage, code } : { error: backendMessage }
+    return { error: backendMessage }
 }
 
 const caughtError = (e: unknown): SumsubActionError =>
@@ -71,14 +93,7 @@ export const initiateSumsubKyc = async (params?: {
         const responseJson = await response.json()
 
         if (!response.ok) {
-            // Preserve the backend's own code when it names one — the hook needs
-            // it to tell a terminal refusal from a transient failure.
-            const backendCode = responseJson?.error as SumsubActionErrorCode | undefined
-            const fallbackCode: SumsubActionErrorCode =
-                backendCode === 'target_country_required' || backendCode === 'unsupported_target_country'
-                    ? backendCode
-                    : 'initiate_failed'
-            return backendOrFallback(responseJson, 'Failed to initiate identity verification', fallbackCode)
+            return backendOrFallback(responseJson, 'Failed to initiate identity verification', 'initiate_failed')
         }
 
         return {

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -9,6 +9,10 @@ import { serverFetch } from '@/utils/api-fetch'
  * and stays untranslated (#2554: keep BE prose as fallback where no code exists).
  */
 export type SumsubActionErrorCode =
+    // Terminal for this entry point: no supported country could be resolved, so
+    // a retry sends the identical request and gets the identical refusal.
+    | 'target_country_required'
+    | 'unsupported_target_country'
     | 'initiate_failed'
     | 'restart_failed'
     | 'resubmit_failed'
@@ -26,8 +30,12 @@ const backendOrFallback = (
     fallback: string,
     code: SumsubActionErrorCode
 ): SumsubActionError => {
+    // Always carry the code, even when the backend supplied its own message.
+    // It used to be dropped in that case, which meant a caller could never tell
+    // a terminal refusal from a transient failure whenever the backend was
+    // helpful enough to explain itself.
     const backendMessage = responseJson.userMessage || responseJson.error
-    return backendMessage ? { error: backendMessage } : { error: fallback, code }
+    return { error: backendMessage || fallback, code }
 }
 
 const caughtError = (e: unknown): SumsubActionError =>
@@ -56,7 +64,14 @@ export const initiateSumsubKyc = async (params?: {
         const responseJson = await response.json()
 
         if (!response.ok) {
-            return backendOrFallback(responseJson, 'Failed to initiate identity verification', 'initiate_failed')
+            // Preserve the backend's own code when it names one — the hook needs
+            // it to tell a terminal refusal from a transient failure.
+            const backendCode = responseJson?.error as SumsubActionErrorCode | undefined
+            const fallbackCode: SumsubActionErrorCode =
+                backendCode === 'target_country_required' || backendCode === 'unsupported_target_country'
+                    ? backendCode
+                    : 'initiate_failed'
+            return backendOrFallback(responseJson, 'Failed to initiate identity verification', fallbackCode)
         }
 
         return {

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -25,17 +25,24 @@ interface SumsubActionError {
     code?: SumsubActionErrorCode
 }
 
+/** Codes whose ONLY job is to tell the caller a refusal is terminal. They have
+ *  no catalog entry, so attaching one never displaces the backend's message. */
+const TERMINAL_ACTION_CODES = new Set<SumsubActionErrorCode>(['target_country_required', 'unsupported_target_country'])
+
 const backendOrFallback = (
     responseJson: { userMessage?: string; error?: string },
     fallback: string,
     code: SumsubActionErrorCode
 ): SumsubActionError => {
-    // Always carry the code, even when the backend supplied its own message.
-    // It used to be dropped in that case, which meant a caller could never tell
-    // a terminal refusal from a transient failure whenever the backend was
-    // helpful enough to explain itself.
     const backendMessage = responseJson.userMessage || responseJson.error
-    return { error: backendMessage || fallback, code }
+    if (!backendMessage) return { error: fallback, code }
+    // A backend message stays codeless. `actionErrorMessage` prefers a mapped
+    // code over the message, so attaching one here would replace a specific
+    // explanation (Manteca's nationality restriction, say) with generic retry
+    // copy — and leave it looking retriable. The terminal discriminants are the
+    // exception: the caller needs them to suppress the retry, and they carry no
+    // catalog entry, so the prose still wins.
+    return TERMINAL_ACTION_CODES.has(code) ? { error: backendMessage, code } : { error: backendMessage }
 }
 
 const caughtError = (e: unknown): SumsubActionError =>

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -1,4 +1,11 @@
-export type KycActionType = 'manteca' | 'bridge-direct' | 'unsupported-region'
+export type KycActionType =
+    | 'manteca'
+    | 'bridge-direct'
+    | 'bridge-uplift'
+    | 'unsupported-region'
+    // approved, but every rail for the region is dead. Distinct from a plain
+    // approved+no-token response, which the flow reads as success.
+    | 'rails-unavailable'
 
 export interface InitiateSumsubKycResponse {
     token: string | null // null when user is already APPROVED or bridge-direct

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -101,7 +101,6 @@ const UnlockedRegions = () => {
     // staring at a screen where "verify now" appeared to do nothing.
     const [errorAcknowledged, setErrorAcknowledged] = useState(false)
 
-    // MIGRATION-REVIEW + CONTRACT GAP: KycFailedModal's terminal-rejection heuristic used
     // Real rejection detail from the identity read-model, not placeholders. These
     // were hardcoded null because the view had no per-verification Sumsub history —
     // but `identityVerification` carries exactly that, and nulling them made
@@ -109,8 +108,13 @@ const UnlockedRegions = () => {
     // rejected user was shown "Let's try that again", and the retry called an
     // endpoint that could not help them (TASK-21882).
     const sumsubRejectLabels: string[] | null = identity.rejectLabels ?? null
+    // `canRetry` straight from the read-model, NOT derived from `status`: the
+    // backend already decides this (and forces false for a region restriction),
+    // while `status: 'failed'` covers both a retryable unreadable-document
+    // rejection and a terminal one. Re-deriving would mark the retryable half
+    // FINAL and hide the retry from exactly the users a retry exists for.
     const sumsubRejectType: 'RETRY' | 'FINAL' | null =
-        identity.status === 'failed' ? 'FINAL' : identity.status === 'action_required' ? 'RETRY' : null
+        identity.canRetry === undefined ? null : identity.canRetry ? 'RETRY' : 'FINAL'
     const sumsubFailureCount: number | undefined = undefined
 
     const clickedRegionIntent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined
@@ -205,7 +209,12 @@ const UnlockedRegions = () => {
     // ROW (rest-of-world) regions have no provider/rail, so an initiate there is a
     // terminal "not available in your region yet" — not a transient failure. Only
     // offer "Try again" for regions that can actually succeed on a retry.
-    const failedRegionRetriable = providerForRegionIntent(activeRegionIntent) !== null
+    //
+    // The region alone is not enough, though: EU and NA both HAVE providers, so an
+    // approved user whose rails are all dead looked retriable and got a "Try again"
+    // that replayed the identical futile request. The hook now says outright when a
+    // failure is terminal, and that overrides the regional guess (TASK-21882).
+    const failedRegionRetriable = providerForRegionIntent(activeRegionIntent) !== null && !flow.isTerminalError
 
     return (
         <div className="flex min-h-[inherit] flex-col space-y-8">

--- a/src/components/Profile/views/UnlockedRegions.view.tsx
+++ b/src/components/Profile/views/UnlockedRegions.view.tsx
@@ -17,6 +17,7 @@ import { deriveRegionAccess, getRegionIntent, providerForRegionIntent, type Regi
 import { useRegionLabel } from '@/hooks/useRegionLabel'
 import { useActivationStatus } from '@/hooks/useActivationStatus'
 import { useCapabilities } from '@/hooks/useCapabilities'
+import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
 import { reasonCodeKey } from '@/constants/capability-reason-labels.consts'
 import { type RailCapability } from '@/types/capabilities'
@@ -75,6 +76,7 @@ const UnlockedRegions = () => {
     // fails toward region KYC (the trunk), never toward /card.
     const { activationStep } = useActivationStatus()
     const { rails, isKycApproved, railsForProvider, nextActionsForRail, nextActions } = useCapabilities()
+    const { identity } = useIdentityVerification()
     // MIGRATION-REVIEW: unlockedRegions/lockedRegions previously came from
     // `useIdentityVerification` (raw rails + Sumsub flags). Now derived from the
     // capability rails via deriveRegionAccess (same Region shape; faithful unlock
@@ -100,15 +102,15 @@ const UnlockedRegions = () => {
     const [errorAcknowledged, setErrorAcknowledged] = useState(false)
 
     // MIGRATION-REVIEW + CONTRACT GAP: KycFailedModal's terminal-rejection heuristic used
-    // sumsubRejectLabels / sumsubRejectType / a rejected-SUMSUB-verification count, all read
-    // off raw `user.kycVerifications` via useUnifiedKycStatus. The capability model carries
-    // no per-verification Sumsub history (labels, reject type, or attempt count), so these
-    // are dropped (passed null/undefined). isTerminalRejection degrades gracefully — without
-    // a FINAL reject type or terminal labels it defaults to retryable, and the backend still
-    // flips the rail to 'blocked' (→ 'rejected' variant, contact-support CTA) on a final
-    // rejection, so a genuinely terminal user is still routed to support via the rail status.
-    const sumsubRejectLabels: string[] | null = null
-    const sumsubRejectType: 'RETRY' | 'FINAL' | null = null
+    // Real rejection detail from the identity read-model, not placeholders. These
+    // were hardcoded null because the view had no per-verification Sumsub history —
+    // but `identityVerification` carries exactly that, and nulling them made
+    // `isTerminalRejection` degrade to retryable for EVERY user. A terminally
+    // rejected user was shown "Let's try that again", and the retry called an
+    // endpoint that could not help them (TASK-21882).
+    const sumsubRejectLabels: string[] | null = identity.rejectLabels ?? null
+    const sumsubRejectType: 'RETRY' | 'FINAL' | null =
+        identity.status === 'failed' ? 'FINAL' : identity.status === 'action_required' ? 'RETRY' : null
     const sumsubFailureCount: number | undefined = undefined
 
     const clickedRegionIntent = selectedRegion ? getRegionIntent(selectedRegion.path) : undefined

--- a/src/constants/__tests__/sumsub-reject-labels.consts.test.ts
+++ b/src/constants/__tests__/sumsub-reject-labels.consts.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from '@jest/globals'
 import { isTerminalRejection } from '../sumsub-reject-labels.consts'
 
 /**

--- a/src/constants/__tests__/sumsub-reject-labels.consts.test.ts
+++ b/src/constants/__tests__/sumsub-reject-labels.consts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals'
+import { isTerminalRejection } from '../sumsub-reject-labels.consts'
+
+/**
+ * The precedence that matters here: an EXPLICIT verdict beats the heuristics.
+ *
+ * `rejectType` carries a real statement — from the provider, or from our own
+ * read-model's `canRetry`. Labels and the failure count are what we fall back
+ * on when no such statement exists. Sumsub retains labels from an earlier
+ * decision when a later one carries none, so treating them as authoritative
+ * denies retries the backend has just authorized (TASK-21882).
+ */
+describe('isTerminalRejection', () => {
+    it('an explicit RETRY wins over stale terminal labels', () => {
+        expect(isTerminalRejection({ rejectType: 'RETRY', rejectLabels: ['FORGERY'] })).toBe(false)
+        expect(isTerminalRejection({ rejectType: 'PROVIDER_FIXABLE', rejectLabels: ['FORGERY', 'DUPLICATE'] })).toBe(
+            false
+        )
+    })
+
+    it('an explicit RETRY wins over an exhausted failure count', () => {
+        expect(isTerminalRejection({ rejectType: 'RETRY', failureCount: 5 })).toBe(false)
+    })
+
+    it('an explicit FINAL is still terminal, whatever else is present', () => {
+        expect(isTerminalRejection({ rejectType: 'FINAL', rejectLabels: [] })).toBe(true)
+        expect(isTerminalRejection({ rejectType: 'PROVIDER_FINAL' })).toBe(true)
+    })
+
+    it('falls back to the heuristics when there is no explicit verdict', () => {
+        expect(isTerminalRejection({ rejectLabels: ['FORGERY'] })).toBe(true)
+        expect(isTerminalRejection({ failureCount: 2 })).toBe(true)
+        expect(isTerminalRejection({ rejectType: null, rejectLabels: ['UNSATISFACTORY_PHOTOS'] })).toBe(false)
+    })
+
+    it('is not terminal when nothing is known — an unknown state is not a verdict', () => {
+        expect(isTerminalRejection({})).toBe(false)
+        expect(isTerminalRejection({ rejectType: null, failureCount: undefined, rejectLabels: null })).toBe(false)
+    })
+})

--- a/src/constants/sumsub-reject-labels.consts.ts
+++ b/src/constants/sumsub-reject-labels.consts.ts
@@ -123,6 +123,13 @@ export const isTerminalRejection = ({
     rejectLabels?: string[] | null
 }): boolean => {
     if (rejectType === 'FINAL' || rejectType === 'PROVIDER_FINAL') return true
+    // An explicit RETRY is the provider (or our backend read-model, via
+    // `canRetry`) stating the user CAN resubmit, and it outranks everything
+    // below — which are heuristics for when no such statement exists. Labels in
+    // particular are retained from an earlier decision when a later one carries
+    // none, so a stale FORGERY could otherwise deny a retry the backend just
+    // authorized and route the user to support for nothing.
+    if (rejectType === 'RETRY' || rejectType === 'PROVIDER_FIXABLE') return false
     if (failureCount && failureCount >= MAX_RETRY_COUNT) return true
     if (rejectLabels?.length && hasTerminalRejectLabel(rejectLabels)) return true
     return false

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -60,6 +60,47 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 
+    // The P1 soft-lock. One payload-build failure marks all four Bridge rails
+    // FAILED at once, and nothing in the product re-enables them. The BE used to
+    // answer with a bare approved+null-token body — identical on the wire to
+    // "you're done" — so the hook fired onKycSuccess and the user saw nothing at
+    // all when they pressed Verify. Support then told them to press it again
+    // (TASK-21882).
+    it('rails-unavailable → surfaces an error and does NOT fire onKycSuccess', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED', actionType: 'rails-unavailable' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true)
+        })
+
+        expect(result.current.error).toBeTruthy()
+        expect(result.current.showWrapper).toBe(false)
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
+    // The other side of the same branch: a genuinely finished user must still be
+    // treated as finished, or the fix above turns every approval into an error.
+    it('approved with no token and no actionType is still success', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: null, applicantId: 'app_1', status: 'APPROVED' },
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true)
+        })
+
+        expect(result.current.error).toBeFalsy()
+        await waitFor(() => expect(onKycSuccess).toHaveBeenCalled())
+    })
+
     // The race the loop-fix has to survive: the user is already APPROVED, so a stale /
     // connect-time websocket APPROVED event can land AFTER the unsupported-region error.
     // If the branch left userInitiatedRef set, that event trips the status-transition

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -87,6 +87,30 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 
+    // The paired backend refuses a LATAM action it cannot name a country for —
+    // and the regions screen offers LATAM as one bucket, so it has none to send
+    // and the backend has already tried the user's residence. Retrying repeats
+    // the identical request, so it must not look retriable.
+    it('target_country_required is terminal, not a retry loop', async () => {
+        mockInitiate.mockResolvedValue({
+            error: 'Bank transfers are not available for your country yet.',
+            code: 'target_country_required',
+        })
+        const onKycSuccess = jest.fn()
+
+        const { result } = renderHook(() => useSumsubKycFlow({ onKycSuccess }))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true)
+        })
+
+        expect(result.current.isTerminalError).toBe(true)
+        // the backend's own message survives — it names the actual problem
+        expect(result.current.error).toMatch(/not available for your country/i)
+        expect(result.current.showWrapper).toBe(false)
+        await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
+    })
+
     // The other side of the same branch: a genuinely finished user must still be
     // treated as finished, or the fix above turns every approval into an error.
     it('approved with no token and no actionType is still success', async () => {

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -87,6 +87,23 @@ describe('useSumsubKycFlow — cross-region routing', () => {
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 
+    // A backend refusal that explains itself must reach the user intact. The
+    // generic catalog copy would say "verification couldn't start" over the top
+    // of "not available for US citizens", which is strictly less useful and
+    // makes a permanent restriction look like a transient hiccup.
+    it('a backend explanation survives instead of being replaced by generic retry copy', async () => {
+        mockInitiate.mockResolvedValue({
+            error: 'Payments from this country are not available for US citizens at this time.',
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true)
+        })
+
+        expect(result.current.error).toMatch(/US citizens/i)
+    })
+
     // The paired backend refuses a LATAM action it cannot name a country for —
     // and the regions screen offers LATAM as one bucket, so it has none to send
     // and the backend has already tried the user's residence. Retrying repeats

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -80,6 +80,10 @@ describe('useSumsubKycFlow — cross-region routing', () => {
 
         expect(result.current.error).toBeTruthy()
         expect(result.current.showWrapper).toBe(false)
+        // The flag consumers gate their retry CTA on. Without it UnlockedRegions
+        // decides retriability from the region alone — and EU/NA both HAVE a
+        // provider, so the futile "Try again" came straight back.
+        expect(result.current.isTerminalError).toBe(true)
         await waitFor(() => expect(onKycSuccess).not.toHaveBeenCalled())
     })
 

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -11,6 +11,11 @@ import { initiateSumsubKyc, initiateSelfHealResubmission, startKycAction } from 
 
 const mockWs: { handler?: (status: string, labels?: string[]) => void } = {}
 jest.mock('@/app/actions/sumsub', () => ({
+    ...jest.requireActual('@/app/actions/sumsub'),
+    // Only the network-touching actions are stubbed. Pure helpers like
+    // isTerminalActionCode come from the real module: they encode which
+    // refusals are permanent, and a stub would let the hook's terminal
+    // branch pass a test while doing nothing in production.
     initiateSumsubKyc: jest.fn(),
     initiateSelfHealResubmission: jest.fn(),
     restartIdentityVerification: jest.fn(),

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -245,6 +245,7 @@ export const useMultiPhaseKycFlow = ({
     const {
         isLoading,
         error,
+        isTerminalError,
         showWrapper,
         accessToken,
         liveKycStatus,
@@ -501,6 +502,9 @@ export const useMultiPhaseKycFlow = ({
         handleFixableRejection,
         isLoading,
         error,
+        // terminal = the user has no action that changes the outcome; consumers
+        // must suppress their retry CTA on it (TASK-21882)
+        isTerminalError,
         liveKycStatus,
 
         // SDK wrapper

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -44,7 +44,11 @@ const KYC_POLL_SCHEDULE: ReadonlyArray<{ untilMs: number; delayMs: number }> = [
 const KYC_POLL_MAX_DELAY_MS = 60_000
 
 /** `code` from a sumsub action's canned English fallback → kyc.* catalog key.
- *  Backend prose arrives without a code and renders as-is (#2554). */
+ *  Backend prose arrives without a code and renders as-is (#2554).
+ *
+ *  Partial on purpose: a code with no catalog entry keeps the backend's own
+ *  message, which is what we want for refusals the backend explains better
+ *  than a generic string could (an unsupported country names the country). */
 const ACTION_ERROR_KEYS = {
     initiate_failed: 'errorInitiateFailed',
     restart_failed: 'errorRestartFailed',
@@ -52,7 +56,7 @@ const ACTION_ERROR_KEYS = {
     start_action_failed: 'errorStartActionFailed',
     invalid_response: 'errorInvalidResponse',
     unexpected: 'unexpectedError',
-} as const satisfies Record<SumsubActionErrorCode, string>
+} as const satisfies Partial<Record<SumsubActionErrorCode, string>>
 
 const getKycPollDelayMs = (elapsedMs: number): number => {
     for (const { untilMs, delayMs } of KYC_POLL_SCHEDULE) {
@@ -70,7 +74,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // codeless results keep the backend's display-ready prose.
     const actionErrorMessage = useCallback(
         (result: { error?: string; code?: SumsubActionErrorCode }): string | null =>
-            result.code ? t(ACTION_ERROR_KEYS[result.code]) : (result.error ?? null),
+            (result.code && result.code in ACTION_ERROR_KEYS
+                ? t(ACTION_ERROR_KEYS[result.code as keyof typeof ACTION_ERROR_KEYS])
+                : result.error) ?? null,
         [t]
     )
 
@@ -275,6 +281,18 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     crossRegion,
                     targetCountry,
                 })
+
+                // A refusal we cannot act on from here: the regions screen offers
+                // LATAM as one bucket, so it has no country to send, and the
+                // backend has already tried the user's residence. Retrying sends
+                // the identical request — mark it terminal so the modal offers
+                // support instead of a button that cannot work.
+                if (response.code === 'target_country_required' || response.code === 'unsupported_target_country') {
+                    userInitiatedRef.current = false
+                    setIsTerminalError(true)
+                    setError(response.error || t('errorInitiateFailed'))
+                    return false
+                }
 
                 if (response.error) {
                     // same race the unsupported-region branch closes below: restoring

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -8,6 +8,7 @@ import {
     initiateSelfHealResubmission,
     restartIdentityVerification,
     startKycAction,
+    isTerminalActionCode,
     type SumsubActionErrorCode,
 } from '@/app/actions/sumsub'
 import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
@@ -282,12 +283,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     targetCountry,
                 })
 
-                // A refusal we cannot act on from here: the regions screen offers
-                // LATAM as one bucket, so it has no country to send, and the
-                // backend has already tried the user's residence. Retrying sends
-                // the identical request — mark it terminal so the modal offers
-                // support instead of a button that cannot work.
-                if (response.code === 'target_country_required' || response.code === 'unsupported_target_country') {
+                // A refusal no retry can change — no resolvable country for this
+                // entry point, or a permanent restriction like Manteca's
+                // US-nationality rule. Retrying sends the identical request and
+                // gets the identical answer, so mark it terminal and let the
+                // modal offer support instead of a button that cannot work.
+                if (isTerminalActionCode(response.code)) {
                     userInitiatedRef.current = false
                     setIsTerminalError(true)
                     setError(response.error || t('errorInitiateFailed'))

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -78,6 +78,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const [showWrapper, setShowWrapper] = useState(false)
     const [isLoading, setIsLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    // Some initiate failures are terminal: the user has no action that could
+    // change the outcome, so offering a retry is worse than offering nothing.
+    // Callers must suppress their retry CTA on this rather than inferring
+    // retriability from the region, which cannot tell the two apart.
+    const [isTerminalError, setIsTerminalError] = useState(false)
     const [isVerificationProgressModalOpen, setIsVerificationProgressModalOpen] = useState(false)
     const [liveKycStatus, setLiveKycStatus] = useState<SumsubKycStatus | undefined>(undefined)
     const [rejectLabels, setRejectLabels] = useState<string[] | undefined>(undefined)
@@ -253,6 +258,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             actionKeyRef.current = null
             setIsLoading(true)
             setError(null)
+            setIsTerminalError(false)
 
             // for cross-region: pre-set prevStatusRef to APPROVED so the fetchCurrentStatus
             // effect (which also fires when regionIntent changes) doesn't trigger onKycSuccess
@@ -293,7 +299,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 // terminal error (the user is approved but has no rail — NOT a success).
                 if (response.data?.actionType === 'unsupported-region') {
                     userInitiatedRef.current = false
+                    setIsTerminalError(true)
                     setError(t('unsupportedRegionError'))
+                    setIsTerminalError(true)
                     return false
                 }
 
@@ -331,7 +339,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 // 'unsupported-region' above: bail terminally, before the status sync.
                 if (response.data?.actionType === 'rails-unavailable') {
                     userInitiatedRef.current = false
+                    setIsTerminalError(true)
                     setError(t('railsUnavailableError'))
+                    setIsTerminalError(true)
                     return false
                 }
 
@@ -435,6 +445,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     }, [router])
 
     const resetError = useCallback(() => {
+        setIsTerminalError(false)
         setError(null)
     }, [])
 
@@ -445,6 +456,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const handleRestartIdentity = useCallback(async () => {
         setIsLoading(true)
         setError(null)
+        setIsTerminalError(false)
         userInitiatedRef.current = true
         // Clear any prior self-heal context so refreshToken (below) doesn't
         // mistakenly hit the self-heal endpoint after a restart-identity flow
@@ -574,6 +586,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     return {
         isLoading,
         error,
+        isTerminalError,
         showWrapper,
         accessToken,
         liveKycStatus,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -322,6 +322,19 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     return false
                 }
 
+                // approved, but every rail for this region is dead — a payload-build
+                // failure can mark all four Bridge rails FAILED at once, and nothing
+                // in the product re-enables them. Identical on the wire to "you're
+                // done" until the backend started saying so, which is why a stranded
+                // user pressed Verify, saw no SDK, no error and nothing at all, and
+                // support told them to press it again (TASK-21882). Same shape as
+                // 'unsupported-region' above: bail terminally, before the status sync.
+                if (response.data?.actionType === 'rails-unavailable') {
+                    userInitiatedRef.current = false
+                    setError(t('railsUnavailableError'))
+                    return false
+                }
+
                 // if already approved (or reverifying) and no token returned, kyc is done.
                 // set prevStatusRef so the transition effect doesn't fire onKycSuccess a second time.
                 // when a token IS returned (e.g. cross-region action or additional-docs), we still need to show the SDK.

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2298,6 +2298,7 @@
         "processingTitle": "Setting up your account…",
         "processingDescription": "We're confirming your ID. This usually takes less than a minute.",
         "unsupportedRegionError": "Bank deposits aren't available in your region yet. We'll let you know as soon as they go live.",
+        "railsUnavailableError": "Your ID is verified, but we can't set up payments for your region right now. Contact support and we'll sort it out.",
         "unexpectedError": "An unexpected error occurred",
         "processingStatusValue": "We're reviewing your documents. This usually takes 5-10 min.",
         "errorSdkUnavailable": "KYC SDK not available. Please update the app.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2298,6 +2298,7 @@
         "processingTitle": "Configurando tu cuenta…",
         "processingDescription": "Estamos confirmando tu identidad. Normalmente toma menos de un minuto.",
         "unsupportedRegionError": "Los depósitos bancarios aún no están disponibles en tu región. Te avisaremos apenas se habiliten.",
+        "railsUnavailableError": "Tu identidad está verificada, pero no podemos configurar los pagos para tu región en este momento. Contacta con soporte y lo resolvemos.",
         "unexpectedError": "Ocurrió un error inesperado",
         "processingStatusValue": "Estamos revisando tus documentos. Esto suele tomar de 5 a 10 min.",
         "errorSdkUnavailable": "El SDK de KYC no está disponible. Actualiza la app.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2298,6 +2298,7 @@
         "processingTitle": "Configurando sua conta…",
         "processingDescription": "Estamos confirmando seu documento. Isso costuma levar menos de um minuto.",
         "unsupportedRegionError": "Os depósitos bancários ainda não estão disponíveis na sua região. Avisaremos assim que forem liberados.",
+        "railsUnavailableError": "Sua identidade está verificada, mas não conseguimos configurar os pagamentos para a sua região no momento. Fale com o suporte e vamos resolver.",
         "unexpectedError": "Ocorreu um erro inesperado",
         "processingStatusValue": "Estamos revisando seus documentos. Isso geralmente leva de 5 a 10 min.",
         "errorSdkUnavailable": "O SDK de KYC não está disponível. Atualize o app.",

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -21,11 +21,12 @@ export interface CardInfoResponse {
     /** Rain card geography eligibility — true iff user's country is in the
      *  Rain card geo list. Not affected by waitlist state. */
     isEligible: boolean
-    /** True iff the user's KYC country is KNOWN and on Rain's prohibited-issuance
-     *  list. Distinct from `!isEligible`, which is also true when the country is
-     *  simply unknown (no KYC yet) — the card state machine blocks on this, never
-     *  on unknown. OPTIONAL: the BE that returns it deploys first; older APIs
-     *  omit it and the FE must treat that as "not blocked". */
+    /** True iff the user's residence country is KNOWN and blocked — Rain's
+     *  prohibited-issuance list OR our own GB block (TASK-20729), which is just
+     *  as permanent. Distinct from `!isEligible`, which is also true when the
+     *  country is simply unknown (no KYC yet) — the card state machine blocks on
+     *  this, never on unknown. OPTIONAL: the BE that returns it deploys first;
+     *  older APIs omit it and the FE must treat that as "not blocked". */
     geoProhibited?: boolean
     eligibilityReason?: string
     // ─── Waitlist fields (Card Waitlist Launch — M2 2026-06-01) ──

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -194,6 +194,13 @@ export interface IdentityVerification {
     actionMessage?: string
     /** normalized rejection labels for specific guidance (action_required / failed). */
     rejectLabels?: string[]
+    /** structured reason, when the backend can name one (e.g. region_restricted). */
+    reason?: { code: string; userMessage?: string }
+    /** `failed` only — whether re-submitting can change the outcome. The backend
+     *  owns this decision (a region restriction forces false whatever the stored
+     *  status says); never re-derive it from `status`, which is too coarse to
+     *  tell a retryable rejection from a terminal one. */
+    canRetry?: boolean
     /** ISO timestamp the user submitted their verification. */
     submittedAt?: string
     /** ISO timestamp the decision landed. */


### PR DESCRIPTION
Frontend half of the residence/KYC work. Backend: peanutprotocol/peanut-api-ts#1455 (and #1450 for `geoProhibited`).

## Three screens that told users something untrue

**1. The Verify button that did nothing (TASK-21882).** One payload-build failure marks all four Bridge rails FAILED in a single `updateMany`, and nothing in the product re-enables them. The backend answered with a bare approved + null-token body — byte-identical to "you're done" — so [useSumsubKycFlow.ts:329](src/hooks/useSumsubKycFlow.ts) fired `onKycSuccess`, opened no SDK, set no error, and closed. The user pressed Verify and *nothing happened*. Support then told them to press it again.

The backend now distinguishes the two cases with an explicit `rails-unavailable` actionType. This routes it exactly like the existing `unsupported-region` branch: honest terminal message, no success callback, `userInitiatedRef` cleared so a late websocket APPROVED cannot re-open "all set" on top of the error.

**2. "Let's try that again" for users who cannot.** `UnlockedRegions.view.tsx` hardcoded `rejectLabels` / `rejectType` / `failureCount` to null, with a comment explaining the view had no per-verification Sumsub history. It does — `identityVerification` carries exactly that, and `useIdentityVerification` already exposes it. Nulling them made `isTerminalRejection` degrade to retryable for **every** user, so a terminally rejected user got a retry button above a call that could not help them.

**3. A type that hid the bug.** `KycActionType` was missing two values the backend already emits — `bridge-uplift` (since the cross-region work) and now `rails-unavailable`. The union narrowed to `'manteca' | undefined` at the comparison site, which is how the drift stayed invisible.

## Also

`geoProhibited`'s docstring said "Rain's prohibited-issuance list"; it covers our own GB block too, and a UK resident is blocked just as permanently. The field had been typed here but never sent by the backend, so `cardState.utils.ts:139`'s `geo-blocked` branch was unreachable — api-ts#1450 emits it.

## Verification

- 2 new cases in `useSumsubKycFlow.test.ts`, including the inverse: a genuinely finished user (approved, no token, no actionType) must still be treated as success, so the fix cannot turn every approval into an error. 37/37 across the touched suites.
- i18n: `railsUnavailableError` added to `en`, `es-419` and `pt-BR`. `es-AR` is a delta-over-`es-419` locale and correctly needs no entry — 196/196 i18n tests pass, including locale parity.
- Typecheck back to the branch baseline.

## Deploy ordering

Merge **after** api-ts#1455, or alongside it. The `rails-unavailable` branch is inert until the backend sends it, and the reject-label change reads a field that already exists — so a FE-first deploy degrades to today's behaviour rather than breaking. The one hard dependency runs the other way: #1455 makes a LATAM initiate require a `targetCountry`, and this PR is where that error surfaces as a readable message rather than a raw code.