### PR TITLE
feat(ios): sentry native crash reporting (TASK-22027)

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -294,6 +294,23 @@ jobs:
                       -exportPath build/ios \
                       -exportOptionsPlist /tmp/ExportOptions.plist
 
+            - name: Upload dSYMs to Sentry
+              # Without debug symbols every native crash arrives as hex offsets.
+              # `uploadSymbols` in ExportOptions.plist goes to App Store Connect only —
+              # Sentry sunset its ASC fetch in 2024. Needs a SENTRY_AUTH_TOKEN repo
+              # secret (org peanut-c34d84c05, project peanut-ui, scope project:releases).
+              # Until it exists this step warns and the release still ships.
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: peanut-c34d84c05
+                  SENTRY_PROJECT: peanut-ui
+              run: |
+                  if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+                      echo "::warning::SENTRY_AUTH_TOKEN not set — dSYMs not uploaded; native iOS crashes will be unsymbolicated in Sentry"
+                      exit 0
+                  fi
+                  pnpm dlx @sentry/cli@2.39.1 debug-files upload build/ios/App.xcarchive/dSYMs
+
             - name: Verify push entitlements + Sentry DSN in exported IPA
               run: |
                   unzip -q build/ios/App.ipa -d /tmp/ipa-check

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -299,7 +299,9 @@ jobs:
               # `uploadSymbols` in ExportOptions.plist goes to App Store Connect only —
               # Sentry sunset its ASC fetch in 2024. Needs a SENTRY_AUTH_TOKEN repo
               # secret (org peanut-c34d84c05, project peanut-ui, scope project:releases).
-              # Until it exists this step warns and the release still ships.
+              # Until it exists this step warns and the release still ships. sentry-cli
+              # is a pinned devDependency so it comes from the lockfile, not a fresh
+              # registry fetch inside the signing job.
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                   SENTRY_ORG: peanut-c34d84c05
@@ -309,7 +311,7 @@ jobs:
                       echo "::warning::SENTRY_AUTH_TOKEN not set — dSYMs not uploaded; native iOS crashes will be unsymbolicated in Sentry"
                       exit 0
                   fi
-                  pnpm dlx @sentry/cli@2.39.1 debug-files upload build/ios/App.xcarchive/dSYMs
+                  pnpm exec sentry-cli debug-files upload build/ios/App.xcarchive/dSYMs
 
             - name: Verify push entitlements + Sentry DSN in exported IPA
               run: |
@@ -321,16 +323,15 @@ jobs:
                       echo "::error::exported ipa aps-environment is '${APS:-missing}', expected production — push would be dead in this build"
                       exit 1
                   fi
-                  # An empty or unexpanded SentryDSN ships a build with native crash
-                  # reporting silently off — the iOS analogue of the gradle warning.
+                  # An empty, unexpanded, or malformed SentryDSN ships a build with native
+                  # crash reporting silently off (sentry-cocoa disables itself on a DSN it
+                  # cannot parse) — the iOS analogue of the gradle warning.
                   DSN=$(plutil -extract SentryDSN raw -o - /tmp/ipa-check/Payload/App.app/Info.plist 2>/dev/null || true)
-                  case "$DSN" in
-                      ''|'$('*)
-                          echo "::error::exported ipa SentryDSN is '${DSN:-missing}' — native crash reporting would be dead in this build"
-                          exit 1
-                          ;;
-                  esac
-                  echo "SentryDSN present"
+                  if ! printf '%s' "$DSN" | grep -Eq '^https://[0-9a-f]+@[a-z0-9.-]+\.sentry\.io/[0-9]+$'; then
+                      echo "::error::exported ipa SentryDSN is ${DSN:+malformed}${DSN:-missing} — native crash reporting would be dead in this build"
+                      exit 1
+                  fi
+                  echo "SentryDSN present and well-formed"
 
             - name: Upload to TestFlight
               uses: apple-actions/upload-testflight-build@1ad58030672057aa084b4e96beb6f7a8c627f9e6 # v5

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -231,6 +231,10 @@ jobs:
                   # upload's build number to exceed the last.
                   IOS_BUILD_NUMBER: ${{ github.run_number }}
                   IOS_VERSION_NAME: ${{ steps.version.outputs.name }}
