### PR TITLE
feat(kyc): say what the hosted (Persona) check needs before handing over

### DIFF
--- a/src/app/(mobile-ui)/profile/identity-verification/additional/page.tsx
+++ b/src/app/(mobile-ui)/profile/identity-verification/additional/page.tsx
@@ -1,5 +1,6 @@
+import type React from 'react'
 import { AdditionalVerificationView } from '@/components/Kyc/AdditionalVerificationView'
 
-export default function AdditionalVerificationPage() {
+export default function AdditionalVerificationPage(): React.JSX.Element {
     return <AdditionalVerificationView />
 }

--- a/src/app/(mobile-ui)/profile/identity-verification/additional/page.tsx
+++ b/src/app/(mobile-ui)/profile/identity-verification/additional/page.tsx
@@ -1,0 +1,5 @@
+import { AdditionalVerificationView } from '@/components/Kyc/AdditionalVerificationView'
+
+export default function AdditionalVerificationPage() {
+    return <AdditionalVerificationView />
+}

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { startBridgeHostedVerification } from '@/app/actions/sumsub'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
 import Carousel from '@/components/Global/Carousel'
 import { Icon } from '@/components/Global/Icons/Icon'
@@ -11,7 +11,6 @@ import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import type { NextAction } from '@/types/capabilities'
 import { bridgeTaskDismissalKey, selectBridgeTasks } from '@/utils/bridge-tasks.utils'
-import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
 import { formatEffectiveDate } from '@/utils/format.utils'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import Card from '../Global/Card'
@@ -58,7 +57,8 @@ function taskCopy(task: NextAction): { title: string; description: string } {
  * The ToS flow is SNAPSHOTTED at tap time: the task list re-derives from every
  * user refetch (~4s auto-refresh while rails are pending), and the open modal
  * must survive its task disappearing mid-flow — the card hides, the flow keeps
- * running. The hosted flow leaves the app entirely (see handleOpenTask).
+ * running. The hosted flow hands off to the vendor, so it goes through the
+ * additional-verification screen first (see AdditionalVerificationView).
  *
  * `dismissible` (the /home mount): each ADVISORY (future-dated) slide carries
  * its own X that dismisses ONLY that task — the other slides stay. Dismissals
@@ -72,11 +72,9 @@ function taskCopy(task: NextAction): { title: string; description: string } {
 export default function PendingVerificationTasks({ dismissible = false }: { dismissible?: boolean }) {
     const t = useTranslations('home')
     const { nextActions } = useCapabilities()
-    const { user, fetchUser } = useAuth()
+    const { user } = useAuth()
     const [activeTosTask, setActiveTosTask] = useState<NextAction | null>(null)
-    const [isStartingHosted, setIsStartingHosted] = useState(false)
-    const [awaitingReturn, setAwaitingReturn] = useState(false)
-    const [error, setError] = useState<string | null>(null)
+    const router = useRouter()
     // Stored dismissals, tagged with the user they were loaded for
     // (localStorage is unreadable during SSR, hence the post-render effect).
     // The dismissible mount must not paint until the CURRENT user's entry is
@@ -87,17 +85,6 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
 
     const userId = user?.user?.userId
     const tasks = selectBridgeTasks(nextActions)
-    const hasHostedTask = tasks.some((task) => task.kind === 'bridge-hosted')
-    const taskKeys = tasks
-        .map((task) => task.key)
-        .sort()
-        .join(',')
-
-    // A new task set means the previous failure context is gone.
-    useEffect(() => {
-        setError(null)
-    }, [taskKeys])
-
     useEffect(() => {
         if (!dismissible || !userId) return
         // Pre-fingerprint native builds (≤1.0.50) persisted this preference as a
@@ -145,135 +132,19 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
           )
 
     const handleOpenTask = useCallback(
-        async (task: NextAction) => {
-            setError(null)
+        (task: NextAction) => {
             if (task.kind === 'accept-tos') {
                 setActiveTosTask(task)
                 return
             }
-            // NOT an iframe: `bridge.withpersona.com` serves
-            // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
-            // "refused to connect" for EVERY user. It has to be a real
-            // top-level page (native: the in-app browser). Bridge's ToS link
-            // (`compliance.bridge.xyz`) sends no framing header, which is why
-            // BridgeTosStep keeps its iframe.
-            //
-            // On web, reserve the tab HERE — synchronously, inside the click's
-            // user-activation window. Fetching the link takes ~800ms, and a
-            // window.open() after that await is no longer gesture-initiated,
-            // so Safari/Firefox block it — the same "nothing happens" symptom
-            // this PR exists to fix. The reserved tab is navigated once the
-            // URL lands, and closed if it never does.
-            // isNativeBridge(), not isCapacitor(): the latter is also true for
-            // any build carrying NEXT_PUBLIC_CAPACITOR_BUILD (vercel previews),
-            // where the native apis don't exist and we'd skip the reservation
-            // in a real browser.
-            const native = isNativeBridge()
-            const reservedTab = native ? null : window.open('', '_blank')
-            // The reserved tab can't carry `noopener` (that returns null and
-            // defeats the reservation), so sever the back-reference by hand —
-            // otherwise Persona, and anything it redirects to, holds a handle
-            // that can navigate the signed-in tab (reverse tabnabbing).
-            if (reservedTab) reservedTab.opener = null
-
-            setIsStartingHosted(true)
-            let url: string | undefined
-            try {
-                ;({ url } = await startBridgeHostedVerification())
-            } catch (error) {
-                // The action body catches its own errors, but a server action
-                // can still REJECT at the transport layer — a dropped network,
-                // or a deploy invalidating the action id mid-flight. Without
-                // this the button stays on "Loading..." forever and the blank
-                // reserved tab is orphaned.
-                reservedTab?.close()
-                console.error('[pending-tasks] start-action rejected', error)
-                setError("We couldn't start the verification. Please try again in a moment.")
-                return
-            } finally {
-                setIsStartingHosted(false)
-            }
-            if (!url) {
-                // Friendly copy regardless of the server detail (a 403 here just
-                // means the action aged out); refetch so a stale card self-corrects.
-                reservedTab?.close()
-                setError("We couldn't start the verification. Please try again in a moment.")
-                void fetchUser().catch(() => undefined)
-                return
-            }
-            try {
-                if (native) {
-                    await openExternalUrl(url)
-                } else if (reservedTab && !reservedTab.closed) {
-                    // `.closed` matters: assigning href to a closed window is a
-                    // silent no-op, so without this the user would tap and see
-                    // nothing — the very failure this PR removes.
-                    reservedTab.location.href = url
-                } else {
-                    // No usable tab: pop-ups blocked, a standalone PWA, or the
-                    // user closed the blank tab while we fetched. Same-tab
-                    // navigation is never gesture-gated, so it always lands.
-                    reservedTab?.close()
-                    window.location.href = url
-                    return
-                }
-            } catch (error) {
-                reservedTab?.close()
-                console.error('[pending-tasks] failed to open Bridge hosted verification', error)
-                setError("We couldn't open the verification. Please try again in a moment.")
-                return
-            }
-            setAwaitingReturn(true)
+            // The hosted flow gets its own screen first. It runs at the vendor,
+            // in a browser we don't control, and keeps no partial progress — a
+            // user who leaves mid-check to find a document restarts from step
+            // one. That is a page's worth of prep, and it owns the handoff.
+            router.push('/profile/identity-verification/additional')
         },
-        [fetchUser]
+        [router]
     )
-
-    // Nothing polls for this cohort — the ~4s user auto-refresh only runs
-    // while a rail is `pending`, and these are `requires-info` — so pick the
-    // result up when the user comes back from the hosted flow.
-    //
-    // Deliberately NOT one-shot: the first return is often incidental (a quick
-    // tab switch back, or Persona telling them to continue on their phone).
-    // Burning the single refetch there would leave the card up forever, so we
-    // keep listening and stop only once the task is actually gone (below).
-    useEffect(() => {
-        if (!awaitingReturn) return
-        const refresh = () => void fetchUser().catch(() => undefined)
-
-        if (isNativeBridge()) {
-            // Android WebViews don't reliably fire `visibilitychange` on
-            // resume — the same defect that makes useNativePlugins drive
-            // TanStack's focusManager off `appStateChange`. The in-app
-            // browser's own close event is the precise signal here.
-            let disposed = false
-            let remove: (() => void) | undefined
-            void import('@capacitor/browser')
-                .then(({ Browser }) => Browser.addListener('browserFinished', refresh))
-                .then((handle) => {
-                    // Cleanup can run while the dynamic import is still in
-                    // flight; without this the listener registers after the
-                    // fact and nobody ever removes it.
-                    if (disposed) handle.remove()
-                    else remove = () => handle.remove()
-                })
-                .catch((error) => console.error('[pending-tasks] browserFinished listener failed', error))
-            return () => {
-                disposed = true
-                remove?.()
-            }
-        }
-
-        const onReturn = () => {
-            if (document.visibilityState === 'visible') refresh()
-        }
-        document.addEventListener('visibilitychange', onReturn)
-        return () => document.removeEventListener('visibilitychange', onReturn)
-    }, [awaitingReturn, fetchUser])
-
-    // Stop listening once the hosted task clears — that's the success signal.
-    useEffect(() => {
-        if (awaitingReturn && !hasHostedTask) setAwaitingReturn(false)
-    }, [awaitingReturn, hasHostedTask])
 
     const closeTos = useCallback(() => setActiveTosTask(null), [])
 
@@ -319,21 +190,15 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                             variant="purple"
                                             shadowSize="4"
                                             className="mt-1 w-full"
-                                            disabled={isStartingHosted}
                                             onClick={() => handleOpenTask(task)}
                                         >
-                                            {isHosted
-                                                ? isStartingHosted
-                                                    ? 'Loading...'
-                                                    : 'Complete verification'
-                                                : 'Review terms'}
+                                            {isHosted ? 'Complete verification' : 'Review terms'}
                                         </Button>
                                     </div>
                                 </Card>
                             )
                         })}
                     </Carousel>
-                    {error && <p className="mt-2 text-center text-body-s text-error">{error}</p>}
                 </div>
             )}
 

--- a/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
+++ b/src/components/Home/__tests__/PendingVerificationTasks.test.tsx
@@ -6,24 +6,20 @@
  * blocking tasks and advisory orphans (future-dated tasks on fully-enabled
  * users, which no rail references). accept-tos routes into the existing
  * BridgeTosStep (its compliance.bridge.xyz link frames fine); bridge-hosted
- * exchanges the key for a Persona URL and opens it in an EXTERNAL browser —
- * bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN and cannot be
- * embedded. The ToS modal is snapshotted at tap time so it survives the task
- * list flapping under the ~4s user auto-refresh.
+ * routes to the additional-verification screen, which owns the prep copy and
+ * the handoff to Persona (see AdditionalVerificationView). The ToS modal is
+ * snapshotted at tap time so it survives the task list flapping under the ~4s
+ * user auto-refresh.
  */
 import React from 'react'
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 import { renderWithIntl as render } from '@/test-utils/intl'
 import type { NextAction } from '@/types/capabilities'
 import PendingVerificationTasks from '../PendingVerificationTasks'
 
 let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn(() => Promise.resolve(null))
