### PR TITLE
fix(errors): report network failures once per endpoint, and stop dropping failed mutations

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -219,3 +219,65 @@ describe('shouldIgnoreError — OneSignal worker-messenger noise', () => {
         expect(shouldIgnoreError(eventWith({ message: '[WM] No SW registration for postMessage' }))).toBe(true)
     })
 })
+
+describe('shouldIgnoreError — fetch-site network captures', () => {
+    function fetchSiteCapture(value: string): ErrorEvent {
+        return {
+            fingerprint: ['network-error', 'https://api.peanut.me/users/me', 'GET'],
+            exception: { values: [{ type: 'TypeError', value }] },
+        } as unknown as ErrorEvent
+    }
+
+    // Both engine spellings, because the split is per-engine: WebKit says
+    // `Load failed`, Chromium (so every Android WebView) says `Failed to fetch`.
+    it.each(['Failed to fetch', 'Load failed', 'Network Error'])(
+        'keeps the explicit fetchWithSentry capture for %s',
+        (value) => {
+            expect(shouldIgnoreError(fetchSiteCapture(value))).toBe(false)
+        }
+    )
+
+    it('still ignores the same message without the fetch-site fingerprint', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'TypeError', value: 'Failed to fetch' }))).toBe(true)
+    })
+
+    it('does not rescue an unrelated fingerprint that merely mentions the network', () => {
+        const event = {
+            fingerprint: ['onesignal-op-failed', 'update-subscription'],
+            exception: { values: [{ type: 'TypeError', value: 'Failed to fetch' }] },
+        } as unknown as ErrorEvent
+        expect(shouldIgnoreError(event)).toBe(true)
+    })
+})
+
+describe('shouldIgnoreError — injected third-party scripts', () => {
+    function framedEvent(filename: string): ErrorEvent {
+        return {
+            exception: {
+                values: [
+                    {
+                        type: 'TypeError',
+                        value: "Cannot read properties of undefined (reading 'M_ID')",
+                        stacktrace: { frames: [{ filename }] },
+                    },
+                ],
+            },
+        } as unknown as ErrorEvent
+    }
+
+    // The scheme-bearing cases were always caught; `app:///executors/` is the
+    // one that forced PEANUT-UI-SNS to be archived by hand.
+    it.each([
+        'chrome-extension://abcdef/inject.js',
+        'moz-extension://abcdef/inject.js',
+        'safari-extension://abcdef/inject.js',
+        'app:///executors/200.js',
+    ])('ignores a frame from %s', (filename) => {
+        expect(shouldIgnoreError(framedEvent(filename))).toBe(true)
+    })
+
+    it('does not ignore our own bundle, including an unresolved app:/// frame', () => {
+        expect(shouldIgnoreError(framedEvent('/_next/static/chunks/main-abc123.js'))).toBe(false)
+        expect(shouldIgnoreError(framedEvent('app:///_next/static/chunks/main-abc123.js'))).toBe(false)
+    })
+})

