### PR TITLE
feat(telemetry): triage qr-pay and withdraw failures too

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -44,7 +44,8 @@ import { EHistoryUserRole } from '@/hooks/useTransactionHistory'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { getCurrencyPrice } from '@/app/actions/currency'
 import { PaymentInfoRow } from '@/components/Payment/PaymentInfoRow'
-import { captureException } from '@sentry/nextjs'
+import { captureNetworkTriagedFailure, isNetworkLayerFailure } from '@/utils/network-triage'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import { isPaymentProcessorQR, EQrType, NAME_BY_QR_TYPE, type QrType } from '@/components/Global/DirectSendQR/utils'
@@ -671,7 +672,9 @@ export default function QRPayPage() {
                     // minimum) — actionable copy, not a Sentry-worthy surprise.
                     setErrorMessage(pixMinAmountErrorMessage)
                 } else {
-                    captureException(error)
+                    void captureNetworkTriagedFailure(error, {
+                        tags: { ...criticalFlowTags('qr-pay'), qr_pay_step: 'initiate' },
+                    })
                     setErrorMessage(t('errors.initiateUnexpected'))
                 }
                 setIsSuccess(false)
@@ -718,9 +721,21 @@ export default function QRPayPage() {
             } else if (classified.kind === 'code' && classified.code === 'genericSupport') {
                 // Keep the flow-specific fallback — "couldn't sign" beats the
                 // generic support copy on a signing failure — and the Sentry report.
-                captureException(error)
+                void captureNetworkTriagedFailure(error, {
+                    tags: { ...criticalFlowTags('qr-pay'), qr_pay_step: 'sign' },
+                })
                 setErrorMessage(t('errors.signFailed'))
             } else {
+                // A classified error is normally a deliberate non-report (backend
+                // wire code, or a user action). Network-layer failures are the
+                // exception: once `connectionLost` existed they classified HERE
+                // instead of genericSupport above, which silently ended their
+                // Sentry reporting altogether (TASK-21956).
+                if (isNetworkLayerFailure(error)) {
+                    void captureNetworkTriagedFailure(error, {
+                        tags: { ...criticalFlowTags('qr-pay'), qr_pay_step: 'sign' },
+                    })
+                }
                 setErrorMessage(toFriendlyError(error), classified.kind === 'text' ? null : classified.code)
             }
             setIsSuccess(false)
