### PR TITLE
fix(native): exclude /dev/payment-graph from the static export

### DIFF
--- a/scripts/__tests__/native-build-scan.test.js
+++ b/scripts/__tests__/native-build-scan.test.js
@@ -54,4 +54,16 @@ describe('native build server-route scan', () => {
         const offenders = detectUncoveredServerRoutes().filter((o) => transformed.has(toPosix(o.rel)))
         expect(offenders).toEqual([])
     })
+
+    // This is the actual anti-rot check: it runs the same scan the native build
+    // guard does, against the real app tree, on every PR — not just on push to
+    // dev via the Capgo deploy workflow. A route added to src/app with `export
+    // const dynamic = 'force-dynamic'` (or a bare route.ts) and missing from
+    // ITEMS_TO_DISABLE fails here instead of silently breaking every native/OTA
+    // build until someone notices dev is red.
+    it('has no server-only route left uncovered by ITEMS_TO_DISABLE or P0_TRANSFORMS', () => {
+        const offenders = detectUncoveredServerRoutes()
+        const describe = offenders.map((o) => `${toPosix(o.rel)} (${o.reason})`).join('\n')
+        expect(describe).toBe('')
+    })
 })

--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -55,6 +55,9 @@ const ITEMS_TO_DISABLE = [
     { path: '(mobile-ui)/qr/[code]/page.tsx', type: 'file' },
     { path: '(mobile-ui)/qr/[code]/success/page.tsx', type: 'file' },
     { path: '(mobile-ui)/pay/[...username]/page.tsx', type: 'file' },
+    // Team-only desktop web tool. force-dynamic cannot be statically exported, and
+    // pruneExportedAssets() deletes /dev from the export anyway, so building it is waste.
+    { path: '(mobile-ui)/dev/payment-graph', type: 'dir' },
 ]
 
 const MODIFIED_FILES = []


### PR DESCRIPTION
## Summary

Fixes the **native build guard, currently red on `dev`** after #2787 merged.

```
❌ Build failed: Native build would break: 1 server-only route(s) are not handled for static export:
    • src/app/(mobile-ui)/dev/payment-graph/page.tsx  (export const dynamic = 'force-dynamic')
```

The rebuilt Payment Network Explorer page added `export const dynamic = 'force-dynamic'`, which `next build` cannot statically export. The page it replaced was a plain client component, so nothing tripped the guard before.

Adds the route to `ITEMS_TO_DISABLE` in `scripts/native-build.js`.

## Why disable rather than make it exportable

`pruneExportedAssets()` already deletes `/dev` from the export unless `KEEP_DEV_PAGES=true`, so this route was being built and then thrown away — it never shipped in the app. It is also a desktop-only, team-gated web tool with no native use. Skipping the build is strictly less work than making a page static that nobody native will ever load.

## Why PR CI missed it

The native `deploy` job runs on **push to `dev`**, not on `pull_request`. #2787 was fully green as a PR — typecheck, unit, e2e, eslint, format, `ci-success` — and the guard only fired after the merge landed. Worth a separate look: this class of regression can only ever be caught post-merge today.

## Verification

Re-ran the guard's own coverage logic (`isCoveredByDisableList`, including the `P0_TRANSFORMS` fallback) against the full `src/app` tree:

- `(mobile-ui)/dev/payment-graph/page.tsx` → now covered
- No other uncovered `force-dynamic` route remains (`(mobile-ui)/claim/page.tsx` is covered via `P0_TRANSFORMS`)

`node --check` and prettier clean.

## Risk

Very low. One entry in a hand-maintained exclusion list, affecting the Capacitor build only. No web behavior changes.