--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -221,9 +221,9 @@ describe('shouldIgnoreError — OneSignal worker-messenger noise', () => {
 })
 
 describe('shouldIgnoreError — fetch-site network captures', () => {
-    function fetchSiteCapture(value: string): ErrorEvent {
+    function fetchSiteCapture(value: string, method = 'POST', kind = 'network-error'): ErrorEvent {
         return {
-            fingerprint: ['network-error', 'https://api.peanut.me/users/me', 'GET'],
+            fingerprint: [kind, 'https://api.peanut.me/charges', method],
             exception: { values: [{ type: 'TypeError', value }] },
         } as unknown as ErrorEvent
     }
@@ -231,11 +231,26 @@ describe('shouldIgnoreError — fetch-site network captures', () => {
     // Both engine spellings, because the split is per-engine: WebKit says
     // `Load failed`, Chromium (so every Android WebView) says `Failed to fetch`.
     it.each(['Failed to fetch', 'Load failed', 'Network Error'])(
-        'keeps the explicit fetchWithSentry capture for %s',
+        'keeps a failed mutation for %s — the user lost progress in a money flow',
         (value) => {
             expect(shouldIgnoreError(fetchSiteCapture(value))).toBe(false)
         }
     )
+
+    it.each(['PUT', 'PATCH', 'DELETE', 'post'])('keeps a failed %s', (method) => {
+        expect(shouldIgnoreError(fetchSiteCapture('Failed to fetch', method))).toBe(false)
+    })
+
+    it('keeps a mutation that timed out (the other fetch-site fingerprint)', () => {
+        expect(shouldIgnoreError(fetchSiteCapture('Failed to fetch', 'POST', 'timeout'))).toBe(false)
+    })
+
+    // 78% of this population is failed GETs on /home — balance and price polls
+    // that retry and succeed. Their rate belongs in PostHog, not as individual
+    // Sentry events.
+    it.each(['GET', 'HEAD'])('still ignores a failed %s', (method) => {
+        expect(shouldIgnoreError(fetchSiteCapture('Failed to fetch', method))).toBe(true)
+    })
 
     it('still ignores the same message without the fetch-site fingerprint', () => {
         expect(shouldIgnoreError(eventWith({ type: 'TypeError', value: 'Failed to fetch' }))).toBe(true)

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -140,6 +140,30 @@ function collapseNoisyFingerprint(event: ErrorEvent): void {
     }
 }
 
+/*
+ * A frame that did not come from our bundle and did not come from a URL we can
+ * name. Extensions are the obvious case, but the ones that actually cost us are
+ * the injected content scripts that carry NO scheme at all: PEANUT-UI-SNS threw
+ * ~3.7k unhandled rejections from `app:///executors/200.js` (a wallet-style
+ * injector reading `M_ID` off an undefined global), which the scheme-only check
+ * could not see, so it had to be archived by hand.
+ *
+ * `app:///` is Sentry's own rewrite for a script whose origin it cannot resolve.
+ * Our first-party frames always resolve to `/_next/`, so keying on the executors
+ * path is safe — deliberately not "any app:/// frame", which would swallow real
+ * bundles whose sourcemap upload lagged a deploy.
+ */
+const THIRD_PARTY_SCRIPT_FRAMES = [
+    'chrome-extension://',
+    'moz-extension://',
+    'safari-extension://',
+    'app:///executors/',
+]
+
+export function isThirdPartyScriptFrame(filename: string): boolean {
+    return THIRD_PARTY_SCRIPT_FRAMES.some((pattern) => filename.includes(pattern))
+}
+
 /**
  * Check if error message matches any ignored pattern
  */
@@ -179,6 +203,30 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
      */
     if (isActionableCapgoError(searchTexts)) return false
 
+    /*
+     * Rescue the explicit fetch-site capture, for the same reason the Capgo
+     * carve-out sits here: once the loop below returns true nothing can take it
+     * back.
+     *
+     * `fetchWithSentry` catches a failed request, sets fingerprint
+     * ['network-error', url, method], captures WITH full context (url, method,
+     * sanitized headers and body, feature tag), and only then rethrows a
+     * ServiceUnavailableError for the UI. `alreadyReported` drops that rethrow
+     * on the stated grounds that "the underlying failure is already captured at
+     * the fetch site" — but it was not: `networkIssues` ate that capture too, on
+     * the engine's own `Failed to fetch` / `Load failed` copy. Both halves of
+     * every browser-native request failure were therefore discarded, and Sentry
+     * recorded 0 of them in 30d while PostHog (whose mirror runs as an
+     * integration processEvent hook, upstream of beforeSend) held ~7.4k/week
+     * across 590 users.
+     *
+     * The fingerprint is the discriminator, not the message: it is set only by
+     * our own wrapper, so this can never rescue an incidental network TypeError
+     * from a third-party SDK. It also groups the survivors per endpoint instead
+     * of per minified call site.
+     */
+    if (event.fingerprint?.[0] === 'network-error') return false
+
     // Check all ignore patterns
     for (const [group, patterns] of Object.entries(IGNORED_ERRORS)) {
         if (isCriticalFlow && group !== 'userRejected') continue
@@ -199,11 +247,7 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     const frames = (event.exception?.values ?? []).flatMap((v) => v.stacktrace?.frames ?? [])
     for (const frame of frames) {
         const filename = frame.filename || ''
-        if (
-            filename.includes('chrome-extension://') ||
-            filename.includes('moz-extension://') ||
-            filename.includes('safari-extension://')
-        ) {
+        if (isThirdPartyScriptFrame(filename)) {
             return true
         }
     }

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -143,9 +143,19 @@ function collapseNoisyFingerprint(event: ErrorEvent): void {
 const FETCH_SITE_FINGERPRINTS = ['network-error', 'timeout']
 const MUTATING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE']
 
+/*
+ * Exported so fetchWithSentry's outage dedupe and the rescue below cannot drift
+ * apart on what counts as a mutation. They have to agree: if the dedupe ever
+ * suppresses a request this rescue would have kept, the event is gone before
+ * `beforeSend` runs and the rescue is silently inert.
+ */
+export function isMutatingMethod(method: string | undefined): boolean {
+    return MUTATING_METHODS.includes((method || '').toUpperCase())
+}
+
 function isFetchSiteMutationFailure(event: ErrorEvent): boolean {
     const [kind, , method] = event.fingerprint ?? []
-    return FETCH_SITE_FINGERPRINTS.includes(kind) && MUTATING_METHODS.includes((method || '').toUpperCase())
+    return FETCH_SITE_FINGERPRINTS.includes(kind) && isMutatingMethod(method)
 }
 
 /*

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -140,6 +140,14 @@ function collapseNoisyFingerprint(event: ErrorEvent): void {
     }
 }
 
+const FETCH_SITE_FINGERPRINTS = ['network-error', 'timeout']
+const MUTATING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE']
+
+function isFetchSiteMutationFailure(event: ErrorEvent): boolean {
+    const [kind, , method] = event.fingerprint ?? []
+    return FETCH_SITE_FINGERPRINTS.includes(kind) && MUTATING_METHODS.includes((method || '').toUpperCase())
+}
+
 /*
  * A frame that did not come from our bundle and did not come from a URL we can
  * name. Extensions are the obvious case, but the ones that actually cost us are
@@ -204,28 +212,31 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
     if (isActionableCapgoError(searchTexts)) return false
 
     /*
-     * Rescue the explicit fetch-site capture, for the same reason the Capgo
-     * carve-out sits here: once the loop below returns true nothing can take it
-     * back.
+     * Rescue the fetch-site capture for MUTATIONS only, and here rather than
+     * lower down for the same reason as the Capgo carve-out: once the loop
+     * below returns true nothing can take it back.
      *
-     * `fetchWithSentry` catches a failed request, sets fingerprint
-     * ['network-error', url, method], captures WITH full context (url, method,
-     * sanitized headers and body, feature tag), and only then rethrows a
-     * ServiceUnavailableError for the UI. `alreadyReported` drops that rethrow
-     * on the stated grounds that "the underlying failure is already captured at
-     * the fetch site" — but it was not: `networkIssues` ate that capture too, on
-     * the engine's own `Failed to fetch` / `Load failed` copy. Both halves of
-     * every browser-native request failure were therefore discarded, and Sentry
-     * recorded 0 of them in 30d while PostHog (whose mirror runs as an
-     * integration processEvent hook, upstream of beforeSend) held ~7.4k/week
-     * across 590 users.
+     * `fetchWithSentry` sets fingerprint [kind, url, method] and captures with
+     * full context before rethrowing a wrapper for the UI. `alreadyReported`
+     * drops that rethrow on the grounds that the fetch-site capture survived —
+     * it did not, `networkIssues` matched the engine's own `Failed to fetch` /
+     * `Load failed` copy and ate it too. So a POST that dies on the network is
+     * invisible: the user gets "contact support" and we get nothing, which is
+     * the exact failure `criticalFlowTags` was added to prevent and never did
+     * (3 call sites, 0 events in 30d).
      *
-     * The fingerprint is the discriminator, not the message: it is set only by
-     * our own wrapper, so this can never rescue an incidental network TypeError
-     * from a third-party SDK. It also groups the survivors per endpoint instead
-     * of per minified call site.
+     * Restricted to mutating methods on purpose. Failed GETs are 78% of this
+     * population and land on /home — balance and price polls that retry and
+     * succeed, whose rate belongs in PostHog (grouped, rate-limited) and not as
+     * ~7k individual Sentry events a week. A failed mutation is different in
+     * kind: it is a user losing progress in a flow that moves money, it cannot
+     * be silently retried, and there are few of them.
+     *
+     * Keyed on the fingerprint, never the message, so it can only ever rescue
+     * our own wrapper and not an incidental network TypeError from a
+     * third-party SDK.
      */
-    if (event.fingerprint?.[0] === 'network-error') return false
+    if (isFetchSiteMutationFailure(event)) return false
 
     // Check all ignore patterns
     for (const [group, patterns] of Object.entries(IGNORED_ERRORS)) {

--- a/src/utils/__tests__/connectivity.test.ts
+++ b/src/utils/__tests__/connectivity.test.ts
@@ -3,6 +3,7 @@ import {
     clearRecentFailures,
     FAILURE_WINDOW_MS,
     getRecentFailures,
+    hasRecentFailure,
     reportNetworkError,
     subscribeConnectivity,
 } from '../connectivity'
@@ -97,5 +98,31 @@ describe('connectivity', () => {
         reportNetworkError('/b')
 
         expect(calls).toBe(1)
+    })
+})
+
+describe('hasRecentFailure — one Sentry report per endpoint per outage', () => {
+    it('is false the first time an endpoint fails and true afterwards', () => {
+        expect(hasRecentFailure('/users/me')).toBe(false)
+
+        reportNetworkError('/users/me')
+        expect(hasRecentFailure('/users/me')).toBe(true)
+    })
+
+    it('does not suppress a different endpoint failing in the same window', () => {
+        reportNetworkError('/users/me')
+        expect(hasRecentFailure('/tokens/price')).toBe(false)
+    })
+
+    it('lets the endpoint be reported again once the window has passed', () => {
+        reportNetworkError('/users/me')
+        jest.advanceTimersByTime(FAILURE_WINDOW_MS + 1)
+        expect(hasRecentFailure('/users/me')).toBe(false)
+    })
+
+    it('reports again immediately after a recovery clears the window', () => {
+        reportNetworkError('/users/me')
+        clearRecentFailures()
+        expect(hasRecentFailure('/users/me')).toBe(false)
     })
 })

--- a/src/utils/__tests__/sentry-fallback.test.ts
+++ b/src/utils/__tests__/sentry-fallback.test.ts
@@ -19,6 +19,9 @@ jest.mock('@/utils/sentry-lazy', () => require('@sentry/nextjs'))
 
 jest.mock('../connectivity', () => ({
     reportNetworkError: jest.fn(),
+    // fetchWithSentry consults this before capturing, to report one failure per
+    // endpoint per window. Always-false keeps every capture assertion below live.
+    hasRecentFailure: jest.fn(() => false),
 }))
 
 jest.mock('../native-http', () => ({

--- a/src/utils/__tests__/sentry-prefer-native.test.ts
+++ b/src/utils/__tests__/sentry-prefer-native.test.ts
@@ -19,6 +19,9 @@ jest.mock('@/utils/sentry-lazy', () => require('@sentry/nextjs'))
 
 jest.mock('../connectivity', () => ({
     reportNetworkError: jest.fn(),
+    // fetchWithSentry consults this before capturing, to report one failure per
+    // endpoint per window. Always-false keeps every capture assertion below live.
+    hasRecentFailure: jest.fn(() => false),
 }))
 
 jest.mock('../native-http', () => ({

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -24,6 +24,7 @@ jest.mock('@/utils/sentry-lazy', () => require('@sentry/nextjs'))
 
 jest.mock('../connectivity', () => ({
     reportNetworkError: jest.fn(),
+    hasRecentFailure: jest.fn(() => false),
 }))
 
 describe('fetchWithSentry — expected-response suppression', () => {
@@ -442,5 +443,49 @@ describe('fetch timeout budgets', () => {
             )
             expect(reportedTimeoutMs()).toBe(1234)
         })
+    })
+})
+
+describe('fetchWithSentry — one report per endpoint per outage window', () => {
+    const { hasRecentFailure, reportNetworkError } = require('../connectivity') as {
+        hasRecentFailure: jest.Mock
+        reportNetworkError: jest.Mock
+    }
+    let infoSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+        global.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    })
+
+    afterEach(() => infoSpy.mockRestore())
+
+    it('captures the first failure for an endpoint', async () => {
+        hasRecentFailure.mockReturnValue(false)
+        await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+            'Something went wrong. Please try again.'
+        )
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+    })
+
+    /*
+     * The amplifier this exists to kill: React Query retries the route, several
+     * mounted hooks fetch it, and a poll keeps firing while the device is
+     * offline. The user still gets the same thrown error — only the duplicate
+     * report is dropped.
+     */
+    it('skips the capture when the endpoint already failed inside the window', async () => {
+        hasRecentFailure.mockReturnValue(true)
+        await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow(
+            'Something went wrong. Please try again.'
+        )
+        expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
+
+    it('still records the failure for the connectivity banner either way', async () => {
+        hasRecentFailure.mockReturnValue(true)
+        await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow()
+        expect(reportNetworkError).toHaveBeenCalledWith('https://api.peanut.me/users/me')
     })
 })

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -483,6 +483,30 @@ describe('fetchWithSentry — one report per endpoint per outage window', () => 
         expect(Sentry.captureException).not.toHaveBeenCalled()
     })
 
+    /*
+     * The dedupe window is keyed by url alone, and REST puts both verbs on one
+     * path: /home polls `GET /charges` while the pay flow issues `POST /charges`.
+     * Suppressing the POST because the poll failed first would hide exactly the
+     * failure this change exists to surface — its capture never happens, so the
+     * shouldIgnoreError rescue never runs and `alreadyReported` eats the rethrow.
+     */
+    it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+        'still captures a failed %s after a GET to the same url failed in the window',
+        async (method) => {
+            hasRecentFailure.mockReturnValue(true)
+            await expect(fetchWithSentry('https://api.peanut.me/charges', { method })).rejects.toThrow(
+                'Something went wrong. Please try again.'
+            )
+            expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+        }
+    )
+
+    it('still dedupes a repeated GET to the same url', async () => {
+        hasRecentFailure.mockReturnValue(true)
+        await expect(fetchWithSentry('https://api.peanut.me/charges', { method: 'GET' })).rejects.toThrow()
+        expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
+
     it('still records the failure for the connectivity banner either way', async () => {
         hasRecentFailure.mockReturnValue(true)
         await expect(fetchWithSentry('https://api.peanut.me/users/me')).rejects.toThrow()

--- a/src/utils/connectivity.ts
+++ b/src/utils/connectivity.ts
@@ -61,6 +61,15 @@ export function reportNetworkError(endpoint: string): void {
     emit()
 }
 
+// Has this endpoint already failed inside the current window? Callers use this
+// to report an outage ONCE rather than once per rejected request: React Query
+// retries, several hooks fetching the same route, and a poll that keeps firing
+// while the device is offline all hit the same endpoint within seconds.
+export function hasRecentFailure(endpoint: string): boolean {
+    prune()
+    return failures.some((f) => f.endpoint === endpoint)
+}
+
 // Distinct endpoints that failed inside the current window.
 export function getRecentFailures(): number {
     prune()

--- a/src/utils/sentry-init.ts
+++ b/src/utils/sentry-init.ts
@@ -1,6 +1,8 @@
 import posthog from 'posthog-js'
 
-import { beforeSendHandler } from '../../sentry.utils'
+import type { ErrorEvent as SentryErrorEvent } from '@sentry/nextjs'
+
+import { beforeSendHandler, isThirdPartyScriptFrame } from '../../sentry.utils'
 import { inferSentryEnvironment } from '@/utils/sentry-env'
 import { loadSentry } from '@/utils/sentry-lazy'
 import { isPaymentNetworkExplorerPath } from '@/utils/private-routes'
@@ -29,6 +31,37 @@ function bufferEvent(event: ErrorEvent | PromiseRejectionEvent): void {
     buffered.push(event)
     // something genuinely broke — pull the SDK in now, wherever we are
     initSentry()
+}
+
+/*
+ * The PostHog mirror is an integration, so its `processEvent` hook runs during
+ * event processing — BEFORE `beforeSend`. Everything `beforeSendHandler` drops
+ * has therefore already been copied into PostHog, which is why PostHog's error
+ * list is Sentry's noise list.
+ *
+ * Mostly that is a feature and we leave it alone: PostHog holding what Sentry
+ * filters is the only reason the browser-native fetch failures were ever
+ * visible. Suppression there is configured server-side (grouping, per-issue
+ * rate limit, suppression rules) where it is tunable without a release.
+ *
+ * The one class worth stopping in the client is injected third-party scripts:
+ * nobody can act on them in either tool, and one wallet injector alone billed
+ * ~3.7k events. Wrapping rather than filtering inside beforeSend, because
+ * beforeSend is downstream of this hook and cannot reach it.
+ */
+function withoutThirdPartyScripts<T extends { processEvent?: (event: SentryErrorEvent) => SentryErrorEvent | null }>(
+    integration: T
+): T {
+    const inner = integration.processEvent?.bind(integration)
+    if (!inner) return integration
+    return {
+        ...integration,
+        processEvent: (event: SentryErrorEvent) => {
+            const frames = (event.exception?.values ?? []).flatMap((v) => v.stacktrace?.frames ?? [])
+            if (frames.some((frame) => isThirdPartyScriptFrame(frame.filename || ''))) return event
+            return inner(event)
+        },
+    }
 }
 
 export function initSentry(): void {
@@ -76,10 +109,12 @@ export function initSentry(): void {
                 // PostHog tag pointing back at the user's profile + session replay.
                 // posthog.init() runs in instrumentation-client.ts; the integration uses
                 // the singleton lazily, so init order doesn't matter.
-                posthog.sentryIntegration({
-                    organization: 'peanut-c34d84c05',
-                    projectId: 4505827431415808,
-                }),
+                withoutThirdPartyScripts(
+                    posthog.sentryIntegration({
+                        organization: 'peanut-c34d84c05',
+                        projectId: 4505827431415808,
+                    })
+                ),
             ],
         })
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -2,6 +2,7 @@ import type { SeverityLevel } from '@sentry/nextjs'
 import * as Sentry from '@/utils/sentry-lazy'
 
 import { type JSONValue } from '../interfaces/interfaces'
+import { isMutatingMethod } from '../../sentry.utils'
 import { hasRecentFailure, reportNetworkError } from './connectivity'
 import { canUseNativeHttp, nativeHttpRequest } from './native-http'
 
@@ -565,7 +566,21 @@ export const fetchWithSentry = async (
          * for exactly this dedupe and is already pruned on read.
          */
         const endpoint = sanitizeUrl(url)
-        const repeatFailure = hasRecentFailure(endpoint)
+        /*
+         * Mutations are never deduped. The connectivity window is keyed by url
+         * alone — it exists to count distinct failing endpoints for the banner —
+         * and REST puts both verbs on one path, so a failed `GET /charges` poll
+         * would otherwise suppress the `POST /charges` that fails ten seconds
+         * later. That POST is the one failure this whole change exists to keep:
+         * its capture is what `shouldIgnoreError` rescues, and with the capture
+         * skipped the rethrown wrapper is dropped by `alreadyReported` too, so
+         * the user loses money-flow progress and we see nothing.
+         *
+         * Nothing is lost by exempting them: mutations are a small share of
+         * traffic, React Query does not auto-retry them, and each failed one is
+         * a distinct user-visible event rather than a poll repeating itself.
+         */
+        const repeatFailure = !isMutatingMethod(method) && hasRecentFailure(endpoint)
         reportNetworkError(endpoint)
         // console.info, not error: captureConsoleIntegration would turn an
         // error-level log into a second Sentry event on top of the explicit

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -2,7 +2,7 @@ import type { SeverityLevel } from '@sentry/nextjs'
 import * as Sentry from '@/utils/sentry-lazy'
 
 import { type JSONValue } from '../interfaces/interfaces'
-import { reportNetworkError } from './connectivity'
+import { hasRecentFailure, reportNetworkError } from './connectivity'
 import { canUseNativeHttp, nativeHttpRequest } from './native-http'
 
 /**
@@ -551,7 +551,22 @@ export const fetchWithSentry = async (
         // fetch rejected (timeout / DNS / connection refused) — the request never
         // completed, so flag a connectivity failure. keyed by sanitized url so
         // React Query retries of one slow route dedupe to a single endpoint.
-        reportNetworkError(sanitizeUrl(url))
+        /*
+         * One Sentry event per endpoint per failure window, not one per rejected
+         * request. A device that loses connectivity does not fail once: React
+         * Query retries the route, several mounted hooks fetch it, and any poll
+         * keeps firing — so /home alone produced 5,776 captures from 237 users
+         * in 7d, and the twelve worst-connected users produced 48% of ALL
+         * network volume (~300 events each) with 6-12 in a single minute.
+         *
+         * That is the amplifier, not the failure rate. Reusing the connectivity
+         * window keeps one report per endpoint per outage minute, which is what
+         * an incident actually is; the sliding window is keyed by sanitized url
+         * for exactly this dedupe and is already pruned on read.
+         */
+        const endpoint = sanitizeUrl(url)
+        const repeatFailure = hasRecentFailure(endpoint)
+        reportNetworkError(endpoint)
         // console.info, not error: captureConsoleIntegration would turn an
         // error-level log into a second Sentry event on top of the explicit
         // captures below.
@@ -561,21 +576,23 @@ export const fetchWithSentry = async (
             const timeoutError = new Error(`Request to ${url} timed out after ${timeoutMs}ms`)
 
             const timeoutFeatureTag = getFeatureTag(url)
-            Sentry.withScope((scope) => {
-                scope.setFingerprint(['timeout', sanitizeUrl(url), options.method || 'GET'])
-                if (timeoutFeatureTag) scope.setTag('feature', timeoutFeatureTag)
+            if (!repeatFailure) {
+                Sentry.withScope((scope) => {
+                    scope.setFingerprint(['timeout', sanitizeUrl(url), options.method || 'GET'])
+                    if (timeoutFeatureTag) scope.setTag('feature', timeoutFeatureTag)
 
-                Sentry.captureException(timeoutError, {
-                    level: 'error',
-                    extra: {
-                        url,
-                        method: options.method || 'GET',
-                        timeoutMs,
-                        requestHeaders: sanitizeHeaders(options.headers || {}),
-                        requestBody: sanitizeRequestBody(url, options.body),
-                    },
+                    Sentry.captureException(timeoutError, {
+                        level: 'error',
+                        extra: {
+                            url,
+                            method: options.method || 'GET',
+                            timeoutMs,
+                            requestHeaders: sanitizeHeaders(options.headers || {}),
+                            requestBody: sanitizeRequestBody(url, options.body),
+                        },
+                    })
                 })
-            })
+            }
 
             const userError = new Error('Peanut is taking too long to respond — check your connection and try again.')
             // distinct name from the generic catch below: this path is our own
@@ -602,23 +619,25 @@ export const fetchWithSentry = async (
         }
 
         const networkFeatureTag = getFeatureTag(url)
-        Sentry.withScope((scope) => {
-            // Set fingerprint for network errors
-            scope.setFingerprint(['network-error', sanitizeUrl(url), options.method || 'GET'])
-            if (networkFeatureTag) scope.setTag('feature', networkFeatureTag)
+        if (!repeatFailure) {
+            Sentry.withScope((scope) => {
+                // Set fingerprint for network errors
+                scope.setFingerprint(['network-error', sanitizeUrl(url), options.method || 'GET'])
+                if (networkFeatureTag) scope.setTag('feature', networkFeatureTag)
 
-            Sentry.captureException(error, {
-                extra: {
-                    url,
-                    method: options.method || 'GET',
-                    requestHeaders: sanitizeHeaders(options.headers || {}),
-                    requestBody: sanitizeRequestBody(url, options.body),
-                    errorMessage,
-                    errorName,
-                    errorStack,
-                },
+                Sentry.captureException(error, {
+                    extra: {
+                        url,
+                        method: options.method || 'GET',
+                        requestHeaders: sanitizeHeaders(options.headers || {}),
+                        requestBody: sanitizeRequestBody(url, options.body),
+                        errorMessage,
+                        errorName,
+                        errorStack,
+                    },
+                })
             })
-        })
+        }
 
         const userError = new Error('Something went wrong. Please try again.')
         userError.name = 'ServiceUnavailableError'


### PR DESCRIPTION
## What these events actually are

Triage of the PostHog error-tracking top-4. The headline `Failed to fetch` / `Load failed` population is ~7.4k occurrences/week across 590 users. Breaking it down:

| | |
|---|---|
| **origin** | 100% mirrored from Sentry's own pipeline (`$sentry_url` set on every one) |
| **capture** | 100% `handled: true` — every one is an explicit `fetchWithSentry` catch |
| **page** | `/home` is 5,776 of ~7,400 (**78%**), 237 users |
| **platform** | Android Chrome 3,198 · iOS Safari 2,680 — mobile web, ~50/50 |
| **concentration** | **12 users produce 3,584 events (48% of all volume)** — ~300 each, 6–12 inside a single minute |

That profile is not an outage. Our API failing would hit desktop equally and spike in time; instead it concentrates in a handful of badly-connected mobile users on the home screen. **The underlying failures are mostly user connectivity and outside our control.**

What *is* in our control is that we report each one dozens of times.

## 1. One report per endpoint per outage window

`fetchWithSentry` captures once per rejected fetch. A device that loses connectivity doesn't fail once — React Query retries the route, several mounted hooks fetch it, polls keep firing. That's the amplifier.

`connectivity.ts` already maintains a 60s sliding window of failures keyed by sanitized url, built for exactly this dedupe on the connectivity-banner side. `hasRecentFailure` exposes it, and both fetch-site captures now skip an endpoint already known to be failing.

The thrown error is unchanged — callers, retry behaviour and user-facing copy are identical. Only the duplicate report goes.

## 2. Failed mutations stop being silently dropped

`fetchWithSentry` sets `fingerprint: [kind, url, method]` and captures with full context, then rethrows a wrapper for the UI. `alreadyReported` drops that rethrow *on the grounds that the fetch-site capture survived* — it didn't: `networkIssues` matched the engine's own `Failed to fetch` / `Load failed` copy and ate it too.

So a POST that dies on the network is invisible: the user gets "contact support", we get nothing. That is precisely what `criticalFlowTags` was added to prevent, and it never did — 3 call sites, **0 events in 30d**.

Restricted to mutating methods deliberately. Failed GETs stay filtered: their rate belongs in PostHog (now grouped and rate-limited), not as individual Sentry issues. Keyed on the fingerprint, never the message, so it can't rescue an incidental network `TypeError` from a third-party SDK.

**Net effect on Sentry volume: small.** Failed mutations only, deduped per endpoint per minute — instead of the ~7k/week an unrestricted carve-out would have added.

## 3. Injected third-party script frames

PEANUT-UI-SNS threw ~3.7k unhandled rejections from `app:///executors/200.js` — a wallet-style injector reading `M_ID` off an undefined global. `M_ID` appears nowhere in this repo. It carries no extension scheme, so the `chrome-extension://`-only frame check couldn't see it and the issue had to be archived by hand.

`isThirdPartyScriptFrame` covers it and now also gates the PostHog mirror — the only place it *can* be gated, since `posthog.sentryIntegration()` is a `processEvent` hook and integration hooks run **upstream of `beforeSend`**. (That ordering is also why PostHog's error list has been, in effect, Sentry's noise list.)

## Also applied — PostHog project config, no deploy

- per-issue rate limit **100 events/min** (was unset — why one retry loop became 700 occurrences)
- grouping rules splitting network failures into **silent** vs **user-visible**, collapsing ~87 fingerprints
- suppression rules for the `M_ID` injector and `signal is aborted without reason`

## Testing

137 tests pass, `tsc --noEmit` clean, prettier clean. New coverage: `hasRecentFailure` window/recovery/per-endpoint semantics; capture skipped on repeat but connectivity still recorded; mutations rescued for both engine spellings and both fetch-site fingerprints; GET/HEAD still filtered; all four third-party frame shapes filtered while our own bundle (including an unresolved `app:///_next/` frame) is not.