### PR TITLE
feat(telemetry): count and attribute every passkey ceremony a flow triggers

### DIFF
--- a/src/app/(mobile-ui)/dev/ceremony-log/page.tsx
+++ b/src/app/(mobile-ui)/dev/ceremony-log/page.tsx
@@ -77,6 +77,7 @@ export default function CeremonyLogPage() {
                                 <div className="flex flex-wrap items-baseline justify-between gap-2">
                                     <span className="font-bold">
                                         #{record.seq} {record.purpose}
+                                        {record.overlapped && ' ⚠️'}
                                     </span>
                                     <span>{record.outcome === 'ok' ? '✅ ok' : `❌ ${record.errorName}`}</span>
                                 </div>
@@ -94,8 +95,9 @@ export default function CeremonyLogPage() {
             )}
 
             <p className="text-xs text-grey-1">
-                These are the ceremonies our JavaScript asked for. More sheets on screen than rows here means the extra
-                prompts come from @capgo/capacitor-passkey or the OS credential manager, not from our call sites.
+                ⚠️ marks a ceremony that overlapped another one — its purpose is a guess, not evidence. These are the
+                ceremonies our JavaScript asked for. More sheets on screen than rows here means the extra prompts come
+                from @capgo/capacitor-passkey or the OS credential manager, not from our call sites.
             </p>
         </DevPageShell>
     )