+                  # native sentry sdk dsn — Info.plist SentryDSN <- $(SENTRY_DSN) build
+                  # setting. same project dsn the js layer bakes into the static export
+                  # above; no new secret needed (mirror of SENTRY_DSN_ANDROID).
+                  SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
               run: |
                   # MARKETING_VERSION comes from the "Resolve release versionName"
                   # step (input > tag > package.json — the same precedence
@@ -271,7 +275,8 @@ jobs:
                   # passed on the command line: global build settings leak onto the SwiftPM
                   # dependency targets (Alamofire, ZIPFoundation, …), which reject a
                   # provisioning profile and fail the archive. Only version numbers, which
-                  # are harmless to inherit, are overridden here.
+                  # are harmless to inherit, and SENTRY_DSN, a custom setting nothing else
+                  # reads, are overridden here.
                   xcodebuild \
                       -project ios/App/App.xcodeproj \
                       -scheme App \
@@ -280,6 +285,7 @@ jobs:
                       -archivePath build/ios/App.xcarchive \
                       CURRENT_PROJECT_VERSION="$IOS_BUILD_NUMBER" \
                       "${MARKETING_ARG[@]}" \
+                      SENTRY_DSN="$SENTRY_DSN" \
                       archive
 
                   xcodebuild \
@@ -288,7 +294,7 @@ jobs:
                       -exportPath build/ios \
                       -exportOptionsPlist /tmp/ExportOptions.plist
 
-            - name: Verify push entitlements in exported IPA
+            - name: Verify push entitlements + Sentry DSN in exported IPA
               run: |
                   unzip -q build/ios/App.ipa -d /tmp/ipa-check
                   APS=$(codesign -d --entitlements :- /tmp/ipa-check/Payload/App.app 2>/dev/null \
@@ -298,6 +304,16 @@ jobs:
                       echo "::error::exported ipa aps-environment is '${APS:-missing}', expected production — push would be dead in this build"
                       exit 1
                   fi
+                  # An empty or unexpanded SentryDSN ships a build with native crash
+                  # reporting silently off — the iOS analogue of the gradle warning.
+                  DSN=$(plutil -extract SentryDSN raw -o - /tmp/ipa-check/Payload/App.app/Info.plist 2>/dev/null || true)
+                  case "$DSN" in
+                      ''|'$('*)
+                          echo "::error::exported ipa SentryDSN is '${DSN:-missing}' — native crash reporting would be dead in this build"
+                          exit 1
+                          ;;
+                  esac
+                  echo "SentryDSN present"
 
             - name: Upload to TestFlight
               uses: apple-actions/upload-testflight-build@1ad58030672057aa084b4e96beb6f7a8c627f9e6 # v5

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
+		5E53A1B2C3D4E5F600000001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 5E53A1B2C3D4E5F600000002 /* Sentry */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
 		7A1C0DE7C11B0A4D2E5F3901 /* AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0DE7C11B0A4D2E5F3902 /* AppViewController.swift */; };
@@ -40,6 +41,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */,
+				5E53A1B2C3D4E5F600000001 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,6 +100,7 @@
 			name = App;
 			packageProductDependencies = (
 				4D22ABE82AF431CB00220026 /* CapApp-SPM */,
+				5E53A1B2C3D4E5F600000002 /* Sentry */,
 			);
 			productName = App;
 			productReference = 504EC3041FED79650016851F /* App.app */;
