### PR TITLE
test(native-build): assert the anti-rot scan finds zero uncovered routes

### DIFF
--- a/scripts/__tests__/native-build-scan.test.js
+++ b/scripts/__tests__/native-build-scan.test.js
@@ -54,4 +54,16 @@ describe('native build server-route scan', () => {
         const offenders = detectUncoveredServerRoutes().filter((o) => transformed.has(toPosix(o.rel)))
         expect(offenders).toEqual([])
     })
+
+    // This is the actual anti-rot check: it runs the same scan the native build
+    // guard does, against the real app tree, on every PR — not just on push to
+    // dev via the Capgo deploy workflow. A route added to src/app with `export
+    // const dynamic = 'force-dynamic'` (or a bare route.ts) and missing from
+    // ITEMS_TO_DISABLE fails here instead of silently breaking every native/OTA
+    // build until someone notices dev is red.
+    it('has no server-only route left uncovered by ITEMS_TO_DISABLE or P0_TRANSFORMS', () => {
+        const offenders = detectUncoveredServerRoutes()
+        const describe = offenders.map((o) => `${toPosix(o.rel)} (${o.reason})`).join('\n')
+        expect(describe).toBe('')
+    })
 })


### PR DESCRIPTION
## Summary
- Stacks on #2868. dev has been red for every push since #2787 added `(mobile-ui)/dev/payment-graph` with `force-dynamic` and no `ITEMS_TO_DISABLE` entry — the anti-rot guard in `scripts/native-build.js` catches it correctly, but that guard only runs in `capgo-deploy.yml`, which fires on push to `dev` post-merge. Nothing ran it on the PR itself.
- Adds an assertion to the existing `scripts/__tests__/native-build-scan.test.js` that `detectUncoveredServerRoutes()` returns zero offenders against the real app tree. That suite runs in `tests.yml` on every PR to `dev`/`main`, so the next uncovered `force-dynamic` page or bare `route.ts` fails in CI before merge instead of breaking every native/OTA build after.
- Verified: fails without #2868's fix (reverted it locally to confirm), passes with it.

## Test plan
- [x] `pnpm jest scripts/__tests__/native-build-scan.test.js` — 5/5 pass
- [x] `pnpm prettier --check scripts/__tests__/native-build-scan.test.js`
- [x] Confirmed the new assertion fails when the `ITEMS_TO_DISABLE` entry from #2868 is reverted