### PR TITLE
docs: point local-rail table at the pt-BR preposition select

### DIFF
--- a/src/components/TransactionDetails/provider-rows/local-rail-countries.ts
+++ b/src/components/TransactionDetails/provider-rows/local-rail-countries.ts
@@ -2,6 +2,9 @@
  * Countries where Peanut has a first-party local payment rail that's cheaper
  * than spending on the Rain card. Add a country here to light up the
  * LocalRailNudge for it — mirrors MANTECA_GEO_RAIL_MAP in peanut-api-ts.
+ * When you add one, also extend the `{iso2, select, …}` preposition in the
+ * pt-BR `transaction.nudge.localRailDescription` message — Portuguese
+ * contracts "em" with the country's article ("no Brasil", "na Argentina").
  *
  * `rail` is the printable, user-facing rail name (reads as "pay with {rail}").
  * `currency` drives the shared `useCardMarkupRate` lookup so the nudge stays


### PR DESCRIPTION
## Summary

Follow-up to #2877 (merged before this landed). A new country in `LOCAL_RAIL_BY_COUNTRY` silently falls back to "Em {country}" in pt-BR; nothing else ties the table to the `{iso2, select, …}` preposition in the pt-BR `transaction.nudge.localRailDescription` message. Comment-only.

## Task

TASK-19614

## Risks / breaking changes

None — a JSDoc comment.

## QA

Screenshots: N/A (no visible change).