### PR TITLE
fix: localize the local-rail nudge country name

### DIFF
--- a/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
+++ b/src/components/TransactionDetails/__tests__/LocalRailNudge.test.tsx
@@ -14,6 +14,8 @@
 import React from 'react'
 import { render as rtlRender, screen } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
+import { NextIntlClientProvider } from 'next-intl'
+import ptBR from '@/i18n/app/messages/pt-BR.json'
 import { LocalRailNudge } from '../provider-rows/LocalRailNudge'
 import { type TransactionDetails } from '../transactionTransformer'
 
@@ -54,6 +56,16 @@ describe('LocalRailNudge', () => {
     it('recovers the country code from a city-joined value', () => {
         render(<LocalRailNudge transaction={tx('card_pay', 'São Paulo, BR')} />)
         expect(screen.getByText(/In Brazil, paying with Pix/)).toBeInTheDocument()
+    })
+
+    it('localizes the country name and its Portuguese preposition', () => {
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <NextIntlClientProvider locale="pt-BR" messages={ptBR} timeZone="UTC">
+                {children}
+            </NextIntlClientProvider>
+        )
+        rtlRender(<LocalRailNudge transaction={tx('card_pay', 'BR')} />, { wrapper })
+        expect(screen.getByText(/No Brasil, pagar com Pix/)).toBeInTheDocument()
     })
 
     it('renders nothing for a country with no local rail', () => {

--- a/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
+++ b/src/components/TransactionDetails/provider-rows/LocalRailNudge.tsx
@@ -6,7 +6,8 @@ import { extractMerchantIso2 } from '@/components/TransactionDetails/transaction
 import { LOCAL_RAIL_BY_COUNTRY } from '@/components/TransactionDetails/provider-rows/local-rail-countries'
 import { useCardMarkupRate } from '@/hooks/useCardMarkupRate'
 import { CARD_FX_MARKUP_BY_CURRENCY } from '@/constants/payment.consts'
-import { useTranslations } from 'next-intl'
+import { localizedCountryName } from '@/utils/country-name.utils'
+import { useLocale, useTranslations } from 'next-intl'
 
 /**
  * Informational nudge on a card-spend receipt: when the merchant is in a
@@ -24,15 +25,16 @@ export function LocalRailNudge({ transaction }: { transaction: TransactionDetail
     // 'card_pay' naturally excludes them — a refund is not a payment choice.
     if (transaction.extraDataForDrawer?.transactionCardType !== 'card_pay') return null
 
-    const iso2 = extractMerchantIso2(transaction.extraDataForDrawer.cardPayment?.merchantCountry)
-    const local = iso2 ? LOCAL_RAIL_BY_COUNTRY[iso2.toUpperCase()] : undefined
-    if (!local) return null
+    const iso2 = extractMerchantIso2(transaction.extraDataForDrawer.cardPayment?.merchantCountry)?.toUpperCase()
+    const local = iso2 ? LOCAL_RAIL_BY_COUNTRY[iso2] : undefined
+    if (!iso2 || !local) return null
 
-    return <LocalRailNudgeBody local={local} />
+    return <LocalRailNudgeBody iso2={iso2} local={local} />
 }
 
-function LocalRailNudgeBody({ local }: { local: (typeof LOCAL_RAIL_BY_COUNTRY)[string] }) {
+function LocalRailNudgeBody({ iso2, local }: { iso2: string; local: (typeof LOCAL_RAIL_BY_COUNTRY)[string] }) {
     const t = useTranslations('transaction')
+    const locale = useLocale()
     const { data: cardMarkup } = useCardMarkupRate(local.currency)
     // `null` means the backend published no comparison, so show none. Only a
     // still-loading `undefined` falls back to the documented assumption.
@@ -46,7 +48,8 @@ function LocalRailNudgeBody({ local }: { local: (typeof LOCAL_RAIL_BY_COUNTRY)[s
             icon="info"
             title={t('nudge.localRailTitle')}
             description={t('nudge.localRailDescription', {
-                country: local.countryName,
+                iso2,
+                country: localizedCountryName(locale, iso2, local.countryName),
                 rail: local.rail,
                 percent,
             })}

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1931,7 +1931,7 @@
         },
         "nudge": {
             "localRailTitle": "Pague como um local na próxima vez",
-            "localRailDescription": "Em {country}, pagar com {rail} custa cerca de {percent}% menos do que usar o cartão.",
+            "localRailDescription": "{iso2, select, BR {No} AR {Na} other {Em}} {country}, pagar com {rail} custa cerca de {percent}% menos do que usar o cartão.",
             "usdAbroadTitle": "Pague na moeda local na próxima vez",
             "usdAbroadDescription": "Você foi cobrado em dólares. Quando a maquininha oferecer cobrar em dólares, escolha a moeda local — a taxa de câmbio da Peanut costuma ser melhor."
         },


### PR DESCRIPTION
## Summary

The card-spend local-rail nudge showed the country in English in every locale: "En Brazil" (es-419) and "Em Brazil" (pt-BR). `LOCAL_RAIL_BY_COUNTRY` carries English catalog names, and the component passed them straight into the message.

- The component now derives the display name with `localizedCountryName(locale, iso2, fallback)` — the same `Intl.DisplayNames` path `CountryList` uses — so es-419 and pt-BR both render "Brasil" with no catalog change.
- pt-BR selects the preposition on the ISO code (`No Brasil`, `Na Argentina`, `Em …` otherwise), because Portuguese contracts `em` with the country's article. es-419 needs no change ("En Brasil" / "En Argentina" are correct).

Supersedes #2875, which keyed an ICU select on the English string (fragile once the name is localized) and left es-419 unfixed.

## Task

TASK-19614 (the original nudge feature)

## Risks / breaking changes

None. `iso2` is an extra ICU argument; en and es-419 ignore it. No API or cross-repo impact.

## QA

`npm test -- LocalRailNudge` — new case renders the nudge under the pt-BR catalog and asserts "No Brasil, pagar com Pix". Manual: set locale to pt-BR or es-419, open a Rain card-spend receipt with a BR merchant.

Screenshots: N/A — copy-only change in one info card; covered by the unit test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved local payment rail messaging for Portuguese-Brazilian users.
  * Merchant country names are now displayed in the selected locale.
  * Country-specific Portuguese prepositions are used for Brazil, Argentina, and other countries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->