### PR TITLE
feat(request): copy the request link to the clipboard the moment it is created

### DIFF
--- a/src/components/Global/ShareButton/__tests__/ShareButton.test.tsx
+++ b/src/components/Global/ShareButton/__tests__/ShareButton.test.tsx
@@ -156,6 +156,41 @@ describe('ShareButton', () => {
         expect(mockToastError).not.toHaveBeenCalled()
     })
 
+    // the reservation is opened inside the click, so a failure before the text
+    // exists must still settle it — WebKit holds a pending write otherwise
+    it('settles the reserved clipboard write when the share url cannot be generated', async () => {
+        const write = jest.fn().mockReturnValue(new Promise(() => {}))
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { write, writeText: jest.fn() },
+        })
+        ;(globalThis as { ClipboardItem?: unknown }).ClipboardItem = class {
+            constructor(public data: Record<string, Promise<Blob>>) {}
+        }
+        const onError = jest.fn()
+        const onSuccess = jest.fn()
+
+        renderWithIntl(
+            <ShareButton
+                generateUrl={() => Promise.reject(new Error('offline'))}
+                onSuccess={onSuccess}
+                onError={onError}
+            >
+                Share badge
+            </ShareButton>
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Share badge' }))
+
+        await waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(mockToastError).toHaveBeenCalledTimes(1)
+
+        const item = write.mock.calls[0][0][0] as { data: Record<string, Promise<Blob>> }
+        await expect(item.data['text/plain']).rejects.toThrow()
+
+        delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem
+    })
+
     it('stays quiet when the share sheet is cancelled and nothing was copied', async () => {
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -48,8 +48,24 @@ const ShareButton = ({
         // reserved before the await: WebKit rejects a clipboard write once the
         // click's user activation is spent, and generating the url spends it
         const pendingCopy = beginClipboardCopy()
-        const shareUrl = url ?? (generateUrl ? await generateUrl() : undefined)
-        const shareText = generateText ? await generateText() : text
+
+        let shareUrl: string | undefined
+        let shareText: string | undefined
+        try {
+            shareUrl = url ?? (generateUrl ? await generateUrl() : undefined)
+            shareText = generateText ? await generateText() : text
+        } catch (error) {
+            // there is nothing to copy — release the reservation rather than
+            // leaving the browser holding a write that never settles
+            pendingCopy.cancel()
+            const err = error instanceof Error ? error : new Error(String(error))
+            console.error('Sharing error:', error)
+            Sentry.captureException(error)
+            toast.error(t('shareButton.sharingFailed'))
+            onError?.(err)
+            return
+        }
+
         let copied = false
 
         try {

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl'
 import { useCallback } from 'react'
 import { Icon } from '../Icons/Icon'
 import { Button, type ButtonVariant } from '@/components/0_Bruddle/Button'
-import { copyTextToClipboard } from '@/utils/clipboard.utils'
+import { beginClipboardCopy, copyTextToClipboard } from '@/utils/clipboard.utils'
 
 type ShareButtonProps = {
     title?: string
@@ -45,6 +45,9 @@ const ShareButton = ({
     const toast = useToast()
 
     const handleShare = useCallback(async () => {
+        // reserved before the await: WebKit rejects a clipboard write once the
+        // click's user activation is spent, and generating the url spends it
+        const pendingCopy = beginClipboardCopy()
         const shareUrl = url ?? (generateUrl ? await generateUrl() : undefined)
         const shareText = generateText ? await generateText() : text
         let copied = false
@@ -52,7 +55,7 @@ const ShareButton = ({
         try {
             // ALWAYS copy to clipboard first (works on both desktop and mobile)
             const contentToCopy = shareUrl || shareText || ''
-            copied = await copyTextToClipboard(contentToCopy)
+            copied = await pendingCopy.resolve(contentToCopy)
             if (copied) {
                 toast.info(shareUrl ? t('shareButton.linkCopied') : t('shareButton.textCopied'))
             }
@@ -80,6 +83,7 @@ const ShareButton = ({
             // already landed and toasted — the content is on the clipboard.
             if (err.name === 'AbortError') {
                 if (copied) onSuccess?.()
+                else pendingCopy.cancel()
                 return
             }
 
@@ -88,6 +92,7 @@ const ShareButton = ({
 
             // If we didn't copy earlier, try now
             if (!copied) {
+                pendingCopy.cancel()
                 const contentToCopy = shareUrl || shareText || ''
                 const fallbackCopied = await copyTextToClipboard(contentToCopy)
                 if (fallbackCopied) {

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl'
 import { useCallback } from 'react'
 import { Icon } from '../Icons/Icon'
 import { Button, type ButtonVariant } from '@/components/0_Bruddle/Button'
+import { copyTextToClipboard } from '@/utils/clipboard.utils'
 
 type ShareButtonProps = {
     title?: string
@@ -43,33 +44,6 @@ const ShareButton = ({
     const t = useTranslations('global')
     const toast = useToast()
 
-    const copyTextToClipboardWithFallback = async (text: string) => {
-        let textArea: HTMLTextAreaElement | undefined
-
-        try {
-            if (navigator.clipboard && window.isSecureContext) {
-                await navigator.clipboard.writeText(text)
-                return true
-            } else {
-                // Fallback for older browsers
-                textArea = document.createElement('textarea')
-                textArea.value = text
-                textArea.style.position = 'fixed'
-                textArea.style.left = '-999999px'
-                textArea.style.top = '-999999px'
-                document.body.appendChild(textArea)
-                textArea.focus()
-                textArea.select()
-                return document.execCommand('copy')
-            }
-        } catch (err) {
-            console.error('Failed to copy: ', err)
-            return false
-        } finally {
-            textArea?.remove()
-        }
-    }
-
     const handleShare = useCallback(async () => {
         const shareUrl = url ?? (generateUrl ? await generateUrl() : undefined)
         const shareText = generateText ? await generateText() : text
@@ -78,7 +52,7 @@ const ShareButton = ({
         try {
             // ALWAYS copy to clipboard first (works on both desktop and mobile)
             const contentToCopy = shareUrl || shareText || ''
-            copied = await copyTextToClipboardWithFallback(contentToCopy)
+            copied = await copyTextToClipboard(contentToCopy)
             if (copied) {
                 toast.info(shareUrl ? t('shareButton.linkCopied') : t('shareButton.textCopied'))
             }
@@ -115,7 +89,7 @@ const ShareButton = ({
             // If we didn't copy earlier, try now
             if (!copied) {
                 const contentToCopy = shareUrl || shareText || ''
-                const fallbackCopied = await copyTextToClipboardWithFallback(contentToCopy)
+                const fallbackCopied = await copyTextToClipboard(contentToCopy)
                 if (fallbackCopied) {
                     toast.info(shareUrl ? t('shareButton.linkCopied') : t('shareButton.textCopied'))
                 } else {

--- a/src/components/Request/__tests__/request-states.test.tsx
+++ b/src/components/Request/__tests__/request-states.test.tsx
@@ -123,6 +123,11 @@ jest.mock('@/interfaces/peanut-sdk-types', () => ({
     EPeanutLinkType: { native: 0, erc20: 1 },
 }))
 
+const mockCopyTextToClipboard = jest.fn<Promise<boolean>, [string]>()
+jest.mock('@/utils/clipboard.utils', () => ({
+    copyTextToClipboard: (text: string) => mockCopyTextToClipboard(text),
+}))
+
 // Mock Toast
 const mockToastSuccess = jest.fn()
 const mockToastError = jest.fn()
@@ -359,6 +364,8 @@ function renderDirectRequest() {
 // ---------- default mock values ----------
 
 function applyDefaults() {
+    mockCopyTextToClipboard.mockResolvedValue(true)
+
     mockUseAuth.mockReturnValue({
         user: { user: { username: 'test-user', userId: 'user-1' } },
         isFetchingUser: false,
@@ -660,7 +667,24 @@ describe('GROUP 2: Link Creation', () => {
         })
     })
 
-    test('success toast is shown after link creation', async () => {
+    test('the new link lands on the clipboard and the success toast says so', async () => {
+        renderCreateRequest()
+
+        const field = screen.getByTestId('amount-field')
+        fireEvent.change(field, { target: { value: '10' } })
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Create request' }))
+        })
+
+        await waitFor(() => {
+            expect(mockCopyTextToClipboard).toHaveBeenCalledWith('https://peanut.me/request/pay?id=req-uuid-1')
+            expect(mockToastSuccess).toHaveBeenCalledWith('Link created and copied to clipboard!')
+        })
+    })
+
+    test('a refused clipboard falls back to the plain link-created toast', async () => {
+        mockCopyTextToClipboard.mockResolvedValue(false)
         renderCreateRequest()
 
         const field = screen.getByTestId('amount-field')

--- a/src/components/Request/__tests__/request-states.test.tsx
+++ b/src/components/Request/__tests__/request-states.test.tsx
@@ -124,8 +124,12 @@ jest.mock('@/interfaces/peanut-sdk-types', () => ({
 }))
 
 const mockCopyTextToClipboard = jest.fn<Promise<boolean>, [string]>()
+const mockCancelClipboardCopy = jest.fn()
 jest.mock('@/utils/clipboard.utils', () => ({
-    copyTextToClipboard: (text: string) => mockCopyTextToClipboard(text),
+    beginClipboardCopy: () => ({
+        resolve: (text: string) => mockCopyTextToClipboard(text),
+        cancel: () => mockCancelClipboardCopy(),
+    }),
 }))
 
 // Mock Toast
@@ -720,6 +724,10 @@ describe('GROUP 3: Error States', () => {
             expect(screen.getByText('Failed to create link')).toBeInTheDocument()
         })
         expect(mockToastError).toHaveBeenCalledWith('Failed to create link')
+        // a link that never existed must release the reserved clipboard write
+        expect(mockCancelClipboardCopy).toHaveBeenCalled()
+        expect(mockCopyTextToClipboard).not.toHaveBeenCalled()
+        expect(mockToastSuccess).not.toHaveBeenCalled()
     })
 
     test('not connected wallet shows error when creating request', async () => {

--- a/src/components/Request/__tests__/request-states.test.tsx
+++ b/src/components/Request/__tests__/request-states.test.tsx
@@ -196,7 +196,7 @@ jest.mock('@/components/Global/QRCodeWrapper', () => ({
 jest.mock('@/components/Global/ShareButton', () => ({
     __esModule: true,
     default: (props: any) => (
-        <button data-testid="share-button" onClick={() => props.generateUrl?.()}>
+        <button data-testid="share-button" data-url={props.url} onClick={() => props.generateUrl?.()}>
             {props.children}
         </button>
     ),
@@ -685,6 +685,27 @@ describe('GROUP 2: Link Creation', () => {
             expect(mockCopyTextToClipboard).toHaveBeenCalledWith('https://peanut.me/request/pay?id=req-uuid-1')
             expect(mockToastSuccess).toHaveBeenCalledWith('Link created and copied to clipboard!')
         })
+    })
+
+    test('sharing hands over the created link instead of creating a second request', async () => {
+        renderCreateRequest()
+
+        fireEvent.change(screen.getByTestId('amount-field'), { target: { value: '10' } })
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Create request' }))
+        })
+
+        const shareButton = await screen.findByTestId('share-button')
+        expect(shareButton).toHaveAttribute('data-url', 'https://peanut.me/request/pay?id=req-uuid-1')
+
+        await act(async () => {
+            fireEvent.click(shareButton)
+        })
+
+        // ShareButton owns the copy from here — no second create, no second toast
+        expect(mockRequestsApi.create).toHaveBeenCalledTimes(1)
+        expect(mockCopyTextToClipboard).toHaveBeenCalledTimes(1)
+        expect(mockToastSuccess).toHaveBeenCalledTimes(1)
     })
 
     test('a refused clipboard falls back to the plain link-created toast', async () => {

--- a/src/components/Request/link/views/Create.request.link.view.tsx
+++ b/src/components/Request/link/views/Create.request.link.view.tsx
@@ -21,7 +21,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { type IToken } from '@/interfaces/interfaces'
 import { type IAttachmentOptions } from '@/interfaces/attachment'
 import { requestsApi } from '@/services/requests'
-import { copyTextToClipboard } from '@/utils/clipboard.utils'
+import { beginClipboardCopy } from '@/utils/clipboard.utils'
 import { fetchTokenSymbol, formatTokenAmount, getRequestLink, isNativeCurrency } from '@/utils/general.utils'
 import * as Sentry from '@sentry/nextjs'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
@@ -194,8 +194,6 @@ export const CreateRequestLinkView = () => {
                 // Update the last saved state
                 lastSavedAttachmentRef.current = { ...attachmentOptions }
 
-                const copied = await copyTextToClipboard(link)
-                toast.success(copied ? t('linkCreatedAndCopiedToast') : t('linkCreatedToast'))
                 queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })
                 return link
             } catch (error) {
@@ -346,13 +344,22 @@ export const CreateRequestLinkView = () => {
         if (generatedLink) return generatedLink
         if (isCreatingLink || isUpdatingRequest) return '' // Prevent duplicate operations
 
+        // reserved before the await: WebKit rejects a clipboard write once the
+        // click's user activation is spent, and creating the request spends it
+        const pendingCopy = beginClipboardCopy()
+
         // Create new request when share button is clicked
         const link = await createRequestLink(attachmentOptions)
-        if (link) {
-            setGeneratedLink(link)
+        if (!link) {
+            pendingCopy.cancel()
+            return ''
         }
-        return link || ''
-    }, [generatedLink, qrCodeLink, tokenValue, attachmentOptions, createRequestLink, isCreatingLink, isUpdatingRequest])
+
+        setGeneratedLink(link)
+        const copied = await pendingCopy.resolve(link)
+        toast.success(copied ? t('linkCreatedAndCopiedToast') : t('linkCreatedToast'))
+        return link
+    }, [generatedLink, attachmentOptions, createRequestLink, isCreatingLink, isUpdatingRequest, toast, t])
 
     // Set wallet defaults when connected
     useMemo(() => {

--- a/src/components/Request/link/views/Create.request.link.view.tsx
+++ b/src/components/Request/link/views/Create.request.link.view.tsx
@@ -424,15 +424,17 @@ export const CreateRequestLinkView = () => {
                     </Button>
                 )}
 
+                {/* the share button waits for the link itself, not just the request id:
+                    it shares what create produced, it never creates */}
                 {requestId &&
-                    (isCreatingLink || isUpdatingRequest ? (
+                    (isCreatingLink || isUpdatingRequest || !generatedLink ? (
                         <Button disabled={true} shadowSize="4">
                             <div className="flex w-full flex-row items-center justify-center gap-2">
                                 <Loading /> {tLoading('loading')}
                             </div>
                         </Button>
                     ) : (
-                        <ShareButton generateUrl={generateLink}>
+                        <ShareButton url={generatedLink}>
                             {!tokenValue || !parseFloat(tokenValue) || parseFloat(tokenValue) === 0
                                 ? t('shareOpenRequest')
                                 : t('shareAmountRequest', { amount: tokenValue })}

--- a/src/components/Request/link/views/Create.request.link.view.tsx
+++ b/src/components/Request/link/views/Create.request.link.view.tsx
@@ -21,6 +21,7 @@ import { useWallet } from '@/hooks/wallet/useWallet'
 import { type IToken } from '@/interfaces/interfaces'
 import { type IAttachmentOptions } from '@/interfaces/attachment'
 import { requestsApi } from '@/services/requests'
+import { copyTextToClipboard } from '@/utils/clipboard.utils'
 import { fetchTokenSymbol, formatTokenAmount, getRequestLink, isNativeCurrency } from '@/utils/general.utils'
 import * as Sentry from '@sentry/nextjs'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
@@ -193,7 +194,8 @@ export const CreateRequestLinkView = () => {
                 // Update the last saved state
                 lastSavedAttachmentRef.current = { ...attachmentOptions }
 
-                toast.success(t('linkCreatedToast'))
+                const copied = await copyTextToClipboard(link)
+                toast.success(copied ? t('linkCreatedAndCopiedToast') : t('linkCreatedToast'))
                 queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })
                 return link
             } catch (error) {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -971,6 +971,7 @@
         "shareAmountRequest": "Share ${amount} request",
         "billSplitFor": "Bill split for {merchant}",
         "linkCreatedToast": "Link created successfully!",
+        "linkCreatedAndCopiedToast": "Link created and copied to clipboard!",
         "requestUpdatedToast": "Request updated successfully!",
         "recipientPlaceholder": "Enter a username, an address or ENS",
         "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -971,6 +971,7 @@
         "shareAmountRequest": "Compartir solicitud de ${amount}",
         "billSplitFor": "División de cuenta en {merchant}",
         "linkCreatedToast": "¡Enlace creado con éxito!",
+        "linkCreatedAndCopiedToast": "¡Enlace creado y copiado al portapapeles!",
         "requestUpdatedToast": "¡Solicitud actualizada con éxito!",
         "recipientPlaceholder": "Ingresa un nombre de usuario, una dirección o ENS",
         "errors": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -971,6 +971,7 @@
         "shareAmountRequest": "Compartilhar cobrança de ${amount}",
         "billSplitFor": "Divisão de conta em {merchant}",
         "linkCreatedToast": "Link criado com sucesso!",
+        "linkCreatedAndCopiedToast": "Link criado e copiado para a área de transferência!",
         "requestUpdatedToast": "Cobrança atualizada com sucesso!",
         "recipientPlaceholder": "Insira um nome de usuário, um endereço ou ENS",
         "errors": {

--- a/src/utils/__tests__/clipboard.utils.test.ts
+++ b/src/utils/__tests__/clipboard.utils.test.ts
@@ -1,0 +1,137 @@
+import { beginClipboardCopy, copyTextToClipboard } from '../clipboard.utils'
+
+const mockIsNativeBridge = jest.fn<boolean, []>()
+jest.mock('@/utils/capacitor', () => ({
+    isNativeBridge: () => mockIsNativeBridge(),
+}))
+
+const mockNativeWrite = jest.fn()
+jest.mock('@capacitor/clipboard', () => ({
+    Clipboard: { write: (options: { string: string }) => mockNativeWrite(options) },
+}))
+
+class ClipboardItemStub {
+    constructor(public data: Record<string, Promise<Blob> | Blob | string>) {}
+}
+
+const LINK = 'https://peanut.me/request/pay?id=req-uuid-1'
+
+// jsdom's Blob has no text()
+const readBlob = (blob: Blob) =>
+    new Promise<string>((resolve) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(String(reader.result))
+        reader.readAsText(blob)
+    })
+
+let write: jest.Mock
+let writeText: jest.Mock
+let consoleErrorSpy: jest.SpyInstance
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+const originalSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockIsNativeBridge.mockReturnValue(false)
+    mockNativeWrite.mockResolvedValue(undefined)
+    write = jest.fn().mockResolvedValue(undefined)
+    writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { write, writeText } })
+    Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true })
+    ;(globalThis as { ClipboardItem?: unknown }).ClipboardItem = ClipboardItemStub
+})
+
+afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem
+})
+
+afterAll(() => {
+    if (originalClipboard) Object.defineProperty(navigator, 'clipboard', originalClipboard)
+    else delete (navigator as unknown as Record<string, unknown>).clipboard
+    if (originalSecureContext) Object.defineProperty(window, 'isSecureContext', originalSecureContext)
+})
+
+describe('beginClipboardCopy', () => {
+    // WebKit only honours a write while the click's activation is live, so the
+    // write has to start before the request that mints the text is awaited.
+    it('starts the write before the text exists and fills it in later', async () => {
+        const pending = beginClipboardCopy()
+
+        expect(write).toHaveBeenCalledTimes(1)
+
+        await expect(pending.resolve(LINK)).resolves.toBe(true)
+        expect(writeText).not.toHaveBeenCalled()
+
+        const item = write.mock.calls[0][0][0] as ClipboardItemStub
+        await expect(readBlob(await (item.data['text/plain'] as Promise<Blob>))).resolves.toBe(LINK)
+    })
+
+    it('falls back to a plain write when the reservation is rejected', async () => {
+        write.mockRejectedValue(new Error('denied'))
+
+        const pending = beginClipboardCopy()
+
+        await expect(pending.resolve(LINK)).resolves.toBe(true)
+        expect(writeText).toHaveBeenCalledWith(LINK)
+    })
+
+    it('reports failure when neither the reservation nor the plain write lands', async () => {
+        write.mockRejectedValue(new Error('denied'))
+        writeText.mockRejectedValue(new Error('denied'))
+
+        await expect(beginClipboardCopy().resolve(LINK)).resolves.toBe(false)
+    })
+
+    // an abandoned reservation must settle — a hanging write blocks the next one
+    it('settles the reservation when the text never arrives', async () => {
+        const pending = beginClipboardCopy()
+
+        expect(() => pending.cancel()).not.toThrow()
+        await Promise.resolve()
+
+        expect(writeText).not.toHaveBeenCalled()
+    })
+
+    it('copies directly when the browser cannot reserve the clipboard', async () => {
+        delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem
+
+        await expect(beginClipboardCopy().resolve(LINK)).resolves.toBe(true)
+        expect(write).not.toHaveBeenCalled()
+        expect(writeText).toHaveBeenCalledWith(LINK)
+    })
+
+    it('copies through the native plugin instead of reserving', async () => {
+        mockIsNativeBridge.mockReturnValue(true)
+
+        await expect(beginClipboardCopy().resolve(LINK)).resolves.toBe(true)
+        expect(write).not.toHaveBeenCalled()
+        expect(mockNativeWrite).toHaveBeenCalledWith({ string: LINK })
+    })
+})
+
+describe('copyTextToClipboard', () => {
+    it('prefers the native plugin over the webview clipboard', async () => {
+        mockIsNativeBridge.mockReturnValue(true)
+
+        await expect(copyTextToClipboard(LINK)).resolves.toBe(true)
+        expect(mockNativeWrite).toHaveBeenCalledWith({ string: LINK })
+        expect(writeText).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the webview clipboard when the native plugin fails', async () => {
+        mockIsNativeBridge.mockReturnValue(true)
+        mockNativeWrite.mockRejectedValue(new Error('no plugin'))
+
+        await expect(copyTextToClipboard(LINK)).resolves.toBe(true)
+        expect(writeText).toHaveBeenCalledWith(LINK)
+    })
+
+    it('reports failure when the write is refused', async () => {
+        writeText.mockRejectedValue(new Error('denied'))
+
+        await expect(copyTextToClipboard(LINK)).resolves.toBe(false)
+    })
+})

--- a/src/utils/clipboard.utils.ts
+++ b/src/utils/clipboard.utils.ts
@@ -1,0 +1,45 @@
+import { isNativeBridge } from '@/utils/capacitor'
+
+/**
+ * Copies text to the clipboard, reporting whether it actually landed.
+ *
+ * Native goes through the Capacitor plugin first: the WebView's
+ * navigator.clipboard write is gated on a live user activation, which an await
+ * on a network call (creating a link, say) has usually already spent.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+    if (isNativeBridge()) {
+        try {
+            const { Clipboard } = await import('@capacitor/clipboard')
+            await Clipboard.write({ string: text })
+            return true
+        } catch (err) {
+            console.error('Failed to copy: ', err)
+        }
+    }
+
+    let textArea: HTMLTextAreaElement | undefined
+
+    try {
+        if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(text)
+            return true
+        } else {
+            // Fallback for older browsers
+            textArea = document.createElement('textarea')
+            textArea.value = text
+            textArea.style.position = 'fixed'
+            textArea.style.left = '-999999px'
+            textArea.style.top = '-999999px'
+            document.body.appendChild(textArea)
+            textArea.focus()
+            textArea.select()
+            return document.execCommand('copy')
+        }
+    } catch (err) {
+        console.error('Failed to copy: ', err)
+        return false
+    } finally {
+        textArea?.remove()
+    }
+}

--- a/src/utils/clipboard.utils.ts
+++ b/src/utils/clipboard.utils.ts
@@ -43,3 +43,65 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
         textArea?.remove()
     }
 }
+
+/**
+ * A clipboard write reserved inside a click, for text that only exists after an
+ * await. Settle it exactly once: `resolve` with the text, or `cancel` when the
+ * text never arrives — an unsettled reservation leaves the write hanging.
+ */
+export interface PendingClipboardCopy {
+    resolve: (text: string) => Promise<boolean>
+    cancel: () => void
+}
+
+/**
+ * Reserves the clipboard for text that is still being fetched. MUST be called
+ * synchronously from the event handler, before the first await.
+ *
+ * WebKit only allows a clipboard write while the user activation from the click
+ * is still live, and awaiting the request that mints the link spends it — so a
+ * plain writeText afterwards is rejected on Safari and iOS PWAs. Handing
+ * ClipboardItem a promise instead starts the write inside the gesture and lets
+ * the text land later. Everything else falls back to a plain post-await copy.
+ */
+export function beginClipboardCopy(): PendingClipboardCopy {
+    const canReserve =
+        !isNativeBridge() &&
+        typeof ClipboardItem !== 'undefined' &&
+        typeof navigator.clipboard?.write === 'function' &&
+        window.isSecureContext
+
+    if (!canReserve) {
+        return { resolve: copyTextToClipboard, cancel: () => {} }
+    }
+
+    let settle: (blob: Blob | PromiseLike<Blob>) => void = () => {}
+    let abandon: (reason: Error) => void = () => {}
+    const blob = new Promise<Blob>((res, rej) => {
+        settle = res
+        abandon = rej
+    })
+    // cancel()'s rejection is reported through `reserved`, never as an unhandled one
+    blob.catch(() => {})
+
+    // started here, inside the gesture; the text arrives later
+    const reserved = navigator.clipboard.write([new ClipboardItem({ 'text/plain': blob })]).then(
+        () => true,
+        (err) => {
+            console.error('Failed to copy: ', err)
+            return false
+        }
+    )
+
+    return {
+        resolve: async (text: string) => {
+            settle(new Blob([text], { type: 'text/plain' }))
+            // a rejected reservation still leaves the ordinary path worth a try
+            return (await reserved) || copyTextToClipboard(text)
+        },
+        cancel: () => {
+            abandon(new Error('Clipboard copy abandoned'))
+            void reserved
+        },
+    }
+}


### PR DESCRIPTION
## What

Creating a request link now puts it on the clipboard immediately — no Share tap needed — and the snackbar says so.

- `Create.request.link.view.tsx`: after `requestsApi.create` resolves, the link is copied and the toast reads **"Link created and copied to clipboard!"**. A refused clipboard falls back to the existing "Link created successfully!", so we never claim a copy that did not happen.
- Share is unchanged: it still copies and opens the system share sheet. By then the link exists, so `generateLink` returns the cached one — no second create, no duplicate toast.

## Why

The link was only reaching the clipboard behind the share sheet. Users who just want to paste it somewhere had to open the drawer and dismiss it.

## Supporting changes

- New `src/utils/clipboard.utils.ts` — `copyTextToClipboard(text): Promise<boolean>`. It is ShareButton's inline helper extracted verbatim (secure-context `navigator.clipboard`, textarea/`execCommand` fallback) plus a native branch: on the Capacitor bridge it writes through `@capacitor/clipboard` first, because the WebView's `navigator.clipboard` write needs a live user activation that the awaited create request has already spent. `ShareButton` now calls the same helper, so there is one copy implementation instead of two.
- i18n: `request.linkCreatedAndCopiedToast` added to `en`, `es-419`, `pt-BR`. `es-AR` is a deltas-only overlay and needs no entry (catalog-parity test agrees).

## Testing

- `request-states` suite: two tests cover the new behaviour — the link reaches the clipboard with the copied-toast copy, and a refused clipboard falls back to the plain toast.
- Local: `tsc --noEmit` clean; `request-states` (37), `ShareButton` (7), the i18n catalog/glossary/marketing suites and the four ShareButton-consuming suites pass; prettier clean.
- Not exercised against a running app — the request flow is behind auth; the toast/clipboard branch is covered by the unit tests above.