@@ -790,7 +805,9 @@ export default function QRPayPage() {
             // Wrong-passkey session: backend rejected the signed UserOp with
             // AA24 / wapk. Unrecoverable without re-auth — force a clean logout.
             if (handleStaleSession(error)) return
-            captureException(error)
+            void captureNetworkTriagedFailure(error, {
+                tags: { ...criticalFlowTags('qr-pay'), qr_pay_step: 'submit' },
+            })
             const errorMsg = (error as Error).message || 'Could not complete payment'
 
             // Handle specific error cases

--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -25,8 +25,10 @@ jest.mock('next/navigation', () => ({
 }))
 
 const mockCaptureMessage = jest.fn()
+const mockCaptureException = jest.fn()
 jest.mock('@sentry/nextjs', () => ({
     captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
 }))
 
 const mockPosthogCapture = jest.fn()

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -24,6 +24,8 @@ import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { useRouter } from 'next/navigation'
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { captureMessage } from '@sentry/nextjs'
+import { captureNetworkTriagedFailure } from '@/utils/network-triage'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import type { Address, Hex, TransactionReceipt } from 'viem'
@@ -499,9 +501,22 @@ export default function WithdrawCryptoPage() {
         } catch (err) {
             console.error('Withdrawal execution failed:', toError(err))
             const errMsg = toFriendlyError(err)
-            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
-                method_type: 'crypto',
-                error_message: errMsg,
+            // Reported here rather than left to the console-capture integration,
+            // which the noise filters then drop: a crypto withdrawal dying was
+            // leaving no queryable Sentry record at all, and `error_message` is
+            // the LOCALIZED copy so it can't be grouped on (TASK-21956).
+            void captureNetworkTriagedFailure(err, {
+                tags: { ...criticalFlowTags('withdraw-crypto'), withdraw_step: 'execute' },
+                extra: { chargeId: chargeDetails?.uuid, usdAmount },
+                analytics: {
+                    event: ANALYTICS_EVENTS.WITHDRAW_FAILED,
+                    props: {
+                        method_type: 'crypto',
+                        error_message: errMsg,
+                        error_name: err instanceof Error ? err.name : 'unknown',
+                        error_raw: err instanceof Error ? err.message : String(err),
+                    },
+                },
             })
             setError(errMsg)
         } finally {

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -34,7 +34,8 @@ import { useModalsContext } from '@/context/ModalsContext'
 import Select from '@/components/Global/Select'
 import { SoundPlayer } from '@/components/Global/SoundPlayer'
 import { useQueryClient } from '@tanstack/react-query'
-import { captureException } from '@sentry/nextjs'
+import { captureNetworkTriagedFailure, isNetworkLayerFailure } from '@/utils/network-triage'
+import { criticalFlowTags } from '@/utils/sentry-critical-flow'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { deriveProviderRejection } from '@/utils/provider-rejection.utils'
@@ -331,7 +332,9 @@ function MantecaBankWithdrawFlow() {
                 setStep('review')
             }
         } catch (error) {
-            captureException(error)
+            void captureNetworkTriagedFailure(error, {
+                tags: { ...criticalFlowTags('withdraw-manteca'), withdraw_step: 'lock-rate' },
+            })
             setErrorMessage(t('errors.lockRateFailed'))
         } finally {
             setIsLockingPrice(false)
@@ -395,9 +398,21 @@ function MantecaBankWithdrawFlow() {
                     setErrorMessage(t('errors.confirmTransaction'))
                 } else if (classified.kind === 'code' && classified.code === 'genericSupport') {
                     // Keep the flow-specific fallback and the Sentry report.
-                    captureException(error)
+                    void captureNetworkTriagedFailure(error, {
+                        tags: { ...criticalFlowTags('withdraw-manteca'), withdraw_step: 'sign' },
+                    })
                     setErrorMessage(t('errors.signFailed'))
                 } else {
+                    // A classified error is normally a deliberate non-report
+                    // (backend wire code, or a user action). Network-layer
+                    // failures are the exception: once `connectionLost` existed
+                    // they classified HERE instead of genericSupport above, which
+                    // silently ended their Sentry reporting (TASK-21956).
+                    if (isNetworkLayerFailure(error)) {
+                        void captureNetworkTriagedFailure(error, {
+                            tags: { ...criticalFlowTags('withdraw-manteca'), withdraw_step: 'sign' },
+                        })
+                    }
                     setErrorMessage(toFriendlyError(error), classified.kind === 'text' ? null : classified.code)
                 }
                 setLoadingState('Idle')
@@ -477,9 +492,21 @@ function MantecaBankWithdrawFlow() {
         } catch (error) {
             console.error('Manteca withdraw error:', error)
             if (handleStaleSession(error)) return
-            posthog.capture(ANALYTICS_EVENTS.WITHDRAW_FAILED, {
-                method_type: 'manteca',
-                error_message: 'Withdraw failed unexpectedly',
+            // Reported here rather than left to the console-capture integration,
+            // which the noise filters then drop: the money leg of an offramp
+            // dying was leaving no queryable Sentry record at all (TASK-21956).
+            void captureNetworkTriagedFailure(error, {
+                tags: { ...criticalFlowTags('withdraw-manteca'), withdraw_step: 'submit' },
+                extra: { amountUsd: usdAmount, country: countryPath },
+                analytics: {
+                    event: ANALYTICS_EVENTS.WITHDRAW_FAILED,
+                    props: {
+                        method_type: 'manteca',
+                        error_message: 'Withdraw failed unexpectedly',
+                        error_name: error instanceof Error ? error.name : 'unknown',
+                        error_raw: error instanceof Error ? error.message : String(error),
+                    },
+                },
             })
             setErrorMessage(t('errors.unexpected'))
             setStep('failure')

--- a/src/services/__tests__/manteca-withdraw-transport.test.ts
+++ b/src/services/__tests__/manteca-withdraw-transport.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+/**
+ * Both withdraw calls flattened every throw into `{ error }`, including
+ * serverFetch's transport failures. The page's `if (result.error)` branch then
+ * returned before its catch ran, so the network-triage capture this flow
+ * depends on never fired for the failure class it exists to record
+ * (TASK-21956) — the money leg of an offramp dying over a dead network left no
+ * queryable Sentry event at all.
+ *
+ * These reject serverFetch itself rather than mocking the service, because the
+ * bug lived in the service's own catch: a test stubbing mantecaApi would have
+ * passed against the broken code.
+ */
+import { mantecaApi } from '@/services/manteca'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn(), serverFetch: jest.fn() }))
+
+const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+
+function transportError(name: string): Error {
+    const e = new Error('Service temporarily unavailable')
+    e.name = name
+    return e
+}
+
+const withdrawBody = {
+    kind: 'rainWithdrawal' as const,
+    priceLockCode: 'lock-1',
+    amount: '10',
+    destinationAddress: '0xabc',
+    currency: 'ARS',
+    signedRainWithdrawal: {} as never,
+    chainId: '8453',
+}
+
+const initBody = { amount: '10', currency: 'ARS', country: 'AR' } as never
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('manteca withdraw transport failures', () => {
+    it.each(['ServiceUnavailableError', 'ConnectionTimeoutError'])(
+        'rethrows %s from the submit call so the page can triage it',
+        async (name) => {
+            mockServerFetch.mockRejectedValue(transportError(name))
+            await expect(mantecaApi.withdrawWithSignedTx(withdrawBody)).rejects.toMatchObject({ name })
+        }
+    )
+
+    it.each(['ServiceUnavailableError', 'ConnectionTimeoutError'])(
+        'rethrows %s from the lock-rate call so the page can triage it',
+        async (name) => {
+            mockServerFetch.mockRejectedValue(transportError(name))
+            await expect(mantecaApi.initiateWithdraw(initBody)).rejects.toMatchObject({ name })
+        }
+    )
+
+    it('rethrows a native WebView fetch rejection, the Android failure shape', async () => {
+        mockServerFetch.mockRejectedValue(new TypeError('Load failed'))
+        await expect(mantecaApi.withdrawWithSignedTx(withdrawBody)).rejects.toBeInstanceOf(TypeError)
+    })
+
+    it('still flattens a non-transport error, so deliberate error copy is unaffected', async () => {
+        mockServerFetch.mockRejectedValue(new Error('CUIT_MISMATCH'))
+        await expect(mantecaApi.withdrawWithSignedTx(withdrawBody)).resolves.toEqual({ error: 'CUIT_MISMATCH' })
+    })
+
+    it('still returns the server error body on a non-ok response', async () => {
+        mockServerFetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: 'TAX_ID_MISMATCH', message: 'nope' }),
+        } as Response)
+        await expect(mantecaApi.withdrawWithSignedTx(withdrawBody)).resolves.toEqual({
+            error: 'TAX_ID_MISMATCH',
+            message: 'nope',
+        })
+    })
+})

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -5,6 +5,7 @@ import {
     type CreateMantecaOnrampParams,
 } from '@/types/manteca.types'
 import { serverFetch } from '@/utils/api-fetch'
