### PR TITLE
feat(analytics): register the bundle release as a PostHog super property

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,3 +1,4 @@
+import { APP_RELEASE } from '@/constants/app-release'
 import posthog from 'posthog-js'
 import { beforeSendHandler } from './sentry.utils'
 import { inferSentryEnvironment } from '@/utils/sentry-env'
@@ -37,6 +38,12 @@ if (
         ui_host: posthogHost,
         person_profiles: 'identified_only',
         capture_pageview: true,
+        // Registered here, not from the async device-context effect: PostHog
+        // captures the initial $pageview during init, and super properties are
+        // persisted — so a late register left the first open after an OTA
+        // carrying the PREVIOUS bundle's release. `loaded` runs before that
+        // first capture, which is the whole point of the denominator.
+        loaded: (ph) => ph.register({ app_release: APP_RELEASE }),
         capture_pageleave: true,
         // The payment explorer contains team-only identity and relationship data.
         // Drop every event on client navigation; direct loads skip init above.

--- a/src/constants/app-release.ts
+++ b/src/constants/app-release.ts
@@ -1,0 +1,11 @@
+/**
+ * The JS bundle's commit — the exact value Sentry sends as `release`, so a
+ * Sentry failure count and a PostHog open count for the same build join on one
+ * key. With OTA updates this can differ from the installed binary, which
+ * Sentry tags separately as `binaryVersion`.
+ *
+ * Deliberately import-free: instrumentation-client registers this before
+ * PostHog's initial $pageview, and must not drag a dependency chain into the
+ * earliest client bundle.
+ */
+export const APP_RELEASE = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? 'unknown'

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -126,8 +126,12 @@ describe('emitDeviceContextToAnalytics', () => {
         setNavigatorLanguage('es-AR')
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
-        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'es-ar', platform: 'web' })
-        expect(store.currentDeviceContext()).toEqual({ device_language: 'es-ar', platform: 'web' })
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.objectContaining({ device_language: 'es-ar', platform: 'web' })
+        )
+        expect(store.currentDeviceContext()).toEqual(
+            expect.objectContaining({ device_language: 'es-ar', platform: 'web' })
+        )
     })
 
     it('reads the raw tag from the native device bridge on Capacitor', async () => {
@@ -137,14 +141,32 @@ describe('emitDeviceContextToAnalytics', () => {
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
         expect(mockGetLanguageTag).toHaveBeenCalled()
-        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'pt-br', platform: 'ios-native' })
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.objectContaining({ device_language: 'pt-br', platform: 'ios-native' })
+        )
     })
 
     it('keeps an unsupported language as-is (never collapses to en — protects the OKR denominator)', async () => {
         setNavigatorLanguage('fr-FR')
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
-        expect(mockRegister).toHaveBeenCalledWith({ device_language: 'fr-fr', platform: 'web' })
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.objectContaining({ device_language: 'fr-fr', platform: 'web' })
+        )
+    })
+
+    /*
+     * Same value Sentry sends as `release`. Without it PostHog opens cannot be
+     * used as the denominator for a Sentry failure count on a given build,
+     * which is the split that separated 3% on one bundle from 21% on the next.
+     */
+    it('registers the bundle release so opens can be joined to Sentry by build', async () => {
+        setNavigatorLanguage('en-US')
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.objectContaining({ app_release: process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? 'unknown' })
+        )
     })
 
     it('emits once per session', async () => {
@@ -165,7 +187,9 @@ describe('emitDeviceContextToAnalytics', () => {
         expect(store.currentDeviceContext()).toBeNull()
         // guard is set only on success, so the next call retries instead of no-op
         await store.emitDeviceContextToAnalytics()
-        expect(store.currentDeviceContext()).toEqual({ device_language: 'en-us', platform: 'web' })
+        expect(store.currentDeviceContext()).toEqual(
+            expect.objectContaining({ device_language: 'en-us', platform: 'web' })
+        )
     })
 })
 

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -5,6 +5,8 @@
  * jest.isolateModules per test.
  */
 
+import { APP_RELEASE } from '@/constants/app-release'
+
 const mockRegister = jest.fn()
 const mockSetPersonProperties = jest.fn()
 const mockIsIdentified = jest.fn()
@@ -156,17 +158,17 @@ describe('emitDeviceContextToAnalytics', () => {
     })
 
     /*
-     * Same value Sentry sends as `release`. Without it PostHog opens cannot be
-     * used as the denominator for a Sentry failure count on a given build,
-     * which is the split that separated 3% on one bundle from 21% on the next.
+     * Also registered in posthog.init's `loaded` callback — that is what covers
+     * the initial $pageview, which init captures before this effect ever runs.
+     * Kept in this context too so a logout's posthog.reset(), which wipes super
+     * properties, brings it back with the rest.
      */
