### PR TITLE
feat(telemetry): triage network-layer send failures — offline vs edge vs CORS-layer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -126,6 +126,10 @@ function contentSecurityPolicyReportOnly(includeReporting = true) {
             'https://*.analytics.google.com',
             'https://stats.g.doubleclick.net',
             'https://www.googletagmanager.com',
+            // Network-failure triage probe (network-triage.ts): Android's own
+            // captive-portal endpoint, used to tell "device offline" from "our
+            // edge unreachable" when a fetch dies without a status.
+            'https://www.gstatic.com',
             // Every Google country domain, because the remarketing beacon goes
             // to the user's own — see csp-google-domains.js for why this cannot
             // be a wildcard. Supersedes the former lone 'https://www.google.com'

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -446,6 +446,11 @@ export function beforeSendHandler(event: ErrorEvent): ErrorEvent | null {
     }
     collapseNoisyFingerprint(event)
     cleanSensitiveHeaders(event)
+    // Whether the device believed it was online at capture time — the free
+    // half of the TASK-21956 network triage (navigator is absent server-side).
+    if (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean') {
+        event.tags = { net_online: String(navigator.onLine), ...event.tags }
+    }
     return event
 }
 

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -13,7 +13,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import { isAmountWithinBalance } from '@/utils/balance.utils'
-import { captureException } from '@sentry/nextjs'
+import { captureNetworkTriagedFailure } from '@/utils/network-triage'
 import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useContext, useEffect, useMemo } from 'react'