+import { isNetworkLayerFailure } from '@/utils/network-triage'
 import { jsonStringify } from '@/utils/general.utils'
 import type { Address } from 'viem'
 import type { SignUserOperationReturnType } from '@zerodev/sdk/actions'
@@ -340,6 +341,9 @@ export const mantecaApi = {
             return { data: result }
         } catch (error) {
             console.error('Error calling manteca withdraw init API:', error)
+            // See withdrawWithSignedTx: a flattened transport error skips the
+            // page's withdraw_step:lock-rate triage capture entirely.
+            if (isNetworkLayerFailure(error)) throw error
             if (error instanceof Error) {
                 return { error: error.message }
             }
@@ -440,6 +444,10 @@ export const mantecaApi = {
             return { data: result }
         } catch (error) {
             console.error('Error calling manteca withdraw complete-with-signed-tx API:', error)
+            // Transport failures must reach the caller's catch: flattening them
+            // into { error } sends the page down its result.error branch, which
+            // returns before the network-triage capture ever runs (TASK-21956).
+            if (isNetworkLayerFailure(error)) throw error
             if (error instanceof Error) {
                 return { error: error.message }
             }

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -1,6 +1,7 @@
 import {
     captureNetworkTriagedFailure,
     isNativeFetchRejection,
+    isNetworkLayerFailure,
     networkTriageTags,
     triageNetworkFailure,
 } from '../network-triage'
@@ -52,6 +53,27 @@ describe('isNativeFetchRejection', () => {
         expect(isNativeFetchRejection('Error', 'Failed to fetch charges: 500')).toBe(false)
         expect(isNativeFetchRejection('TypeError', 'Failed to fetch charges: 500')).toBe(false)
         expect(isNativeFetchRejection(undefined, undefined)).toBe(false)
+    })
+})
+
+// The predicate the qr-pay / withdraw catches use to report selectively: their
+// other branches are deliberate non-reports (backend wire codes, user actions),
+// so they need to single out the network class without capturing everything.
+describe('isNetworkLayerFailure', () => {
+    test.each([
+        ['a raw engine rejection', new TypeError('Failed to fetch')],
+        ['a fetchWithSentry timeout', Object.assign(new Error('slow'), { name: 'ConnectionTimeoutError' })],
+        ['a fetchWithSentry generic wrap', Object.assign(new Error('nope'), { name: 'ServiceUnavailableError' })],
+    ])('accepts %s', (_label, error) => {
+        expect(isNetworkLayerFailure(error)).toBe(true)
+    })
+
+    test.each([
+        ['a server decision', Object.assign(new Error('insufficient collateral'), { name: 'ApiError' })],
+        ['our own wrapped fetch copy', new Error('Failed to fetch charges: 500')],
+        ['a non-Error throw', 'something odd'],
+    ])('rejects %s', (_label, error) => {
+        expect(isNetworkLayerFailure(error)).toBe(false)
     })
 })
 

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -94,10 +94,25 @@ describe('triageNetworkFailure', () => {
         expect(triage?.observed).toBe('api_reachable')
     })
 
