### PR TITLE
feat(native): restore the transport canary, failure-only, iOS included

### DIFF
--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -10,6 +10,7 @@ import 'react-tooltip/dist/react-tooltip.css'
 import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
 import { authReady } from '@/utils/auth-token'
 import { installNativeAuthCapture } from '@/utils/native-auth-capture'
+import { scheduleTransportCanary } from '@/utils/native-canary'
 import { installCeremonyTelemetry } from '@/utils/webauthn-ceremony-telemetry'
 // Note: Sentry configs are auto-loaded by @sentry/nextjs via next.config.js
 // DO NOT import them here - it bundles server/edge configs into client code
@@ -35,6 +36,7 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
         if (isCapacitor()) {
             void authReady() // start Preferences hydration before any API call needs it
             installNativeAuthCapture()
+            scheduleTransportCanary()
             import('@capgo/capacitor-passkey').then(({ CapacitorPasskey }) => {
                 const nativeRpId = getNativeRpId()
 

--- a/src/utils/__tests__/native-canary.test.ts
+++ b/src/utils/__tests__/native-canary.test.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/nextjs'
-import { runCanary } from '../native-canary'
+import { runCanary, scheduleTransportCanary } from '../native-canary'
 
 jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }))
-jest.mock('../capacitor', () => ({ isCapacitor: () => true }))
+jest.mock('../capacitor', () => ({ isNativeBridge: jest.fn(() => true) }))
 jest.mock('../native-auth-capture', () => ({ getUnderlyingFetch: () => null }))
 jest.mock('../native-http', () => ({ nativeHttpRequest: jest.fn() }))
 jest.mock('@capacitor/app', () => ({ App: { getInfo: async () => ({ version: '1.0.57', build: '412' }) } }), {
@@ -10,6 +10,7 @@ jest.mock('@capacitor/app', () => ({ App: { getInfo: async () => ({ version: '1.
 })
 
 const { nativeHttpRequest } = jest.requireMock('../native-http') as { nativeHttpRequest: jest.Mock }
+const { isNativeBridge } = jest.requireMock('../capacitor') as { isNativeBridge: jest.Mock }
 const captureMessage = Sentry.captureMessage as jest.Mock
 
 const ok = (status = 200) => ({ status }) as Response
@@ -99,5 +100,22 @@ describe('transport canary', () => {
         expect(modes).toHaveLength(2)
         expect(modes.every((m) => m === undefined)).toBe(true)
         expect(nativeHttpRequest).toHaveBeenCalledTimes(1)
+    })
+
+    /*
+     * isCapacitor() is true for NEXT_PUBLIC_CAPACITOR_BUILD Vercel previews
+     * that have no bridge; probing there files web-fallback results as native
+     * transport evidence under appVersion 'unknown'.
+     */
+    it('does not schedule on a capacitor-flavoured build with no native bridge', () => {
+        jest.useFakeTimers()
+        isNativeBridge.mockReturnValue(false)
+
+        scheduleTransportCanary(0)
+        jest.runAllTimers()
+
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(nativeHttpRequest).not.toHaveBeenCalled()
+        jest.useRealTimers()
     })
 })

--- a/src/utils/__tests__/native-canary.test.ts
+++ b/src/utils/__tests__/native-canary.test.ts
@@ -1,0 +1,103 @@
+import * as Sentry from '@sentry/nextjs'
+import { runCanary } from '../native-canary'
+
+jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }))
+jest.mock('../capacitor', () => ({ isCapacitor: () => true }))
+jest.mock('../native-auth-capture', () => ({ getUnderlyingFetch: () => null }))
+jest.mock('../native-http', () => ({ nativeHttpRequest: jest.fn() }))
+jest.mock('@capacitor/app', () => ({ App: { getInfo: async () => ({ version: '1.0.57', build: '412' }) } }), {
+    virtual: true,
+})
+
+const { nativeHttpRequest } = jest.requireMock('../native-http') as { nativeHttpRequest: jest.Mock }
+const captureMessage = Sentry.captureMessage as jest.Mock
+
+const ok = (status = 200) => ({ status }) as Response
+
+function mockWebFetch(impl: (url: string, init?: RequestInit) => Promise<Response>) {
+    global.fetch = jest.fn((url: RequestInfo | URL, init?: RequestInit) =>
+        impl(String(url), init)
+    ) as unknown as typeof fetch
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    nativeHttpRequest.mockResolvedValue(ok())
+    mockWebFetch(async () => ok())
+})
+
+describe('transport canary', () => {
+    it('stays silent when every probe succeeds', async () => {
+        await runCanary()
+        expect(captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('stays silent on non-2xx, because a completed request is not a transport failure', async () => {
+        mockWebFetch(async (_url, init) => ok(init?.method === 'POST' ? 405 : 200))
+        await runCanary()
+        expect(captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('reports the Android shape: webview GET fails while POST and native succeed', async () => {
+        mockWebFetch(async (_url, init) => {
+            if ((init?.method ?? 'GET') === 'GET') throw new TypeError('Failed to fetch: net::ERR_FAILED')
+            return ok(405)
+        })
+
+        await runCanary()
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        const [message, options] = captureMessage.mock.calls[0]
+        expect(message).toBe('native canary: get:fail post:ok native:ok')
+        expect(options.level).toBe('warning')
+        expect(options.tags).toMatchObject({
+            canary: 'transport',
+            canary_get: 'network-error',
+            canary_post: 'http-405',
+            canary_native: 'http-200',
+            appVersion: '1.0.57',
+            appBuild: '412',
+        })
+        // the net:: code is the field most likely to name the root cause
+        expect(options.extra.get.errorMessage).toContain('net::ERR_FAILED')
+    })
+
+    it('classifies an aborted probe as a timeout', async () => {
+        mockWebFetch(async () => {
+            const e = new Error('aborted')
+            e.name = 'AbortError'
+            throw e
+        })
+        nativeHttpRequest.mockResolvedValue(ok())
+
+        await runCanary()
+
+        const [message, options] = captureMessage.mock.calls[0]
+        expect(message).toBe('native canary: get:fail post:fail native:ok')
+        expect(options.tags.canary_get).toBe('timeout')
+    })
+
+    it('reports a total outage rather than staying silent', async () => {
+        mockWebFetch(async () => {
+            throw new TypeError('Failed to fetch')
+        })
+        nativeHttpRequest.mockRejectedValue(new TypeError('Failed to fetch'))
+
+        await runCanary()
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(captureMessage.mock.calls[0][0]).toBe('native canary: get:fail post:fail native:fail')
+    })
+
+    it('issues exactly three probes, none of them no-cors — iOS serves no opaque responses', async () => {
+        mockWebFetch(async () => {
+            throw new TypeError('Failed to fetch')
+        })
+        await runCanary()
+
+        const modes = (global.fetch as jest.Mock).mock.calls.map(([, init]) => init?.mode)
+        expect(modes).toHaveLength(2)
+        expect(modes.every((m) => m === undefined)).toBe(true)
+        expect(nativeHttpRequest).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/utils/native-canary.ts
+++ b/src/utils/native-canary.ts
@@ -39,7 +39,7 @@
 
 import * as Sentry from '@sentry/nextjs'
 import { PEANUT_API_URL } from '@/constants/general.consts'
-import { isCapacitor } from './capacitor'
+import { isNativeBridge } from './capacitor'
 import { getUnderlyingFetch } from './native-auth-capture'
 import { nativeHttpRequest } from './native-http'
 
@@ -158,8 +158,16 @@ export async function runCanary(): Promise<void> {
     })
 }
 
+/*
+ * isNativeBridge, NOT isCapacitor: the latter is true for
+ * NEXT_PUBLIC_CAPACITOR_BUILD Vercel previews, which have no bridge at all.
+ * Running there would drive the CapacitorHttp probe through a plugin that
+ * cannot work and file the result as native transport evidence, under
+ * appVersion 'unknown' — fabricated data in the one dataset this exists to
+ * keep clean.
+ */
 export function scheduleTransportCanary(delayMs: number = 4_000): void {
-    if (!isCapacitor() || scheduled || typeof window === 'undefined') return
+    if (!isNativeBridge() || scheduled || typeof window === 'undefined') return
     scheduled = true
     setTimeout(() => {
         void runCanary().catch(() => {

--- a/src/utils/native-canary.ts
+++ b/src/utils/native-canary.ts
@@ -1,0 +1,169 @@
+/*
+ * Startup transport canary — restored, failure-only.
+ *
+ * The retired v3 canary (`c45f7655`) answered the question this app could not
+ * answer any other way: on Android, a WebView GET fails while a POST and an
+ * OS-client GET to the same host in the same second succeed. No per-failure
+ * error report can show that, because the comparison IS the evidence — it is
+ * what ruled out both "the network was down" and "Cloudflare blocked them".
+ *
+ * It was retired for real cost: five `captureMessage` calls per launch on
+ * every platform (~550 events/day, all `level:info`) plus five extra round
+ * trips on every cold start. This restores the signal without the bill:
+ *
+ * - ONE event per launch, and only when something actually failed. A clean
+ *   launch reports nothing at all, so the steady-state cost is zero.
+ * - Three probes, not five. `get-users-me` added an auth variable to a
+ *   reachability question, and `get-healthz-nocors` is unusable — see below.
+ * - `level:warning`, so this can never rejoin the `level:info` flood that
+ *   made the original a deletion target.
+ *
+ * NO `no-cors` PROBE, which is what makes this safe to run on iOS. WKWebView
+ * serves no opaque responses at all: the retired canary measured that probe
+ * failing 108/108 on iOS while every other probe in the same batch succeeded
+ * 100%. Including it would mean every iOS launch reports a failure that did
+ * not happen. It is also blocked by `Cross-Origin-Resource-Policy: same-site`
+ * on `/healthz` from the native `https://localhost` origin until
+ * peanut-api-ts#1456 deploys. All three probes below are ordinary CORS
+ * requests, so they mean the same thing on both platforms.
+ *
+ * Denominator lives in PostHog (app opens), not here — that is the whole
+ * reason this can skip success events. Note PostHog's registered device
+ * context carries `platform` but NOT the app version, so per-build rates
+ * (the split that surfaced 3% on `8016c68` vs 21% on `d4bd3ab`) need
+ * `app_version` added to that `posthog.register` call to be reproducible.
+ *
+ * Query: message starts `native canary:` — the message carries the outcome
+ * signature so each distinct failure shape is its own Sentry issue.
+ */
+
+import * as Sentry from '@sentry/nextjs'
+import { PEANUT_API_URL } from '@/constants/general.consts'
+import { isCapacitor } from './capacitor'
+import { getUnderlyingFetch } from './native-auth-capture'
+import { nativeHttpRequest } from './native-http'
+
+const CANARY_TIMEOUT_MS = 10_000
+
+let scheduled = false
+
+interface ProbeResult {
+    outcome: string
+    durationMs: number
+    errorName?: string
+    errorMessage?: string
+}
+
+function isFailure(result: ProbeResult): boolean {
+    return result.outcome === 'timeout' || result.outcome === 'network-error'
+}
+
+function toProbeError(error: unknown, startedAt: number): ProbeResult {
+    const e = error instanceof Error ? error : new Error(String(error))
+    return {
+        outcome: e.name === 'AbortError' ? 'timeout' : 'network-error',
+        durationMs: Date.now() - startedAt,
+        errorName: e.name,
+        // Android WebView TypeErrors carry net:: codes in the message — the
+        // one field most likely to name the actual root cause
+        errorMessage: e.message,
+    }
+}
+
+async function probe(path: string, init: RequestInit): Promise<ProbeResult> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), CANARY_TIMEOUT_MS)
+    const startedAt = Date.now()
+    try {
+        const response = await fetch(`${PEANUT_API_URL}${path}`, { ...init, signal: controller.signal })
+        // any HTTP status counts as success: 404/405 still proves the request
+        // completed end to end, which is the only thing being measured
+        return { outcome: `http-${response.status}`, durationMs: Date.now() - startedAt }
+    } catch (error) {
+        return toProbeError(error, startedAt)
+    } finally {
+        clearTimeout(timeoutId)
+    }
+}
+
+async function nativeProbe(path: string): Promise<ProbeResult> {
+    const startedAt = Date.now()
+    try {
+        const response = await nativeHttpRequest(`${PEANUT_API_URL}${path}`, { method: 'GET' }, CANARY_TIMEOUT_MS)
+        return { outcome: `http-${response.status}`, durationMs: Date.now() - startedAt }
+    } catch (error) {
+        return toProbeError(error, startedAt)
+    }
+}
+
+async function getBinaryInfo(): Promise<{ appVersion: string; appBuild: string }> {
+    try {
+        const { App } = await import('@capacitor/app')
+        const info = await App.getInfo()
+        return { appVersion: info.version, appBuild: info.build }
+    } catch {
+        return { appVersion: 'unknown', appBuild: 'unknown' }
+    }
+}
+
+export async function runCanary(): Promise<void> {
+    const probes = [
+        { name: 'get', transport: 'webview', run: () => probe('/healthz', { method: 'GET' }) },
+        {
+            name: 'post',
+            transport: 'webview',
+            run: () =>
+                probe('/healthz', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' }),
+        },
+        { name: 'native', transport: 'cap-native-http', run: () => nativeProbe('/healthz') },
+    ]
+
+    // Parallel so a dead network costs one CANARY_TIMEOUT_MS, not three.
+    const results = await Promise.all(probes.map(({ run }) => run()))
+    if (!results.some(isFailure)) return
+
+    const outcomes = Object.fromEntries(probes.map(({ name }, i) => [name, results[i].outcome]))
+    const signature = probes.map(({ name }, i) => `${name}:${isFailure(results[i]) ? 'fail' : 'ok'}`).join(' ')
+
+    // CapacitorWebFetch is assigned unconditionally by the native bridge; only
+    // an actual patch of window.fetch means the CapacitorHttp proxy is active.
+    const capWebFetch = (window as unknown as { CapacitorWebFetch?: typeof fetch }).CapacitorWebFetch
+    const baseFetch = getUnderlyingFetch() ?? window.fetch
+    const { appVersion, appBuild } = await getBinaryInfo()
+
+    Sentry.captureMessage(`native canary: ${signature}`, {
+        level: 'warning',
+        tags: {
+            canary: 'transport',
+            canaryVersion: '4',
+            canary_signature: signature,
+            canary_get: outcomes.get,
+            canary_post: outcomes.post,
+            canary_native: outcomes.native,
+            webviewTransport: !!capWebFetch && baseFetch !== capWebFetch ? 'cap-http-proxy' : 'direct',
+            appVersion,
+            appBuild,
+            online: String(navigator.onLine),
+        },
+        extra: Object.fromEntries(
+            probes.map(({ name }, i) => [
+                name,
+                {
+                    durationMs: results[i].durationMs,
+                    errorName: results[i].errorName,
+                    errorMessage: results[i].errorMessage,
+                },
+            ])
+        ),
+    })
+}
+
+export function scheduleTransportCanary(delayMs: number = 4_000): void {
+    if (!isCapacitor() || scheduled || typeof window === 'undefined') return
+    scheduled = true
+    setTimeout(() => {
+        void runCanary().catch(() => {
+            // a canary that breaks the app is worse than no canary
+        })
+    }, delayMs)
+}


### PR DESCRIPTION
## Why

The retired v3 canary (`c45f7655`) answered the one question no per-failure error report can: on Android a WebView **GET** fails while a **POST** and an **OS-client GET** to the same host in the same second succeed. The comparison *is* the evidence — it is what ruled out both the connectivity theory and the Cloudflare/WAF theory.

It is gone from `dev`, so the next release ends the data. That matters more than it looked, because the failure is **release-dependent and the newest reporting bundle is the worst**:

| build | date | ok | failed | fail rate | users |
|---|---|---|---|---|---|
| `d0a9834` (1.0.50) | Aug 8 | 0 | 25 | 100% | 16 |
| `9ceeb94` (1.0.53) | Aug 17 | 14 | 0 | 0% | — |
| `8016c68` | Aug 21 | 201 | 6 | **2.9%** | 4 |
| `d4bd3ab` (ota-1.0.56) | Aug 26 | 68 | 18 | **20.9%** | 10 |

Android only, so this is not the platform confound. The newest bundle fails ~7× more than the Aug 21 one, across 10 distinct users. This is live and possibly regressing, not a historical artifact — and without the canary we cannot tell regression from noise.

Caveat worth stating: releases are not randomized cohorts, and `d4bd3ab`'s n (86) is smaller than `8016c68`'s (207), so some of that gap may be population rather than build. Confirming that is part of what this restores.

## What changed vs the retired version

It was retired for real cost — five `captureMessage` calls per launch on every platform (~550 events/day, all `level:info`) plus five extra cold-start round trips. Those reasons were legitimate, so this is not a straight revert:

- **One event per launch, and only when a probe actually failed.** A clean launch reports nothing, so steady-state cost is zero. Denominator comes from PostHog app opens rather than success events.
- **Three probes, not five.** `get-users-me` added an auth variable to a reachability question; `get-healthz-nocors` is unusable (below).
- **`level:warning`**, so it can never rejoin the `level:info` flood that made the original a deletion target.

Estimated ~20–40 events/day against the old ~550.

## Why there is no no-cors probe

This runs on **iOS as well as Android**, which is exactly why that probe is gone. WKWebView serves no opaque responses at all — the retired canary measured it failing **108/108 on iOS** while every other probe in the same batch succeeded 100%. Including it would report a failure that did not happen on every iOS launch.

It is separately blocked by `Cross-Origin-Resource-Policy: same-site` on `/healthz` from the native `https://localhost` origin. Verified against production while writing this:

```
$ curl -sSI https://api.peanut.me/healthz
HTTP/2 200
cross-origin-resource-policy: same-site
```

peanutprotocol/peanut-api-ts#1456 fixes that header and is **merged but not yet deployed**. Nothing here depends on that deploy — all three probes are ordinary CORS requests and mean the same thing on both platforms.

## Follow-up, not included here

PostHog's registered device context (`src/i18n/app/locale-store.ts`) carries `platform` but **not** the app version, so the per-build split in the table above is not reproducible from PostHog as it stands. Adding `app_version` to that `posthog.register` call would close it. Left out deliberately to keep this PR to one concern.

## Test plan

- `src/utils/__tests__/native-canary.test.ts` — 6 tests: silence on all-success, silence on non-2xx (a completed request is not a transport failure), the Android GET-fails/POST-ok/native-ok shape including the `net::` code capture, abort→timeout classification, total outage, and an assertion that exactly three probes fire and **none** is no-cors.
- `pnpm typecheck` clean.