--- a/src/app/(mobile-ui)/dev/ceremony-log/page.tsx
+++ b/src/app/(mobile-ui)/dev/ceremony-log/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+/**
+ * Dev page: every WebAuthn ceremony this app session requested, in order.
+ *
+ * Repro on-device (Android), then open this page: one row per passkey sheet our
+ * code asked for, tagged with the call path that asked. If a link creation shows
+ * three rows, the purposes name the three call sites. If it shows fewer rows than
+ * sheets you actually saw, the surplus came from the native plugin or the OS.
+ */
+
+import { useCallback, useState } from 'react'
+import { Button } from '@/components/0_Bruddle/Button'
+import { clearCeremonyLog, getCeremonyLog, type CeremonyRecord } from '@/utils/webauthn-ceremony-telemetry'
+import DevPageShell from '../_components/DevPageShell'
+
+const formatMs = (ms: number | null | undefined) => (ms === null || ms === undefined ? '—' : `${ms} ms`)
+
+export default function CeremonyLogPage() {
+    const [records, setRecords] = useState<CeremonyRecord[]>([])
+    const [copied, setCopied] = useState(false)
+
+    const refresh = useCallback(() => setRecords(getCeremonyLog()), [])
+
+    const copy = useCallback(async () => {
+        await navigator.clipboard.writeText(JSON.stringify(getCeremonyLog(), null, 2))
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+    }, [])
+
+    const byFlow = records.reduce<Record<string, number>>((acc, record) => {
+        const key = record.flow ?? 'no flow'
+        acc[key] = (acc[key] ?? 0) + 1
+        return acc
+    }, {})
+
+    return (
+        <DevPageShell
+            title="WebAuthn ceremony log"
+            description="Every passkey sheet this app session requested, with the call path that requested it. Reproduce the flow, then hit Refresh."
+            width="prose"
+        >
+            <div className="flex flex-wrap gap-2">
+                <Button onClick={refresh}>Refresh</Button>
+                <Button variant="stroke" onClick={copy}>
+                    {copied ? 'Copied' : 'Copy JSON'}
+                </Button>
+                <Button
+                    variant="stroke"
+                    onClick={() => {
+                        clearCeremonyLog()
+                        refresh()
+                    }}
+                >
+                    Clear
+                </Button>
+            </div>
+
+            {records.length === 0 ? (
+                <p className="text-sm text-grey-1">
+                    Nothing recorded yet. Create a send link (or sign in), then come back and hit Refresh.
+                </p>
+            ) : (
+                <>
+                    <div className="rounded-sm border border-n-1 p-3 text-sm">
+                        <div className="font-bold">{records.length} ceremonies this session</div>
+                        {Object.entries(byFlow).map(([flow, count]) => (
+                            <div key={flow}>
+                                {flow}: {count}
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="flex flex-col gap-2">
+                        {records.map((record) => (
+                            <div key={record.seq} className="rounded-sm border border-n-1 p-3 text-sm">
+                                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                    <span className="font-bold">
+                                        #{record.seq} {record.purpose}
+                                    </span>
+                                    <span>{record.outcome === 'ok' ? '✅ ok' : `❌ ${record.errorName}`}</span>
+                                </div>
+                                <div className="text-grey-1">
+                                    {record.kind} · flow {record.flow ?? '—'} · took {formatMs(record.durationMs)} · gap
+                                    before {formatMs(record.gapMs)}
+                                    {record.allowCredentials !== undefined &&
+                                        ` · allowCredentials ${record.allowCredentials}`}
+                                    {record.errorCode && ` · ${record.errorCode}`}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </>
+            )}
+
+            <p className="text-xs text-grey-1">
+                These are the ceremonies our JavaScript asked for. More sheets on screen than rows here means the extra
+                prompts come from @capgo/capacitor-passkey or the OS credential manager, not from our call sites.
+            </p>
+        </DevPageShell>
+    )
+}

--- a/src/app/(mobile-ui)/dev/page.tsx
+++ b/src/app/(mobile-ui)/dev/page.tsx
@@ -103,6 +103,13 @@ export default function DevToolsPage() {
             icon: 'info',
         },
         {
+            name: 'WebAuthn ceremony log',
+            description:
+                'Every passkey sheet this app session requested, tagged with the call path that asked — for diagnosing repeat prompts on a device.',
+            path: '/dev/ceremony-log',
+            icon: 'info',
+        },
+        {
             name: 'Card session approve',
             description:
                 'Grants the combined Rain session-key permission (auto-balancer + withdraw policies) in one passkey tap.',

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -18,6 +18,7 @@ import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.co
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignTypedData } from 'wagmi'
+import { withCeremonyFlow } from '@/utils/webauthn-ceremony-telemetry'
 
 export const useCreateLink = () => {
     const { setLoadingState } = useContext(loadingStateContext)
@@ -45,82 +46,91 @@ export const useCreateLink = () => {
     // Priority: Low (rare edge case in less common flow)
     const createLink = useCallback(
         async (amount: bigint) => {
-            setLoadingState('Generating details')
-            const password = await generatePassword()
-            const generatedKeys = generateKeysFromString(password)
-            saveToLocalStorage(`sendLink::password::${generatedKeys.address}`, password)
+            let strategy: string | undefined
+            return withCeremonyFlow(
+                'link_create',
+                async () => {
+                    setLoadingState('Generating details')
+                    const password = await generatePassword()
+                    const generatedKeys = generateKeysFromString(password)
+                    saveToLocalStorage(`sendLink::password::${generatedKeys.address}`, password)
 
-            const chainId = PEANUT_WALLET_CHAIN.id.toString()
-            const contractVersion = getLatestContractVersion({
-                chainId,
-                type: 'normal',
-            })
-            const tokenAddress = PEANUT_WALLET_TOKEN as Hash
-            const contractAbi = getContractAbi(contractVersion)
-            const contractAddress: Address = getContractAddress(
-                PEANUT_WALLET_CHAIN.id.toString(),
-                contractVersion
-            ) as Hash
+                    const chainId = PEANUT_WALLET_CHAIN.id.toString()
+                    const contractVersion = getLatestContractVersion({
+                        chainId,
+                        type: 'normal',
+                    })
+                    const tokenAddress = PEANUT_WALLET_TOKEN as Hash
+                    const contractAbi = getContractAbi(contractVersion)
+                    const contractAddress: Address = getContractAddress(
+                        PEANUT_WALLET_CHAIN.id.toString(),
+                        contractVersion
+                    ) as Hash
 
-            const approveData = encodeFunctionData({
-                abi: parseAbi(['function approve(address _spender, uint256 _amount) external returns (bool)']),
-                functionName: 'approve',
-                args: [contractAddress, amount],
-            })
-            const makeDepositData = encodeFunctionData({
-                abi: contractAbi,
-                functionName: 'makeDeposit',
-                args: [tokenAddress, 1, amount, 0, generatedKeys.address as Hash],
-            })
-            // Route through sendTransactions with `requiredUsdcAmount` so a Rain
-            // collateral withdraw is prepended to the UserOp when the smart
-            // account is short. Covers the mixed (smart + collateral) case.
-            const [nextIndex, { receipt, intentId }] = await Promise.all([
-                getNextDepositIndex(contractVersion),
-                sendTransactions(
-                    [
-                        { to: tokenAddress, value: 0n, data: approveData },
-                        { to: contractAddress, value: 0n, data: makeDepositData },
-                    ],
-                    { chainId, requiredUsdcAmount: amount, kind: 'LINK_CREATE' }
-                ),
-            ])
-            let depositIdx: number
-            let txHash: Hash | undefined = undefined
-            if (receipt !== null) {
-                const depositEvent = parseEventLogs({
-                    abi: contractAbi,
-                    eventName: 'DepositEvent',
-                    logs: receipt.logs,
-                })[0]
-                depositIdx = bytesToNumber(toBytes(depositEvent.topics[1]!))
-                txHash = depositEvent.transactionHash
-            } else {
-                depositIdx = nextIndex
-            }
+                    const approveData = encodeFunctionData({
+                        abi: parseAbi(['function approve(address _spender, uint256 _amount) external returns (bool)']),
+                        functionName: 'approve',
+                        args: [contractAddress, amount],
+                    })
+                    const makeDepositData = encodeFunctionData({
+                        abi: contractAbi,
+                        functionName: 'makeDeposit',
+                        args: [tokenAddress, 1, amount, 0, generatedKeys.address as Hash],
+                    })
+                    // Route through sendTransactions with `requiredUsdcAmount` so a Rain
+                    // collateral withdraw is prepended to the UserOp when the smart
+                    // account is short. Covers the mixed (smart + collateral) case.
+                    const [nextIndex, sendResult] = await Promise.all([
+                        getNextDepositIndex(contractVersion),
+                        sendTransactions(
+                            [
+                                { to: tokenAddress, value: 0n, data: approveData },
+                                { to: contractAddress, value: 0n, data: makeDepositData },
+                            ],
+                            { chainId, requiredUsdcAmount: amount, kind: 'LINK_CREATE' }
+                        ),
+                    ])
+                    const { receipt, intentId } = sendResult
+                    strategy = 'strategy' in sendResult ? sendResult.strategy : undefined
+                    let depositIdx: number
+                    let txHash: Hash | undefined = undefined
+                    if (receipt !== null) {
+                        const depositEvent = parseEventLogs({
+                            abi: contractAbi,
+                            eventName: 'DepositEvent',
+                            logs: receipt.logs,
+                        })[0]
+                        depositIdx = bytesToNumber(toBytes(depositEvent.topics[1]!))
+                        txHash = depositEvent.transactionHash
+                    } else {
+                        depositIdx = nextIndex
+                    }
 
-            const link = getLinkFromParams(
-                chainId,
-                contractVersion,
-                depositIdx,
-                password,
-                `${process.env.NEXT_PUBLIC_BASE_URL!}/claim`,
-                undefined
+                    const link = getLinkFromParams(
+                        chainId,
+                        contractVersion,
+                        depositIdx,
+                        password,
+                        `${process.env.NEXT_PUBLIC_BASE_URL!}/claim`,
+                        undefined
+                    )
+                    return {
+                        link,
+                        pubKey: generatedKeys.address,
+                        chainId,
+                        contractVersion,
+                        depositIdx,
+                        txHash,
+                        amount,
+                        tokenAddress,
+                        // Present only for collateral-funded ("mixed") links — the Rain
+                        // prepare intent id, threaded to /send-links so the backend
+                        // adopts it instead of minting a duplicate SEND_LINK.
+                        preparationId: intentId,
+                    }
+                },
+                () => ({ strategy })
             )
-            return {
-                link,
-                pubKey: generatedKeys.address,
-                chainId,
-                contractVersion,
-                depositIdx,
-                txHash,
-                amount,
-                tokenAddress,
-                // Present only for collateral-funded ("mixed") links — the Rain
-                // prepare intent id, threaded to /send-links so the backend
-                // adopts it instead of minting a duplicate SEND_LINK.
-                preparationId: intentId,
-            }
         },
         [sendTransactions, setLoadingState]
     )

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -87,11 +87,19 @@ export const useCreateLink = () => {
                                 { to: tokenAddress, value: 0n, data: approveData },
                                 { to: contractAddress, value: 0n, data: makeDepositData },
                             ],
-                            { chainId, requiredUsdcAmount: amount, kind: 'LINK_CREATE' }
+                            {
+                                chainId,
+                                requiredUsdcAmount: amount,
+                                kind: 'LINK_CREATE',
+                                // as soon as routing decides, not when it succeeds — a
+                                // cancelled flow still has to be readable by strategy
+                                onStrategyDecided: (decided) => {
+                                    strategy = decided
+                                },
+                            }
                         ),
                     ])
                     const { receipt, intentId } = sendResult
-                    strategy = 'strategy' in sendResult ? sendResult.strategy : undefined
                     let depositIdx: number
                     let txHash: Hash | undefined = undefined
                     if (receipt !== null) {

--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -10,6 +10,7 @@ import 'react-tooltip/dist/react-tooltip.css'
 import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
 import { authReady } from '@/utils/auth-token'
 import { installNativeAuthCapture } from '@/utils/native-auth-capture'
+import { installCeremonyTelemetry } from '@/utils/webauthn-ceremony-telemetry'
 // Note: Sentry configs are auto-loaded by @sentry/nextjs via next.config.js
 // DO NOT import them here - it bundles server/edge configs into client code
 
@@ -83,7 +84,12 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
                     .catch((err: unknown) => {
                         console.warn('[PeanutProvider] passkey shim init failed:', err)
                     })
+                    // only meaningful once the shim owns navigator.credentials — patching
+                    // before it would wrap the browser API the shim then replaces
+                    .finally(() => installCeremonyTelemetry())
             })
+        } else {
+            installCeremonyTelemetry()
         }
     }, [])
 

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -295,6 +295,14 @@ export const ANALYTICS_EVENTS = {
     // refused/wedged, e.g. 1Password on iOS), `context` is the signing call site.
     PASSKEY_SIGN_FAILED: 'passkey_sign_failed',
 
+    // One event per WebAuthn ceremony our code requests, tagged with the purpose
+    // stack (`kernel_migration>user_op`, `admin_eip712`, …) and the flow it ran
+    // in. `webauthn_ceremony_flow` closes a flow with the total count — that
+    // count is what says whether a 2–3 prompt report is our call sites, a retry,
+    // or the native shim presenting extra sheets on its own.
+    WEBAUTHN_CEREMONY: 'webauthn_ceremony',
+    WEBAUTHN_CEREMONY_FLOW: 'webauthn_ceremony_flow',
+
     // Rain withdrawal-signature cooldown tripped during a spend. Handled
     // gracefully in-flow (no captureException), so this is the only telemetry.
     RAIN_COOLDOWN_HIT: 'rain_cooldown_hit',

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -11,6 +11,7 @@ import { getFromCookie, removeFromCookie, saveToCookie, saveToLocalStorage } fro
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
 import { capturePasskeySignFailure, classifyPasskeyError } from '@/utils/webauthn.utils'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { toWebAuthnKey, WebAuthnMode } from '@zerodev/passkey-validator'
 import { useCallback, useContext } from 'react'
 import type { TransactionReceipt, Hex, Hash } from 'viem'
@@ -81,16 +82,18 @@ export const useZeroDev = () => {
 
             // @capgo/capacitor-passkey shim patches navigator.credentials on native,
             // so toWebAuthnKey works on all platforms (web, android, ios).
-            const webAuthnKey = await toWebAuthnKey({
-                passkeyName: _getPasskeyName(username),
-                passkeyServerUrl: PASSKEY_SERVER_URL as string,
-                mode: WebAuthnMode.Register,
-                // Consent-ledger echo (tos-v1 phase 2): the ZeroDev SDK owns the
-                // register/verify request body, so the terms+privacy versions the
-                // signup screen displayed ride in a header the backend ledgers.
-                passkeyServerHeaders: { 'x-accepted-legal': JSON.stringify(signupConsentDocuments()) },
-                rpID: rpId,
-            })
+            const webAuthnKey = await withCeremonyPurpose('registration', () =>
+                toWebAuthnKey({
+                    passkeyName: _getPasskeyName(username),
+                    passkeyServerUrl: PASSKEY_SERVER_URL as string,
+                    mode: WebAuthnMode.Register,
+                    // Consent-ledger echo (tos-v1 phase 2): the ZeroDev SDK owns the
+                    // register/verify request body, so the terms+privacy versions the
+                    // signup screen displayed ride in a header the backend ledgers.
+                    passkeyServerHeaders: { 'x-accepted-legal': JSON.stringify(signupConsentDocuments()) },
+                    rpID: rpId,
+                })
+            )
 
             const inviteCodeFromCookie = getFromCookie('inviteCode')
 
@@ -260,13 +263,15 @@ export const useZeroDev = () => {
 
             const rpId = isCapacitor() ? getNativeRpId() : window.location.hostname.replace(/^www\./, '')
 
-            const webAuthnKey = await toWebAuthnKey({
-                passkeyName: '[]',
-                passkeyServerUrl: PASSKEY_SERVER_URL as string,
-                mode: WebAuthnMode.Login,
-                passkeyServerHeaders,
-                rpID: rpId,
-            })
+            const webAuthnKey = await withCeremonyPurpose('login', () =>
+                toWebAuthnKey({
+                    passkeyName: '[]',
+                    passkeyServerUrl: PASSKEY_SERVER_URL as string,
+                    mode: WebAuthnMode.Login,
+                    passkeyServerHeaders,
+                    rpID: rpId,
+                })
+            )
 
             setWebAuthnKey(webAuthnKey)
             saveToCookie(WEB_AUTHN_COOKIE_KEY, webAuthnKey, 90)
@@ -319,10 +324,12 @@ export const useZeroDev = () => {
 
             let userOpHash: Hash
             try {
-                userOpHash = await client.sendUserOperation({
-                    account: client.account,
-                    callData: await client.account!.encodeCalls(calls),
-                })
+                userOpHash = await withCeremonyPurpose('user_op', async () =>
+                    client.sendUserOperation({
+                        account: client.account,
+                        callData: await client.account!.encodeCalls(calls),
+                    })
+                )
             } catch (error) {
                 console.error('Error sending UserOp:', error)
                 capturePasskeySignFailure(error, 'send-user-op')

--- a/src/hooks/wallet/useGrantSessionKey.ts
+++ b/src/hooks/wallet/useGrantSessionKey.ts
@@ -17,6 +17,7 @@ import { toECDSASigner } from '@zerodev/permissions/signers'
 import { accountMetadata, createKernelAccount, getPluginsEnableTypedData, KernelV3AccountAbi } from '@zerodev/sdk'
 import { getEntryPoint, KERNEL_V3_1 } from '@zerodev/sdk/constants'
 import { serializePermissionAccount } from '@zerodev/permissions'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { peanutPublicClient } from '@/app/actions/clients'
 import { rainApi } from '@/services/rain'
 import { useZeroDev } from '@/hooks/useZeroDev'
@@ -308,7 +309,9 @@ export const useGrantSessionKey = (): GrantSessionKeyResult => {
         })
         // Same sudo validator + signing path the SDK uses internally, so for
         // healthy nonce=1 accounts this yields an identical approval.
-        const enableSignature = await patchedSudoValidator.signTypedData(enableTypedData)
+        const enableSignature = await withCeremonyPurpose('session_key_grant', () =>
+            patchedSudoValidator.signTypedData(enableTypedData)
+        )
 
         const serialized = await serializePermissionAccount(sessionKernelAccount, undefined, enableSignature)
         return { ok: true, serialized }

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { useQueryClient } from '@tanstack/react-query'
 import type { Address, Hex } from 'viem'
 import { encodeFunctionData, erc20Abi } from 'viem'
@@ -226,8 +227,8 @@ export const useSignSpendBundle = () => {
                         kind,
                     })
 
-                    const adminSignature = (await activeAccount.signTypedData(
-                        buildRainWithdrawTypedData(prep, chainIdNum)
+                    const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
+                        activeAccount.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                     )) as Hex
 
                     return {
@@ -266,8 +267,8 @@ export const useSignSpendBundle = () => {
                     totalAmountCents: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                 })
 
-                const adminSignature = (await activeAccount.signTypedData(
-                    buildRainWithdrawTypedData(prep, chainIdNum)
+                const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
+                    activeAccount.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                 )) as Hex
 
                 const withdrawCall = {

--- a/src/hooks/wallet/useSignUserOp.ts
+++ b/src/hooks/wallet/useSignUserOp.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { useKernelClient } from '@/context/kernelClient.context'
 import { signUserOperation } from '@zerodev/sdk/actions'
 import {
@@ -44,10 +45,12 @@ export const useSignUserOp = () => {
                 if (!client.account) {
                     throw new Error('Smart account not initialized')
                 }
-                const signedUserOp = await signUserOperation(client, {
-                    account: client.account,
-                    callData: await client.account.encodeCalls(calls),
-                })
+                const signedUserOp = await withCeremonyPurpose('user_op', async () =>
+                    signUserOperation(client, {
+                        account: client.account!,
+                        callData: await client.account!.encodeCalls(calls),
+                    })
+                )
                 return {
                     signedUserOp,
                     chainId,

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { useQueryClient } from '@tanstack/react-query'
 import type { Address, Hash, Hex, TransactionReceipt } from 'viem'
 import { encodeFunctionData, erc20Abi } from 'viem'
@@ -201,8 +202,8 @@ export const useSpendBundle = () => {
                         chargeId,
                     })
 
-                    const adminSignature = (await activeClient.account!.signTypedData(
-                        buildRainWithdrawTypedData(prep, chainIdNum)
+                    const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
+                        activeClient.account!.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                     )) as Hex
 
                     const { txHash } = await rainApi.submitWithdrawal({
@@ -325,8 +326,8 @@ export const useSpendBundle = () => {
                     })
                 }
 
-                const adminSignature = (await activeClient.account!.signTypedData(
-                    buildRainWithdrawTypedData(prep, chainIdNum)
+                const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
+                    activeClient.account!.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                 )) as Hex
 
                 // Mixed = two passkey taps. The admin EIP-712 sig (tap #1) just

--- a/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
+++ b/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
@@ -114,6 +114,24 @@ describe('webauthn ceremony telemetry', () => {
         expect(events('webauthn_ceremony_flow')[0]).toMatchObject({ ceremony_count: 1, outcome: 'error' })
     })
 
+    it('keeps an annotation recorded before the failure — a cancelled mixed link stays segmentable', async () => {
+        get.mockRejectedValueOnce(new Error('NotAllowedError'))
+        let strategy: string | undefined
+
+        await expect(
+            withCeremonyFlow(
+                'link_create',
+                async () => {
+                    strategy = 'mixed'
+                    return withCeremonyPurpose('admin_eip712', () => navigator.credentials.get({}))
+                },
+                () => ({ strategy })
+            )
+        ).rejects.toThrow('NotAllowedError')
+
+        expect(events('webauthn_ceremony_flow')[0]).toMatchObject({ outcome: 'error', strategy: 'mixed' })
+    })
+
     it('measures the gap between back-to-back sheets', async () => {
         await withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
         await withCeremonyPurpose('user_op', () => navigator.credentials.get({}))

--- a/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
+++ b/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
@@ -1,0 +1,132 @@
+const capture = jest.fn()
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: (...args: unknown[]) => capture(...args) },
+}))
+
+jest.mock('@sentry/nextjs', () => ({
+    addBreadcrumb: jest.fn(),
+}))
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => true,
+}))
+
+import {
+    clearCeremonyLog,
+    getCeremonyLog,
+    installCeremonyTelemetry,
+    withCeremonyFlow,
+    withCeremonyPurpose,
+} from '@/utils/webauthn-ceremony-telemetry'
+
+const get = jest.fn()
+const create = jest.fn()
+
+beforeAll(() => {
+    Object.defineProperty(global.navigator, 'credentials', {
+        configurable: true,
+        value: { get, create },
+    })
+    installCeremonyTelemetry()
+})
+
+beforeEach(() => {
+    capture.mockClear()
+    get.mockReset().mockResolvedValue({ id: 'cred' })
+    create.mockReset().mockResolvedValue({ id: 'cred' })
+    clearCeremonyLog()
+})
+
+const events = (name: string) => capture.mock.calls.filter(([event]) => event === name).map(([, props]) => props)
+
+describe('webauthn ceremony telemetry', () => {
+    it('records one entry per ceremony, tagged with the purpose stack', async () => {
+        await withCeremonyPurpose('user_op', () =>
+            navigator.credentials.get({
+                publicKey: { challenge: new Uint8Array(1) } as PublicKeyCredentialRequestOptions,
+            })
+        )
+
+        const log = getCeremonyLog()
+        expect(log).toHaveLength(1)
+        expect(log[0]).toMatchObject({ seq: 1, kind: 'get', purpose: 'user_op', outcome: 'ok', native: true })
+        expect(events('webauthn_ceremony')).toHaveLength(1)
+    })
+
+    it('joins nested purposes so a migration userOp is distinguishable from a payment one', async () => {
+        await withCeremonyPurpose('kernel_migration', () =>
+            withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+        )
+
+        expect(getCeremonyLog()[0].purpose).toBe('kernel_migration>user_op')
+    })
+
+    it('labels an unattributed ceremony rather than dropping it', async () => {
+        await navigator.credentials.create({})
+
+        expect(getCeremonyLog()[0]).toMatchObject({ kind: 'create', purpose: 'unknown' })
+    })
+
+    it('records a failed ceremony with its classified code, and rethrows', async () => {
+        const error = new Error('cancelled')
+        error.name = 'NotAllowedError'
+        get.mockRejectedValueOnce(error)
+
+        await expect(withCeremonyPurpose('login', () => navigator.credentials.get({}))).rejects.toThrow('cancelled')
+
+        expect(getCeremonyLog()[0]).toMatchObject({
+            outcome: 'error',
+            errorName: 'NotAllowedError',
+            errorCode: 'LOGIN_CANCELED',
+        })
+    })
+
+    it('counts every ceremony a flow triggered — the 2-vs-3 prompt question', async () => {
+        await withCeremonyFlow(
+            'link_create',
+            async () => {
+                await withCeremonyPurpose('admin_eip712', () => navigator.credentials.get({}))
+                await withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+            },
+            () => ({ strategy: 'mixed' })
+        )
+
+        const [flow] = events('webauthn_ceremony_flow')
+        expect(flow).toMatchObject({
+            flow: 'link_create',
+            ceremony_count: 2,
+            purposes: ['admin_eip712', 'user_op'],
+            outcome: 'ok',
+            strategy: 'mixed',
+        })
+        expect(getCeremonyLog().every((record) => record.flow === 'link_create')).toBe(true)
+    })
+
+    it('still reports the flow when it fails mid-ceremony', async () => {
+        get.mockRejectedValueOnce(new Error('boom'))
+
+        await expect(
+            withCeremonyFlow('link_create', () => withCeremonyPurpose('user_op', () => navigator.credentials.get({})))
+        ).rejects.toThrow('boom')
+
+        expect(events('webauthn_ceremony_flow')[0]).toMatchObject({ ceremony_count: 1, outcome: 'error' })
+    })
+
+    it('measures the gap between back-to-back sheets', async () => {
+        await withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+        await withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+
+        const log = getCeremonyLog()
+        expect(log[0].gapMs).toBeNull()
+        expect(log[1].gapMs).not.toBeNull()
+    })
+
+    it('patches navigator.credentials only once', async () => {
+        const patched = navigator.credentials.get
+        installCeremonyTelemetry()
+
+        expect(navigator.credentials.get).toBe(patched)
+    })
+})

--- a/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
+++ b/src/utils/__tests__/webauthn-ceremony-telemetry.test.ts
@@ -123,10 +123,68 @@ describe('webauthn ceremony telemetry', () => {
         expect(log[1].gapMs).not.toBeNull()
     })
 
+    it('flags a ceremony that overlapped another one, so its attribution reads as a guess', async () => {
+        let release: (value: unknown) => void = () => {}
+        get.mockImplementationOnce(() => new Promise((resolve) => (release = resolve)))
+
+        const first = withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+        await withCeremonyPurpose('app_lock', () => navigator.credentials.get({}))
+        release({ id: 'cred' })
+        await first
+
+        // The crossed stacks are the known limit of ambient attribution: app_lock
+        // inherits the still-open user_op frame. That is exactly what `overlapped`
+        // exists to disclose, so the row is readable as a guess rather than evidence.
+        const [second] = getCeremonyLog().filter((record) => record.seq === 2)
+        expect(second).toMatchObject({ purpose: 'user_op>app_lock', overlapped: true })
+        expect(getCeremonyLog().find((record) => record.seq === 1)?.overlapped).toBe(false)
+    })
+
+    it('survives a telemetry sink that throws — the ceremony still resolves', async () => {
+        capture.mockImplementationOnce(() => {
+            throw new Error('posthog not initialised')
+        })
+
+        await expect(withCeremonyPurpose('user_op', () => navigator.credentials.get({}))).resolves.toEqual({
+            id: 'cred',
+        })
+        expect(getCeremonyLog()).toHaveLength(1)
+    })
+
     it('patches navigator.credentials only once', async () => {
         const patched = navigator.credentials.get
         installCeremonyTelemetry()
 
         expect(navigator.credentials.get).toBe(patched)
+    })
+})
+
+describe('after a reload in the same browser session', () => {
+    it("keeps the tester's earlier ceremonies and continues the sequence", async () => {
+        const earlier = {
+            seq: 7,
+            kind: 'get',
+            purpose: 'admin_eip712',
+            flow: 'link_create',
+            flowId: 'link_create-1-1',
+            startedAt: Date.now() - 5000,
+            durationMs: 10,
+            gapMs: null,
+            outcome: 'ok',
+            native: true,
+            overlapped: false,
+            openFlows: 1,
+        }
+        window.sessionStorage.setItem('__webauthn_ceremony_log', JSON.stringify([earlier]))
+
+        jest.resetModules()
+        const fresh = await import('@/utils/webauthn-ceremony-telemetry')
+        fresh.installCeremonyTelemetry()
+        await fresh.withCeremonyPurpose('user_op', () => navigator.credentials.get({}))
+
+        const log = fresh.getCeremonyLog()
+        expect(log.map((record) => record.seq)).toEqual([7, 8])
+        expect(log[1]).toMatchObject({ purpose: 'user_op' })
+        expect(log[1].gapMs).not.toBeNull()
     })
 })

--- a/src/utils/app-lock.ts
+++ b/src/utils/app-lock.ts
@@ -13,6 +13,7 @@
 // gaps the guarded mode closes.
 
 import { base64URLToBytes } from './native-webauthn'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 
 /** How long the app may sit in the background before it relocks. */
 export const LOCK_AFTER_BACKGROUND_MS = 5 * 60 * 1000
@@ -40,16 +41,18 @@ export async function requestLocalUserPresence(credentialId?: string): Promise<U
     crypto.getRandomValues(challenge)
 
     try {
-        const assertion = await navigator.credentials.get({
-            publicKey: {
-                challenge,
-                // Copy into a fresh buffer: BufferSource wants Uint8Array<ArrayBuffer>,
-                // and base64URLToBytes is typed over the wider ArrayBufferLike.
-                allowCredentials: [{ id: new Uint8Array(base64URLToBytes(credentialId)), type: 'public-key' }],
-                userVerification: 'required',
-                timeout: 60_000,
-            },
-        })
+        const assertion = await withCeremonyPurpose('app_lock', () =>
+            navigator.credentials.get({
+                publicKey: {
+                    challenge,
+                    // Copy into a fresh buffer: BufferSource wants Uint8Array<ArrayBuffer>,
+                    // and base64URLToBytes is typed over the wider ArrayBufferLike.
+                    allowCredentials: [{ id: new Uint8Array(base64URLToBytes(credentialId)), type: 'public-key' }],
+                    userVerification: 'required',
+                    timeout: 60_000,
+                },
+            })
+        )
         return assertion ? 'unlocked' : 'dismissed'
     } catch (error) {
         // A cancelled prompt and a genuinely broken authenticator are

--- a/src/utils/ephemeralSpendKey.ts
+++ b/src/utils/ephemeralSpendKey.ts
@@ -1,4 +1,5 @@
 import type { Address, Chain, Hex, PublicClient } from 'viem'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { http, pad, slice, toFunctionSelector, toHex } from 'viem'
 import type { KernelValidator } from '@zerodev/sdk/types'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
@@ -293,7 +294,9 @@ export async function createEphemeralSpendSession(args: {
         })
 
         // THE passkey tap.
-        const enableSignature = await patchedSudoValidator.signTypedData(enableTypedData)
+        const enableSignature = await withCeremonyPurpose('ephemeral_enable', () =>
+            patchedSudoValidator.signTypedData(enableTypedData)
+        )
 
         // Rebuild the account with the precomputed enable signature injected so
         // the SDK's enable-mode UserOp encoding uses OUR nonce-verified

--- a/src/utils/kernelMigration.utils.ts
+++ b/src/utils/kernelMigration.utils.ts
@@ -1,4 +1,5 @@
 import type { Address, Hex, TransactionReceipt } from 'viem'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { encodeFunctionData, erc20Abi } from 'viem'
 import { PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 
@@ -99,7 +100,9 @@ export async function ensureRootValidatorMigrated<TClient extends { account?: un
     const migrated = await account.getRootValidatorMigrationStatus()
     if (!migrated) {
         deps.onEvent?.('attempted')
-        const { receipt } = await deps.sendNoopUserOp(buildMigrationNoopCall(account.address))
+        const { receipt } = await withCeremonyPurpose('kernel_migration', () =>
+            deps.sendNoopUserOp(buildMigrationNoopCall(account.address))
+        )
         if (receipt?.status === 'reverted') {
             // The bundle itself reverted — deterministic; retrying cannot help.
             throw new KernelMigrationFailedError()

--- a/src/utils/webauthn-ceremony-telemetry.ts
+++ b/src/utils/webauthn-ceremony-telemetry.ts
@@ -18,6 +18,12 @@ import { classifyPasskeyError } from '@/utils/webauthn.utils'
  * The count here is the number of ceremonies OUR CODE requested. If a device
  * shows more sheets than this log has entries, the extra ones come from the
  * native plugin or the OS, not from us — which is itself the answer.
+ *
+ * Attribution is ambient (a module-level purpose/flow stack), which is exact
+ * while ceremonies stay serialized — as the OS enforces for the sheet itself.
+ * Two genuinely overlapping flows (app-lock racing a spend) can cross the
+ * stacks, so every record carries `overlapped` / `openFlows`: when `overlapped`
+ * is true, read that row's purpose as a guess, not as evidence.
  */
 
 export type CeremonyPurpose =
@@ -28,6 +34,7 @@ export type CeremonyPurpose =
     | 'login'
     | 'registration'
     | 'app_lock'
+    | 'ephemeral_enable'
 
 export type CeremonyRecord = {
     seq: number
@@ -46,6 +53,9 @@ export type CeremonyRecord = {
     allowCredentials?: number
     rpId?: string
     native: boolean
+    /** True when another ceremony was already in flight — attribution is unreliable for this row. */
+    overlapped: boolean
+    openFlows: number
 }
 
 type FlowFrame = { id: string; name: string; startedAt: number; fromSeq: number }
@@ -54,12 +64,37 @@ const LOG_LIMIT = 40
 const STORAGE_KEY = '__webauthn_ceremony_log'
 
 let installed = false
+let hydrated = false
+let inFlight = 0
 let seq = 0
 let flowCounter = 0
 let lastEndedAt: number | null = null
 const purposeStack: CeremonyPurpose[] = []
 const flowStack: FlowFrame[] = []
 let log: CeremonyRecord[] = []
+
+/**
+ * A hard reload resets module state while sessionStorage still holds the
+ * tester's earlier ceremonies. Without this, the first ceremony after a reload
+ * appends to an empty array and persists it, erasing the reproduction we asked
+ * them to capture.
+ */
+function hydrate(): void {
+    if (hydrated) return
+    hydrated = true
+    try {
+        const stored = window.sessionStorage.getItem(STORAGE_KEY)
+        if (!stored) return
+        const parsed = JSON.parse(stored) as CeremonyRecord[]
+        if (!Array.isArray(parsed) || parsed.length === 0) return
+        log = parsed
+        seq = parsed.reduce((max, record) => Math.max(max, record.seq ?? 0), 0)
+        const newest = parsed[parsed.length - 1]
+        lastEndedAt = newest.startedAt + newest.durationMs
+    } catch {
+        // an unreadable mirror just means this session starts clean
+    }
+}
 
 function persist(): void {
     try {
@@ -70,18 +105,12 @@ function persist(): void {
 }
 
 export function getCeremonyLog(): CeremonyRecord[] {
-    if (log.length === 0) {
-        try {
-            const stored = window.sessionStorage.getItem(STORAGE_KEY)
-            if (stored) log = JSON.parse(stored) as CeremonyRecord[]
-        } catch {
-            // ignore — an unreadable mirror just means an empty log
-        }
-    }
+    hydrate()
     return [...log]
 }
 
 export function clearCeremonyLog(): void {
+    hydrated = true
     log = []
     seq = 0
     lastEndedAt = null
@@ -97,32 +126,66 @@ function describeOptions(kind: 'get' | 'create', options?: CredentialCreationOpt
     return { rpId: publicKey?.rp?.id, allowCredentials: undefined }
 }
 
+/**
+ * Nothing in here may throw: this runs inside the `navigator.credentials`
+ * wrapper, so an exception would turn a successful ceremony into a failed one
+ * (or mask the real NotAllowedError on the error path).
+ */
 function commit(record: CeremonyRecord): void {
-    lastEndedAt = record.startedAt + record.durationMs
-    log.push(record)
-    if (log.length > LOG_LIMIT) log = log.slice(-LOG_LIMIT)
-    persist()
+    try {
+        lastEndedAt = record.startedAt + record.durationMs
+        log.push(record)
+        if (log.length > LOG_LIMIT) log = log.slice(-LOG_LIMIT)
+        persist()
+        capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY, {
+            seq: record.seq,
+            kind: record.kind,
+            purpose: record.purpose,
+            flow: record.flow,
+            flow_id: record.flowId,
+            duration_ms: record.durationMs,
+            gap_ms: record.gapMs,
+            outcome: record.outcome,
+            error_name: record.errorName,
+            error_code: record.errorCode,
+            allow_credentials: record.allowCredentials,
+            overlapped: record.overlapped,
+            open_flows: record.openFlows,
+            native: record.native,
+        })
+        Sentry.addBreadcrumb({
+            category: 'webauthn.ceremony',
+            level: record.outcome === 'ok' ? 'info' : 'warning',
+            message: `#${record.seq} ${record.purpose} (${record.outcome})`,
+            data: { ...record },
+        })
+    } catch {
+        // telemetry never gets to break the ceremony it is measuring
+    }
+}
 
-    posthog.capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY, {
-        seq: record.seq,
-        kind: record.kind,
-        purpose: record.purpose,
-        flow: record.flow,
-        flow_id: record.flowId,
-        duration_ms: record.durationMs,
-        gap_ms: record.gapMs,
-        outcome: record.outcome,
-        error_name: record.errorName,
-        error_code: record.errorCode,
-        allow_credentials: record.allowCredentials,
-        native: record.native,
-    })
-    Sentry.addBreadcrumb({
-        category: 'webauthn.ceremony',
-        level: record.outcome === 'ok' ? 'info' : 'warning',
-        message: `#${record.seq} ${record.purpose} (${record.outcome})`,
-        data: { ...record },
-    })
+function capture(event: string, properties: Record<string, unknown>): void {
+    try {
+        posthog.capture(event, properties)
+    } catch {
+        // posthog may not be initialised yet; the local log still has the record
+    }
+}
+
+function safeErrorCode(error: unknown): string | undefined {
+    try {
+        return classifyPasskeyError(error)?.code
+    } catch {
+        return undefined
+    }
+}
+
+function safeExtra(extra?: () => Record<string, unknown>): Record<string, unknown> {
+    try {
+        return extra?.() ?? {}
+    } catch {
+        return {}
+    }
 }
 
 async function trace<T>(
@@ -130,8 +193,10 @@ async function trace<T>(
     options: CredentialCreationOptions | CredentialRequestOptions | undefined,
     run: () => Promise<T>
 ): Promise<T> {
+    hydrate()
     const startedAt = Date.now()
     const flow = flowStack[flowStack.length - 1]
+    inFlight += 1
     const base = {
         seq: ++seq,
         kind,
@@ -141,6 +206,8 @@ async function trace<T>(
         startedAt,
         gapMs: lastEndedAt === null ? null : startedAt - lastEndedAt,
         native: isCapacitor(),
+        overlapped: inFlight > 1,
+        openFlows: flowStack.length,
         ...describeOptions(kind, options),
     }
 
@@ -154,9 +221,11 @@ async function trace<T>(
             durationMs: Date.now() - startedAt,
             outcome: 'error',
             errorName: error instanceof Error ? error.name : 'unknown',
-            errorCode: classifyPasskeyError(error).code,
+            errorCode: safeErrorCode(error),
         })
         throw error
+    } finally {
+        inFlight -= 1
     }
 }
 
@@ -170,6 +239,7 @@ export function installCeremonyTelemetry(): void {
     if (installed) return
     if (typeof navigator === 'undefined' || !navigator.credentials) return
     installed = true
+    hydrate()
 
     const credentials = navigator.credentials
     const originalGet = credentials.get.bind(credentials)
@@ -193,7 +263,7 @@ export function endCeremonyFlow(id: string, extra: Record<string, unknown> = {})
     const [frame] = flowStack.splice(index, 1)
     const ceremonies = log.filter((record) => record.seq > frame.fromSeq && record.startedAt >= frame.startedAt)
 
-    posthog.capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY_FLOW, {
+    capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY_FLOW, {
         flow: frame.name,
         flow_id: frame.id,
         ceremony_count: ceremonies.length,
@@ -213,13 +283,13 @@ export async function withCeremonyFlow<T>(
     const id = beginCeremonyFlow(name)
     try {
         const result = await fn()
-        endCeremonyFlow(id, { outcome: 'ok', ...extra?.() })
+        endCeremonyFlow(id, { outcome: 'ok', ...safeExtra(extra) })
         return result
     } catch (error) {
         endCeremonyFlow(id, {
             outcome: 'error',
             error_name: error instanceof Error ? error.name : 'unknown',
-            ...extra?.(),
+            ...safeExtra(extra),
         })
         throw error
     }

--- a/src/utils/webauthn-ceremony-telemetry.ts
+++ b/src/utils/webauthn-ceremony-telemetry.ts
@@ -1,0 +1,235 @@
+import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { isCapacitor } from '@/utils/capacitor'
+import { classifyPasskeyError } from '@/utils/webauthn.utils'
+
+/**
+ * Counts every WebAuthn ceremony the app actually asks for, and attributes each
+ * one to the code path that asked.
+ *
+ * Testers report 2–3 passkey sheets for a single send-link creation, and the
+ * flow has four legitimate prompt sources (kernel migration, session-key grant,
+ * Rain admin EIP-712, UserOp) plus the @capgo/capacitor-passkey shim in between
+ * our JS and the OS. Reading the code can't tell you which ones fired on a given
+ * device, so this instruments the one place they all funnel through —
+ * `navigator.credentials` — and labels it from an ambient purpose stack.
+ *
+ * The count here is the number of ceremonies OUR CODE requested. If a device
+ * shows more sheets than this log has entries, the extra ones come from the
+ * native plugin or the OS, not from us — which is itself the answer.
+ */
+
+export type CeremonyPurpose =
+    | 'user_op'
+    | 'admin_eip712'
+    | 'session_key_grant'
+    | 'kernel_migration'
+    | 'login'
+    | 'registration'
+    | 'app_lock'
+
+export type CeremonyRecord = {
+    seq: number
+    kind: 'get' | 'create'
+    /** Purpose stack joined innermost-last, e.g. `kernel_migration>user_op`. */
+    purpose: string
+    flow: string | null
+    flowId: string | null
+    startedAt: number
+    durationMs: number
+    /** Idle time since the previous ceremony ended — back-to-back sheets show as a small gap. */
+    gapMs: number | null
+    outcome: 'ok' | 'error'
+    errorName?: string
+    errorCode?: string
+    allowCredentials?: number
+    rpId?: string
+    native: boolean
+}
+
+type FlowFrame = { id: string; name: string; startedAt: number; fromSeq: number }
+
+const LOG_LIMIT = 40
+const STORAGE_KEY = '__webauthn_ceremony_log'
+
+let installed = false
+let seq = 0
+let flowCounter = 0
+let lastEndedAt: number | null = null
+const purposeStack: CeremonyPurpose[] = []
+const flowStack: FlowFrame[] = []
+let log: CeremonyRecord[] = []
+
+function persist(): void {
+    try {
+        window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(log))
+    } catch {
+        // sessionStorage is a convenience for the dev page, never a requirement
+    }
+}
+
+export function getCeremonyLog(): CeremonyRecord[] {
+    if (log.length === 0) {
+        try {
+            const stored = window.sessionStorage.getItem(STORAGE_KEY)
+            if (stored) log = JSON.parse(stored) as CeremonyRecord[]
+        } catch {
+            // ignore — an unreadable mirror just means an empty log
+        }
+    }
+    return [...log]
+}
+
+export function clearCeremonyLog(): void {
+    log = []
+    seq = 0
+    lastEndedAt = null
+    persist()
+}
+
+function describeOptions(kind: 'get' | 'create', options?: CredentialCreationOptions | CredentialRequestOptions) {
+    if (kind === 'get') {
+        const publicKey = (options as CredentialRequestOptions | undefined)?.publicKey
+        return { rpId: publicKey?.rpId, allowCredentials: publicKey?.allowCredentials?.length }
+    }
+    const publicKey = (options as CredentialCreationOptions | undefined)?.publicKey
+    return { rpId: publicKey?.rp?.id, allowCredentials: undefined }
+}
+
+function commit(record: CeremonyRecord): void {
+    lastEndedAt = record.startedAt + record.durationMs
+    log.push(record)
+    if (log.length > LOG_LIMIT) log = log.slice(-LOG_LIMIT)
+    persist()
+
+    posthog.capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY, {
+        seq: record.seq,
+        kind: record.kind,
+        purpose: record.purpose,
+        flow: record.flow,
+        flow_id: record.flowId,
+        duration_ms: record.durationMs,
+        gap_ms: record.gapMs,
+        outcome: record.outcome,
+        error_name: record.errorName,
+        error_code: record.errorCode,
+        allow_credentials: record.allowCredentials,
+        native: record.native,
+    })
+    Sentry.addBreadcrumb({
+        category: 'webauthn.ceremony',
+        level: record.outcome === 'ok' ? 'info' : 'warning',
+        message: `#${record.seq} ${record.purpose} (${record.outcome})`,
+        data: { ...record },
+    })
+}
+
+async function trace<T>(
+    kind: 'get' | 'create',
+    options: CredentialCreationOptions | CredentialRequestOptions | undefined,
+    run: () => Promise<T>
+): Promise<T> {
+    const startedAt = Date.now()
+    const flow = flowStack[flowStack.length - 1]
+    const base = {
+        seq: ++seq,
+        kind,
+        purpose: purposeStack.length > 0 ? purposeStack.join('>') : 'unknown',
+        flow: flow?.name ?? null,
+        flowId: flow?.id ?? null,
+        startedAt,
+        gapMs: lastEndedAt === null ? null : startedAt - lastEndedAt,
+        native: isCapacitor(),
+        ...describeOptions(kind, options),
+    }
+
+    try {
+        const result = await run()
+        commit({ ...base, durationMs: Date.now() - startedAt, outcome: 'ok' })
+        return result
+    } catch (error) {
+        commit({
+            ...base,
+            durationMs: Date.now() - startedAt,
+            outcome: 'error',
+            errorName: error instanceof Error ? error.name : 'unknown',
+            errorCode: classifyPasskeyError(error).code,
+        })
+        throw error
+    }
+}
+
+/**
+ * Patches `navigator.credentials` in place. On native this MUST run after
+ * `CapacitorPasskey.autoShimWebAuthn()` resolves — patching first would capture
+ * the browser implementation the shim then replaces, and the wrapper would both
+ * miss every ceremony and call an API that doesn't work inside the WebView.
+ */
+export function installCeremonyTelemetry(): void {
+    if (installed) return
+    if (typeof navigator === 'undefined' || !navigator.credentials) return
+    installed = true
+
+    const credentials = navigator.credentials
+    const originalGet = credentials.get.bind(credentials)
+    const originalCreate = credentials.create.bind(credentials)
+
+    credentials.get = ((options?: CredentialRequestOptions) =>
+        trace('get', options, () => originalGet(options))) as typeof credentials.get
+    credentials.create = ((options?: CredentialCreationOptions) =>
+        trace('create', options, () => originalCreate(options))) as typeof credentials.create
+}
+
+export function beginCeremonyFlow(name: string): string {
+    const id = `${name}-${++flowCounter}-${Date.now()}`
+    flowStack.push({ id, name, startedAt: Date.now(), fromSeq: seq })
+    return id
+}
+
+export function endCeremonyFlow(id: string, extra: Record<string, unknown> = {}): void {
+    const index = flowStack.findIndex((frame) => frame.id === id)
+    if (index === -1) return
+    const [frame] = flowStack.splice(index, 1)
+    const ceremonies = log.filter((record) => record.seq > frame.fromSeq && record.startedAt >= frame.startedAt)
+
+    posthog.capture(ANALYTICS_EVENTS.WEBAUTHN_CEREMONY_FLOW, {
+        flow: frame.name,
+        flow_id: frame.id,
+        ceremony_count: ceremonies.length,
+        purposes: ceremonies.map((record) => record.purpose),
+        outcomes: ceremonies.map((record) => record.outcome),
+        total_ms: Date.now() - frame.startedAt,
+        native: isCapacitor(),
+        ...extra,
+    })
+}
+
+export async function withCeremonyFlow<T>(
+    name: string,
+    fn: () => Promise<T>,
+    extra?: () => Record<string, unknown>
+): Promise<T> {
+    const id = beginCeremonyFlow(name)
+    try {
+        const result = await fn()
+        endCeremonyFlow(id, { outcome: 'ok', ...extra?.() })
+        return result
+    } catch (error) {
+        endCeremonyFlow(id, {
+            outcome: 'error',
+            error_name: error instanceof Error ? error.name : 'unknown',
+            ...extra?.(),
+        })
+        throw error
+    }
+}
+
+export async function withCeremonyPurpose<T>(purpose: CeremonyPurpose, fn: () => Promise<T>): Promise<T> {
+    purposeStack.push(purpose)
+    try {
+        return await fn()
+    } finally {
+        purposeStack.pop()
+    }
+}


### PR DESCRIPTION
## Why

Testers report the passkey sheet appearing **2–3 times for a single send-link creation** ([Native-App bug #27](https://app.notion.com/p/3b4838117579816f8552f365b074e726), TASK-21612). The flow has four legitimate prompt sources and one opaque layer between us and the OS:

| Source | When |
|---|---|
| root-validator migration no-op UserOp | mixed spend on a pre-2025-09-18 wrapper account, once |
| session-key grant | first collateral-only spend |
| Rain admin EIP-712 | collateral-only and mixed |
| the UserOp itself | smart-only and mixed |
| `CapacitorPasskey.autoShim` | every native ceremony, patching `navigator.credentials` |

Reading the code cannot tell you which of those fired on a given device — that is why the ticket has sat on "where to look" since 2026-08-06. This measures it instead.

## What

`navigator.credentials.get/create` is wrapped once, **after** the shim installs (`.finally` on the autoShim chain, so a failed shim still gets instrumented). Every ceremony is recorded with:

- the **purpose stack** that asked — `kernel_migration>user_op`, `admin_eip712`, `session_key_grant`, `user_op`, `login`, `registration`, `app_lock`
- duration, and the **gap since the previous ceremony ended** — back-to-back sheets show as a ~0 ms gap, a retry-driven repeat shows as ~1 s
- outcome, `error_name`, and the classified passkey code

Two events: `webauthn_ceremony` per ceremony, and `webauthn_ceremony_flow` closing a bracketed flow with `ceremony_count` + ordered `purposes`. Link creation is bracketed as `link_create` and reports the spend `strategy`, so the count reads against smart-only/mixed routing.

`/dev/ceremony-log` renders the same records on-device for a tester who can reproduce but can't read PostHog.

## Reading the result

- **3 rows, purposes named** → our call sites; the ticket becomes "collapse these", and the dark-flagged one-tap session-key spend already covers the mixed pair.
- **More sheets than rows** → the surplus is `@capgo/capacitor-passkey` or the OS credential manager re-presenting, not our code.
- **Two rows, same purpose, ~1 s apart** → a retry.

## Notes

- No flag. Ceremonies are rare (a handful per session), and gating this would defeat the point — the reporters are outsourced testers on production builds.
- Pure JS: ships to testers over OTA, no binary release needed.
- Purpose tags were added to **both** spend engines (`useSpendBundle` and `useSignSpendBundle`) — `spendPreflight`'s module comment is explicit that the two must not drift.

## Verification

- 8 new unit tests (counting, nested purpose paths, error classification, flow payload, gap measurement, patch idempotence).
- Ran in the real app on a dev server: the wrapper is installed (`navigator.credentials.get` → `trace('get', …)`), a real ceremony was intercepted and recorded end-to-end with rpId/duration/outcome/error code, and the gap between two consecutive ceremonies was measured (39.8 s, then 1 ms).
- `typecheck` clean, `prettier --check` clean, 43 related suites / 311 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development tool for viewing WebAuthn ceremony logs, including outcomes, timing, credential settings, and error details.
  * Added options to refresh, copy formatted logs, clear session records, and view grouped flow summaries.
  * Added detailed tracking for passkey-related actions, app unlock, session keys, spending, and migrations.

* **Bug Fixes**
  * Improved passkey ceremony attribution across native and web environments.

* **Tests**
  * Added coverage for ceremony tracking, failures, nested flows, timing, native detection, and log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->