-    it('registers the bundle release so opens can be joined to Sentry by build', async () => {
+    it('re-registers the bundle release with the context, for the post-reset path', async () => {
         setNavigatorLanguage('en-US')
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
-        expect(mockRegister).toHaveBeenCalledWith(
-            expect.objectContaining({ app_release: process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? 'unknown' })
-        )
+        expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining({ app_release: APP_RELEASE }))
+        expect(store.currentDeviceContext()).toEqual(expect.objectContaining({ app_release: APP_RELEASE }))
     })
 
     it('emits once per session', async () => {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -5,6 +5,7 @@
 
 import Cookies from 'js-cookie'
 import posthog from 'posthog-js'
+import { APP_RELEASE } from '@/constants/app-release'
 import { getPlatform, isCapacitor } from '@/utils/capacitor'
 import { readStoredValue, writeStoredValue } from '@/utils/safe-storage'
 import { resolveLocale, type AppLocale } from './config'
@@ -93,9 +94,11 @@ export async function emitDeviceContextToAnalytics(): Promise<void> {
         const context = {
             device_language: tag ? tag.trim().toLowerCase() : 'unknown',
             platform: getPlatform(),
-            // Same value Sentry sends as `release`, so PostHog opens can be used
-            // as the denominator for a Sentry failure count on the same build.
-            app_release: process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? 'unknown',
+            // Also registered in posthog.init's `loaded` callback, which is what
+            // covers the initial $pageview. Repeated here so a logout's
+            // posthog.reset() — which wipes super properties — re-registers it
+            // along with the rest of this context.
+            app_release: APP_RELEASE,
         }
         posthog.register(context)
         // set only after a successful register — a throw leaves this null so a

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -77,10 +77,12 @@ async function readDeviceTag(): Promise<string | null> {
 // KYC/nationality join. The resolved context is cached (not just a bool) so the
 // logout handler can re-register it after posthog.reset() wipes super
 // properties, mirroring app_locale. Fenced so analytics can never break the app.
-let deviceContext: { device_language: string; platform: string } | null = null
+type DeviceContext = { device_language: string; platform: string; app_release: string }
+
+let deviceContext: DeviceContext | null = null
 
 /** Last device context registered — for re-register after posthog.reset() on logout. */
-export function currentDeviceContext(): { device_language: string; platform: string } | null {
+export function currentDeviceContext(): DeviceContext | null {
     return deviceContext
 }
 
@@ -91,6 +93,9 @@ export async function emitDeviceContextToAnalytics(): Promise<void> {
         const context = {
             device_language: tag ? tag.trim().toLowerCase() : 'unknown',
             platform: getPlatform(),
+            // Same value Sentry sends as `release`, so PostHog opens can be used
+            // as the denominator for a Sentry failure count on the same build.
+            app_release: process.env.NEXT_PUBLIC_GIT_COMMIT_HASH ?? 'unknown',
         }
         posthog.register(context)
         // set only after a successful register — a throw leaves this null so a


### PR DESCRIPTION
## Why

PostHog's registered device context carried `platform` but not which build the client was running, so app opens could only ever be split iOS vs Android. That makes them unusable as a **denominator for a per-build failure rate** — which is the split that matters here:

| build | date | Android fail rate |
|---|---|---|
| `8016c68` | Aug 21 | **2.9%** (n=207) |
| `d4bd3ab` (ota-1.0.56) | Aug 26 | **20.9%** (n=86) |

That gap is the reason the Android transport problem reads as live and possibly regressing rather than already fixed. Reproducing it without success events — the design #2871 deliberately chose — requires opens counted per build.

## What

Register `NEXT_PUBLIC_GIT_COMMIT_HASH` as a super property. That is the **exact value Sentry sends as `release`** (`instrumentation-client.ts`), so a Sentry failure count and a PostHog open count for the same build join on one key with no mapping table.

Named `app_release`, not `app_version`, on purpose: this is the **JS bundle's** commit, and with OTA updates it can differ from the installed binary. That skew already caused one misdiagnosis (PEANUT-UI-R5F looked like it came from a build it didn't), which is why Sentry tags the binary separately as `binaryVersion` / `binaryBuild`. Calling this one `app_version` would invite exactly that confusion again.

Not included: mirroring `binaryVersion` into PostHog. It needs an async `@capacitor/app` import and is a separate question from the denominator; happy to add it if wanted.

## Test plan

- New test asserting the release rides along, with the reasoning recorded next to it.
- Five existing assertions widened from exact-object to `objectContaining`. They pinned the entire super-property object, so *any* future addition would have broken them — worth noting as a small trap that was sitting there.
- `src/i18n/app/__tests__/locale-store.test.ts` 15 passed. `pnpm typecheck` clean.