@@ -130,6 +133,7 @@
 			mainGroup = 504EC2FB1FED79650016851F;
 			packageReferences = (
 				D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */,
+				5E53A1B2C3D4E5F600000003 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			productRefGroup = 504EC3051FED79650016851F /* Products */;
 			projectDirPath = "";
@@ -377,11 +381,27 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		5E53A1B2C3D4E5F600000003 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
+			requirement = {
+				kind = exactVersion;
+				version = 9.26.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		4D22ABE82AF431CB00220026 /* CapApp-SPM */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */;
 			productName = "CapApp-SPM";
+		};
+		5E53A1B2C3D4E5F600000002 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E53A1B2C3D4E5F600000003 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,6 +38,15 @@
       }
     },
     {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "cd213f98af160e6497eeff0707bc3f6a205b159c",
+        "version" : "9.26.0"
+      }
+    },
+    {
       "identity" : "version",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mrackwitz/Version.git",

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Capacitor
+import Sentry
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -7,7 +8,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // Sentry native crash reporting — the iOS half of TASK-20964 (Android:
+        // AndroidManifest.xml). Captures what the JS SDK inside the WKWebView can't:
+        // process crashes, app hangs, Swift plugin exceptions, WebView content-process
+        // kills — and tracks native sessions, which is what makes crash-free-session %
+        // measurable per release. DSN comes from Info.plist `SentryDSN` <- $(SENTRY_DSN)
+        // build setting, set in ios-release.yml; an empty DSN leaves the SDK off, so
+        // local builds stay silent. Release defaults to bundleId@version+build, the
+        // same shape Android reports (me.peanut.wallet@1.1.0+123).
+        if let dsn = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String, !dsn.isEmpty {
+            SentrySDK.start { options in
+                options.dsn = dsn
+                options.environment = "native"
+            }
+            // Reconciliation hook (mirror of MainActivity.maybeSentryTestCrash): only a
+            // developer can pass launch arguments to an iOS app — Xcode scheme, or
+            //   xcrun devicectl device process launch --device <udid> me.peanut.wallet -sentry_test_crash
+            // — so this is unreachable for users and needs no one-shot guard.
+            if ProcessInfo.processInfo.arguments.contains("-sentry_test_crash") {
+                SentrySDK.crash()
+            }
+        } else {
+            NSLog("SentryDSN not set — native crash reporting is DISABLED in this build. Fine locally; a release build without it ships blind.")
+        }
         return true
     }
 

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -9,22 +9,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Sentry native crash reporting — the iOS half of TASK-20964 (Android:
-        // AndroidManifest.xml). Captures what the JS SDK inside the WKWebView can't:
-        // process crashes, app hangs, Swift plugin exceptions, WebView content-process
-        // kills — and tracks native sessions, which is what makes crash-free-session %
-        // measurable per release. DSN comes from Info.plist `SentryDSN` <- $(SENTRY_DSN)
-        // build setting, set in ios-release.yml; an empty DSN leaves the SDK off, so
-        // local builds stay silent. Release defaults to bundleId@version+build, the
-        // same shape Android reports (me.peanut.wallet@1.1.0+123).
+        // AndroidManifest.xml). The JS SDK inside the WKWebView cannot see process
+        // crashes, app hangs, or Swift plugin exceptions; this SDK does. It also
+        // tracks native sessions, which makes crash-free-session % measurable per
+        // release. The DSN comes from Info.plist `SentryDSN` <- $(SENTRY_DSN), set in
+        // ios-release.yml. An empty DSN leaves the SDK off, so local builds stay
+        // silent. The release defaults to bundleId@version+build, the same shape
+        // Android reports (me.peanut.wallet@1.1.0+123).
         if let dsn = Bundle.main.object(forInfoDictionaryKey: "SentryDSN") as? String, !dsn.isEmpty {
             SentrySDK.start { options in
                 options.dsn = dsn
                 options.environment = "native"
             }
-            // Reconciliation hook (mirror of MainActivity.maybeSentryTestCrash): only a
-            // developer can pass launch arguments to an iOS app — Xcode scheme, or
+            // Reconciliation hook (mirror of MainActivity.maybeSentryTestCrash).
+            // Only a developer can pass launch arguments to an iOS app: an Xcode
+            // scheme, or
             //   xcrun devicectl device process launch --device <udid> me.peanut.wallet -sentry_test_crash
-            // — so this is unreachable for users and needs no one-shot guard.
+            // Users cannot reach it, so it needs no one-shot guard.
             if ProcessInfo.processInfo.arguments.contains("-sentry_test_crash") {
                 SentrySDK.crash()
             }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -77,5 +77,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>SentryDSN</key>
+	<string>$(SENTRY_DSN)</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
         "@next/bundle-analyzer": "^16.1.1",
         "@next/eslint-plugin-next": "^16.2.4",
         "@playwright/test": "^1.58.0",
+        "@sentry/cli": "2.39.1",
         "@size-limit/preset-app": "^11.2.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/dom": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.0
         version: 1.58.2
+      '@sentry/cli':
+        specifier: 2.39.1
+        version: 2.39.1
       '@size-limit/preset-app':
         specifier: ^11.2.0
         version: 11.2.0(bufferutil@4.1.0)(size-limit@11.2.0)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Summary

iOS has had **no native crash reporting** — only the JS Sentry SDK inside the WKWebView, which cannot see process crashes, app hangs, or Swift plugin exceptions. Android has shipped `sentry-android` since 1.0.48 (TASK-20964, #2602). This is the iOS half:

- `sentry-cocoa` **9.26.0** (SPM, exact pin, published 2026-08-12 → past the 14-day floor) added to the App target + `Package.resolved`.
- `AppDelegate` starts the SDK with `environment: native`. Release defaults to `me.peanut.wallet@<version>+<build>` — same naming as Android, so [Sentry → Releases](https://peanut-c34d84c05.sentry.io/releases/?project=4505827431415808) shows crash-free session % per iOS build.
- DSN: `Info.plist SentryDSN` ← `$(SENTRY_DSN)` build setting ← `ios-release.yml` from the existing `NEXT_PUBLIC_SENTRY_DSN` secret (mirror of `SENTRY_DSN_ANDROID`). Empty DSN = SDK off, so local/Xcode builds stay silent.
- New `Upload dSYMs to Sentry` step (`pnpm exec sentry-cli debug-files upload` on the archive; `@sentry/cli` 2.39.1 pinned as a devDependency so it rides the lockfile) so native frames symbolicate. ⚠️ Needs a **`SENTRY_AUTH_TOKEN`** repo secret (org `peanut-c34d84c05`, project `peanut-ui`, scope `project:releases`) — until it exists the step warns and the release still ships, unsymbolicated.
- IPA verify step now also fails the release if `SentryDSN` is missing, unexpanded, or malformed (sentry-cocoa disables itself on a DSN it cannot parse) — the iOS analogue of the gradle "ships blind" warning.
- Reconciliation hook: launch argument `-sentry_test_crash` calls `SentrySDK.crash()` (mirror of `MainActivity.maybeSentryTestCrash`). Only a developer can pass launch arguments to an iOS app (Xcode scheme / `xcrun devicectl device process launch`), so it is unreachable for users.

## Task

TASK-22027 — https://app.notion.com/p/3cd83811757981c1a1f5f457407be823

## Design notes / accepted trade-offs

- `environment: native` is shared with the Android native SDK and the JS SDK in the WebView (`sentry-env.ts`). Kept for parity with Android and the runbook; the streams separate on `sdk.name` / release shape (`me.peanut.wallet@…` vs git short hash). Renaming both platforms is a follow-up, not this PR.

## Risks / breaking changes

- **No PR-time iOS build exists** (`ios-release.yml` runs on tag / dispatch only) and this machine has Command Line Tools, not Xcode, so the pbxproj/SPM wiring is hand-written and lint-checked (`plutil -lint`), not compiled. ⚠️ **Before merging, dispatch `iOS Release (TestFlight)` on this branch** — it archives, verifies the DSN in the IPA, and uploads a TestFlight build; that build is also the reconciliation vehicle below.
- New native dependency; ships only via a TestFlight/App Store build, never Capgo OTA.
- No user-visible change. No backend impact.

## QA

1. Dispatch `iOS Release (TestFlight)` on `feat/ios-native-sentry`; the "Verify push entitlements + Sentry DSN" step must print `SentryDSN present`.
2. Install the TestFlight build on a paired device, then `xcrun devicectl device process launch --device <udid> me.peanut.wallet -sentry_test_crash`, reopen the app.
3. Sentry: an issue under `environment:native` with `sdk.name:sentry.cocoa`, and the release `me.peanut.wallet@<version>+<build>` shows a crashed session.

Screenshots: N/A (no visible change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release validation by rejecting missing or malformed Sentry DSNs.
  * Continued validating required push notification entitlements.
  * Improved debug symbol uploads during iOS releases for more reliable error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->