-    test('nothing reachable → offline', async () => {
+    // iOS WKWebView serves no opaque responses at all: the retired native
+    // canary measured its no-cors probe failing 108/108 while every other iOS
+    // probe succeeded. Both no-cors probes below therefore always fail there,
+    // so their failure must never be read as evidence of a dead network.
+    test('nothing reachable but the device says online → unknown, never offline', async () => {
         mockProbes({ apiCors: false, internet: false })
         const triage = await triageNetworkFailure(fetchRejection)
-        expect(triage?.observed).toBe('offline')
+        expect(triage?.observed).toBe('unknown')
+    })
+
+    test('nothing reachable and the device says offline → offline', async () => {
+        mockProbes({ apiCors: false, internet: false })
+        Object.defineProperty(navigator, 'onLine', { configurable: true, value: false })
+        try {
+            const triage = await triageNetworkFailure(fetchRejection)
+            expect(triage?.observed).toBe('offline')
+        } finally {
+            Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+        }
     })
 
     test('also triages fetchWithSentry-wrapped failures by their rethrown name', async () => {

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -37,6 +37,15 @@ function classifyNetworkFailure(error: unknown): NetworkErrorClass | null {
     return null
 }
 
+/**
+ * Did this error die at the network layer (rather than being something a
+ * server, or the user, decided)? For call sites that report selectively —
+ * a catch whose other branches are deliberate non-reports.
+ */
+export function isNetworkLayerFailure(error: unknown): boolean {
+    return classifyNetworkFailure(error) !== null
+}
+
 export interface NetworkTriage {
     /**
      * What the probes OBSERVED in the seconds after the failure — not proof of

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -51,9 +51,12 @@ export interface NetworkTriage {
      *   — a WAF/bot challenge or a CORS-less error page. The direct evidence
      *   for the failure mode this whole diagnostic exists to find.
      * - `edge_unreachable`: the internet answered, our edge did not
-     * - `offline`: nothing answered
+     * - `offline`: nothing answered AND the device says it is offline
+     * - `unknown`: nothing answered but the device claims to be online. NOT
+     *   reported as `offline`, because the no-cors channel every remaining
+     *   probe depends on is itself unavailable on some platforms — see below.
      */
-    observed: 'api_reachable' | 'api_cors_blocked' | 'edge_unreachable' | 'offline'
+    observed: 'api_reachable' | 'api_cors_blocked' | 'edge_unreachable' | 'offline' | 'unknown'
     errorClass: NetworkErrorClass
     online: boolean
     effectiveType?: string
@@ -77,6 +80,16 @@ const PROBE_TIMEOUT_MS = 2500
  * error pages that carry no CORS headers at all. So cors-fails-while-no-cors-
  * succeeds is precisely "something answered but the browser wouldn't let the
  * app read it", the shape a WAF challenge or CORS-less 5xx takes.
+ *
+ * The no-cors channel is NOT universally available, which is why its failure
+ * can never be read as "the network is down". The retired native canary
+ * (`native-canary.ts` on `main`, probe `get-healthz-nocors`) measured exactly
+ * this over 30 days: on Android it works (681 opaque / 625 network-error),
+ * while on iOS it failed 108/108 — 100% — with every other iOS probe at 100%
+ * success in the same batch. WKWebView's scheme handler simply does not serve
+ * opaque responses. So on iOS BOTH no-cors probes below always fail, and a
+ * verdict that treated that as evidence would label every iOS failure
+ * `offline` — the exact mislabelling this module exists to remove.
  */
 async function probe(url: string, mode: 'cors' | 'no-cors'): Promise<boolean> {
     const controller = new AbortController()
@@ -113,7 +126,12 @@ export async function triageNetworkFailure(error: unknown): Promise<NetworkTriag
               ? 'api_cors_blocked'
               : internetReachable
                 ? 'edge_unreachable'
-                : 'offline',
+                : // Every remaining branch rests on the no-cors channel, which
+                  // iOS does not provide at all. Claim `offline` only when the
+                  // device itself says so; otherwise admit we cannot tell.
+                  online
+                  ? 'unknown'
+                  : 'offline',
         errorClass,
         online,
         effectiveType: connection?.effectiveType,


### PR DESCRIPTION
Follow-up to #2867 (**stacked on it** — merge that first; this diff reads clean against it). Closes the `qr-pay` / `withdraw` gap both #2860 and #2867 flagged as out of scope.

## What I expected to find, and what was actually there

The expected gap was the send-link one: `captureException` untagged, so `IGNORED_ERRORS.networkIssues` silently drops any "Failed to fetch". That was there. Two worse things were not expected:

**1. Two sites stopped reporting entirely when #2860 landed.** `qr-pay` sign and `manteca` withdraw sign only call `captureException` inside the `classified.code === 'genericSupport'` branch:

```ts
} else if (classified.kind === 'code' && classified.code === 'genericSupport') {
    captureException(error)          // ← the only report in this catch
    setErrorMessage(t('errors.signFailed'))
} else {
    setErrorMessage(toFriendlyError(error), ...)   // ← no report
}
```

Before #2860 a `TypeError: Failed to fetch` classified as `genericSupport`, so it was captured (then dropped by the noise filter). After #2860 it classifies as `connectionLost` — which lands in the `else` — so **no event is created at all**. Same net observability (zero), but the fix has to add the report, not just tag it. Nothing regressed for users; it's the diagnosis path that got quieter.

**2. Two money-leg catches never reported to Sentry at all.** `manteca` submit and `crypto` execute emitted only a PostHog event whose `error_message` is the **localized** copy — ungroupable across locales, and nothing in Sentry. A withdrawal failing at the money leg left nothing queryable anywhere.

## Sites wired (7)

| flow | step | was |
|---|---|---|
| qr-pay | `initiate` | untagged capture |
| qr-pay | `sign` | **captured only for genericSupport** |
| qr-pay | `submit` | untagged capture |
| withdraw-manteca | `lock-rate` | untagged capture |
| withdraw-manteca | `sign` | **captured only for genericSupport** |
| withdraw-manteca | `submit` | **no Sentry capture at all** |
| withdraw-crypto | `execute` | **no Sentry capture at all** |

All now go through `captureNetworkTriagedFailure` with `criticalFlowTags(flow)` + a step tag, so the noise filters keep them and the `net_probe` / `net_error_class` observation rides along. The two PostHog-only sites keep their existing event and gain `error_name` / `error_raw` beside the localized string.

## New export: `isNetworkLayerFailure`

The two selective catches must not start reporting everything — their other branches are deliberate non-reports (backend wire codes, or the user declining a passkey). So the `else` branch reports **only** when the error is network-class:

```ts
if (isNetworkLayerFailure(error)) {
    void captureNetworkTriagedFailure(error, { tags: {...} })
}
```

## Deliberately not changed

- The `SessionKeyGrantRequiredError` and `'not allowed'` branches stay silent — a user declining biometric auth is not a defect.
- `PIX_MIN_AMOUNT` in qr-pay stays out of Sentry (existing comment says why: deterministic rail-minimum rejection).
- The `captureMessage` calls in the crypto withdraw's recordPayment paths are untouched — different concern (funds already moved), already reported.
- Camera failures in `QRScanner` / `QRScannerOverlay` are out of scope; #2864 classifies those.

## Verification

- `pnpm typecheck` clean
- `network-triage.test.ts` — 23 passed (6 new for `isNetworkLayerFailure`, incl. the `Failed to fetch charges: 500` false-positive trap and a non-`Error` throw)
- `withdraw-states.test.tsx` + `qr-pay-states.test.tsx` — 63 passed, 3 skipped (unchanged)
- `prettier --check` clean