@@ -130,7 +130,7 @@ const LinkSendInitialView = () => {
                 } catch (error) {
                     // we want to capture any errors here because we are already in the background
                     console.error(error)
-                    captureException(error, {
+                    void captureNetworkTriagedFailure(error, {
                         tags: { ...criticalFlowTags('send-link'), send_link_step: 'persist' },
                     })
                 }
@@ -139,22 +139,24 @@ const LinkSendInitialView = () => {
             // handle errors
             const errorString = toFriendlyError(error)
             setErrorState({ showError: true, errorMessage: errorString })
-            // `error_message` is the LOCALIZED copy the user saw, so it can't be
-            // grouped on — carry the raw class/message alongside it, which is what
-            // actually identifies the failing substep (TASK-21956).
-            posthog.capture(ANALYTICS_EVENTS.SEND_LINK_FAILED, {
-                amount: tokenValue,
-                error_message: errorString,
-                error_name: error instanceof Error ? error.name : 'unknown',
-                error_raw: error instanceof Error ? error.message : String(error),
-            })
             // Tagged, or the noise filters drop it: a send link that dies on a
             // failed fetch matched `networkIssues` in sentry.utils.ts and was
-            // silently discarded, leaving the user on "contact support" and us
-            // with nothing to look at — the exact gap in TASK-21956.
-            captureException(error, {
+            // silently discarded (TASK-21956). Fire-and-forget: the triage
+            // probes may take up to 2.5s and must not hold up `finally`.
+            // `error_message` is the LOCALIZED copy the user saw, so it can't be
+            // grouped on — error_name/error_raw carry the raw class alongside.
+            void captureNetworkTriagedFailure(error, {
                 tags: { ...criticalFlowTags('send-link'), send_link_step: 'create' },
                 extra: { amount: tokenValue, hasAttachment: !!attachmentOptions?.rawFile },
+                analytics: {
+                    event: ANALYTICS_EVENTS.SEND_LINK_FAILED,
+                    props: {
+                        amount: tokenValue,
+                        error_message: errorString,
+                        error_name: error instanceof Error ? error.name : 'unknown',
+                        error_raw: error instanceof Error ? error.message : String(error),
+                    },
+                },
             })
         } finally {
             setLoadingState('Idle')

--- a/src/features/payment-network-explorer/__tests__/sentryServerEdge.test.ts
+++ b/src/features/payment-network-explorer/__tests__/sentryServerEdge.test.ts
@@ -28,9 +28,25 @@ describe('server and edge payment explorer Sentry guard', () => {
         const normalTransaction = { transaction: 'GET /home', request: { url: 'https://peanut.me/home' } }
         expect(beforeSendRouteAwareTransaction(privateTransaction)).toBeNull()
         expect(beforeSendRouteAwareTransaction(normalTransaction)).toBe(normalTransaction)
+        // jsdom exposes navigator.onLine, so the kept event gains the ambient
+        // browser connectivity tag; the server/edge shape is the case below.
         expect(beforeSendRouteAwareHandler({ message: 'real error' } as ErrorEvent)).toEqual({
             message: 'real error',
+            tags: { net_online: 'true' },
         })
+    })
+
+    it('leaves kept events untagged when the runtime has no navigator.onLine (server/edge)', () => {
+        // Node and the Vercel edge runtime expose a navigator without onLine —
+        // model that by shadowing jsdom's prototype getter with undefined.
+        Object.defineProperty(navigator, 'onLine', { configurable: true, value: undefined })
+        try {
+            expect(beforeSendRouteAwareHandler({ message: 'real error' } as ErrorEvent)).toEqual({
+                message: 'real error',
+            })
+        } finally {
+            delete (navigator as { onLine?: boolean }).onLine
+        }
     })
 
     it.each(['sentry.server.config', 'sentry.edge.config'])('wires both route-aware hooks in %s', (moduleName) => {

--- a/src/features/payments/flows/direct-send/useDirectSendFlow.ts
+++ b/src/features/payments/flows/direct-send/useDirectSendFlow.ts
@@ -23,9 +23,9 @@ import { useAuth } from '@/context/authContext'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN, PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { useFriendlyError } from '@/hooks/useFriendlyError'
 import { useTranslations } from 'next-intl'
-import { captureException } from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { captureNetworkTriagedFailure } from '@/utils/network-triage'
 import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import { resolveSettledTxHash } from '@/utils/settled-tx-hash.utils'
 import { isDemoMode } from '@/utils/demo'
@@ -214,12 +214,9 @@ export function useDirectSendFlow() {
             // only WebAuthn-named failures to PostHog, so a send that ended in
             // "contact support" left no queryable record anywhere.
             const errorName = err instanceof Error ? err.name : 'unknown'
-            posthog.capture(ANALYTICS_EVENTS.SEND_FAILED, {
-                step: failedStep,
-                charge_id: chargeId,
-                error_name: errorName,
-            })
-            captureException(err, {
+            // Fire-and-forget: the triage probes may take up to 2.5s and must
+            // not hold up `finally` resetting the loading state.
+            void captureNetworkTriagedFailure(err, {
                 tags: { ...criticalFlowTags('direct-send'), send_step: failedStep },
                 extra: {
                     chargeId,
@@ -227,6 +224,14 @@ export function useDirectSendFlow() {
                     amount,
                     usdAmount,
                     userId: user?.user?.userId,
+                },
+                analytics: {
+                    event: ANALYTICS_EVENTS.SEND_FAILED,
+                    props: {
+                        step: failedStep,
+                        charge_id: chargeId,
+                        error_name: errorName,
+                    },
                 },
             })
         } finally {

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -1,0 +1,133 @@
+import {
+    captureNetworkTriagedFailure,
+    isNativeFetchRejection,
+    networkTriageTags,
+    triageNetworkFailure,
+} from '../network-triage'
+import { captureException } from '@sentry/nextjs'
+import posthog from 'posthog-js'
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+jest.mock('@/constants/general.consts', () => ({ PEANUT_API_URL: 'https://api.peanut.me' }))
+
+const fetchRejection = new TypeError('Failed to fetch')
+const wrappedRejection = Object.assign(new Error('Something went wrong. Please try again.'), {
+    name: 'ServiceUnavailableError',
+})
+
+// url → resolve or reject, so each probe's outcome is scripted independently
+function mockProbes({ api, internet }: { api: boolean; internet: boolean }) {
+    global.fetch = jest.fn((input: RequestInfo | URL) => {
+        const url = String(input)
+        const ok = url.includes('api.peanut.me') ? api : internet
+        return ok ? Promise.resolve({} as Response) : Promise.reject(new TypeError('Failed to fetch'))
+    }) as jest.Mock
+}
+
+afterEach(() => {
+    jest.clearAllMocks()
+})
+
+describe('isNativeFetchRejection', () => {
+    test.each(['Failed to fetch', 'Load failed', 'NetworkError when attempting to fetch resource.'])(
+        'matches TypeError with engine message %p',
+        (message) => {
+            expect(isNativeFetchRejection('TypeError', message)).toBe(true)
+        }
+    )
+
+    test('rejects our own wrapped copy that merely contains the engine string', () => {
+        expect(isNativeFetchRejection('Error', 'Failed to fetch charges: 500')).toBe(false)
+        expect(isNativeFetchRejection('TypeError', 'Failed to fetch charges: 500')).toBe(false)
+        expect(isNativeFetchRejection(undefined, undefined)).toBe(false)
+    })
+})
+
+describe('triageNetworkFailure', () => {
+    test('returns null for a non-network error without probing', async () => {
+        mockProbes({ api: true, internet: true })
+        expect(await triageNetworkFailure(new Error('insufficient balance'))).toBeNull()
+        expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    test('api probe succeeding means the failure was NOT connectivity', async () => {
+        mockProbes({ api: true, internet: true })
+        const triage = await triageNetworkFailure(fetchRejection)
+        expect(triage?.verdict).toBe('api_reachable')
+    })
+
+    test('internet up but edge down → edge_unreachable', async () => {
+        mockProbes({ api: false, internet: true })
+        const triage = await triageNetworkFailure(fetchRejection)
+        expect(triage?.verdict).toBe('edge_unreachable')
+    })
+
+    test('nothing reachable → offline', async () => {
+        mockProbes({ api: false, internet: false })
+        const triage = await triageNetworkFailure(fetchRejection)
+        expect(triage?.verdict).toBe('offline')
+    })
+
+    test('also triages fetchWithSentry-wrapped failures by their rethrown name', async () => {
+        mockProbes({ api: true, internet: true })
+        const triage = await triageNetworkFailure(wrappedRejection)
+        expect(triage?.verdict).toBe('api_reachable')
+    })
+
+    test('probes with no-cors so an opaque (even non-2xx) response still counts as reachable', async () => {
+        mockProbes({ api: true, internet: true })
+        await triageNetworkFailure(fetchRejection)
+        const calls = (global.fetch as jest.Mock).mock.calls
+        expect(calls.length).toBe(2)
+        for (const [, init] of calls) {
+            expect(init).toMatchObject({ method: 'HEAD', mode: 'no-cors', cache: 'no-store' })
+        }
+    })
+})
+
+describe('networkTriageTags', () => {
+    test('flattens the triage for use as Sentry tags / analytics props', () => {
+        expect(networkTriageTags({ verdict: 'api_reachable', online: true, effectiveType: '4g', probeMs: 12 })).toEqual(
+            { net_triage: 'api_reachable', net_online: 'true', net_effective_type: '4g' }
+        )
+    })
+
+    test('is empty when triage was inapplicable', () => {
+        expect(networkTriageTags(null)).toEqual({})
+    })
+})
+
+describe('captureNetworkTriagedFailure', () => {
+    test('rides the verdict on BOTH the Sentry event and the analytics event', async () => {
+        mockProbes({ api: true, internet: true })
+        await captureNetworkTriagedFailure(fetchRejection, {
+            tags: { critical_flow: 'send-link', send_link_step: 'create' },
+            extra: { amount: '9' },
+            analytics: { event: 'send_link_failed', props: { error_name: 'TypeError' } },
+        })
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'send_link_failed',
+            expect.objectContaining({ error_name: 'TypeError', net_triage: 'api_reachable' })
+        )
+        expect(captureException).toHaveBeenCalledWith(fetchRejection, {
+            tags: expect.objectContaining({
+                critical_flow: 'send-link',
+                send_link_step: 'create',
+                net_triage: 'api_reachable',
+            }),
+            extra: { amount: '9' },
+        })
+    })
+
+    test('still reports untriaged errors, without triage tags', async () => {
+        mockProbes({ api: true, internet: true })
+        const err = new Error('insufficient balance')
+        await captureNetworkTriagedFailure(err, { tags: { critical_flow: 'send-link' } })
+        expect(captureException).toHaveBeenCalledWith(err, {
+            tags: { critical_flow: 'send-link' },
+            extra: undefined,
+        })
+        expect(posthog.capture).not.toHaveBeenCalled()
+    })
+})

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -51,28 +51,39 @@ describe('triageNetworkFailure', () => {
         expect(global.fetch).not.toHaveBeenCalled()
     })
 
-    test('api probe succeeding means the failure was NOT connectivity', async () => {
+    test('api probe succeeding is recorded as an observation, with the error class alongside', async () => {
         mockProbes({ api: true, internet: true })
         const triage = await triageNetworkFailure(fetchRejection)
-        expect(triage?.verdict).toBe('api_reachable')
+        expect(triage?.observed).toBe('api_reachable')
+        expect(triage?.errorClass).toBe('fetch_rejection')
     })
 
     test('internet up but edge down → edge_unreachable', async () => {
         mockProbes({ api: false, internet: true })
         const triage = await triageNetworkFailure(fetchRejection)
-        expect(triage?.verdict).toBe('edge_unreachable')
+        expect(triage?.observed).toBe('edge_unreachable')
     })
 
     test('nothing reachable → offline', async () => {
         mockProbes({ api: false, internet: false })
         const triage = await triageNetworkFailure(fetchRejection)
-        expect(triage?.verdict).toBe('offline')
+        expect(triage?.observed).toBe('offline')
     })
 
     test('also triages fetchWithSentry-wrapped failures by their rethrown name', async () => {
         mockProbes({ api: true, internet: true })
         const triage = await triageNetworkFailure(wrappedRejection)
-        expect(triage?.verdict).toBe('api_reachable')
+        expect(triage?.observed).toBe('api_reachable')
+        expect(triage?.errorClass).toBe('service_unavailable')
+    })
+
+    test('a timeout carries its own error class so api_reachable cannot read as CORS evidence', async () => {
+        mockProbes({ api: true, internet: true })
+        const timeout = Object.assign(new Error('Peanut is taking too long to respond'), {
+            name: 'ConnectionTimeoutError',
+        })
+        const triage = await triageNetworkFailure(timeout)
+        expect(triage?.errorClass).toBe('timeout')
     })
 
     test('probes with no-cors so an opaque (even non-2xx) response still counts as reachable', async () => {
@@ -88,9 +99,20 @@ describe('triageNetworkFailure', () => {
 
 describe('networkTriageTags', () => {
     test('flattens the triage for use as Sentry tags / analytics props', () => {
-        expect(networkTriageTags({ verdict: 'api_reachable', online: true, effectiveType: '4g', probeMs: 12 })).toEqual(
-            { net_triage: 'api_reachable', net_online: 'true', net_effective_type: '4g' }
-        )
+        expect(
+            networkTriageTags({
+                observed: 'api_reachable',
+                errorClass: 'fetch_rejection',
+                online: true,
+                effectiveType: '4g',
+                probeMs: 12,
+            })
+        ).toEqual({
+            net_probe: 'api_reachable',
+            net_error_class: 'fetch_rejection',
+            net_online: 'true',
+            net_effective_type: '4g',
+        })
     })
 
     test('is empty when triage was inapplicable', () => {
@@ -99,7 +121,7 @@ describe('networkTriageTags', () => {
 })
 
 describe('captureNetworkTriagedFailure', () => {
-    test('rides the verdict on BOTH the Sentry event and the analytics event', async () => {
+    test('rides the observation on BOTH the Sentry event and the analytics event', async () => {
         mockProbes({ api: true, internet: true })
         await captureNetworkTriagedFailure(fetchRejection, {
             tags: { critical_flow: 'send-link', send_link_step: 'create' },
@@ -108,15 +130,21 @@ describe('captureNetworkTriagedFailure', () => {
         })
         expect(posthog.capture).toHaveBeenCalledWith(
             'send_link_failed',
-            expect.objectContaining({ error_name: 'TypeError', net_triage: 'api_reachable' })
+            expect.objectContaining({
+                error_name: 'TypeError',
+                net_probe: 'api_reachable',
+                net_error_class: 'fetch_rejection',
+                net_probe_ms: expect.any(Number),
+            })
         )
         expect(captureException).toHaveBeenCalledWith(fetchRejection, {
             tags: expect.objectContaining({
                 critical_flow: 'send-link',
                 send_link_step: 'create',
-                net_triage: 'api_reachable',
+                net_probe: 'api_reachable',
+                net_error_class: 'fetch_rejection',
             }),
-            extra: { amount: '9' },
+            extra: { amount: '9', net_probe_ms: expect.any(Number) },
         })
     })
 

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -16,11 +16,22 @@ const wrappedRejection = Object.assign(new Error('Something went wrong. Please t
     name: 'ServiceUnavailableError',
 })
 
-// url → resolve or reject, so each probe's outcome is scripted independently
-function mockProbes({ api, internet }: { api: boolean; internet: boolean }) {
-    global.fetch = jest.fn((input: RequestInfo | URL) => {
-        const url = String(input)
-        const ok = url.includes('api.peanut.me') ? api : internet
+// (url, mode) → resolve or reject, so each of the three probes is scripted
+// independently. `apiCors` and `apiNoCors` are separate because the pair is
+// the whole discriminator: a WAF challenge or CORS-less error page answers the
+// no-cors probe while failing the cors one.
+function mockProbes({
+    apiCors,
+    apiNoCors = apiCors,
+    internet,
+}: {
+    apiCors: boolean
+    apiNoCors?: boolean
+    internet: boolean
+}) {
+    global.fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const isApi = String(input).includes('api.peanut.me')
+        const ok = isApi ? (init?.mode === 'cors' ? apiCors : apiNoCors) : internet
         return ok ? Promise.resolve({} as Response) : Promise.reject(new TypeError('Failed to fetch'))
     }) as jest.Mock
 }
@@ -46,39 +57,58 @@ describe('isNativeFetchRejection', () => {
 
 describe('triageNetworkFailure', () => {
     test('returns null for a non-network error without probing', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         expect(await triageNetworkFailure(new Error('insufficient balance'))).toBeNull()
         expect(global.fetch).not.toHaveBeenCalled()
     })
 
     test('api probe succeeding is recorded as an observation, with the error class alongside', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         const triage = await triageNetworkFailure(fetchRejection)
         expect(triage?.observed).toBe('api_reachable')
         expect(triage?.errorClass).toBe('fetch_rejection')
     })
 
     test('internet up but edge down → edge_unreachable', async () => {
-        mockProbes({ api: false, internet: true })
+        mockProbes({ apiCors: false, internet: true })
         const triage = await triageNetworkFailure(fetchRejection)
         expect(triage?.observed).toBe('edge_unreachable')
     })
 
+    // The failure mode this whole diagnostic exists to find: a WAF challenge
+    // or CORS-less error page completes the transaction (no-cors resolves) but
+    // carries no CORS headers (cors rejects).
+    test('something answered but unreadably → api_cors_blocked, not edge_unreachable', async () => {
+        mockProbes({ apiCors: false, apiNoCors: true, internet: true })
+        const triage = await triageNetworkFailure(fetchRejection)
+        expect(triage?.observed).toBe('api_cors_blocked')
+    })
+
+    // CORP is enforced on no-cors requests only, so the cors probe still sees
+    // a healthy edge while /healthz serves same-site (until api-ts#1456
+    // deploys) and the native origin https://localhost is cross-site. Without
+    // the cors probe this exact case mislabels a healthy edge as unreachable.
+    test('a CORP-blocked no-cors probe still reports api_reachable via the cors probe', async () => {
+        mockProbes({ apiCors: true, apiNoCors: false, internet: true })
+        const triage = await triageNetworkFailure(fetchRejection)
+        expect(triage?.observed).toBe('api_reachable')
+    })
+
     test('nothing reachable → offline', async () => {
-        mockProbes({ api: false, internet: false })
+        mockProbes({ apiCors: false, internet: false })
         const triage = await triageNetworkFailure(fetchRejection)
         expect(triage?.observed).toBe('offline')
     })
 
     test('also triages fetchWithSentry-wrapped failures by their rethrown name', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         const triage = await triageNetworkFailure(wrappedRejection)
         expect(triage?.observed).toBe('api_reachable')
         expect(triage?.errorClass).toBe('service_unavailable')
     })
 
     test('a timeout carries its own error class so api_reachable cannot read as CORS evidence', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         const timeout = Object.assign(new Error('Peanut is taking too long to respond'), {
             name: 'ConnectionTimeoutError',
         })
@@ -86,14 +116,16 @@ describe('triageNetworkFailure', () => {
         expect(triage?.errorClass).toBe('timeout')
     })
 
-    test('probes with no-cors so an opaque (even non-2xx) response still counts as reachable', async () => {
-        mockProbes({ api: true, internet: true })
+    test('fires both API probe modes plus the neutral internet probe', async () => {
+        mockProbes({ apiCors: true, internet: true })
         await triageNetworkFailure(fetchRejection)
-        const calls = (global.fetch as jest.Mock).mock.calls
-        expect(calls.length).toBe(2)
+        const calls = (global.fetch as jest.Mock).mock.calls as [string, RequestInit][]
+        expect(calls).toHaveLength(3)
         for (const [, init] of calls) {
-            expect(init).toMatchObject({ method: 'HEAD', mode: 'no-cors', cache: 'no-store' })
+            expect(init).toMatchObject({ method: 'HEAD', cache: 'no-store' })
         }
+        const shape = calls.map(([url, init]) => `${url.includes('api.peanut.me') ? 'api' : 'internet'}:${init.mode}`)
+        expect(shape.sort()).toEqual(['api:cors', 'api:no-cors', 'internet:no-cors'])
     })
 })
 
@@ -122,7 +154,7 @@ describe('networkTriageTags', () => {
 
 describe('captureNetworkTriagedFailure', () => {
     test('rides the observation on BOTH the Sentry event and the analytics event', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         await captureNetworkTriagedFailure(fetchRejection, {
             tags: { critical_flow: 'send-link', send_link_step: 'create' },
             extra: { amount: '9' },
@@ -149,7 +181,7 @@ describe('captureNetworkTriagedFailure', () => {
     })
 
     test('still reports untriaged errors, without triage tags', async () => {
-        mockProbes({ api: true, internet: true })
+        mockProbes({ apiCors: true, internet: true })
         const err = new Error('insufficient balance')
         await captureNetworkTriagedFailure(err, { tags: { critical_flow: 'send-link' } })
         expect(captureException).toHaveBeenCalledWith(err, {

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -1,4 +1,5 @@
 import { API_ERROR_CODES, apiErrorStatus, wireErrorCode, type ApiErrorCode } from '@/services/api-error'
+import { isNativeFetchRejection } from '@/utils/network-triage'
 
 /** Safely extract a string-form of an unknown error + its `.message` if any.
  *  Lets the matchers below use `string` methods without unsafe property access
@@ -293,13 +294,8 @@ export const friendlyError = (error: unknown): FriendlyError => {
     // response that very much DID arrive, and those carry no `status` to be
     // caught by the ApiError branch above. A substring match would tell a user
     // whose connection is fine that they are offline — the same mislabelling
-    // this whole change exists to remove, pointed the other way.
-    if (
-        name === 'TypeError' &&
-        (message === 'Failed to fetch' ||
-            message === 'Load failed' ||
-            message === 'NetworkError when attempting to fetch resource.')
-    )
-        return code('connectionLost')
+    // this whole change exists to remove, pointed the other way. The predicate
+    // is shared with network-triage.ts so the copy and the probes can't drift.
+    if (isNativeFetchRejection(name, message)) return code('connectionLost')
     return code('genericSupport')
 }

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -46,11 +46,14 @@ export interface NetworkTriage {
      * failures is not a connectivity story). Read alongside `errorClass` — for
      * a `timeout`, `api_reachable` means "edge up, endpoint slow", saying
      * nothing about CORS.
-     * - `api_reachable`: the edge answered the probe after the request failed
+     * - `api_reachable`: the edge answered a CORS-valid response
+     * - `api_cors_blocked`: something answered for the edge, but not readably
+     *   — a WAF/bot challenge or a CORS-less error page. The direct evidence
+     *   for the failure mode this whole diagnostic exists to find.
      * - `edge_unreachable`: the internet answered, our edge did not
      * - `offline`: nothing answered
      */
-    observed: 'api_reachable' | 'edge_unreachable' | 'offline'
+    observed: 'api_reachable' | 'api_cors_blocked' | 'edge_unreachable' | 'offline'
     errorClass: NetworkErrorClass
     online: boolean
     effectiveType?: string
@@ -59,11 +62,27 @@ export interface NetworkTriage {
 
 const PROBE_TIMEOUT_MS = 2500
 
-async function probe(url: string): Promise<boolean> {
+/*
+ * Two probes at the API, because each is blind where the other sees.
+ *
+ * `cors` resolves ONLY on a response carrying valid CORS headers, so it is the
+ * honest "the edge answered us properly" signal — and unlike the no-cors probe
+ * it is untouched by Cross-Origin-Resource-Policy, which browsers apply to
+ * no-cors requests only. That matters because `/healthz` serves CORP
+ * `same-site` until api-ts#1456 deploys, which would block the no-cors probe
+ * from the native app's cross-site `https://localhost` origin and make a
+ * healthy edge read as unreachable.
+ *
+ * `noCors` resolves on ANY completed transaction — including the challenge and
+ * error pages that carry no CORS headers at all. So cors-fails-while-no-cors-
+ * succeeds is precisely "something answered but the browser wouldn't let the
+ * app read it", the shape a WAF challenge or CORS-less 5xx takes.
+ */
+async function probe(url: string, mode: 'cors' | 'no-cors'): Promise<boolean> {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
     try {
-        await fetch(url, { method: 'HEAD', mode: 'no-cors', cache: 'no-store', signal: controller.signal })
+        await fetch(url, { method: 'HEAD', mode, cache: 'no-store', signal: controller.signal })
         return true
     } catch {
         return false
@@ -78,15 +97,23 @@ export async function triageNetworkFailure(error: unknown): Promise<NetworkTriag
     if (!errorClass) return null
     const online = navigator.onLine
     const started = Date.now()
+    const healthz = `${PEANUT_API_URL}/healthz`
     // gstatic's generate_204 is Android's own captive-portal check — the most
     // dependable "is the internet there at all" endpoint a WebView can reach.
-    const [apiReachable, internetReachable] = await Promise.all([
-        probe(`${PEANUT_API_URL}/healthz`),
-        probe('https://www.gstatic.com/generate_204'),
+    const [apiCorsOk, apiAnswered, internetReachable] = await Promise.all([
+        probe(healthz, 'cors'),
+        probe(healthz, 'no-cors'),
+        probe('https://www.gstatic.com/generate_204', 'no-cors'),
     ])
     const connection = (navigator as Navigator & { connection?: { effectiveType?: string } }).connection
     return {
-        observed: apiReachable ? 'api_reachable' : internetReachable ? 'edge_unreachable' : 'offline',
+        observed: apiCorsOk
+            ? 'api_reachable'
+            : apiAnswered
+              ? 'api_cors_blocked'
+              : internetReachable
+                ? 'edge_unreachable'
+                : 'offline',
         errorClass,
         online,
         effectiveType: connection?.effectiveType,

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -25,22 +25,33 @@ export function isNativeFetchRejection(name: string | undefined, message: string
     return name === 'TypeError' && message !== undefined && NATIVE_FETCH_REJECTION_MESSAGES.includes(message)
 }
 
+type NetworkErrorClass = 'fetch_rejection' | 'timeout' | 'service_unavailable'
+
 // fetchWithSentry rethrows its network-layer failures under these names, so a
 // flow-level catch only sees the raw TypeError for calls that bypassed it.
-function isNetworkLayerFailure(error: unknown): boolean {
-    if (!(error instanceof Error)) return false
-    if (isNativeFetchRejection(error.name, error.message)) return true
-    return error.name === 'ServiceUnavailableError' || error.name === 'ConnectionTimeoutError'
+function classifyNetworkFailure(error: unknown): NetworkErrorClass | null {
+    if (!(error instanceof Error)) return null
+    if (isNativeFetchRejection(error.name, error.message)) return 'fetch_rejection'
+    if (error.name === 'ConnectionTimeoutError') return 'timeout'
+    if (error.name === 'ServiceUnavailableError') return 'service_unavailable'
+    return null
 }
 
 export interface NetworkTriage {
     /**
-     * - `api_reachable`: the edge answered the probe while the real request
-     *   failed → CORS-layer / WAF / edge-error-page problem, NOT connectivity.
-     * - `edge_unreachable`: internet is up but our edge isn't answering.
-     * - `offline`: nothing reachable — the device really is offline.
+     * What the probes OBSERVED in the seconds after the failure — not proof of
+     * what caused it: a transient radio drop can recover inside that gap and
+     * still read `api_reachable`. Per event this is a hint; the causal signal
+     * is the distribution (a population of `api_reachable` + `net_online:true`
+     * failures is not a connectivity story). Read alongside `errorClass` — for
+     * a `timeout`, `api_reachable` means "edge up, endpoint slow", saying
+     * nothing about CORS.
+     * - `api_reachable`: the edge answered the probe after the request failed
+     * - `edge_unreachable`: the internet answered, our edge did not
+     * - `offline`: nothing answered
      */
-    verdict: 'api_reachable' | 'edge_unreachable' | 'offline'
+    observed: 'api_reachable' | 'edge_unreachable' | 'offline'
+    errorClass: NetworkErrorClass
     online: boolean
     effectiveType?: string
     probeMs: number
@@ -63,7 +74,9 @@ async function probe(url: string): Promise<boolean> {
 
 export async function triageNetworkFailure(error: unknown): Promise<NetworkTriage | null> {
     if (typeof navigator === 'undefined' || typeof fetch === 'undefined') return null
-    if (!isNetworkLayerFailure(error)) return null
+    const errorClass = classifyNetworkFailure(error)
+    if (!errorClass) return null
+    const online = navigator.onLine
     const started = Date.now()
     // gstatic's generate_204 is Android's own captive-portal check — the most
     // dependable "is the internet there at all" endpoint a WebView can reach.
@@ -73,8 +86,9 @@ export async function triageNetworkFailure(error: unknown): Promise<NetworkTriag
     ])
     const connection = (navigator as Navigator & { connection?: { effectiveType?: string } }).connection
     return {
-        verdict: apiReachable ? 'api_reachable' : internetReachable ? 'edge_unreachable' : 'offline',
-        online: navigator.onLine,
+        observed: apiReachable ? 'api_reachable' : internetReachable ? 'edge_unreachable' : 'offline',
+        errorClass,
+        online,
         effectiveType: connection?.effectiveType,
         probeMs: Date.now() - started,
     }
@@ -83,7 +97,8 @@ export async function triageNetworkFailure(error: unknown): Promise<NetworkTriag
 export function networkTriageTags(triage: NetworkTriage | null): Record<string, string> {
     if (!triage) return {}
     return {
-        net_triage: triage.verdict,
+        net_probe: triage.observed,
+        net_error_class: triage.errorClass,
         net_online: String(triage.online),
         ...(triage.effectiveType ? { net_effective_type: triage.effectiveType } : {}),
     }
@@ -113,8 +128,12 @@ export async function captureNetworkTriagedFailure(
         // diagnostics must never mask the failure being reported
     }
     const triageTags = networkTriageTags(triage)
+    // probeMs rides in extra/props, not tags — millisecond values would blow
+    // up tag cardinality while still mattering for reading a single event
+    // (how stale the observation is relative to the failure).
+    const timing = triage ? { net_probe_ms: triage.probeMs } : {}
     if (analytics) {
-        posthog.capture(analytics.event, { ...analytics.props, ...triageTags })
+        posthog.capture(analytics.event, { ...analytics.props, ...triageTags, ...timing })
     }
-    captureException(error, { tags: { ...tags, ...triageTags }, extra })
+    captureException(error, { tags: { ...tags, ...triageTags }, extra: triage ? { ...extra, ...timing } : extra })
 }

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -1,0 +1,120 @@
+import { captureException } from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+
+/*
+ * `TypeError: Failed to fetch` proves nothing about the user's connection: a
+ * WAF challenge on the API hostname, a CORS-less edge error page (Cloudflare
+ * 5xx), a blocked preflight and a dead radio all surface identically, with no
+ * status to look at (TASK-21956 — the reported device was online and the PWA
+ * worked). A no-cors probe separates them: it resolves with an opaque response
+ * whenever the network transaction completes — ANY status, no ACAO header
+ * required, no preflight — so it answers "did the edge answer at all" where a
+ * normal fetch cannot.
+ */
+
+// Engine-exact rejection copy; also matched by the connectionLost classifier
+// in friendly-error.utils.tsx, which imports this predicate to stay in sync.
+export const NATIVE_FETCH_REJECTION_MESSAGES: readonly string[] = [
+    'Failed to fetch', // Chromium, so every Android WebView
+    'Load failed', // WebKit
+    'NetworkError when attempting to fetch resource.', // Gecko
+]
+
+export function isNativeFetchRejection(name: string | undefined, message: string | undefined): boolean {
+    return name === 'TypeError' && message !== undefined && NATIVE_FETCH_REJECTION_MESSAGES.includes(message)
+}
+
+// fetchWithSentry rethrows its network-layer failures under these names, so a
+// flow-level catch only sees the raw TypeError for calls that bypassed it.
+function isNetworkLayerFailure(error: unknown): boolean {
+    if (!(error instanceof Error)) return false
+    if (isNativeFetchRejection(error.name, error.message)) return true
+    return error.name === 'ServiceUnavailableError' || error.name === 'ConnectionTimeoutError'
+}
+
+export interface NetworkTriage {
+    /**
+     * - `api_reachable`: the edge answered the probe while the real request
+     *   failed → CORS-layer / WAF / edge-error-page problem, NOT connectivity.
+     * - `edge_unreachable`: internet is up but our edge isn't answering.
+     * - `offline`: nothing reachable — the device really is offline.
+     */
+    verdict: 'api_reachable' | 'edge_unreachable' | 'offline'
+    online: boolean
+    effectiveType?: string
+    probeMs: number
+}
+
+const PROBE_TIMEOUT_MS = 2500
+
+async function probe(url: string): Promise<boolean> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+    try {
+        await fetch(url, { method: 'HEAD', mode: 'no-cors', cache: 'no-store', signal: controller.signal })
+        return true
+    } catch {
+        return false
+    } finally {
+        clearTimeout(timer)
+    }
+}
+
+export async function triageNetworkFailure(error: unknown): Promise<NetworkTriage | null> {
+    if (typeof navigator === 'undefined' || typeof fetch === 'undefined') return null
+    if (!isNetworkLayerFailure(error)) return null
+    const started = Date.now()
+    // gstatic's generate_204 is Android's own captive-portal check — the most
+    // dependable "is the internet there at all" endpoint a WebView can reach.
+    const [apiReachable, internetReachable] = await Promise.all([
+        probe(`${PEANUT_API_URL}/healthz`),
+        probe('https://www.gstatic.com/generate_204'),
+    ])
+    const connection = (navigator as Navigator & { connection?: { effectiveType?: string } }).connection
+    return {
+        verdict: apiReachable ? 'api_reachable' : internetReachable ? 'edge_unreachable' : 'offline',
+        online: navigator.onLine,
+        effectiveType: connection?.effectiveType,
+        probeMs: Date.now() - started,
+    }
+}
+
+export function networkTriageTags(triage: NetworkTriage | null): Record<string, string> {
+    if (!triage) return {}
+    return {
+        net_triage: triage.verdict,
+        net_online: String(triage.online),
+        ...(triage.effectiveType ? { net_effective_type: triage.effectiveType } : {}),
+    }
+}
+
+interface CaptureOptions {
+    tags: Record<string, string>
+    extra?: Record<string, unknown>
+    analytics?: { event: string; props: Record<string, unknown> }
+}
+
+/**
+ * Report a flow failure with the triage verdict riding on the SAME Sentry and
+ * analytics events, so every occurrence self-labels instead of needing a
+ * cross-referenced probe event. Awaiting the probes (bounded at 2.5s) is why
+ * callers must fire-and-forget from their catch block AFTER setting UI error
+ * state — nothing here may hold up the render or `finally` cleanup.
+ */
+export async function captureNetworkTriagedFailure(
+    error: unknown,
+    { tags, extra, analytics }: CaptureOptions
+): Promise<void> {
+    let triage: NetworkTriage | null = null
+    try {
+        triage = await triageNetworkFailure(error)
+    } catch {
+        // diagnostics must never mask the failure being reported
+    }
+    const triageTags = networkTriageTags(triage)
+    if (analytics) {
+        posthog.capture(analytics.event, { ...analytics.props, ...triageTags })
+    }
+    captureException(error, { tags: { ...tags, ...triageTags }, extra })
+}


### PR DESCRIPTION
Follow-up to #2860 / TASK-21956.

## Why the diagnosis needed evidence

#2860 concluded Hugo's device "lost connectivity". Hugo reports the opposite: his connection was good and the PWA worked at the same moment — only the native app failed. Both stories are consistent with the only signal we had, because `TypeError: Failed to fetch` carries no status and is produced identically by:

- a **WAF/bot challenge** on `api.peanut.me` (Cloudflare scores an Android WebView UA very differently from real Chrome — a mechanism where native fails while the PWA succeeds on the same network),
- a **CORS-less edge error page** (Cloudflare 502/522/524 and challenge pages carry no `Access-Control-Allow-Origin`, so a cross-origin fetch from the native `https://localhost` origin surfaces them as a bare TypeError),
- a **blocked preflight** (native requests always preflight — `Authorization` header),
- and a genuinely **dead radio**.

We have no Cloudflare access, so this PR makes every future occurrence label itself from the client side instead.

## How

**`src/utils/network-triage.ts`** — a `no-cors` fetch resolves with an opaque response whenever the network transaction completes: ANY status, no ACAO required, no preflight. So when a flow fails on a network-layer error, two bounded (2.5s) parallel probes run:

1. `HEAD {PEANUT_API_URL}/healthz` — unauthenticated, rate-limit-exempt, `no-store`. Resolving means the edge answered *something* — even a 403 challenge page counts, which is exactly right: the real request died anyway, so the failure was in the CORS/response-visibility layer, **not** connectivity.
2. `HEAD https://www.gstatic.com/generate_204` — Android's own captive-portal endpoint — separating "our edge is unreachable" from "device is offline".

Observation → `net_probe` tag: `api_reachable`, `edge_unreachable`, or `offline`, plus `net_error_class` (`fetch_rejection` / `timeout` / `service_unavailable`), `net_online`, `net_effective_type`, and `net_probe_ms` in extra/props. Deliberately framed as a post-failure *observation*, not a causal verdict: a transient radio drop can recover inside the ~2.5s probe window and still read `api_reachable` — per event it is a hint, and the causal signal is the distribution.

**Wiring** — `captureNetworkTriagedFailure()` replaces the bare `posthog.capture` + `captureException` pairs at both send-link sites (`create` and background `persist`) and in `useDirectSendFlow`, so the verdict rides on the **same** Sentry and PostHog events rather than needing a cross-referenced probe event. Triage triggers on the three engine-exact rejection messages **and** on `ServiceUnavailableError`/`ConnectionTimeoutError` — `fetchWithSentry` rethrows under those names, so flow-level catches only see the raw TypeError for calls that bypassed it.

**Shared predicate** — the engine-message list moved into `network-triage.ts` and the `connectionLost` classifier in `friendly-error.utils.tsx` now imports it, so copy and probes can't drift.

**Ambient signal** — `beforeSendHandler` stamps `net_online` on every kept browser event (guarded for server/edge runtimes). Free coarse evidence across all flows.

**CSP** — `connect-src` entry for `https://www.gstatic.com` (policy is report-only, but the probe shouldn't be the loudest violation).

## Tradeoffs

- The failure reports are now **fire-and-forget behind the probes** (≤2.5s). UI error state is set before the helper is invoked and `finally` cleanup is not delayed; the risk is a user killing the app inside that window loses the report — the same in-memory-queue loss that already existed, widened by up to 2.5s. Accepted: the verdict is the entire point.
- A challenge page resolving the `no-cors` probe is *why* `api_reachable` is trustworthy, but it means the verdict can't distinguish "challenged" from "CORS-less 5xx". Both are our side, not the user's — enough to act on.

## How this resolves the question

Once deployed, the existing Sentry issue for send failures gains `net_probe`. If Hugo's pattern is Cloudflare challenging WebViews, the population will show `net_probe:api_reachable` + `net_error_class:fetch_rejection` + `net_online:true` — and the fix moves to Cloudflare config (exempt `api.peanut.me` from challenge actions). If it's genuinely connectivity, `offline` verdicts confirm #2860's original story.

## Not done here

- `qr-pay` / `withdraw` still have the untagged-capture gap noted in #2860 — same follow-up as before; the helper is ready for them.
- No copy change: `connectionLost` still says "check your connection" even when the verdict says otherwise. Deliberate — copy should follow evidence, not precede it.

## Verification

- `pnpm typecheck` clean
- `network-triage.test.ts` — 12 new tests (verdict matrix, exact-message predicate incl. the wrapped-copy trap, no-cors probe options, tag merging on both capture paths)
- `friendly-error.utils.test.tsx` — 32 passed (unchanged, now exercising the shared predicate)
- `Initial.link.send.view.test.tsx` — 7 passed
- `prettier --check` clean