-const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
 let mockStoredDismissal: string[] | undefined
-let mockReservedTab: { location: { href: string }; close: jest.Mock; closed: boolean; opener: unknown }
-const mockAssignHref = jest.fn()
-let mockWindowOpen: jest.SpyInstance
 const mockUpdatePreferences = jest.fn()
 
 jest.mock('@/hooks/useCapabilities', () => ({
@@ -37,33 +33,20 @@ jest.mock('@/utils/general.utils', () => ({
     getUserPreferences: () => ({ pendingVerificationTasksDismissed: mockStoredDismissal }),
     updateUserPreferences: (userId: string, prefs: Record<string, unknown>) => mockUpdatePreferences(userId, prefs),
 }))
-jest.mock('@/app/actions/sumsub', () => ({
-    startBridgeHostedVerification: () => mockStartHosted(),
-}))
 jest.mock('@/components/Kyc/BridgeTosStep', () => ({
     BridgeTosStep: (props: { visible: boolean; reasonCode?: string }) =>
         props.visible ? <div data-testid="tos-step">{props.reasonCode}</div> : null,
 }))
-const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
-let mockIsCapacitor = false
 jest.mock('@/utils/capacitor', () => ({
-    isNativeBridge: () => mockIsCapacitor,
+    isNativeBridge: () => false,
     // mobile-release's mascot picker + useAppHaptic call these
     isAndroidNative: () => false,
     isCapacitor: () => false,
-    openExternalUrl: (url: string) => mockOpenExternalUrl(url),
 }))
-const mockBrowserListener = { remove: jest.fn() }
-const mockBrowserAddListener = jest.fn<Promise<{ remove: jest.Mock }>, [string, () => void]>(() =>
-    Promise.resolve(mockBrowserListener)
-)
-jest.mock(
-    '@capacitor/browser',
-    () => ({
-        Browser: { addListener: (event: string, cb: () => void) => mockBrowserAddListener(event, cb) },
-    }),
-    { virtual: true }
-)
+const mockRouterPush = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockRouterPush }),
+}))
 
 const tosAction: NextAction = { key: 'accept-tos', kind: 'accept-tos', purpose: 'accept-bridge-tos' }
 const sepaTosAction: NextAction = {
@@ -83,29 +66,7 @@ describe('PendingVerificationTasks', () => {
         mockNextActions = []
         mockFetchUser.mockReset()
         mockFetchUser.mockResolvedValue(null)
-        mockStartHosted.mockReset()
-        mockOpenExternalUrl.mockReset()
-        mockOpenExternalUrl.mockResolvedValue(undefined)
-        mockIsCapacitor = false
-        mockAssignHref.mockReset()
-        // jsdom refuses real navigation; capture the same-tab fallback instead.
-        Object.defineProperty(window, 'location', {
-            configurable: true,
-            value: {
-                get href() {
-                    return 'http://localhost/home'
-                },
-                set href(value: string) {
-                    mockAssignHref(value)
-                },
-            },
-        })
-        mockBrowserAddListener.mockClear()
-        mockBrowserAddListener.mockReturnValue(Promise.resolve(mockBrowserListener))
-        mockBrowserListener.remove.mockClear()
-        mockReservedTab = { location: { href: '' }, close: jest.fn(), closed: false, opener: {} }
-        mockWindowOpen = jest.spyOn(window, 'open').mockReturnValue(mockReservedTab as unknown as Window)
-        mockWindowOpen.mockClear()
+        mockRouterPush.mockReset()
         mockStoredDismissal = undefined
         mockUpdatePreferences.mockReset()
         mockUserId = 'user-1'
@@ -138,171 +99,15 @@ describe('PendingVerificationTasks', () => {
         expect(screen.getByTestId('tos-step')).toHaveTextContent('bridge_tos_v2_required')
     })
 
-    it('bridge-hosted reserves a tab IN the click, then navigates it — never an iframe', async () => {
-        // bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN — embedding
-        // it rendered "refused to connect" for every user in prod. And the tab
-        // must be reserved inside the user gesture: after the ~800ms
-        // start-action round-trip, window.open() is popup-blocked on Safari.
+    it('bridge-hosted routes to the prep screen rather than handing straight to the vendor', () => {
+        // Persona runs in a browser we don't control and saves nothing: a user
+        // who leaves mid-check to find a document restarts from step one. The
+        // screen that says so owns the handoff, so the card only navigates.
         mockNextActions = [hostedAction]
-        let resolveUrl: (v: { url: string }) => void = () => {}
-        mockStartHosted.mockReturnValue(new Promise((r) => (resolveUrl = r)))
         render(<PendingVerificationTasks />)
 
         fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        // Reserved synchronously, BEFORE the URL exists.
-        expect(mockWindowOpen).toHaveBeenCalledWith('', '_blank')
-        expect(mockReservedTab.location.href).toBe('')
-
-        resolveUrl({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        await waitFor(() => expect(mockReservedTab.location.href).toBe('https://bridge.withpersona.com/verify?x=1'))
-        expect(document.querySelector('iframe')).toBeNull()
-        expect(mockReservedTab.close).not.toHaveBeenCalled()
-    })
-
-    it('no usable tab (pop-up blocked / standalone PWA) falls back to same-tab navigation', async () => {
-        // A post-await window.open would be blocked and its null return is
-        // unobservable; same-tab navigation is never gesture-gated.
-        mockWindowOpen.mockReturnValue(null)
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
-        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
-    })
-
-    it('a REJECTED start-action closes the tab and unsticks the button (transport-layer failure)', async () => {
-        // The action body catches its own errors, but the server action itself
-        // can reject — dropped network, or a deploy invalidating the action id.
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockRejectedValue(new Error('Failed to find Server Action'))
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
-        expect(mockReservedTab.close).toHaveBeenCalledTimes(1)
-        // Not stranded on "Loading..." — the button is tappable again.
-        expect(screen.getByRole('button', { name: /complete verification/i })).toBeEnabled()
-        expect(mockAssignHref).not.toHaveBeenCalled()
-    })
-
-    it('a tab closed mid-fetch falls back instead of silently navigating a dead window', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        mockReservedTab.closed = true
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
-        expect(mockReservedTab.location.href).toBe('')
-        expect(mockReservedTab.close).toHaveBeenCalled()
-    })
-
-    it('severs window.opener on the reserved tab (reverse tabnabbing)', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(mockReservedTab.opener).toBeNull()
-    })
-
-    it('native waits on the in-app browser close event, not visibilitychange', async () => {
-        mockIsCapacitor = true
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() =>
-            expect(mockBrowserAddListener).toHaveBeenCalledWith('browserFinished', expect.any(Function))
-        )
-
-        // Android WebViews may never fire visibilitychange on resume.
-        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
-        document.dispatchEvent(new Event('visibilitychange'))
-        expect(mockFetchUser).not.toHaveBeenCalled()
-
-        const onFinished = mockBrowserAddListener.mock.calls[0][1]
-        onFinished()
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-    })
-
-    it('closes the reserved tab when the hosted URL never arrives', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
-        await waitFor(() => expect(mockReservedTab.close).toHaveBeenCalledTimes(1))
-    })
-
-    it('native (Capacitor) skips the tab reservation and uses the in-app browser', async () => {
-        mockIsCapacitor = true
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() =>
-            expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1')
-        )
-        expect(mockWindowOpen).not.toHaveBeenCalled()
-    })
-
-    it('refetches the user when they come back to the app (nothing polls a requires-info rail)', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
-        expect(mockFetchUser).not.toHaveBeenCalled()
-
-        // Leaving the app fires visibilitychange too — only the return refetches.
-        Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
-        document.dispatchEvent(new Event('visibilitychange'))
-        expect(mockFetchUser).not.toHaveBeenCalled()
-
-        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
-        document.dispatchEvent(new Event('visibilitychange'))
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-
-        // NOT one-shot: an incidental switch-back must not burn the refetch,
-        // so a later real return refreshes again.
-        document.dispatchEvent(new Event('visibilitychange'))
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
-    })
-
-    it('start-action failure surfaces FRIENDLY copy (never the raw server error) and resyncs the user', async () => {
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
-        render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
-        expect(screen.queryByText('Action not allowed for this user')).not.toBeInTheDocument()
-        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
-        expect(mockFetchUser).toHaveBeenCalledTimes(1)
-    })
-
-    it('a browserFinished listener resolving AFTER cleanup removes itself', async () => {
-        mockIsCapacitor = true
-        mockNextActions = [hostedAction]
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
-        // Registration still in flight when the component goes away.
-        let resolveListener: (v: { remove: jest.Mock }) => void = () => {}
-        mockBrowserAddListener.mockReturnValue(new Promise((r) => (resolveListener = r)))
-        const { unmount } = render(<PendingVerificationTasks />)
-
-        fireEvent.click(screen.getByRole('button', { name: /complete verification/i }))
-        await waitFor(() => expect(mockBrowserAddListener).toHaveBeenCalled())
-        unmount()
-
-        resolveListener(mockBrowserListener)
-        await waitFor(() => expect(mockBrowserListener.remove).toHaveBeenCalledTimes(1))
+        expect(mockRouterPush).toHaveBeenCalledWith('/profile/identity-verification/additional')
     })
 
     it('advisory task renders its deadline and keep-access copy; blocking renders enable copy', () => {

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -37,16 +37,18 @@ export const AdditionalVerificationView = () => {
     const tCommon = useTranslations('common')
     const router = useRouter()
     const onBack = useSafeBack(IDENTITY_ROUTE)
-    const { nextActions } = useCapabilities()
-    const { start, isStarting, awaitingReturn, error } = useBridgeHostedVerification()
+    const { nextActions, isLoading: isLoadingCapabilities } = useCapabilities()
+    const { start, isStarting, error } = useBridgeHostedVerification()
     const hasHostedTask = nextActions.some((action) => action.kind === 'bridge-hosted')
 
-    // Gated on `awaitingReturn` rather than on the task alone: capabilities can
-    // read empty for a beat on a cold mount, and redirecting off that would
-    // bounce the user straight back out of the screen they just opened.
+    // Keyed off a LOADED capability set, not off this render's return-listener:
+    // the no-usable-tab branch navigates the current tab away before it can arm
+    // that listener, so a user who comes back — by deep link, or by Back —
+    // remounts with nothing in memory saying they ever left. `isLoading` is what
+    // separates "the task is gone" from "the user query has not landed yet".
     useEffect(() => {
-        if (awaitingReturn && !hasHostedTask) router.replace(IDENTITY_ROUTE)
-    }, [awaitingReturn, hasHostedTask, router])
+        if (!isLoadingCapabilities && !hasHostedTask) router.replace(IDENTITY_ROUTE)
+    }, [isLoadingCapabilities, hasHostedTask, router])
 
     return (
         <div className="flex w-full flex-col gap-6">

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -25,18 +24,19 @@ import { useSafeBack } from '@/hooks/useSafeBack'
  * The CTA calls `start` straight out of the click: the reserved tab depends on
  * that user gesture (see useBridgeHostedVerification).
  *
- * The task DISAPPEARING is the success signal — nothing else reports it. The
- * card this replaced got that for free by unmounting; a route has to act on
- * it, or a returning user sits on a live CTA whose only outcome is a 403.
+ * The task DISAPPEARING is the success signal — nothing else reports it, since
+ * nothing polls a requires-info rail. The card this replaced got that for free
+ * by unmounting; a route has to say something, or a returning user sits on a
+ * live CTA whose only outcome is a 403 on an action that no longer exists.
+ *
+ * It says so IN PLACE rather than navigating. nextActions re-derives on every
+ * user refetch and this screen can be polled (4s) while it is being read, so
+ * any auto-exit has to decide whether a missing task is real or one bad tick —
+ * and a wrong guess yanks a reader off the page mid-sentence. Swapping the
+ * panel costs nothing if a later tick puts the task back, so the question
+ * stops needing an answer.
  */
 const IDENTITY_ROUTE = '/profile/identity-verification'
-
-/**
- * Grace given to a task that vanishes with no return behind it. Longer than
- * useUserAutoRefresh's 4s poll on purpose: a shorter window cannot outlast the
- * tick that dropped the task, so it could never see the next one put it back.
- */
-const CONFIRM_ABSENCE_MS = 6000
 
 export const AdditionalVerificationView = (): React.JSX.Element => {
     const t = useTranslations('kyc.hostedPrep')
@@ -45,42 +45,29 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
     const router = useRouter()
     const onBack = useSafeBack(IDENTITY_ROUTE)
     const { nextActions, isLoading: isLoadingCapabilities } = useCapabilities()
-    const { start, isStarting, error, refreshSeq } = useBridgeHostedVerification()
-    const hasHostedTask = nextActions.some((action) => action.kind === 'bridge-hosted')
+    const { start, isStarting, error } = useBridgeHostedVerification()
+    const hostedTask = nextActions.find((action) => action.kind === 'bridge-hosted')
+    // A future-dated action is advisory: those rails still work today, and this
+    // screen must not tell that user their transfers are blocked.
+    const isAdvisory = !!hostedTask?.effectiveDate
 
-    const sawHostedTask = useRef(false)
-
-    // Keyed off a LOADED capability set, not off the hook's return-listener: the
-    // no-usable-tab branch navigates the current tab away before it can arm
-    // that listener, so a user who comes back — by deep link, or by Back —
-    // remounts with nothing in memory saying they ever left. `isLoading` is what
-    // separates "the task is gone" from "the user query has not landed yet".
-    useEffect(() => {
-        if (hasHostedTask) {
-            sawHostedTask.current = true
-            return
-        }
-        if (isLoadingCapabilities) return
-        // Never present while we were here: the screen was opened without a
-        // task and has nothing to serve. Nothing to wait for.
-        if (!sawHostedTask.current) {
-            router.replace(IDENTITY_ROUTE)
-            return
-        }
-        // Present and then gone IS the success signal. Whether to trust it
-        // straight away comes down to WHY we are looking at a new capability
-        // set: a return from the vendor forced this read, so the absence is the
-        // answer we asked for and the user should not sit on a finished screen.
-        if (refreshSeq > 0) {
-            router.replace(IDENTITY_ROUTE)
-            return
-        }
-        // Nobody came back — the task dropped out of a poll while someone was
-        // reading. That can be one bad tick, so wait past the next one and let
-        // it put the task back rather than navigating out from under them.
-        const timer = setTimeout(() => router.replace(IDENTITY_ROUTE), CONFIRM_ABSENCE_MS)
-        return () => clearTimeout(timer)
-    }, [isLoadingCapabilities, hasHostedTask, refreshSeq, router])
+    // Loaded, and the task is gone: it was completed, or the partner stopped
+    // asking. Either way there is nothing here to start.
+    if (!isLoadingCapabilities && !hostedTask) {
+        return (
+            <div className="flex w-full flex-col gap-6">
+                <NavHeader title={t('title')} onPrev={onBack} />
+                <div className="flex flex-col items-center gap-3 text-center" data-testid="hosted-task-done">
+                    <IconBubble icon="check-circle" size="l" color="green" />
+                    <p className="text-body-m font-bold">{t('done.title')}</p>
+                    <p className="text-body-s text-foreground-secondary">{t('done.description')}</p>
+                </div>
+                <Button variant="purple" shadowSize="4" onClick={() => router.replace(IDENTITY_ROUTE)}>
+                    {t('done.cta')}
+                </Button>
+            </div>
+        )
+    }
 
     return (
         <div className="flex w-full flex-col gap-6">
@@ -88,7 +75,9 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
 
             <div className="flex flex-col items-center gap-3 text-center">
                 <IconBubble icon="user-id" size="l" color="yellow" />
-                <p className="text-body-s text-foreground-secondary">{t('description')}</p>
+                <p className="text-body-s text-foreground-secondary">
+                    {isAdvisory ? t('descriptionAdvisory') : t('description')}
+                </p>
             </div>
 
             <KycPrepChecklist path="hosted" />

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -31,7 +31,10 @@ import { useSafeBack } from '@/hooks/useSafeBack'
  */
 const IDENTITY_ROUTE = '/profile/identity-verification'
 
-export const AdditionalVerificationView = () => {
+/** Grace given to a task that vanishes mid-read before acting on it. */
+const CONFIRM_ABSENCE_MS = 1500
+
+export const AdditionalVerificationView = (): React.JSX.Element => {
     const t = useTranslations('kyc.hostedPrep')
     const tPrep = useTranslations('kyc.prep')
     const tCommon = useTranslations('common')
@@ -41,13 +44,31 @@ export const AdditionalVerificationView = () => {
     const { start, isStarting, error } = useBridgeHostedVerification()
     const hasHostedTask = nextActions.some((action) => action.kind === 'bridge-hosted')
 
-    // Keyed off a LOADED capability set, not off this render's return-listener:
-    // the no-usable-tab branch navigates the current tab away before it can arm
+    const sawHostedTask = useRef(false)
+
+    // Keyed off a LOADED capability set, not off the hook's return-listener: the
+    // no-usable-tab branch navigates the current tab away before it can arm
     // that listener, so a user who comes back — by deep link, or by Back —
     // remounts with nothing in memory saying they ever left. `isLoading` is what
     // separates "the task is gone" from "the user query has not landed yet".
     useEffect(() => {
-        if (!isLoadingCapabilities && !hasHostedTask) router.replace(IDENTITY_ROUTE)
+        if (hasHostedTask) {
+            sawHostedTask.current = true
+            return
+        }
+        if (isLoadingCapabilities) return
+        // Never present while we were here: the screen was opened without a
+        // task and has nothing to serve. Nothing to wait for.
+        if (!sawHostedTask.current) {
+            router.replace(IDENTITY_ROUTE)
+            return
+        }
+        // Present and then gone IS the success signal — but nextActions
+        // re-derives on every user refetch, and this screen can be polled while
+        // someone is still reading it. Let one flapping payload put the task
+        // back before navigating out from under them.
+        const timer = setTimeout(() => router.replace(IDENTITY_ROUTE), CONFIRM_ABSENCE_MS)
+        return () => clearTimeout(timer)
     }, [isLoadingCapabilities, hasHostedTask, router])
 
     return (

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -1,12 +1,16 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useTranslations } from 'next-intl'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/0_Bruddle/Button'
 import { IconBubble } from '@/components/0_Bruddle/IconBubble'
+import { Notification } from '@/components/0_Bruddle/Notification'
 import NavHeader from '@/components/Global/NavHeader'
 import KycPrepChecklist from '@/components/Kyc/KycPrepChecklist'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
 import { useBridgeHostedVerification } from '@/hooks/useBridgeHostedVerification'
+import { useCapabilities } from '@/hooks/useCapabilities'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
 /**
@@ -20,13 +24,29 @@ import { useSafeBack } from '@/hooks/useSafeBack'
  *
  * The CTA calls `start` straight out of the click: the reserved tab depends on
  * that user gesture (see useBridgeHostedVerification).
+ *
+ * The task DISAPPEARING is the success signal — nothing else reports it. The
+ * card this replaced got that for free by unmounting; a route has to act on
+ * it, or a returning user sits on a live CTA whose only outcome is a 403.
  */
+const IDENTITY_ROUTE = '/profile/identity-verification'
+
 export const AdditionalVerificationView = () => {
     const t = useTranslations('kyc.hostedPrep')
     const tPrep = useTranslations('kyc.prep')
     const tCommon = useTranslations('common')
-    const onBack = useSafeBack('/profile/identity-verification')
-    const { start, isStarting, error } = useBridgeHostedVerification()
+    const router = useRouter()
+    const onBack = useSafeBack(IDENTITY_ROUTE)
+    const { nextActions } = useCapabilities()
+    const { start, isStarting, awaitingReturn, error } = useBridgeHostedVerification()
+    const hasHostedTask = nextActions.some((action) => action.kind === 'bridge-hosted')
+
+    // Gated on `awaitingReturn` rather than on the task alone: capabilities can
+    // read empty for a beat on a cold mount, and redirecting off that would
+    // bounce the user straight back out of the screen they just opened.
+    useEffect(() => {
+        if (awaitingReturn && !hasHostedTask) router.replace(IDENTITY_ROUTE)
+    }, [awaitingReturn, hasHostedTask, router])
 
     return (
         <div className="flex w-full flex-col gap-6">
@@ -40,7 +60,14 @@ export const AdditionalVerificationView = () => {
             <KycPrepChecklist path="hosted" />
 
             <div className="flex flex-col gap-3">
-                {error && <p className="text-body-s text-error">{error}</p>}
+                {/* Notification, not a bare <p>: it carries role="alert", so a
+                    screen reader hears the failure instead of leaving focus on
+                    a CTA that silently did nothing. */}
+                {error && (
+                    <Notification priority="error" data-testid="hosted-start-error">
+                        {error}
+                    </Notification>
+                )}
                 <Button
                     variant="purple"
                     shadowSize="4"

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -31,8 +31,12 @@ import { useSafeBack } from '@/hooks/useSafeBack'
  */
 const IDENTITY_ROUTE = '/profile/identity-verification'
 
-/** Grace given to a task that vanishes mid-read before acting on it. */
-const CONFIRM_ABSENCE_MS = 1500
+/**
+ * Grace given to a task that vanishes with no return behind it. Longer than
+ * useUserAutoRefresh's 4s poll on purpose: a shorter window cannot outlast the
+ * tick that dropped the task, so it could never see the next one put it back.
+ */
+const CONFIRM_ABSENCE_MS = 6000
 
 export const AdditionalVerificationView = (): React.JSX.Element => {
     const t = useTranslations('kyc.hostedPrep')
@@ -41,7 +45,7 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
     const router = useRouter()
     const onBack = useSafeBack(IDENTITY_ROUTE)
     const { nextActions, isLoading: isLoadingCapabilities } = useCapabilities()
-    const { start, isStarting, error } = useBridgeHostedVerification()
+    const { start, isStarting, error, refreshSeq } = useBridgeHostedVerification()
     const hasHostedTask = nextActions.some((action) => action.kind === 'bridge-hosted')
 
     const sawHostedTask = useRef(false)
@@ -63,13 +67,20 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
             router.replace(IDENTITY_ROUTE)
             return
         }
-        // Present and then gone IS the success signal — but nextActions
-        // re-derives on every user refetch, and this screen can be polled while
-        // someone is still reading it. Let one flapping payload put the task
-        // back before navigating out from under them.
+        // Present and then gone IS the success signal. Whether to trust it
+        // straight away comes down to WHY we are looking at a new capability
+        // set: a return from the vendor forced this read, so the absence is the
+        // answer we asked for and the user should not sit on a finished screen.
+        if (refreshSeq > 0) {
+            router.replace(IDENTITY_ROUTE)
+            return
+        }
+        // Nobody came back — the task dropped out of a poll while someone was
+        // reading. That can be one bad tick, so wait past the next one and let
+        // it put the task back rather than navigating out from under them.
         const timer = setTimeout(() => router.replace(IDENTITY_ROUTE), CONFIRM_ABSENCE_MS)
         return () => clearTimeout(timer)
-    }, [isLoadingCapabilities, hasHostedTask, router])
+    }, [isLoadingCapabilities, hasHostedTask, refreshSeq, router])
 
     return (
         <div className="flex w-full flex-col gap-6">

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
+import { IconBubble } from '@/components/0_Bruddle/IconBubble'
+import NavHeader from '@/components/Global/NavHeader'
+import KycPrepChecklist from '@/components/Kyc/KycPrepChecklist'
+import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
+import { useBridgeHostedVerification } from '@/hooks/useBridgeHostedVerification'
+import { useSafeBack } from '@/hooks/useSafeBack'
+
+/**
+ * "What to expect" screen in front of Bridge's hosted verification (Persona).
+ * The tap used to hand the user straight to the vendor, which is the one flow
+ * where that hurts: it runs at the vendor — the in-app browser sheet on
+ * native, a new tab on web — and keeps no partial progress, so anyone who
+ * leaves mid-way to find a document loses everything and starts over. It is a page rather than a sheet because the prep is the
+ * whole content — a modal that needs scrolling to reach its own CTA reads as
+ * an interruption, not as the step it actually is.
+ *
+ * The CTA calls `start` straight out of the click: the reserved tab depends on
+ * that user gesture (see useBridgeHostedVerification).
+ */
+export const AdditionalVerificationView = () => {
+    const t = useTranslations('kyc.hostedPrep')
+    const tPrep = useTranslations('kyc.prep')
+    const tCommon = useTranslations('common')
+    const onBack = useSafeBack('/profile/identity-verification')
+    const { start, isStarting, error } = useBridgeHostedVerification()
+
+    return (
+        <div className="flex w-full flex-col gap-6">
+            <NavHeader title={t('title')} onPrev={onBack} />
+
+            <div className="flex flex-col items-center gap-3 text-center">
+                <IconBubble icon="user-id" size="l" color="yellow" />
+                <p className="text-body-s text-foreground-secondary">{t('description')}</p>
+            </div>
+
+            <KycPrepChecklist path="hosted" />
+
+            <div className="flex flex-col gap-3">
+                {error && <p className="text-body-s text-error">{error}</p>}
+                <Button
+                    variant="purple"
+                    shadowSize="4"
+                    icon="check-circle"
+                    iconPosition="left"
+                    disabled={isStarting}
+                    onClick={start}
+                >
+                    {isStarting ? tCommon('loading') : tPrep('startCta')}
+                </Button>
+                <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
+            </div>
+        </div>
+    )
+}

--- a/src/components/Kyc/KycPrepChecklist.tsx
+++ b/src/components/Kyc/KycPrepChecklist.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { Icon } from '@/components/Global/Icons/Icon'
+import { Notification } from '@/components/0_Bruddle/Notification'
 import { useTranslations } from 'next-intl'
 
-export type KycPrepPath = 'standard' | 'extended'
+export type KycPrepPath = 'standard' | 'extended' | 'hosted'
 
 /**
  * The "before you start" prep content shown before the verification SDK
@@ -12,15 +13,28 @@ export type KycPrepPath = 'standard' | 'extended'
  * adds the tax ID and the regulatory questions the provider asks there.
  * Rendered inside the unlock/initiate modals, never as its own route, so
  * every entry into the SDK passes through it.
+ *
+ * The hosted path is Bridge's hosted flow (Persona), which runs outside the
+ * app and — unlike the Sumsub SDK — keeps no partial progress: a user who
+ * leaves to find a document restarts from the first step. It trades the
+ * "we'll ask later if we need more" note for a single-session warning, placed
+ * AFTER the list so it reads as the consequence of not having those documents
+ * rather than as a preamble to them.
  */
 const KycPrepChecklist = ({ path }: { path: KycPrepPath }) => {
     const t = useTranslations('kyc.prep')
-    const items = path === 'extended' ? (['id', 'selfie', 'taxId', 'questions'] as const) : (['id', 'selfie'] as const)
+    const isHosted = path === 'hosted'
+    const items =
+        path === 'extended'
+            ? (['id', 'selfie', 'taxId', 'questions'] as const)
+            : isHosted
+              ? (['id', 'selfie', 'proofOfAddress'] as const)
+              : (['id', 'selfie'] as const)
 
     return (
         <div className="flex w-full flex-col gap-3 text-left" data-testid="kyc-prep-checklist">
-            <p className="text-body-s">{t(`intro.${path}`)}</p>
-            <div className="overflow-hidden rounded-sm border border-border-default dark:border-white">
+            {!isHosted && <p className="text-body-s">{t(`intro.${path}`)}</p>}
+            <div className="overflow-hidden rounded-sm border border-border-default bg-background-default dark:border-white dark:bg-foreground-primary">
                 {items.map((item) => (
                     <div
                         key={item}
@@ -36,11 +50,24 @@ const KycPrepChecklist = ({ path }: { path: KycPrepPath }) => {
                     </div>
                 ))}
             </div>
-            <div className="rounded-sm border border-border-default p-3 dark:border-white">
-                <span className="block text-body-xs font-bold tracking-wide uppercase">{t('howLongLabel')}</span>
-                <span className="block text-body-xs">{t(`howLong.${path}`)}</span>
+            {isHosted && (
+                <Notification
+                    priority="attention"
+                    title={t('singleSession.title')}
+                    data-testid="kyc-prep-single-session"
+                >
+                    {/* The banner's own body step is text-body-m, which reads
+                        louder than the requirement titles right above it. */}
+                    <span className="text-body-s">{t('singleSession.body')}</span>
+                </Notification>
+            )}
+            {/* Plain prose, not a card: the framed box read as one more
+                requirement alongside the list above it, when it is only a note. */}
+            <div className="flex flex-col gap-0.5">
+                <span className="text-body-xs font-bold tracking-wide uppercase">{t('howLongLabel')}</span>
+                <span className="text-body-xs text-foreground-secondary">{t(`howLong.${path}`)}</span>
             </div>
-            <p className="text-body-xs text-foreground-secondary">{t('extraDocNote')}</p>
+            {!isHosted && <p className="text-body-xs text-foreground-secondary">{t('extraDocNote')}</p>}
         </div>
     )
 }

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -58,8 +58,9 @@ jest.mock('next/navigation', () => ({
     useRouter: () => ({ push: jest.fn(), replace: mockRouterReplace, back: jest.fn() }),
 }))
 let mockNextActions: NextAction[] = []
+let mockCapabilitiesLoading = false
 jest.mock('@/hooks/useCapabilities', () => ({
-    useCapabilities: () => ({ nextActions: mockNextActions }),
+    useCapabilities: () => ({ nextActions: mockNextActions, isLoading: mockCapabilitiesLoading }),
 }))
 
 const startVerification = () => fireEvent.click(screen.getByRole('button', { name: /i have these, start/i }))
@@ -67,6 +68,7 @@ const startVerification = () => fireEvent.click(screen.getByRole('button', { nam
 describe('AdditionalVerificationView', () => {
     beforeEach(() => {
         mockNextActions = [hostedAction]
+        mockCapabilitiesLoading = false
         mockRouterReplace.mockReset()
         mockFetchUser.mockReset()
         mockFetchUser.mockResolvedValue(null)
@@ -272,14 +274,27 @@ describe('AdditionalVerificationView', () => {
         await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'))
     })
 
-    it('an empty capability read on a COLD mount does not bounce the user off the screen', () => {
-        // Capabilities can read empty for a beat before the user query lands.
-        // Only a return from the vendor is evidence the task is done.
+    it('an in-flight capability read does not bounce the user off the screen', () => {
+        // nextActions reads empty until the user query lands. Redirecting on
+        // that would throw the user straight out of the screen they just opened.
         mockNextActions = []
+        mockCapabilitiesLoading = true
         render(<AdditionalVerificationView />)
 
         expect(mockRouterReplace).not.toHaveBeenCalled()
         expect(screen.getByRole('button', { name: /i have these, start/i })).toBeEnabled()
+    })
+
+    it('a REMOUNT with no hosted task leaves, even though nothing armed the return listener', () => {
+        // The no-usable-tab branch assigns window.location.href and the tab
+        // navigates away, so `awaitingReturn` never gets set. A user who comes
+        // back — deep link, or Back — remounts with nothing in memory saying
+        // they left, and a loaded-but-empty capability set is the only evidence.
+        mockNextActions = []
+        mockCapabilitiesLoading = false
+        render(<AdditionalVerificationView />)
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification')
     })
 
     it('announces a launch failure to screen readers instead of leaving focus on a dead CTA', async () => {

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -12,7 +12,15 @@
 import React from 'react'
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithIntl as render } from '@/test-utils/intl'
+import type { NextAction } from '@/types/capabilities'
 import { AdditionalVerificationView } from '../AdditionalVerificationView'
+
+const hostedAction: NextAction = {
+    key: 'bridge-hosted',
+    kind: 'bridge-hosted',
+    purpose: 'bridge-additional-verification',
+    requirementKey: 'kyc_approval',
+}
 
 const mockFetchUser = jest.fn(() => Promise.resolve(null))
 const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
@@ -45,14 +53,21 @@ jest.mock(
     }),
     { virtual: true }
 )
+const mockRouterReplace = jest.fn()
 jest.mock('next/navigation', () => ({
-    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useRouter: () => ({ push: jest.fn(), replace: mockRouterReplace, back: jest.fn() }),
+}))
+let mockNextActions: NextAction[] = []
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ nextActions: mockNextActions }),
 }))
 
 const startVerification = () => fireEvent.click(screen.getByRole('button', { name: /i have these, start/i }))
 
 describe('AdditionalVerificationView', () => {
     beforeEach(() => {
+        mockNextActions = [hostedAction]
+        mockRouterReplace.mockReset()
         mockFetchUser.mockReset()
         mockFetchUser.mockResolvedValue(null)
         mockStartHosted.mockReset()
@@ -238,6 +253,45 @@ describe('AdditionalVerificationView', () => {
         // so a later real return refreshes again.
         document.dispatchEvent(new Event('visibilitychange'))
         await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
+    })
+
+    it('leaves the screen once the task clears — the ONLY signal the check passed', async () => {
+        // Nothing else reports success: the ~4s auto-refresh does not run for a
+        // requires-info rail, so the refetch on return is what clears the task.
+        // The card this replaced got the exit for free by unmounting; a route
+        // has to act on it, or the user sits on a CTA whose only outcome is 403.
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        const { rerender } = render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+
+        mockNextActions = []
+        rerender(<AdditionalVerificationView />)
+        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'))
+    })
+
+    it('an empty capability read on a COLD mount does not bounce the user off the screen', () => {
+        // Capabilities can read empty for a beat before the user query lands.
+        // Only a return from the vendor is evidence the task is done.
+        mockNextActions = []
+        render(<AdditionalVerificationView />)
+
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+        expect(screen.getByRole('button', { name: /i have these, start/i })).toBeEnabled()
+    })
+
+    it('announces a launch failure to screen readers instead of leaving focus on a dead CTA', async () => {
+        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        // Scoped by testid, not by role: the single-session banner is an
+        // `attention` Notification, which the DS also gives role="alert".
+        const alert = await screen.findByTestId('hosted-start-error')
+        expect(alert).toHaveAttribute('role', 'alert')
+        expect(alert).toHaveTextContent(/couldn't start the verification/i)
     })
 
     it('a browserFinished listener resolving AFTER cleanup removes itself', async () => {

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -269,25 +269,31 @@ describe('AdditionalVerificationView', () => {
         await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
         expect(mockRouterReplace).not.toHaveBeenCalled()
 
+        // The return refetch is what produced this read, so the absence is the
+        // answer we asked for — no waiting the user out on a finished screen.
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
         mockNextActions = []
         rerender(<AdditionalVerificationView />)
-        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'), {
-            timeout: 4000,
-        })
+        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'))
     })
 
-    it('a single flapping snapshot does not eject someone still reading the screen', async () => {
-        // nextActions re-derives on every user refetch, and this screen can be
-        // polled while it is being read. The old card merely hid in that case;
-        // a route would actively navigate the reader away.
+    it('a poll that drops the task with nobody returning does NOT eject the reader', async () => {
+        // useUserAutoRefresh polls every 4s for anyone with a pending rail, and
+        // nextActions re-derives on each read. The old card merely hid on a bad
+        // tick; a route would navigate the reader away mid-sentence. Nothing
+        // here came back from the vendor, so one dropped tick proves nothing.
         const { rerender } = render(<AdditionalVerificationView />)
 
         mockNextActions = []
         rerender(<AdditionalVerificationView />)
+        // Well inside CONFIRM_ABSENCE_MS, which outlasts the 4s poll on purpose.
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(mockRouterReplace).not.toHaveBeenCalled()
+
         mockNextActions = [hostedAction]
         rerender(<AdditionalVerificationView />)
-
-        await new Promise((resolve) => setTimeout(resolve, 2000))
+        await new Promise((resolve) => setTimeout(resolve, 500))
         expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -271,7 +271,24 @@ describe('AdditionalVerificationView', () => {
 
         mockNextActions = []
         rerender(<AdditionalVerificationView />)
-        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'))
+        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'), {
+            timeout: 4000,
+        })
+    })
+
+    it('a single flapping snapshot does not eject someone still reading the screen', async () => {
+        // nextActions re-derives on every user refetch, and this screen can be
+        // polled while it is being read. The old card merely hid in that case;
+        // a route would actively navigate the reader away.
+        const { rerender } = render(<AdditionalVerificationView />)
+
+        mockNextActions = []
+        rerender(<AdditionalVerificationView />)
+        mockNextActions = [hostedAction]
+        rerender(<AdditionalVerificationView />)
+
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+        expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 
     it('an in-flight capability read does not bounce the user off the screen', () => {
@@ -307,6 +324,34 @@ describe('AdditionalVerificationView', () => {
         const alert = await screen.findByTestId('hosted-start-error')
         expect(alert).toHaveAttribute('role', 'alert')
         expect(alert).toHaveTextContent(/couldn't start the verification/i)
+    })
+
+    it('a BFCache restore refetches — refetchOnWindowFocus would be skipped as fresh', async () => {
+        // The same-tab fallback navigates this tab away without arming the
+        // return listener, and Back can restore the page without re-running a
+        // single effect. The user query has staleTime 5m, so TanStack's focus
+        // refetch is a no-op; only an explicit refetch sees the cleared task.
+        mockWindowOpen.mockReturnValue(null)
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockAssignHref).toHaveBeenCalled())
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        const restore = new Event('pageshow') as PageTransitionEvent
+        Object.defineProperty(restore, 'persisted', { value: true })
+        window.dispatchEvent(restore)
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+    })
+
+    it('a fresh (non-BFCache) pageshow does not refetch', () => {
+        render(<AdditionalVerificationView />)
+
+        const firstLoad = new Event('pageshow') as PageTransitionEvent
+        Object.defineProperty(firstLoad, 'persisted', { value: false })
+        window.dispatchEvent(firstLoad)
+        expect(mockFetchUser).not.toHaveBeenCalled()
     })
 
     it('a browserFinished listener resolving AFTER cleanup removes itself', async () => {

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * AdditionalVerificationView — the "what to expect" screen in front of
+ * Bridge's hosted verification (Persona).
+ *
+ * Persona serves X-Frame-Options: SAMEORIGIN and cannot be embedded, so the
+ * handoff opens a real top-level page (native: the in-app browser) — and the
+ * tab has to be reserved INSIDE the click, before the ~800ms start-action
+ * round-trip, or Safari blocks it. The prep copy exists because Persona keeps
+ * no partial progress: a user who leaves mid-check to find a document
+ * restarts from step one.
+ */
+import React from 'react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithIntl as render } from '@/test-utils/intl'
+import { AdditionalVerificationView } from '../AdditionalVerificationView'
+
+const mockFetchUser = jest.fn(() => Promise.resolve(null))
+const mockStartHosted = jest.fn<Promise<{ url?: string; error?: string }>, []>()
+let mockReservedTab: { location: { href: string }; close: jest.Mock; closed: boolean; opener: unknown }
+const mockAssignHref = jest.fn()
+let mockWindowOpen: jest.SpyInstance
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { userId: 'user-1' } }, fetchUser: mockFetchUser, logoutUser: jest.fn() }),
+}))
+jest.mock('@/app/actions/sumsub', () => ({
+    startBridgeHostedVerification: () => mockStartHosted(),
+}))
+const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
+let mockIsCapacitor = false
+jest.mock('@/utils/capacitor', () => ({
+    isNativeBridge: () => mockIsCapacitor,
+    isAndroidNative: () => false,
+    isCapacitor: () => false,
+    openExternalUrl: (url: string) => mockOpenExternalUrl(url),
+}))
+const mockBrowserListener = { remove: jest.fn() }
+const mockBrowserAddListener = jest.fn<Promise<{ remove: jest.Mock }>, [string, () => void]>(() =>
+    Promise.resolve(mockBrowserListener)
+)
+jest.mock(
+    '@capacitor/browser',
+    () => ({
+        Browser: { addListener: (event: string, cb: () => void) => mockBrowserAddListener(event, cb) },
+    }),
+    { virtual: true }
+)
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+}))
+
+const startVerification = () => fireEvent.click(screen.getByRole('button', { name: /i have these, start/i }))
+
+describe('AdditionalVerificationView', () => {
+    beforeEach(() => {
+        mockFetchUser.mockReset()
+        mockFetchUser.mockResolvedValue(null)
+        mockStartHosted.mockReset()
+        mockOpenExternalUrl.mockReset()
+        mockOpenExternalUrl.mockResolvedValue(undefined)
+        mockIsCapacitor = false
+        mockAssignHref.mockReset()
+        // jsdom refuses real navigation; capture the same-tab fallback instead.
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                get href() {
+                    return 'http://localhost/profile/identity-verification/additional'
+                },
+                set href(value: string) {
+                    mockAssignHref(value)
+                },
+            },
+        })
+        mockBrowserAddListener.mockClear()
+        mockBrowserAddListener.mockReturnValue(Promise.resolve(mockBrowserListener))
+        mockBrowserListener.remove.mockClear()
+        mockReservedTab = { location: { href: '' }, close: jest.fn(), closed: false, opener: {} }
+        mockWindowOpen = jest.spyOn(window, 'open').mockReturnValue(mockReservedTab as unknown as Window)
+        mockWindowOpen.mockClear()
+    })
+
+    it('states the single-session constraint and the documents BEFORE anything is fetched', () => {
+        render(<AdditionalVerificationView />)
+
+        expect(screen.getByTestId('kyc-prep-single-session')).toHaveTextContent(/start again from the first step/i)
+        const checklist = screen.getByTestId('kyc-prep-checklist')
+        expect(checklist).toHaveTextContent(/government id/i)
+        expect(checklist).toHaveTextContent(/proof of your address/i)
+        expect(mockStartHosted).not.toHaveBeenCalled()
+        expect(mockWindowOpen).not.toHaveBeenCalled()
+    })
+
+    it('the warning follows the document list — it is the consequence of not having them', () => {
+        render(<AdditionalVerificationView />)
+
+        const checklist = screen.getByTestId('kyc-prep-checklist')
+        const warning = screen.getByTestId('kyc-prep-single-session')
+        const items = [...checklist.children]
+        expect(items.indexOf(warning)).toBeGreaterThan(items.findIndex((el) => /government id/i.test(el.textContent!)))
+    })
+
+    it('reserves a tab IN the click, then navigates it — never an iframe', async () => {
+        // bridge.withpersona.com sends X-Frame-Options: SAMEORIGIN — embedding
+        // it rendered "refused to connect" for every user in prod. And the tab
+        // must be reserved inside the user gesture: after the ~800ms
+        // start-action round-trip, window.open() is popup-blocked on Safari.
+        let resolveUrl: (v: { url: string }) => void = () => {}
+        mockStartHosted.mockReturnValue(new Promise((r) => (resolveUrl = r)))
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        // Reserved synchronously, BEFORE the URL exists.
+        expect(mockWindowOpen).toHaveBeenCalledWith('', '_blank')
+        expect(mockReservedTab.location.href).toBe('')
+
+        resolveUrl({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        await waitFor(() => expect(mockReservedTab.location.href).toBe('https://bridge.withpersona.com/verify?x=1'))
+        expect(document.querySelector('iframe')).toBeNull()
+        expect(mockReservedTab.close).not.toHaveBeenCalled()
+    })
+
+    it('no usable tab (pop-up blocked / standalone PWA) falls back to same-tab navigation', async () => {
+        // A post-await window.open would be blocked and its null return is
+        // unobservable; same-tab navigation is never gesture-gated.
+        mockWindowOpen.mockReturnValue(null)
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
+        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
+    })
+
+    it('a REJECTED start-action closes the tab and unsticks the button (transport-layer failure)', async () => {
+        // The action body catches its own errors, but the server action itself
+        // can reject — dropped network, or a deploy invalidating the action id.
+        mockStartHosted.mockRejectedValue(new Error('Failed to find Server Action'))
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
+        expect(mockReservedTab.close).toHaveBeenCalledTimes(1)
+        // Not stranded on "Loading..." — the button is tappable again.
+        expect(screen.getByRole('button', { name: /i have these, start/i })).toBeEnabled()
+        expect(mockAssignHref).not.toHaveBeenCalled()
+    })
+
+    it('a tab closed mid-fetch falls back instead of silently navigating a dead window', async () => {
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        mockReservedTab.closed = true
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockAssignHref).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1'))
+        expect(mockReservedTab.location.href).toBe('')
+        expect(mockReservedTab.close).toHaveBeenCalled()
+    })
+
+    it('severs window.opener on the reserved tab (reverse tabnabbing)', () => {
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        expect(mockReservedTab.opener).toBeNull()
+    })
+
+    it('native (Capacitor) skips the tab reservation and uses the in-app browser', async () => {
+        mockIsCapacitor = true
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() =>
+            expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://bridge.withpersona.com/verify?x=1')
+        )
+        expect(mockWindowOpen).not.toHaveBeenCalled()
+    })
+
+    it('native waits on the in-app browser close event, not visibilitychange', async () => {
+        mockIsCapacitor = true
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() =>
+            expect(mockBrowserAddListener).toHaveBeenCalledWith('browserFinished', expect.any(Function))
+        )
+
+        // Android WebViews may never fire visibilitychange on resume.
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        const onFinished = mockBrowserAddListener.mock.calls[0][1]
+        onFinished()
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+    })
+
+    it('closes the reserved tab when the hosted URL never arrives', async () => {
+        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
+        await waitFor(() => expect(mockReservedTab.close).toHaveBeenCalledTimes(1))
+    })
+
+    it('start-action failure surfaces FRIENDLY copy (never the raw server error) and resyncs the user', async () => {
+        mockStartHosted.mockResolvedValue({ error: 'Action not allowed for this user' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        expect(await screen.findByText(/couldn't start the verification/i)).toBeInTheDocument()
+        expect(screen.queryByText('Action not allowed for this user')).not.toBeInTheDocument()
+        expect(mockOpenExternalUrl).not.toHaveBeenCalled()
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
+    })
+
+    it('refetches the user when they come back to the app (nothing polls a requires-info rail)', async () => {
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        // Leaving the app fires visibilitychange too — only the return refetches.
+        Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(mockFetchUser).not.toHaveBeenCalled()
+
+        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+        document.dispatchEvent(new Event('visibilitychange'))
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+
+        // NOT one-shot: an incidental switch-back must not burn the refetch,
+        // so a later real return refreshes again.
+        document.dispatchEvent(new Event('visibilitychange'))
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
+    })
+
+    it('a browserFinished listener resolving AFTER cleanup removes itself', async () => {
+        mockIsCapacitor = true
+        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+        // Registration still in flight when the screen goes away.
+        let resolveListener: (v: { remove: jest.Mock }) => void = () => {}
+        mockBrowserAddListener.mockReturnValue(new Promise((r) => (resolveListener = r)))
+        const { unmount } = render(<AdditionalVerificationView />)
+
+        startVerification()
+        await waitFor(() => expect(mockBrowserAddListener).toHaveBeenCalled())
+        unmount()
+
+        resolveListener(mockBrowserListener)
+        await waitFor(() => expect(mockBrowserListener.remove).toHaveBeenCalledTimes(1))
+    })
+})

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -257,67 +257,56 @@ describe('AdditionalVerificationView', () => {
         await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
     })
 
-    it('leaves the screen once the task clears — the ONLY signal the check passed', async () => {
-        // Nothing else reports success: the ~4s auto-refresh does not run for a
-        // requires-info rail, so the refetch on return is what clears the task.
-        // The card this replaced got the exit for free by unmounting; a route
-        // has to act on it, or the user sits on a CTA whose only outcome is 403.
-        mockStartHosted.mockResolvedValue({ url: 'https://bridge.withpersona.com/verify?x=1' })
+    it('replaces the CTA with a done state once the task clears — the ONLY success signal', async () => {
+        // Nothing polls a requires-info rail, so the refetch on return from the
+        // vendor is what clears the task. The card this replaced got the exit
+        // for free by unmounting; a route has to say something, or the user
+        // sits on a CTA whose only outcome is a 403.
         const { rerender } = render(<AdditionalVerificationView />)
+        expect(screen.getByRole('button', { name: /i have these, start/i })).toBeInTheDocument()
 
-        startVerification()
-        await waitFor(() => expect(mockReservedTab.location.href).toContain('withpersona'))
-        expect(mockRouterReplace).not.toHaveBeenCalled()
-
-        // The return refetch is what produced this read, so the absence is the
-        // answer we asked for — no waiting the user out on a finished screen.
-        Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
-        document.dispatchEvent(new Event('visibilitychange'))
         mockNextActions = []
         rerender(<AdditionalVerificationView />)
-        await waitFor(() => expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification'))
+
+        expect(await screen.findByTestId('hosted-task-done')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /i have these, start/i })).not.toBeInTheDocument()
     })
 
-    it('a poll that drops the task with nobody returning does NOT eject the reader', async () => {
-        // useUserAutoRefresh polls every 4s for anyone with a pending rail, and
-        // nextActions re-derives on each read. The old card merely hid on a bad
-        // tick; a route would navigate the reader away mid-sentence. Nothing
-        // here came back from the vendor, so one dropped tick proves nothing.
+    it('a bad poll tick swaps the panel back, and never navigates the reader away', async () => {
+        // useUserAutoRefresh polls every 4s for anyone with a pending rail and
+        // nextActions re-derives on each read. Deciding whether a missing task
+        // is real would mean guessing; showing it in place costs nothing when a
+        // later tick puts the task back, so nothing here is a navigation.
         const { rerender } = render(<AdditionalVerificationView />)
 
         mockNextActions = []
         rerender(<AdditionalVerificationView />)
-        // Well inside CONFIRM_ABSENCE_MS, which outlasts the 4s poll on purpose.
-        await new Promise((resolve) => setTimeout(resolve, 500))
-        expect(mockRouterReplace).not.toHaveBeenCalled()
+        expect(await screen.findByTestId('hosted-task-done')).toBeInTheDocument()
 
         mockNextActions = [hostedAction]
         rerender(<AdditionalVerificationView />)
-        await new Promise((resolve) => setTimeout(resolve, 500))
+        expect(await screen.findByRole('button', { name: /i have these, start/i })).toBeInTheDocument()
         expect(mockRouterReplace).not.toHaveBeenCalled()
     })
 
-    it('an in-flight capability read does not bounce the user off the screen', () => {
-        // nextActions reads empty until the user query lands. Redirecting on
-        // that would throw the user straight out of the screen they just opened.
+    it('an in-flight capability read shows the prep screen, not the done state', () => {
+        // nextActions reads empty until the user query lands. Treating that as
+        // "done" would flash the wrong panel at everyone opening the screen.
         mockNextActions = []
         mockCapabilitiesLoading = true
         render(<AdditionalVerificationView />)
 
-        expect(mockRouterReplace).not.toHaveBeenCalled()
+        expect(screen.queryByTestId('hosted-task-done')).not.toBeInTheDocument()
         expect(screen.getByRole('button', { name: /i have these, start/i })).toBeEnabled()
     })
 
-    it('a REMOUNT with no hosted task leaves, even though nothing armed the return listener', () => {
-        // The no-usable-tab branch assigns window.location.href and the tab
-        // navigates away, so `awaitingReturn` never gets set. A user who comes
-        // back — deep link, or Back — remounts with nothing in memory saying
-        // they left, and a loaded-but-empty capability set is the only evidence.
-        mockNextActions = []
-        mockCapabilitiesLoading = false
+    it('an ADVISORY task does not tell the user their working transfers are blocked', () => {
+        // A future-dated action means those rails still work today.
+        mockNextActions = [{ ...hostedAction, effectiveDate: '2099-01-01T00:00:00.000Z' }]
         render(<AdditionalVerificationView />)
 
-        expect(mockRouterReplace).toHaveBeenCalledWith('/profile/identity-verification')
+        expect(screen.getByText(/keep your bank transfers working/i)).toBeInTheDocument()
+        expect(screen.queryByText(/before your bank transfers work/i)).not.toBeInTheDocument()
     })
 
     it('announces a launch failure to screen readers instead of leaving focus on a dead CTA', async () => {

--- a/src/hooks/useBridgeHostedVerification.ts
+++ b/src/hooks/useBridgeHostedVerification.ts
@@ -138,5 +138,5 @@ export function useBridgeHostedVerification() {
         return () => document.removeEventListener('visibilitychange', onReturn)
     }, [awaitingReturn, fetchUser])
 
-    return { start, isStarting, awaitingReturn, error }
+    return { start, isStarting, error }
 }

--- a/src/hooks/useBridgeHostedVerification.ts
+++ b/src/hooks/useBridgeHostedVerification.ts
@@ -12,7 +12,15 @@ import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
  * `start` must be called STRAIGHT out of a click handler — it reserves the tab
  * synchronously, inside the user-activation window (see below).
  */
-export function useBridgeHostedVerification() {
+interface BridgeHostedVerification {
+    /** Call STRAIGHT out of a click — the tab reservation needs the gesture. */
+    start: () => Promise<void>
+    isStarting: boolean
+    /** Friendly copy for a failed launch; never the raw server detail. */
+    error: string | null
+}
+
+export function useBridgeHostedVerification(): BridgeHostedVerification {
     const { fetchUser } = useAuth()
     const [isStarting, setIsStarting] = useState(false)
     const [awaitingReturn, setAwaitingReturn] = useState(false)
@@ -94,6 +102,20 @@ export function useBridgeHostedVerification() {
             return
         }
         setAwaitingReturn(true)
+    }, [fetchUser])
+
+    // The same-tab fallback navigates THIS tab away, so the listener below is
+    // never armed for it — and a Back that restores from BFCache re-runs no
+    // effects at all. `refetchOnWindowFocus` does fire on that restore, but the
+    // user query carries staleTime 5m (hooks/query/user.ts) and TanStack skips
+    // it as fresh, so a user who just finished the check would still read as
+    // having the task. `refetch` ignores staleness, which is the point.
+    useEffect(() => {
+        const onPageShow = (event: PageTransitionEvent) => {
+            if (event.persisted) void fetchUser().catch(() => undefined)
+        }
+        window.addEventListener('pageshow', onPageShow)
+        return () => window.removeEventListener('pageshow', onPageShow)
     }, [fetchUser])
 
     // Nothing polls for this cohort — the ~4s user auto-refresh only runs

--- a/src/hooks/useBridgeHostedVerification.ts
+++ b/src/hooks/useBridgeHostedVerification.ts
@@ -18,6 +18,13 @@ interface BridgeHostedVerification {
     isStarting: boolean
     /** Friendly copy for a failed launch; never the raw server detail. */
     error: string | null
+    /**
+     * How many times a RETURN from the vendor has forced a re-read. Non-zero
+     * means the capability set on screen came from a refetch we asked for
+     * because the user came back — which is what separates "the task really
+     * is done" from a poll that happened to drop it for one tick.
+     */
+    refreshSeq: number
 }
 
 export function useBridgeHostedVerification(): BridgeHostedVerification {
@@ -25,6 +32,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     const [isStarting, setIsStarting] = useState(false)
     const [awaitingReturn, setAwaitingReturn] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [refreshSeq, setRefreshSeq] = useState(0)
 
     const start = useCallback(async () => {
         setError(null)
@@ -112,7 +120,9 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     // having the task. `refetch` ignores staleness, which is the point.
     useEffect(() => {
         const onPageShow = (event: PageTransitionEvent) => {
-            if (event.persisted) void fetchUser().catch(() => undefined)
+            if (!event.persisted) return
+            setRefreshSeq((seq) => seq + 1)
+            void fetchUser().catch(() => undefined)
         }
         window.addEventListener('pageshow', onPageShow)
         return () => window.removeEventListener('pageshow', onPageShow)
@@ -128,7 +138,10 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     // so we keep listening for as long as this screen is mounted.
     useEffect(() => {
         if (!awaitingReturn) return
-        const refresh = () => void fetchUser().catch(() => undefined)
+        const refresh = () => {
+            setRefreshSeq((seq) => seq + 1)
+            void fetchUser().catch(() => undefined)
+        }
 
         if (isNativeBridge()) {
             // Android WebViews don't reliably fire `visibilitychange` on
@@ -160,5 +173,5 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
         return () => document.removeEventListener('visibilitychange', onReturn)
     }, [awaitingReturn, fetchUser])
 
-    return { start, isStarting, error }
+    return { start, isStarting, error, refreshSeq }
 }

--- a/src/hooks/useBridgeHostedVerification.ts
+++ b/src/hooks/useBridgeHostedVerification.ts
@@ -1,0 +1,142 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { startBridgeHostedVerification } from '@/app/actions/sumsub'
+import { useAuth } from '@/context/authContext'
+import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
+
+/**
+ * Drives the handoff to Bridge's hosted verification (Persona) and the wait
+ * for the user to come back from it.
+ *
+ * `start` must be called STRAIGHT out of a click handler — it reserves the tab
+ * synchronously, inside the user-activation window (see below).
+ */
+export function useBridgeHostedVerification() {
+    const { fetchUser } = useAuth()
+    const [isStarting, setIsStarting] = useState(false)
+    const [awaitingReturn, setAwaitingReturn] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const start = useCallback(async () => {
+        setError(null)
+        // NOT an iframe: `bridge.withpersona.com` serves
+        // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
+        // "refused to connect" for EVERY user. It has to be a real
+        // top-level page (native: the in-app browser). Bridge's ToS link
+        // (`compliance.bridge.xyz`) sends no framing header, which is why
+        // BridgeTosStep keeps its iframe.
+        //
+        // On web, reserve the tab HERE — synchronously, inside the click's
+        // user-activation window. Fetching the link takes ~800ms, and a
+        // window.open() after that await is no longer gesture-initiated,
+        // so Safari/Firefox block it — the same "nothing happens" symptom
+        // this PR exists to fix. The reserved tab is navigated once the
+        // URL lands, and closed if it never does.
+        // isNativeBridge(), not isCapacitor(): the latter is also true for
+        // any build carrying NEXT_PUBLIC_CAPACITOR_BUILD (vercel previews),
+        // where the native apis don't exist and we'd skip the reservation
+        // in a real browser.
+        const native = isNativeBridge()
+        const reservedTab = native ? null : window.open('', '_blank')
+        // The reserved tab can't carry `noopener` (that returns null and
+        // defeats the reservation), so sever the back-reference by hand —
+        // otherwise Persona, and anything it redirects to, holds a handle
+        // that can navigate the signed-in tab (reverse tabnabbing).
+        if (reservedTab) reservedTab.opener = null
+
+        setIsStarting(true)
+        let url: string | undefined
+        try {
+            ;({ url } = await startBridgeHostedVerification())
+        } catch (error) {
+            // The action body catches its own errors, but a server action
+            // can still REJECT at the transport layer — a dropped network,
+            // or a deploy invalidating the action id mid-flight. Without
+            // this the button stays on "Loading..." forever and the blank
+            // reserved tab is orphaned.
+            reservedTab?.close()
+            console.error('[bridge-hosted] start-action rejected', error)
+            setError("We couldn't start the verification. Please try again in a moment.")
+            return
+        } finally {
+            setIsStarting(false)
+        }
+        if (!url) {
+            // Friendly copy regardless of the server detail (a 403 here just
+            // means the action aged out); refetch so a stale entry point
+            // self-corrects.
+            reservedTab?.close()
+            setError("We couldn't start the verification. Please try again in a moment.")
+            void fetchUser().catch(() => undefined)
+            return
+        }
+        try {
+            if (native) {
+                await openExternalUrl(url)
+            } else if (reservedTab && !reservedTab.closed) {
+                // `.closed` matters: assigning href to a closed window is a
+                // silent no-op, so without this the user would tap and see
+                // nothing — the very failure this PR removes.
+                reservedTab.location.href = url
+            } else {
+                // No usable tab: pop-ups blocked, a standalone PWA, or the
+                // user closed the blank tab while we fetched. Same-tab
+                // navigation is never gesture-gated, so it always lands.
+                reservedTab?.close()
+                window.location.href = url
+                return
+            }
+        } catch (error) {
+            reservedTab?.close()
+            console.error('[bridge-hosted] failed to open Bridge hosted verification', error)
+            setError("We couldn't open the verification. Please try again in a moment.")
+            return
+        }
+        setAwaitingReturn(true)
+    }, [fetchUser])
+
+    // Nothing polls for this cohort — the ~4s user auto-refresh only runs
+    // while a rail is `pending`, and these are `requires-info` — so pick the
+    // result up when the user comes back from the hosted flow.
+    //
+    // Deliberately NOT one-shot: the first return is often incidental (a quick
+    // tab switch back, or Persona telling them to continue on their phone).
+    // Burning the single refetch there would leave the screen stale forever,
+    // so we keep listening for as long as this screen is mounted.
+    useEffect(() => {
+        if (!awaitingReturn) return
+        const refresh = () => void fetchUser().catch(() => undefined)
+
+        if (isNativeBridge()) {
+            // Android WebViews don't reliably fire `visibilitychange` on
+            // resume — the same defect that makes useNativePlugins drive
+            // TanStack's focusManager off `appStateChange`. The in-app
+            // browser's own close event is the precise signal here.
+            let disposed = false
+            let remove: (() => void) | undefined
+            void import('@capacitor/browser')
+                .then(({ Browser }) => Browser.addListener('browserFinished', refresh))
+                .then((handle) => {
+                    // Cleanup can run while the dynamic import is still in
+                    // flight; without this the listener registers after the
+                    // fact and nobody ever removes it.
+                    if (disposed) handle.remove()
+                    else remove = () => handle.remove()
+                })
+                .catch((error) => console.error('[bridge-hosted] browserFinished listener failed', error))
+            return () => {
+                disposed = true
+                remove?.()
+            }
+        }
+
+        const onReturn = () => {
+            if (document.visibilityState === 'visible') refresh()
+        }
+        document.addEventListener('visibilitychange', onReturn)
+        return () => document.removeEventListener('visibilitychange', onReturn)
+    }, [awaitingReturn, fetchUser])
+
+    return { start, isStarting, awaitingReturn, error }
+}

--- a/src/hooks/useBridgeHostedVerification.ts
+++ b/src/hooks/useBridgeHostedVerification.ts
@@ -18,13 +18,6 @@ interface BridgeHostedVerification {
     isStarting: boolean
     /** Friendly copy for a failed launch; never the raw server detail. */
     error: string | null
-    /**
-     * How many times a RETURN from the vendor has forced a re-read. Non-zero
-     * means the capability set on screen came from a refetch we asked for
-     * because the user came back — which is what separates "the task really
-     * is done" from a poll that happened to drop it for one tick.
-     */
-    refreshSeq: number
 }
 
 export function useBridgeHostedVerification(): BridgeHostedVerification {
@@ -32,7 +25,6 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     const [isStarting, setIsStarting] = useState(false)
     const [awaitingReturn, setAwaitingReturn] = useState(false)
     const [error, setError] = useState<string | null>(null)
-    const [refreshSeq, setRefreshSeq] = useState(0)
 
     const start = useCallback(async () => {
         setError(null)
@@ -120,9 +112,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     // having the task. `refetch` ignores staleness, which is the point.
     useEffect(() => {
         const onPageShow = (event: PageTransitionEvent) => {
-            if (!event.persisted) return
-            setRefreshSeq((seq) => seq + 1)
-            void fetchUser().catch(() => undefined)
+            if (event.persisted) void fetchUser().catch(() => undefined)
         }
         window.addEventListener('pageshow', onPageShow)
         return () => window.removeEventListener('pageshow', onPageShow)
@@ -138,10 +128,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
     // so we keep listening for as long as this screen is mounted.
     useEffect(() => {
         if (!awaitingReturn) return
-        const refresh = () => {
-            setRefreshSeq((seq) => seq + 1)
-            void fetchUser().catch(() => undefined)
-        }
+        const refresh = () => void fetchUser().catch(() => undefined)
 
         if (isNativeBridge()) {
             // Android WebViews don't reliably fire `visibilitychange` on
@@ -173,5 +160,5 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
         return () => document.removeEventListener('visibilitychange', onReturn)
     }, [awaitingReturn, fetchUser])
 
-    return { start, isStarting, error, refreshSeq }
+    return { start, isStarting, error }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2855,15 +2855,28 @@
                 "questions": {
                     "title": "A few short questions",
                     "body": "Regulatory declarations we are required to ask for."
+                },
+                "proofOfAddress": {
+                    "title": "Proof of your address, if you have one",
+                    "body": "A utility bill, bank statement, or official letter from the last 3 months showing your name and address. Not everyone is asked for it, and there is no way to add it later."
                 }
             },
             "howLongLabel": "How long",
             "howLong": {
                 "standard": "Under 2 minutes for most people. If a reviewer has to look at it, 1 to 3 business days.",
-                "extended": "Longer than the usual check. If a reviewer has to look at it, 1 to 3 business days."
+                "extended": "Longer than the usual check. If a reviewer has to look at it, 1 to 3 business days.",
+                "hosted": "About 5 minutes with your documents in hand. If a reviewer has to look at it, 1 to 3 business days."
             },
             "extraDocNote": "Some people are asked for one more document, like a proof of address. If that is you, we will say so before the camera opens.",
-            "startCta": "I have these, start"
+            "startCta": "I have these, start",
+            "singleSession": {
+                "title": "Finish it in one go",
+                "body": "Our partner does not save your progress. If you close the page or step away to look for a document, you start again from the first step."
+            }
+        },
+        "hostedPrep": {
+            "title": "What to expect",
+            "description": "Our payment partner needs a few more things before your bank transfers work."
         }
     },
     "identity": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2876,7 +2876,13 @@
         },
         "hostedPrep": {
             "title": "What to expect",
-            "description": "Our payment partner needs a few more things before your bank transfers work."
+            "description": "Our payment partner needs a few more things before your bank transfers work.",
+            "descriptionAdvisory": "Our payment partner needs a few more things to keep your bank transfers working.",
+            "done": {
+                "title": "Nothing left to do here",
+                "description": "This verification step is no longer needed. Your current status is on your profile.",
+                "cta": "See my status"
+            }
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2855,15 +2855,28 @@
                 "questions": {
                     "title": "Unas preguntas breves",
                     "body": "Declaraciones regulatorias que estamos obligados a pedir."
+                },
+                "proofOfAddress": {
+                    "title": "Un comprobante de domicilio, si tienes uno",
+                    "body": "Una factura de servicios, un estado de cuenta bancario o una carta oficial de los últimos 3 meses con tu nombre y tu domicilio. No se lo piden a todo el mundo, y después no hay forma de agregarlo."
                 }
             },
             "howLongLabel": "Cuánto tarda",
             "howLong": {
                 "standard": "Menos de 2 minutos para la mayoría. Si un revisor debe verlo, de 1 a 3 días hábiles.",
-                "extended": "Más que la verificación habitual. Si un revisor debe verlo, de 1 a 3 días hábiles."
+                "extended": "Más que la verificación habitual. Si un revisor debe verlo, de 1 a 3 días hábiles.",
+                "hosted": "Unos 5 minutos si tienes tus documentos a la mano. Si un revisor debe verlo, de 1 a 3 días hábiles."
             },
             "extraDocNote": "A algunas personas se les pide un documento más, como un comprobante de domicilio. Si es tu caso, te lo diremos antes de abrir la cámara.",
-            "startCta": "Los tengo, empezar"
+            "startCta": "Los tengo, empezar",
+            "singleSession": {
+                "title": "Termínala de una sola vez",
+                "body": "Nuestro socio no guarda tu progreso. Si cierras la página o te levantas a buscar un documento, vuelves a empezar desde el primer paso."
+            }
+        },
+        "hostedPrep": {
+            "title": "Qué esperar",
+            "description": "Nuestro socio de pagos necesita algunas cosas más antes de que funcionen tus transferencias bancarias."
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2876,7 +2876,13 @@
         },
         "hostedPrep": {
             "title": "Qué esperar",
-            "description": "Nuestro socio de pagos necesita algunas cosas más antes de que funcionen tus transferencias bancarias."
+            "description": "Nuestro socio de pagos necesita algunas cosas más antes de que funcionen tus transferencias bancarias.",
+            "descriptionAdvisory": "Nuestro socio de pagos necesita algunas cosas más para que tus transferencias bancarias sigan funcionando.",
+            "done": {
+                "title": "Aquí ya no queda nada por hacer",
+                "description": "Este paso de verificación ya no es necesario. Tu estado actual está en tu perfil.",
+                "cta": "Ver mi estado"
+            }
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1230,15 +1230,24 @@
                 "questions": {
                     "title": "Unas preguntas breves",
                     "body": "Declaraciones regulatorias que estamos obligados a pedir."
+                },
+                "proofOfAddress": {
+                    "title": "Un comprobante de domicilio, si tenés uno",
+                    "body": "Una factura de servicios, un resumen bancario o una carta oficial de los últimos 3 meses con tu nombre y tu domicilio. No se lo piden a todo el mundo, y después no hay forma de agregarlo."
                 }
             },
             "howLongLabel": "Cuánto tarda",
             "howLong": {
                 "standard": "Menos de 2 minutos para la mayoría. Si un revisor debe verlo, de 1 a 3 días hábiles.",
-                "extended": "Más que la verificación habitual. Si un revisor debe verlo, de 1 a 3 días hábiles."
+                "extended": "Más que la verificación habitual. Si un revisor debe verlo, de 1 a 3 días hábiles.",
+                "hosted": "Unos 5 minutos si tenés tus documentos a mano. Si un revisor debe verlo, de 1 a 3 días hábiles."
             },
             "extraDocNote": "A algunas personas se les pide un documento más, como un comprobante de domicilio. Si es tu caso, te lo diremos antes de abrir la cámara.",
-            "startCta": "Los tengo, empezar"
+            "startCta": "Los tengo, empezar",
+            "singleSession": {
+                "title": "Terminala de una sola vez",
+                "body": "Nuestro socio no guarda tu progreso. Si cerrás la página o te levantás a buscar un documento, volvés a empezar desde el primer paso."
+            }
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1248,6 +1248,11 @@
                 "title": "Terminala de una sola vez",
                 "body": "Nuestro socio no guarda tu progreso. Si cerrás la página o te levantás a buscar un documento, volvés a empezar desde el primer paso."
             }
+        },
+        "hostedPrep": {
+            "done": {
+                "title": "Acá ya no queda nada por hacer"
+            }
         }
     },
     "identity": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2876,7 +2876,13 @@
         },
         "hostedPrep": {
             "title": "O que esperar",
-            "description": "Nosso parceiro de pagamentos precisa de mais algumas coisas antes que suas transferências bancárias funcionem."
+            "description": "Nosso parceiro de pagamentos precisa de mais algumas coisas antes que suas transferências bancárias funcionem.",
+            "descriptionAdvisory": "Nosso parceiro de pagamentos precisa de mais algumas coisas para que suas transferências bancárias continuem funcionando.",
+            "done": {
+                "title": "Não há mais nada a fazer aqui",
+                "description": "Esta etapa de verificação não é mais necessária. Seu status atual está no seu perfil.",
+                "cta": "Ver meu status"
+            }
         }
     },
     "identity": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2855,15 +2855,28 @@
                 "questions": {
                     "title": "Algumas perguntas rápidas",
                     "body": "Declarações regulatórias que somos obrigados a pedir."
+                },
+                "proofOfAddress": {
+                    "title": "Um comprovante de residência, se você tiver",
+                    "body": "Uma conta de consumo, um extrato bancário ou uma carta oficial dos últimos 3 meses com seu nome e seu endereço. Nem todo mundo precisa enviar, e depois não dá para adicionar."
                 }
             },
             "howLongLabel": "Quanto tempo leva",
             "howLong": {
                 "standard": "Menos de 2 minutos para a maioria das pessoas. Se um revisor precisar analisar, de 1 a 3 dias úteis.",
-                "extended": "Mais do que a verificação comum. Se um revisor precisar analisar, de 1 a 3 dias úteis."
+                "extended": "Mais do que a verificação comum. Se um revisor precisar analisar, de 1 a 3 dias úteis.",
+                "hosted": "Cerca de 5 minutos com seus documentos em mãos. Se um revisor precisar analisar, de 1 a 3 dias úteis."
             },
             "extraDocNote": "Algumas pessoas precisam enviar mais um documento, como um comprovante de residência. Se for o seu caso, avisaremos antes de abrir a câmera.",
-            "startCta": "Tenho tudo, começar"
+            "startCta": "Tenho tudo, começar",
+            "singleSession": {
+                "title": "Faça tudo de uma vez só",
+                "body": "Nosso parceiro não salva seu progresso. Se você fechar a página ou sair para procurar um documento, começa de novo da primeira etapa."
+            }
+        },
+        "hostedPrep": {
+            "title": "O que esperar",
+            "description": "Nosso parceiro de pagamentos precisa de mais algumas coisas antes que suas transferências bancárias funcionem."
         }
     },
     "identity": {


### PR DESCRIPTION
## What

The `bridge-hosted` task — Bridge's hosted verification, which runs on Persona — was the one KYC path that handed the user to the vendor with no prep at all. Tap **Complete verification** on the pending-tasks card and the browser sheet opens on step one.

It is also the path where that hurts most: unlike the Sumsub SDK, the hosted flow keeps **no partial progress**. Anyone who leaves mid-check to go find a proof of address loses everything and restarts from the first step.

This adds a screen in front of it at `/profile/identity-verification/additional`:

- the documents to have in hand (government ID, selfie, proof of address — with the "there is no way to add it later" caveat)
- a **"Finish it in one go"** warning, placed *after* the list so it reads as the consequence of not having those documents
- how long it takes
- the CTA, which owns the handoff

## Why a page and not a modal

It started as a sheet. At 375×812 the panel came out ~926px tall, and `ActionModal` centres its panel in the overlay's scroll container — so the overflow went *past the top*, where nothing could scroll it back. The prep is the whole content here, not an interruption to something else, so it is a route.

## The handoff is unchanged

The launch moves out of the card into `useBridgeHostedVerification` verbatim:

- the tab is still reserved **synchronously inside the click** — a `window.open` after the ~800ms start-action round-trip is popup-blocked on Safari
- `opener` is still severed on the reserved tab (reverse tabnabbing)
- the return still refetches off `browserFinished` on native / `visibilitychange` on web, and is still deliberately not one-shot
- still not an iframe: `bridge.withpersona.com` sends `X-Frame-Options: SAMEORIGIN`

The CTA calls it straight out of the click, so the user gesture the reservation depends on is intact.

## Also in here

Two fixes to the shared `KycPrepChecklist`, which the Sumsub unlock modals also render:

- the **HOW LONG** note loses its frame. It read as one more thing to go and fetch, alongside the requirements above it, when it is only a note. (This restores `7e924dc0f` from `fix/signup-finish-screen`, which has not landed on `dev`.)
- the bordered list takes **its own surface**. It was never white in its own right — it was transparent, and the modal panel behind it painted white. On a page it landed on the page surface. Now `bg-background-default dark:bg-foreground-primary`, matching how `UnlockPayments.view.tsx` does it on the same screen family.

## Testing

- new 13-test suite for the screen, carrying over every launch-path case from the card: popup blocked, tab closed mid-fetch, reverse tabnabbing, native in-app browser, transport-layer rejection, friendly-copy-not-raw-server-error, listener-resolves-after-unmount
- the card suite now asserts it navigates rather than launching
- 343 tests pass across `Kyc` / `Home` / `i18n`; typecheck and prettier clean
- copy added in en / es-419 / pt-BR with es-AR voseo deltas; catalog parity, duplicate-drift and ICU compilation tests pass
- rendered against the `kyc-action-required` fixture at 375×812

## Note on scope

The proof-of-address row is worded conditionally ("if you have one") rather than promising it is required. Bridge sends arbitrary `requirementKey`s for this action (`kyc_approval`, `proof_of_address`, …), so branching the list on it would be guesswork.