### PR TITLE
feat(ota): five-tap beta switch that puts a tester on the staging channel

### DIFF
--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -331,12 +331,18 @@ from the dashboard instead.
 
 Three prerequisites, all one-time:
 
-- The account must be in the **`beta-ota-channel`** PostHog cohort. The tap gesture only
-  hides the switch; this is what decides who may use it, because `staging` runs unreleased
-  code against production money and self-assignment is open to any device once enabled.
-  Non-prod builds bypass the flag so QA doesn't need a cohort edit.
+- The account must be in the **`beta-ota-channel`** PostHog cohort, which is what keeps
+  the switch off customer devices. Read what it is, though: a client-side flag that
+  decides whether a React component renders. `setChannel` talks to Capgo directly with
+  the app key shipped in every binary, and non-prod builds skip the flag entirely, so
+  anyone running a modified client can self-assign regardless. It stops people who did
+  not mean to be on beta, not people who do. Move the join behind the backend (verify
+  the account server-side, assign the device through Capgo's API) if that ever needs to
+  be a real boundary.
 - `staging` must have **"Allow devices to self dissociate/associate"** enabled, or
-  `setChannel()` is refused and the app says so. Changing it needs a Super Admin.
+  `setChannel()` is refused and the app says so. Changing it needs a Super Admin — and
+  it is the decision that actually opens the channel: from that point any install that
+  can call the plugin can join, whatever the cohort says.
 - The tester's binary must not outrank the bundle: `disable_auto_update_under_native`
   makes a device on versionName 1.1.x refuse anything sorting below it. Staging's
   commit-count band sits far above production's, so this only bites right after a native

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -352,6 +352,13 @@ Leaving the channel unsets it **and** calls `reset()` back to the store bundle: 
 versions outrank every production one, so no production OTA could ever replace a beta
 bundle on its own.
 
+One asymmetry to know before forcing anyone from the dashboard: `unsetChannel()` is
+local-only in the plugin (it drops a stored preference and returns ok), so a **dashboard
+device override survives it** and Capgo keeps serving beta. The switch detects that —
+it re-reads the effective channel and says an admin has to remove the override rather
+than resetting into an exit that undoes itself on the next launch — but the removal is
+dashboard-side. Self-assignment is the cleaner enrolment path for that reason.
+
 ---
 
 ## 10. Pre-submission verification

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -329,8 +329,12 @@ Beta-updates switch that calls `setChannel('staging')` — no dashboard work per
 the row also prints the device ID for the times someone has to be forced onto a channel
 from the dashboard instead.
 
-Two prerequisites, both in Capgo, both one-time:
+Three prerequisites, all one-time:
 
+- The account must be in the **`beta-ota-channel`** PostHog cohort. The tap gesture only
+  hides the switch; this is what decides who may use it, because `staging` runs unreleased
+  code against production money and self-assignment is open to any device once enabled.
+  Non-prod builds bypass the flag so QA doesn't need a cohort edit.
 - `staging` must have **"Allow devices to self dissociate/associate"** enabled, or
   `setChannel()` is refused and the app says so. Changing it needs a Super Admin.
 - The tester's binary must not outrank the bundle: `disable_auto_update_under_native`

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -357,7 +357,9 @@ local-only in the plugin (it drops a stored preference and returns ok), so a **d
 device override survives it** and Capgo keeps serving beta. The switch detects that —
 it re-reads the effective channel and says an admin has to remove the override rather
 than resetting into an exit that undoes itself on the next launch — but the removal is
-dashboard-side. Self-assignment is the cleaner enrolment path for that reason.
+dashboard-side. Self-assignment is the cleaner enrolment path for that reason. When Capgo
+cannot be reached to answer that question, the switch refuses to reset at all and asks the
+tester to retry online: only a confirmed answer licenses the reset.
 
 ---
 

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -321,6 +321,27 @@ own `out/` under the binary's versionName, then assert the channel serves it.
 - **Boundary:** OTA ships web assets only. New plugins, Gradle, permissions, versionCode
   → Play release.
 
+### Internal testing (the `staging` channel on a real device)
+
+Every merge to `dev` already publishes to `staging`; the missing half was a way for a
+tester's device to read it. Five taps on the version line in **Profile → About** reveal a
+Beta-updates switch that calls `setChannel('staging')` — no dashboard work per tester, and
+the row also prints the device ID for the times someone has to be forced onto a channel
+from the dashboard instead.
+
+Two prerequisites, both in Capgo, both one-time:
+
+- `staging` must have **"Allow devices to self dissociate/associate"** enabled, or
+  `setChannel()` is refused and the app says so. Changing it needs a Super Admin.
+- The tester's binary must not outrank the bundle: `disable_auto_update_under_native`
+  makes a device on versionName 1.1.x refuse anything sorting below it. Staging's
+  commit-count band sits far above production's, so this only bites right after a native
+  release.
+
+Leaving the channel unsets it **and** calls `reset()` back to the store bundle: staging
+versions outrank every production one, so no production OTA could ever replace a beta
+bundle on its own.
+
 ---
 
 ## 10. Pre-submission verification

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -359,7 +359,11 @@ it re-reads the effective channel and says an admin has to remove the override r
 than resetting into an exit that undoes itself on the next launch — but the removal is
 dashboard-side. Self-assignment is the cleaner enrolment path for that reason. When Capgo
 cannot be reached to answer that question, the switch refuses to reset at all and asks the
-tester to retry online: only a confirmed answer licenses the reset.
+tester to retry online: only a confirmed answer licenses the reset. That attempt is recorded
+in local storage **before** the channel is cleared, and the switch keeps reading as "on beta"
+until the store bundle is actually the one running — otherwise a device whose channel was
+cleared but whose bundle was not looks settled while running beta code that no production OTA
+can replace, and the card that offers the retry would disappear for anyone outside the cohort.
 
 ---
 

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -47,7 +47,8 @@ export const BetaUpdatesCard = () => {
     }
 
     const onToggle = async (beta: boolean) => {
-        switch (await setBeta(beta)) {
+        const result = await setBeta(beta)
+        switch (result) {
             case 'staged':
                 toast.success(t('staged'))
                 break
@@ -74,6 +75,12 @@ export const BetaUpdatesCard = () => {
             case 'left':
                 toast.success(t('left'))
                 break
+            default: {
+                // Every outcome owes the tester a sentence. This PR added three
+                // of them; a fourth added silently would toast nothing at all.
+                const unhandled: never = result
+                console.warn('[capgo] unhandled channel switch result:', unhandled)
+            }
         }
     }
 

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -66,6 +66,9 @@ export const BetaUpdatesCard = () => {
             case 'left-still-beta':
                 toast.error(t('leftStillBeta'))
                 break
+            case 'left-override':
+                toast.error(t('leftOverride'))
+                break
             // Only reached when reset() did not reload — a device already on the
             // store bundle. Otherwise the app is gone before this runs.
             case 'left':

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -66,7 +66,11 @@ export const BetaUpdatesCard = () => {
             case 'left-still-beta':
                 toast.error(t('leftStillBeta'))
                 break
-            // 'left' reloads the app onto the store bundle — no toast survives it.
+            // Only reached when reset() did not reload — a device already on the
+            // store bundle. Otherwise the app is gone before this runs.
+            case 'left':
+                toast.success(t('left'))
+                break
         }
     }
 

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import Card from '@/components/Global/Card'
+import { Toggle } from '@/components/0_Bruddle/Toggle'
+import { useToast } from '@/components/0_Bruddle/Toast'
+import { useOtaChannel } from '@/hooks/useOtaChannel'
+import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
+import { copyTextToClipboardWithFallback } from '@/utils/general.utils'
+import { useTranslations } from 'next-intl'
+
+/**
+ * Internal-testing switch, revealed by five taps on the version line. Joining
+ * points the device at the `staging` Capgo channel, which every merge to `dev`
+ * publishes to; leaving drops it back to the store bundle.
+ */
+export const BetaUpdatesCard = () => {
+    const t = useTranslations('profile.about.beta')
+    const toast = useToast()
+    const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
+
+    if (!supported) return null
+
+    const onToggle = async (beta: boolean) => {
+        const result = await setBeta(beta)
+        if (result === 'closed') toast.error(t('closed', { channel: BETA_OTA_CHANNEL }))
+        else if (result === 'failed') toast.error(t('failed'))
+        else if (beta) toast.success(t('joined'))
+        // Leaving reloads the app onto the store bundle, so there is no toast to see.
+    }
+
+    return (
+        <Card position="single" className="space-y-3 p-4">
+            <div className="flex items-center justify-between gap-4">
+                <div>
+                    <h2 className="text-body-s font-bold text-black">{t('heading')}</h2>
+                    <p className="text-body-xs text-foreground-secondary">
+                        {t('description', { channel: BETA_OTA_CHANNEL })}
+                    </p>
+                </div>
+                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
+            </div>
+
+            <dl className="space-y-1 text-body-xs text-foreground-secondary">
+                <div className="flex justify-between gap-4">
+                    <dt>{t('channelLabel')}</dt>
+                    <dd>{status?.channel ?? t('defaultChannel')}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                    <dt>{t('bundleLabel')}</dt>
+                    <dd>{status?.bundleVersion ?? '—'}</dd>
+                </div>
+                {status?.deviceId && (
+                    <div className="flex justify-between gap-4">
+                        <dt>{t('deviceLabel')}</dt>
+                        <dd>
+                            <button
+                                type="button"
+                                className="text-left break-all underline"
+                                onClick={() =>
+                                    copyTextToClipboardWithFallback(status.deviceId!).then(() =>
+                                        toast.info(t('deviceCopied'))
+                                    )
+                                }
+                            >
+                                {status.deviceId}
+                            </button>
+                        </dd>
+                    </div>
+                )}
+            </dl>
+        </Card>
+    )
+}

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -3,6 +3,7 @@
 import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { useToast } from '@/components/0_Bruddle/Toast'
+import { useFeatureFlags } from '@/hooks/useFeatureFlag'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboardWithFallback } from '@/utils/general.utils'
@@ -12,20 +13,43 @@ import { useTranslations } from 'next-intl'
  * Internal-testing switch, revealed by five taps on the version line. Joining
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
+ *
+ * The tap gesture hides the control; the PostHog flag decides who may use it.
+ * `staging` carries unreleased code against production money, so eligibility is
+ * a cohort someone maintains — not a gesture any customer can stumble into once
+ * self-assignment is enabled on the channel.
  */
+export const BETA_OTA_FLAG = 'beta-ota-channel'
+
 export const BetaUpdatesCard = () => {
     const t = useTranslations('profile.about.beta')
     const toast = useToast()
+    const isEnabled = useFeatureFlags()
     const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
 
-    if (!supported) return null
+    // nonProdBypass: previews and local builds are already non-production by
+    // definition, and QA needs the switch there without a cohort edit.
+    if (!supported || !isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })) return null
 
     const onToggle = async (beta: boolean) => {
-        const result = await setBeta(beta)
-        if (result === 'closed') toast.error(t('closed', { channel: BETA_OTA_CHANNEL }))
-        else if (result === 'failed') toast.error(t('failed'))
-        else if (beta) toast.success(t('joined'))
-        // Leaving reloads the app onto the store bundle, so there is no toast to see.
+        switch (await setBeta(beta)) {
+            case 'staged':
+                toast.success(t('staged'))
+                break
+            case 'joined':
+                toast.success(t('joined'))
+                break
+            case 'join-no-bundle':
+                toast.warning(t('joinedWithoutBundle'))
+                break
+            case 'closed':
+                toast.error(t('closed', { channel: BETA_OTA_CHANNEL }))
+                break
+            case 'failed':
+                toast.error(t('failed'))
+                break
+            // 'left' reloads the app onto the store bundle — no toast survives it.
+        }
     }
 
     return (

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -70,6 +70,9 @@ export const BetaUpdatesCard = () => {
             case 'left-override':
                 toast.error(t('leftOverride'))
                 break
+            case 'left-unconfirmed':
+                toast.error(t('leftUnconfirmed'))
+                break
             // Only reached when reset() did not reload — a device already on the
             // store bundle. Otherwise the app is gone before this runs.
             case 'left':

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -14,10 +14,15 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * The tap gesture hides the control; the PostHog flag decides who may use it.
- * `staging` carries unreleased code against production money, so eligibility is
- * a cohort someone maintains — not a gesture any customer can stumble into once
- * self-assignment is enabled on the channel.
+ * The tap gesture hides the control; the PostHog cohort keeps customers from
+ * joining once self-assignment is open on the channel. Neither is a security
+ * boundary — `setChannel` talks to Capgo directly — they keep `staging` off the
+ * devices of people who did not mean to be there.
+ *
+ * A device already ON the channel keeps the card whatever the cohort says: the
+ * off switch is the only way back to the store bundle, and hiding it when
+ * someone is offboarded (or the flag fails to load) would strand them on beta
+ * code forever.
  */
 export const BETA_OTA_FLAG = 'beta-ota-channel'
 
@@ -29,7 +34,17 @@ export const BetaUpdatesCard = () => {
 
     // nonProdBypass: previews and local builds are already non-production by
     // definition, and QA needs the switch there without a cohort edit.
-    if (!supported || !isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })) return null
+    const mayJoin = isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })
+    if (!supported || (!mayJoin && !isBeta)) return null
+
+    const copyDeviceId = async (deviceId: string) => {
+        try {
+            await copyTextToClipboardWithFallback(deviceId)
+            toast.info(t('deviceCopied'))
+        } catch {
+            toast.error(t('deviceCopyFailed'))
+        }
+    }
 
     const onToggle = async (beta: boolean) => {
         switch (await setBeta(beta)) {
@@ -48,6 +63,9 @@ export const BetaUpdatesCard = () => {
             case 'failed':
                 toast.error(t('failed'))
                 break
+            case 'left-still-beta':
+                toast.error(t('leftStillBeta'))
+                break
             // 'left' reloads the app onto the store bundle — no toast survives it.
         }
     }
@@ -61,7 +79,12 @@ export const BetaUpdatesCard = () => {
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>
                 </div>
-                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
+                <Toggle
+                    checked={isBeta}
+                    disabled={busy || (!mayJoin && !isBeta)}
+                    onChange={onToggle}
+                    aria-label={t('heading')}
+                />
             </div>
 
             <dl className="space-y-1 text-body-xs text-foreground-secondary">
@@ -80,11 +103,7 @@ export const BetaUpdatesCard = () => {
                             <button
                                 type="button"
                                 className="text-left break-all underline"
-                                onClick={() =>
-                                    copyTextToClipboardWithFallback(status.deviceId!).then(() =>
-                                        toast.info(t('deviceCopied'))
-                                    )
-                                }
+                                onClick={() => void copyDeviceId(status.deviceId!)}
                             >
                                 {status.deviceId}
                             </button>

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -75,6 +75,19 @@ it('says the app is still on beta code when the reset half of the exit fails', a
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Reinstall')))
 })
 
+// reset() normally reloads the app, so this toast is unobservable — except on a
+// device already running the store bundle, where a silent no-op would look like
+// the switch had failed.
+it('confirms the exit when the app did not reload', async () => {
+    setup({
+        isBeta: true,
+        status: { channel: 'staging', bundleVersion: '1.1.0', deviceId: 'abc-123' },
+        ...switching('left'),
+    })
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('released version')))
+})
+
 it('tells the tester to get the channel opened when Capgo refuses', async () => {
     setup(switching('closed'))
     fireEvent.click(screen.getByRole('switch'))

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -88,6 +88,16 @@ it('confirms the exit when the app did not reload', async () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('released version')))
 })
 
+it('sends dashboard-assigned testers to an admin, since the app cannot unassign them', async () => {
+    setup({
+        isBeta: true,
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        ...switching('left-override'),
+    })
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Capgo dashboard')))
+})
+
 it('tells the tester to get the channel opened when Capgo refuses', async () => {
     setup(switching('closed'))
     fireEvent.click(screen.getByRole('switch'))

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -54,6 +54,27 @@ it('stays hidden for accounts outside the internal cohort', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
+// Offboarding a tester (or a flag that fails to load) must not take the exit
+// with it: the device is already on staging, and nothing else can bring it back.
+it('keeps the exit reachable for a device already on the channel', async () => {
+    flags.enabled = []
+    setup({ isBeta: true, status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' } })
+    const toggle = screen.getByRole('switch')
+    expect(toggle).toBeEnabled()
+    fireEvent.click(toggle)
+    await waitFor(() => expect(channel.current.setBeta).toHaveBeenCalledWith(false))
+})
+
+it('says the app is still on beta code when the reset half of the exit fails', async () => {
+    setup({
+        isBeta: true,
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        ...switching('left-still-beta'),
+    })
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Reinstall')))
+})
+
 it('tells the tester to get the channel opened when Capgo refuses', async () => {
     setup(switching('closed'))
     fireEvent.click(screen.getByRole('switch'))

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,49 +1,80 @@
 /**
- * The card is native-only, and the failure a tester is most likely to hit is a
- * channel that has not been opened for self-assignment — that must read as a
- * concrete instruction, not a generic error.
+ * Two things keep the staging lane off customer devices: the card is native-only
+ * and it is gated on an internal PostHog cohort — the five-tap gesture only
+ * hides it. Beyond that, every join outcome has to read honestly: a tester told
+ * to restart when nothing was downloaded goes looking for a build that isn't
+ * there.
  */
 import React from 'react'
 import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
-import { BetaUpdatesCard } from '../BetaUpdatesCard'
+import { BETA_OTA_FLAG, BetaUpdatesCard } from '../BetaUpdatesCard'
 import type { OtaChannelSwitchResult, UseOtaChannel } from '@/hooks/useOtaChannel'
 
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
-const toast = { success: jest.fn(), error: jest.fn(), info: jest.fn() }
+const toast = { success: jest.fn(), error: jest.fn(), info: jest.fn(), warning: jest.fn() }
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
+
+const flags = { enabled: [BETA_OTA_FLAG] as string[] }
+jest.mock('@/hooks/useFeatureFlag', () => ({
+    useFeatureFlags: () => (flag: string) => flags.enabled.includes(flag),
+}))
 
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
 
-const setup = (overrides: Partial<UseOtaChannel> & { setBeta?: () => Promise<OtaChannelSwitchResult> } = {}) => {
+const setup = (overrides: Partial<UseOtaChannel> = {}) => {
     channel.current = {
         supported: true,
         status: { channel: null, bundleVersion: '1.1.0', deviceId: 'abc-123' },
         isBeta: false,
         busy: false,
-        setBeta: jest.fn().mockResolvedValue('ok'),
+        setBeta: jest.fn().mockResolvedValue('staged' satisfies OtaChannelSwitchResult),
         ...overrides,
     }
     render(<BetaUpdatesCard />)
 }
 
-beforeEach(() => jest.clearAllMocks())
+const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mockResolvedValue(result) })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    flags.enabled = [BETA_OTA_FLAG]
+})
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
     setup({ supported: false })
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
+it('stays hidden for accounts outside the internal cohort', () => {
+    flags.enabled = []
+    setup()
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+})
+
 it('tells the tester to get the channel opened when Capgo refuses', async () => {
-    setup({ setBeta: jest.fn().mockResolvedValue('closed') })
+    setup(switching('closed'))
     fireEvent.click(screen.getByRole('switch'))
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('self-assignment')))
 })
 
-it('asks for a restart once the device is on the beta channel', async () => {
-    setup()
+it('asks for a restart only when a bundle is actually waiting', async () => {
+    setup(switching('staged'))
     fireEvent.click(screen.getByRole('switch'))
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Restart')))
+})
+
+it('says so when the join downloaded nothing', async () => {
+    setup(switching('join-no-bundle'))
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(expect.stringContaining('no beta build')))
+    expect(toast.success).not.toHaveBeenCalled()
+})
+
+it('does not promise a build when there is simply nothing newer', async () => {
+    setup(switching('joined'))
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('no newer beta build')))
 })

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -98,6 +98,17 @@ it('sends dashboard-assigned testers to an admin, since the app cannot unassign 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Capgo dashboard')))
 })
 
+it('keeps the switch on when the exit could not be confirmed', async () => {
+    setup({
+        isBeta: true,
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        ...switching('left-unconfirmed'),
+    })
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('still on the beta build')))
+    expect(screen.getByRole('switch')).toBeChecked()
+})
+
 it('tells the tester to get the channel opened when Capgo refuses', async () => {
     setup(switching('closed'))
     fireEvent.click(screen.getByRole('switch'))

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -27,7 +27,7 @@ jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current
 const setup = (overrides: Partial<UseOtaChannel> = {}) => {
     channel.current = {
         supported: true,
-        status: { channel: null, bundleVersion: '1.1.0', deviceId: 'abc-123' },
+        status: { channel: null, bundleVersion: '1.1.0', deviceId: 'abc-123', onBuiltinBundle: false },
         isBeta: false,
         busy: false,
         setBeta: jest.fn().mockResolvedValue('staged' satisfies OtaChannelSwitchResult),
@@ -58,7 +58,10 @@ it('stays hidden for accounts outside the internal cohort', () => {
 // with it: the device is already on staging, and nothing else can bring it back.
 it('keeps the exit reachable for a device already on the channel', async () => {
     flags.enabled = []
-    setup({ isBeta: true, status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' } })
+    setup({
+        isBeta: true,
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
+    })
     const toggle = screen.getByRole('switch')
     expect(toggle).toBeEnabled()
     fireEvent.click(toggle)
@@ -68,7 +71,7 @@ it('keeps the exit reachable for a device already on the channel', async () => {
 it('says the app is still on beta code when the reset half of the exit fails', async () => {
     setup({
         isBeta: true,
-        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
         ...switching('left-still-beta'),
     })
     fireEvent.click(screen.getByRole('switch'))
@@ -81,7 +84,7 @@ it('says the app is still on beta code when the reset half of the exit fails', a
 it('confirms the exit when the app did not reload', async () => {
     setup({
         isBeta: true,
-        status: { channel: 'staging', bundleVersion: '1.1.0', deviceId: 'abc-123' },
+        status: { channel: 'staging', bundleVersion: '1.1.0', deviceId: 'abc-123', onBuiltinBundle: false },
         ...switching('left'),
     })
     fireEvent.click(screen.getByRole('switch'))
@@ -91,7 +94,7 @@ it('confirms the exit when the app did not reload', async () => {
 it('sends dashboard-assigned testers to an admin, since the app cannot unassign them', async () => {
     setup({
         isBeta: true,
-        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
         ...switching('left-override'),
     })
     fireEvent.click(screen.getByRole('switch'))
@@ -101,7 +104,7 @@ it('sends dashboard-assigned testers to an admin, since the app cannot unassign 
 it('keeps the switch on when the exit could not be confirmed', async () => {
     setup({
         isBeta: true,
-        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123' },
+        status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
         ...switching('left-unconfirmed'),
     })
     fireEvent.click(screen.getByRole('switch'))

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * The card is native-only, and the failure a tester is most likely to hit is a
+ * channel that has not been opened for self-assignment — that must read as a
+ * concrete instruction, not a generic error.
+ */
+import React from 'react'
+import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { BetaUpdatesCard } from '../BetaUpdatesCard'
+import type { OtaChannelSwitchResult, UseOtaChannel } from '@/hooks/useOtaChannel'
+
+const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
+
+const toast = { success: jest.fn(), error: jest.fn(), info: jest.fn() }
+jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
+
+const channel = { current: {} as UseOtaChannel }
+jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
+
+const setup = (overrides: Partial<UseOtaChannel> & { setBeta?: () => Promise<OtaChannelSwitchResult> } = {}) => {
+    channel.current = {
+        supported: true,
+        status: { channel: null, bundleVersion: '1.1.0', deviceId: 'abc-123' },
+        isBeta: false,
+        busy: false,
+        setBeta: jest.fn().mockResolvedValue('ok'),
+        ...overrides,
+    }
+    render(<BetaUpdatesCard />)
+}
+
+beforeEach(() => jest.clearAllMocks())
+
+it('renders nothing off native, where there is no OTA layer at all', () => {
+    setup({ supported: false })
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+})
+
+it('tells the tester to get the channel opened when Capgo refuses', async () => {
+    setup({ setBeta: jest.fn().mockResolvedValue('closed') })
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('self-assignment')))
+})
+
+it('asks for a restart once the device is on the beta channel', async () => {
+    setup()
+    fireEvent.click(screen.getByRole('switch'))
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringContaining('Restart')))
+})

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -4,8 +4,10 @@ import Card from '@/components/Global/Card'
 import DocsLink from '@/components/Global/DocsLink'
 import NavHeader from '@/components/Global/NavHeader'
 import NavigationArrow from '@/components/Global/NavigationArrow'
+import { BetaUpdatesCard } from '@/components/Profile/components/BetaUpdatesCard'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useTranslations } from 'next-intl'
+import { useRef, useState } from 'react'
 
 /**
  * The one place every policy is reachable from inside the app, mirroring the
@@ -27,9 +29,28 @@ const POLICY_LINKS: ReadonlyArray<{ name: string; href: string }> = [
 const cardPosition = (index: number, total: number) =>
     index === 0 ? ('first' as const) : index === total - 1 ? ('last' as const) : ('middle' as const)
 
+const TAPS_TO_REVEAL_BETA = 5
+const TAP_WINDOW_MS = 2_000
+
 export const AboutView = ({ appVersion }: { appVersion: string }) => {
     const t = useTranslations('profile.about')
     const onBack = useSafeBack('/profile', { replace: true })
+    const [betaRevealed, setBetaRevealed] = useState(false)
+    const taps = useRef(0)
+    const tapWindow = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+    const onVersionTap = () => {
+        clearTimeout(tapWindow.current)
+        taps.current += 1
+        if (taps.current >= TAPS_TO_REVEAL_BETA) {
+            taps.current = 0
+            setBetaRevealed(true)
+            return
+        }
+        tapWindow.current = setTimeout(() => {
+            taps.current = 0
+        }, TAP_WINDOW_MS)
+    }
 
     return (
         <div className="space-y-4 mb-6">
@@ -49,7 +70,10 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
                 ))}
             </div>
 
-            <p className="text-center text-body-xs text-foreground-secondary">
+            {betaRevealed && <BetaUpdatesCard />}
+
+            {/* Five taps reveal the internal-testing channel switch. */}
+            <p className="text-center text-body-xs text-foreground-secondary" onClick={onVersionTap}>
                 {t('version', { version: appVersion })}
             </p>
         </div>

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * The beta-updates switch is deliberately unreachable by accident: it appears
+ * only after five taps on the version line, and only on a native build, since
+ * OTA channels mean nothing on the web.
+ */
+import React from 'react'
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { AboutView } from '../About.view'
+
+const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
+
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Profile/components/BetaUpdatesCard', () => ({
+    BetaUpdatesCard: () => <div data-testid="beta-updates-card" />,
+}))
+
+const tapVersion = (times: number) => {
+    const version = screen.getByText(/^Version /)
+    for (let i = 0; i < times; i++) fireEvent.click(version)
+}
+
+describe('AboutView', () => {
+    it('keeps the beta switch hidden until the fifth tap', () => {
+        render(<AboutView appVersion="1.2.3" />)
+        tapVersion(4)
+        expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
+        tapVersion(1)
+        expect(screen.getByTestId('beta-updates-card')).toBeInTheDocument()
+    })
+
+    it('forgets a partial tap streak once the window lapses', () => {
+        jest.useFakeTimers()
+        try {
+            render(<AboutView appVersion="1.2.3" />)
+            tapVersion(4)
+            jest.advanceTimersByTime(2_000)
+            tapVersion(4)
+            expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
+        } finally {
+            jest.useRealTimers()
+        }
+    })
+})

--- a/src/hooks/__tests__/useOtaChannel.test.ts
+++ b/src/hooks/__tests__/useOtaChannel.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The half-finished exit: the channel is already cleared but the beta bundle is
+ * still running. Reading the channel alone calls that "not on beta", which hides
+ * the card from anyone outside the cohort — and the card is the only way to
+ * finish leaving, on a device no production OTA can reach.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useOtaChannel } from '../useOtaChannel'
+
+const status = {
+    channel: null as string | null,
+    bundleVersion: '1.1.10846',
+    deviceId: 'abc-123',
+    onBuiltinBundle: false,
+}
+const pending = { value: true }
+
+jest.mock('@/utils/capacitor', () => ({ isNativeBridge: () => true }))
+jest.mock('@/utils/capgo-updater', () => ({
+    BETA_OTA_CHANNEL: 'staging',
+    OtaChannelClosedError: class extends Error {},
+    OtaChannelOverrideError: class extends Error {},
+    OtaChannelUnknownError: class extends Error {},
+    OtaResetFailedError: class extends Error {},
+    readOtaChannelStatus: () => Promise.resolve(status),
+    hasPendingBetaExit: () => pending.value,
+    clearPendingBetaExit: () => {
+        pending.value = false
+    },
+}))
+
+beforeEach(() => {
+    pending.value = true
+    status.channel = null
+    status.onBuiltinBundle = false
+})
+
+it('still reads as beta while an exit is owed', async () => {
+    const { result } = renderHook(() => useOtaChannel())
+    await waitFor(() => expect(result.current.status).not.toBeNull())
+    expect(result.current.isBeta).toBe(true)
+})
+
+it('clears the marker once the store bundle is the one running', async () => {
+    status.onBuiltinBundle = true
+    const { result } = renderHook(() => useOtaChannel())
+    await waitFor(() => expect(result.current.status).not.toBeNull())
+    expect(pending.value).toBe(false)
+    expect(result.current.isBeta).toBe(false)
+})
+
+it('keeps the marker while the channel is still beta', async () => {
+    status.channel = 'staging'
+    status.onBuiltinBundle = true
+    await act(async () => {
+        renderHook(() => useOtaChannel())
+    })
+    expect(pending.value).toBe(true)
+})

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -4,7 +4,16 @@ import { useCallback, useEffect, useState } from 'react'
 import { isNativeBridge } from '@/utils/capacitor'
 import { BETA_OTA_CHANNEL, OtaChannelClosedError, type OtaChannelStatus } from '@/utils/capgo-updater'
 
-export type OtaChannelSwitchResult = 'ok' | 'closed' | 'failed'
+/**
+ * - `staged`: on the channel, beta bundle downloaded, waiting for a restart
+ * - `joined`: on the channel with nothing newer to download
+ * - `join-no-bundle`: on the channel, but the bundle could not be fetched — the
+ *   `disable_auto_update_under_native` case after a native release lands here
+ * - `left`: back on the default channel and the store bundle
+ * - `closed`: the channel does not accept self-assignment
+ * - `failed`: the switch itself failed (offline, rate limited, misconfigured)
+ */
+export type OtaChannelSwitchResult = 'staged' | 'joined' | 'join-no-bundle' | 'left' | 'closed' | 'failed'
 
 export interface UseOtaChannel {
     supported: boolean
@@ -41,11 +50,15 @@ export function useOtaChannel(): UseOtaChannel {
             setBusy(true)
             try {
                 const { joinBetaOtaChannel, leaveBetaOtaChannel } = await import('@/utils/capgo-updater')
-                // leaveBetaOtaChannel() reloads the app, so nothing after it runs.
-                if (beta) await joinBetaOtaChannel()
-                else await leaveBetaOtaChannel()
+                if (!beta) {
+                    // Reloads the app onto the store bundle: nothing after this runs.
+                    await leaveBetaOtaChannel()
+                    return 'left'
+                }
+                const outcome = await joinBetaOtaChannel()
                 await refresh()
-                return 'ok'
+                if (outcome === 'staged') return 'staged'
+                return outcome === 'up-to-date' ? 'joined' : 'join-no-bundle'
             } catch (err) {
                 console.warn('[capgo] channel switch failed:', err)
                 return err instanceof OtaChannelClosedError ? 'closed' : 'failed'

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -5,6 +5,7 @@ import { isNativeBridge } from '@/utils/capacitor'
 import {
     BETA_OTA_CHANNEL,
     OtaChannelClosedError,
+    OtaChannelOverrideError,
     OtaResetFailedError,
     type OtaChannelStatus,
 } from '@/utils/capgo-updater'
@@ -19,6 +20,8 @@ import {
  *   UI to catch up
  * - `left-still-beta`: channel unset, but the beta bundle is still running and
  *   no production OTA can replace it — the app has to be reinstalled
+ * - `left-override`: Capgo still routes this device to beta — someone assigned
+ *   it from the dashboard, and only the dashboard can take it back
  * - `closed`: the channel does not accept self-assignment
  * - `failed`: the switch itself failed (offline, rate limited, misconfigured)
  */
@@ -28,6 +31,7 @@ export type OtaChannelSwitchResult =
     | 'join-no-bundle'
     | 'left'
     | 'left-still-beta'
+    | 'left-override'
     | 'closed'
     | 'failed'
 
@@ -81,6 +85,7 @@ export function useOtaChannel(): UseOtaChannel {
                 return outcome === 'up-to-date' ? 'joined' : 'join-no-bundle'
             } catch (err) {
                 console.warn('[capgo] channel switch failed:', err)
+                if (err instanceof OtaChannelOverrideError) return 'left-override'
                 if (err instanceof OtaResetFailedError) return 'left-still-beta'
                 return err instanceof OtaChannelClosedError ? 'closed' : 'failed'
             } finally {

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -80,7 +80,9 @@ export function useOtaChannel(): UseOtaChannel {
                     return 'left'
                 }
                 const outcome = await joinBetaOtaChannel()
-                await refresh()
+                // Best-effort: the join already happened, and a failed status
+                // read must not report it as a failed switch.
+                await refresh().catch(() => undefined)
                 if (outcome === 'staged') return 'staged'
                 return outcome === 'up-to-date' ? 'joined' : 'join-no-bundle'
             } catch (err) {

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { isNativeBridge } from '@/utils/capacitor'
 import {
     BETA_OTA_CHANNEL,
+    clearPendingBetaExit,
+    hasPendingBetaExit,
     OtaChannelClosedError,
     OtaChannelOverrideError,
     OtaChannelUnknownError,
@@ -24,7 +26,8 @@ import {
  * - `left-override`: Capgo still routes this device to beta — someone assigned
  *   it from the dashboard, and only the dashboard can take it back
  * - `left-unconfirmed`: Capgo could not be reached to confirm the exit, so the
- *   device is still on the beta bundle and the switch stays on
+ *   device is still on the beta bundle and the switch stays on, backed by a
+ *   stored marker that survives a restart
  * - `closed`: the channel does not accept self-assignment
  * - `failed`: the switch itself failed (offline, rate limited, misconfigured)
  */
@@ -57,9 +60,17 @@ export function useOtaChannel(): UseOtaChannel {
     const [status, setStatus] = useState<OtaChannelStatus | null>(null)
     const [busy, setBusy] = useState(false)
 
+    const [pendingExit, setPendingExit] = useState(false)
+
     const refresh = useCallback(async () => {
         const { readOtaChannelStatus } = await import('@/utils/capgo-updater')
-        setStatus(await readOtaChannelStatus())
+        const next = await readOtaChannelStatus()
+        setStatus(next)
+        // An unfinished exit is only over once the store bundle is the one
+        // running; until then the device is on beta code whatever the channel says.
+        const owed = hasPendingBetaExit() && !(next.onBuiltinBundle && next.channel !== BETA_OTA_CHANNEL)
+        if (hasPendingBetaExit() && !owed) clearPendingBetaExit()
+        setPendingExit(owed)
     }, [])
 
     // isNativeBridge() reads window, so it can only run after hydration.
@@ -102,5 +113,9 @@ export function useOtaChannel(): UseOtaChannel {
         [refresh]
     )
 
-    return { supported, status, isBeta: status?.channel === BETA_OTA_CHANNEL, busy, setBeta }
+    // A pending exit counts as being on beta: the bundle is still the beta one,
+    // and reading the channel alone would hide the card — and with it the only
+    // way to finish leaving — from anyone outside the cohort.
+    const isBeta = status?.channel === BETA_OTA_CHANNEL || pendingExit
+    return { supported, status, isBeta, busy, setBeta }
 }

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -14,7 +14,9 @@ import {
  * - `joined`: on the channel with nothing newer to download
  * - `join-no-bundle`: on the channel, but the bundle could not be fetched — the
  *   `disable_auto_update_under_native` case after a native release lands here
- * - `left`: back on the default channel and the store bundle
+ * - `left`: back on the default channel. Usually unobservable — reset() reloads
+ *   the app — but a device already on the store bundle stays put and needs the
+ *   UI to catch up
  * - `left-still-beta`: channel unset, but the beta bundle is still running and
  *   no production OTA can replace it — the app has to be reinstalled
  * - `closed`: the channel does not accept self-assignment
@@ -65,8 +67,12 @@ export function useOtaChannel(): UseOtaChannel {
             try {
                 const { joinBetaOtaChannel, leaveBetaOtaChannel } = await import('@/utils/capgo-updater')
                 if (!beta) {
-                    // Reloads the app onto the store bundle: nothing after this runs.
+                    // Normally reloads the app onto the store bundle and nothing
+                    // after this runs — but a device already on that bundle just
+                    // resolves, and then the stale channel would snap the switch
+                    // back to on.
                     await leaveBetaOtaChannel()
+                    await refresh()
                     return 'left'
                 }
                 const outcome = await joinBetaOtaChannel()

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -2,7 +2,12 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { isNativeBridge } from '@/utils/capacitor'
-import { BETA_OTA_CHANNEL, OtaChannelClosedError, type OtaChannelStatus } from '@/utils/capgo-updater'
+import {
+    BETA_OTA_CHANNEL,
+    OtaChannelClosedError,
+    OtaResetFailedError,
+    type OtaChannelStatus,
+} from '@/utils/capgo-updater'
 
 /**
  * - `staged`: on the channel, beta bundle downloaded, waiting for a restart
@@ -10,10 +15,19 @@ import { BETA_OTA_CHANNEL, OtaChannelClosedError, type OtaChannelStatus } from '
  * - `join-no-bundle`: on the channel, but the bundle could not be fetched — the
  *   `disable_auto_update_under_native` case after a native release lands here
  * - `left`: back on the default channel and the store bundle
+ * - `left-still-beta`: channel unset, but the beta bundle is still running and
+ *   no production OTA can replace it — the app has to be reinstalled
  * - `closed`: the channel does not accept self-assignment
  * - `failed`: the switch itself failed (offline, rate limited, misconfigured)
  */
-export type OtaChannelSwitchResult = 'staged' | 'joined' | 'join-no-bundle' | 'left' | 'closed' | 'failed'
+export type OtaChannelSwitchResult =
+    | 'staged'
+    | 'joined'
+    | 'join-no-bundle'
+    | 'left'
+    | 'left-still-beta'
+    | 'closed'
+    | 'failed'
 
 export interface UseOtaChannel {
     supported: boolean
@@ -61,6 +75,7 @@ export function useOtaChannel(): UseOtaChannel {
                 return outcome === 'up-to-date' ? 'joined' : 'join-no-bundle'
             } catch (err) {
                 console.warn('[capgo] channel switch failed:', err)
+                if (err instanceof OtaResetFailedError) return 'left-still-beta'
                 return err instanceof OtaChannelClosedError ? 'closed' : 'failed'
             } finally {
                 setBusy(false)

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -1,0 +1,60 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { isNativeBridge } from '@/utils/capacitor'
+import { BETA_OTA_CHANNEL, OtaChannelClosedError, type OtaChannelStatus } from '@/utils/capgo-updater'
+
+export type OtaChannelSwitchResult = 'ok' | 'closed' | 'failed'
+
+export interface UseOtaChannel {
+    supported: boolean
+    status: OtaChannelStatus | null
+    isBeta: boolean
+    busy: boolean
+    setBeta: (beta: boolean) => Promise<OtaChannelSwitchResult>
+}
+
+/**
+ * Reads and switches the device's Capgo channel. Native-only: the plugin has no
+ * web implementation worth calling, so `supported` stays false everywhere else
+ * and the caller hides the control entirely.
+ */
+export function useOtaChannel(): UseOtaChannel {
+    const [supported, setSupported] = useState(false)
+    const [status, setStatus] = useState<OtaChannelStatus | null>(null)
+    const [busy, setBusy] = useState(false)
+
+    const refresh = useCallback(async () => {
+        const { readOtaChannelStatus } = await import('@/utils/capgo-updater')
+        setStatus(await readOtaChannelStatus())
+    }, [])
+
+    // isNativeBridge() reads window, so it can only run after hydration.
+    useEffect(() => {
+        if (!isNativeBridge()) return
+        setSupported(true)
+        refresh().catch((err) => console.warn('[capgo] channel read failed:', err))
+    }, [refresh])
+
+    const setBeta = useCallback(
+        async (beta: boolean): Promise<OtaChannelSwitchResult> => {
+            setBusy(true)
+            try {
+                const { joinBetaOtaChannel, leaveBetaOtaChannel } = await import('@/utils/capgo-updater')
+                // leaveBetaOtaChannel() reloads the app, so nothing after it runs.
+                if (beta) await joinBetaOtaChannel()
+                else await leaveBetaOtaChannel()
+                await refresh()
+                return 'ok'
+            } catch (err) {
+                console.warn('[capgo] channel switch failed:', err)
+                return err instanceof OtaChannelClosedError ? 'closed' : 'failed'
+            } finally {
+                setBusy(false)
+            }
+        },
+        [refresh]
+    )
+
+    return { supported, status, isBeta: status?.channel === BETA_OTA_CHANNEL, busy, setBeta }
+}

--- a/src/hooks/useOtaChannel.ts
+++ b/src/hooks/useOtaChannel.ts
@@ -6,6 +6,7 @@ import {
     BETA_OTA_CHANNEL,
     OtaChannelClosedError,
     OtaChannelOverrideError,
+    OtaChannelUnknownError,
     OtaResetFailedError,
     type OtaChannelStatus,
 } from '@/utils/capgo-updater'
@@ -22,6 +23,8 @@ import {
  *   no production OTA can replace it — the app has to be reinstalled
  * - `left-override`: Capgo still routes this device to beta — someone assigned
  *   it from the dashboard, and only the dashboard can take it back
+ * - `left-unconfirmed`: Capgo could not be reached to confirm the exit, so the
+ *   device is still on the beta bundle and the switch stays on
  * - `closed`: the channel does not accept self-assignment
  * - `failed`: the switch itself failed (offline, rate limited, misconfigured)
  */
@@ -32,6 +35,7 @@ export type OtaChannelSwitchResult =
     | 'left'
     | 'left-still-beta'
     | 'left-override'
+    | 'left-unconfirmed'
     | 'closed'
     | 'failed'
 
@@ -87,6 +91,7 @@ export function useOtaChannel(): UseOtaChannel {
                 return outcome === 'up-to-date' ? 'joined' : 'join-no-bundle'
             } catch (err) {
                 console.warn('[capgo] channel switch failed:', err)
+                if (err instanceof OtaChannelUnknownError) return 'left-unconfirmed'
                 if (err instanceof OtaChannelOverrideError) return 'left-override'
                 if (err instanceof OtaResetFailedError) return 'left-still-beta'
                 return err instanceof OtaChannelClosedError ? 'closed' : 'failed'

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -530,7 +530,9 @@
                 "bundleLabel": "Running bundle",
                 "deviceLabel": "Device ID",
                 "deviceCopied": "Device ID copied",
-                "joined": "You are on beta updates. Restart the app to load the newest beta build.",
+                "staged": "You are on beta updates. Restart the app to load the newest beta build.",
+                "joined": "You are on beta updates. There is no newer beta build right now.",
+                "joinedWithoutBundle": "You are on beta updates, but no beta build could be downloaded. The app will try again on the next launch.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel."
             }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -521,7 +521,19 @@
             "title": "About Peanut",
             "intro": "Peanut makes dollars easy: hold your balance, send to any @username, and move money on local rails after one ID check. Built by Squirrel Labs.",
             "policiesHeading": "Policies",
-            "version": "Version {version}"
+            "version": "Version {version}",
+            "beta": {
+                "heading": "Beta updates",
+                "description": "Receive builds from the {channel} channel before they ship to everyone. Internal testing only.",
+                "channelLabel": "Update channel",
+                "defaultChannel": "Default",
+                "bundleLabel": "Running bundle",
+                "deviceLabel": "Device ID",
+                "deviceCopied": "Device ID copied",
+                "joined": "You are on beta updates. Restart the app to load the newest beta build.",
+                "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
+                "failed": "Could not change the update channel."
+            }
         }
     },
     "settings": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -537,6 +537,7 @@
                 "leftStillBeta": "Left beta updates, but the app is still running the beta build. Reinstall it from the store to get back to the released version.",
                 "left": "Beta updates off. This device is back on the released version.",
                 "leftOverride": "This device was put on beta from the Capgo dashboard, so the app cannot take it off. Ask an admin to remove the device's channel override.",
+                "leftUnconfirmed": "Could not reach Capgo to confirm the switch, so this device is still on the beta build. Try again when you are back online.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel."
             }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -533,6 +533,8 @@
                 "staged": "You are on beta updates. Restart the app to load the newest beta build.",
                 "joined": "You are on beta updates. There is no newer beta build right now.",
                 "joinedWithoutBundle": "You are on beta updates, but no beta build could be downloaded. The app will try again on the next launch.",
+                "deviceCopyFailed": "Could not copy the device ID.",
+                "leftStillBeta": "Left beta updates, but the app is still running the beta build. Reinstall it from the store to get back to the released version.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel."
             }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -535,6 +535,7 @@
                 "joinedWithoutBundle": "You are on beta updates, but no beta build could be downloaded. The app will try again on the next launch.",
                 "deviceCopyFailed": "Could not copy the device ID.",
                 "leftStillBeta": "Left beta updates, but the app is still running the beta build. Reinstall it from the store to get back to the released version.",
+                "left": "Beta updates off. This device is back on the released version.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel."
             }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -536,6 +536,7 @@
                 "deviceCopyFailed": "Could not copy the device ID.",
                 "leftStillBeta": "Left beta updates, but the app is still running the beta build. Reinstall it from the store to get back to the released version.",
                 "left": "Beta updates off. This device is back on the released version.",
+                "leftOverride": "This device was put on beta from the Capgo dashboard, so the app cannot take it off. Ask an admin to remove the device's channel override.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel."
             }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -536,6 +536,7 @@
                 "deviceCopyFailed": "No se pudo copiar el ID del dispositivo.",
                 "leftStillBeta": "Saliste de las actualizaciones beta, pero la app sigue ejecutando la compilación beta. Reinstalala desde la tienda para volver a la versión publicada.",
                 "left": "Actualizaciones beta desactivadas. Este dispositivo volvió a la versión publicada.",
+                "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones."
             }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -533,6 +533,8 @@
                 "staged": "Ya estás en actualizaciones beta. Reiniciá la app para cargar la compilación beta más reciente.",
                 "joined": "Ya estás en actualizaciones beta. Por ahora no hay una compilación beta más reciente.",
                 "joinedWithoutBundle": "Ya estás en actualizaciones beta, pero no se pudo descargar ninguna compilación beta. La app lo intentará de nuevo en el próximo inicio.",
+                "deviceCopyFailed": "No se pudo copiar el ID del dispositivo.",
+                "leftStillBeta": "Saliste de las actualizaciones beta, pero la app sigue ejecutando la compilación beta. Reinstalala desde la tienda para volver a la versión publicada.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones."
             }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -521,7 +521,19 @@
             "title": "Acerca de Peanut",
             "intro": "Peanut hace fáciles los dólares: guarda tu saldo, envía a cualquier @usuario y mueve dinero por rieles locales después de una sola verificación de identidad. Creado por Squirrel Labs.",
             "policiesHeading": "Políticas",
-            "version": "Versión {version}"
+            "version": "Versión {version}",
+            "beta": {
+                "heading": "Actualizaciones beta",
+                "description": "Recibí compilaciones del canal {channel} antes de que lleguen a todos. Solo para pruebas internas.",
+                "channelLabel": "Canal de actualizaciones",
+                "defaultChannel": "Predeterminado",
+                "bundleLabel": "Paquete en uso",
+                "deviceLabel": "ID del dispositivo",
+                "deviceCopied": "ID del dispositivo copiado",
+                "joined": "Ya estás en actualizaciones beta. Reiniciá la app para cargar la compilación beta más reciente.",
+                "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
+                "failed": "No se pudo cambiar el canal de actualizaciones."
+            }
         }
     },
     "settings": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -535,6 +535,7 @@
                 "joinedWithoutBundle": "Ya estás en actualizaciones beta, pero no se pudo descargar ninguna compilación beta. La app lo intentará de nuevo en el próximo inicio.",
                 "deviceCopyFailed": "No se pudo copiar el ID del dispositivo.",
                 "leftStillBeta": "Saliste de las actualizaciones beta, pero la app sigue ejecutando la compilación beta. Reinstalala desde la tienda para volver a la versión publicada.",
+                "left": "Actualizaciones beta desactivadas. Este dispositivo volvió a la versión publicada.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones."
             }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -530,7 +530,9 @@
                 "bundleLabel": "Paquete en uso",
                 "deviceLabel": "ID del dispositivo",
                 "deviceCopied": "ID del dispositivo copiado",
-                "joined": "Ya estás en actualizaciones beta. Reiniciá la app para cargar la compilación beta más reciente.",
+                "staged": "Ya estás en actualizaciones beta. Reiniciá la app para cargar la compilación beta más reciente.",
+                "joined": "Ya estás en actualizaciones beta. Por ahora no hay una compilación beta más reciente.",
+                "joinedWithoutBundle": "Ya estás en actualizaciones beta, pero no se pudo descargar ninguna compilación beta. La app lo intentará de nuevo en el próximo inicio.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones."
             }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -537,6 +537,7 @@
                 "leftStillBeta": "Saliste de las actualizaciones beta, pero la app sigue ejecutando la compilación beta. Reinstalala desde la tienda para volver a la versión publicada.",
                 "left": "Actualizaciones beta desactivadas. Este dispositivo volvió a la versión publicada.",
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
+                "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones."
             }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -537,6 +537,7 @@
                 "leftStillBeta": "Você saiu das atualizações beta, mas o app ainda está rodando a versão beta. Reinstale pela loja para voltar à versão publicada.",
                 "left": "Atualizações beta desativadas. Este aparelho voltou para a versão publicada.",
                 "leftOverride": "Este aparelho foi colocado em beta pelo painel do Capgo, então o app não consegue tirá-lo. Peça a um administrador para remover a atribuição de canal do aparelho.",
+                "leftUnconfirmed": "Não foi possível falar com o Capgo para confirmar a mudança, então este aparelho continua na versão beta. Tente de novo quando estiver online.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações."
             }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -535,6 +535,7 @@
                 "joinedWithoutBundle": "Você está nas atualizações beta, mas nenhuma versão beta pôde ser baixada. O app tentará de novo na próxima abertura.",
                 "deviceCopyFailed": "Não foi possível copiar o ID do dispositivo.",
                 "leftStillBeta": "Você saiu das atualizações beta, mas o app ainda está rodando a versão beta. Reinstale pela loja para voltar à versão publicada.",
+                "left": "Atualizações beta desativadas. Este aparelho voltou para a versão publicada.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações."
             }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -536,6 +536,7 @@
                 "deviceCopyFailed": "Não foi possível copiar o ID do dispositivo.",
                 "leftStillBeta": "Você saiu das atualizações beta, mas o app ainda está rodando a versão beta. Reinstale pela loja para voltar à versão publicada.",
                 "left": "Atualizações beta desativadas. Este aparelho voltou para a versão publicada.",
+                "leftOverride": "Este aparelho foi colocado em beta pelo painel do Capgo, então o app não consegue tirá-lo. Peça a um administrador para remover a atribuição de canal do aparelho.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações."
             }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -521,7 +521,19 @@
             "title": "Sobre o Peanut",
             "intro": "O Peanut torna os dólares fáceis: guarde seu saldo, envie para qualquer @usuário e mova dinheiro pelos trilhos locais após uma única verificação de identidade. Criado pela Squirrel Labs.",
             "policiesHeading": "Políticas",
-            "version": "Versão {version}"
+            "version": "Versão {version}",
+            "beta": {
+                "heading": "Atualizações beta",
+                "description": "Receba versões do canal {channel} antes de chegarem a todos. Apenas para testes internos.",
+                "channelLabel": "Canal de atualizações",
+                "defaultChannel": "Padrão",
+                "bundleLabel": "Pacote em uso",
+                "deviceLabel": "ID do dispositivo",
+                "deviceCopied": "ID do dispositivo copiado",
+                "joined": "Você está nas atualizações beta. Reinicie o app para carregar a versão beta mais recente.",
+                "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
+                "failed": "Não foi possível alterar o canal de atualizações."
+            }
         }
     },
     "settings": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -533,6 +533,8 @@
                 "staged": "Você está nas atualizações beta. Reinicie o app para carregar a versão beta mais recente.",
                 "joined": "Você está nas atualizações beta. No momento não há uma versão beta mais recente.",
                 "joinedWithoutBundle": "Você está nas atualizações beta, mas nenhuma versão beta pôde ser baixada. O app tentará de novo na próxima abertura.",
+                "deviceCopyFailed": "Não foi possível copiar o ID do dispositivo.",
+                "leftStillBeta": "Você saiu das atualizações beta, mas o app ainda está rodando a versão beta. Reinstale pela loja para voltar à versão publicada.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações."
             }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -530,7 +530,9 @@
                 "bundleLabel": "Pacote em uso",
                 "deviceLabel": "ID do dispositivo",
                 "deviceCopied": "ID do dispositivo copiado",
-                "joined": "Você está nas atualizações beta. Reinicie o app para carregar a versão beta mais recente.",
+                "staged": "Você está nas atualizações beta. Reinicie o app para carregar a versão beta mais recente.",
+                "joined": "Você está nas atualizações beta. No momento não há uma versão beta mais recente.",
+                "joinedWithoutBundle": "Você está nas atualizações beta, mas nenhuma versão beta pôde ser baixada. O app tentará de novo na próxima abertura.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações."
             }

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -175,6 +175,26 @@ describe('beta channel opt-in', () => {
 
     // A staging bundle outranks every production one, so unsetting the channel
     // alone would leave the tester stuck on beta code forever.
+    // Same hazard as the join, worse outcome: a check resolved against staging
+    // that lands after the reset stages beta code on a device with no channel.
+    it('waits for an in-flight check before unsetting and resetting', async () => {
+        const { leaveBetaOtaChannel } = await import('../capgo-updater')
+        let releaseLaunchCheck: (value: { url?: string; version?: string }) => void = () => {}
+        mockUpdater.getLatest.mockReturnValueOnce(new Promise((resolve) => (releaseLaunchCheck = resolve)))
+
+        await initCapgoUpdater()
+        await jest.advanceTimersByTimeAsync(5_000)
+
+        const left = leaveBetaOtaChannel()
+        await jest.advanceTimersByTimeAsync(0)
+        expect(mockUpdater.unsetChannel).not.toHaveBeenCalled()
+
+        releaseLaunchCheck({})
+        await left
+        expect(mockUpdater.unsetChannel).toHaveBeenCalled()
+        expect(mockUpdater.reset).toHaveBeenCalled()
+    })
+
     it('drops back to the store bundle when leaving', async () => {
         const { leaveBetaOtaChannel } = await import('../capgo-updater')
         await leaveBetaOtaChannel()

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -12,6 +12,7 @@ const mockUpdater = {
     next: jest.fn().mockResolvedValue(undefined),
     setChannel: jest.fn(),
     unsetChannel: jest.fn().mockResolvedValue(undefined),
+    getChannel: jest.fn(),
     reset: jest.fn().mockResolvedValue(undefined),
 }
 
@@ -90,6 +91,7 @@ describe('beta channel opt-in', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockUpdater.setChannel.mockResolvedValue({ status: 'ok' })
+        mockUpdater.getChannel.mockResolvedValue({ channel: null, status: 'default' })
         mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
     })
 
@@ -204,6 +206,23 @@ describe('beta channel opt-in', () => {
 
     // Channel unset + beta bundle still running is the one state no OTA can
     // repair, so a failed reset must not be reported as a clean exit.
+    // unsetChannel() is local-only on both platforms (it drops a stored key), so a
+    // device forced onto the channel from the dashboard stays there — resetting
+    // would undo itself on the next launch and reload away the explanation.
+    it('refuses to claim an exit while Capgo still routes the device to beta', async () => {
+        const { leaveBetaOtaChannel, OtaChannelOverrideError } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockResolvedValue({ channel: 'staging', status: 'override' })
+        await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelOverrideError)
+        expect(mockUpdater.reset).not.toHaveBeenCalled()
+    })
+
+    it('still resets when the effective channel cannot be read', async () => {
+        const { leaveBetaOtaChannel } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockRejectedValue(new Error('Failed to fetch'))
+        await expect(leaveBetaOtaChannel()).resolves.toBeUndefined()
+        expect(mockUpdater.reset).toHaveBeenCalled()
+    })
+
     it('retries a failed reset and reports the device is still on beta code', async () => {
         const { leaveBetaOtaChannel, OtaResetFailedError } = await import('../capgo-updater')
         mockUpdater.reset.mockRejectedValue(new Error('reset failed'))

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -122,15 +122,18 @@ describe('beta channel opt-in', () => {
         expect(mockUpdater.getLatest).not.toHaveBeenCalled()
     })
 
-    it('reads the reason off a CapacitorException data code', async () => {
-        const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
-        mockUpdater.setChannel.mockRejectedValue(
-            Object.assign(new Error('setChannel failed'), {
-                data: { error: 'channel_private' },
-            })
-        )
-        await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)
-    })
+    // iOS normalises the private-channel case to `channel_private`; Android
+    // rejects with the backend's own codes, which read nothing like it.
+    it.each(['channel_private', 'cannot_update_via_private_channel', 'channel_self_set_not_allowed'])(
+        'reads %s off a CapacitorException data code',
+        async (code) => {
+            const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
+            mockUpdater.setChannel.mockRejectedValue(
+                Object.assign(new Error('setChannel failed'), { data: { error: code } })
+            )
+            await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)
+        }
+    )
 
     // A timeout must not send the tester chasing a dashboard toggle that is
     // already correct.
@@ -153,5 +156,20 @@ describe('beta channel opt-in', () => {
         await leaveBetaOtaChannel()
         expect(mockUpdater.unsetChannel).toHaveBeenCalled()
         expect(mockUpdater.reset).toHaveBeenCalled()
+    })
+
+    // Channel unset + beta bundle still running is the one state no OTA can
+    // repair, so a failed reset must not be reported as a clean exit.
+    it('retries a failed reset and reports the device is still on beta code', async () => {
+        const { leaveBetaOtaChannel, OtaResetFailedError } = await import('../capgo-updater')
+        mockUpdater.reset.mockRejectedValue(new Error('reset failed'))
+        await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaResetFailedError)
+        expect(mockUpdater.reset).toHaveBeenCalledTimes(2)
+    })
+
+    it('accepts a reset that only succeeds on the retry', async () => {
+        const { leaveBetaOtaChannel } = await import('../capgo-updater')
+        mockUpdater.reset.mockRejectedValueOnce(new Error('reset failed')).mockResolvedValueOnce(undefined)
+        await expect(leaveBetaOtaChannel()).resolves.toBeUndefined()
     })
 })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -216,9 +216,25 @@ describe('beta channel opt-in', () => {
         expect(mockUpdater.reset).not.toHaveBeenCalled()
     })
 
-    it('still resets when the effective channel cannot be read', async () => {
+    // Resetting on an unreadable answer is the forced tester's worst case: the app
+    // reloads onto the store bundle, the reload eats the explanation, and the
+    // surviving override routes the device back to beta on the next check.
+    it.each([
+        ['the request fails', () => mockUpdater.getChannel.mockRejectedValue(new Error('Failed to fetch'))],
+        [
+            'the plugin is rate limited',
+            () => mockUpdater.getChannel.mockResolvedValue({ error: 'rate_limit_exceeded' }),
+        ],
+    ])('treats an unreadable effective channel as indeterminate when %s', async (_case, arrange) => {
+        const { leaveBetaOtaChannel, OtaChannelUnknownError } = await import('../capgo-updater')
+        arrange()
+        await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelUnknownError)
+        expect(mockUpdater.reset).not.toHaveBeenCalled()
+    })
+
+    it('resets once Capgo confirms no channel is assigned', async () => {
         const { leaveBetaOtaChannel } = await import('../capgo-updater')
-        mockUpdater.getChannel.mockRejectedValue(new Error('Failed to fetch'))
+        mockUpdater.getChannel.mockResolvedValue({ channel: '', status: 'default' })
         await expect(leaveBetaOtaChannel()).resolves.toBeUndefined()
         expect(mockUpdater.reset).toHaveBeenCalled()
     })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -93,6 +93,30 @@ describe('beta channel opt-in', () => {
         mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
     })
 
+    // The launch check can still be downloading when the tester joins. Two
+    // overlapping checks both call next(), and the bundle that boots is whichever
+    // write lands last — possibly the one resolved against the old channel.
+    it('waits for an in-flight launch check instead of racing it', async () => {
+        const { joinBetaOtaChannel } = await import('../capgo-updater')
+        let releaseLaunchCheck: (value: { url?: string; version?: string }) => void = () => {}
+        mockUpdater.getLatest.mockReturnValueOnce(new Promise((resolve) => (releaseLaunchCheck = resolve)))
+
+        await initCapgoUpdater()
+        await jest.advanceTimersByTimeAsync(5_000)
+        expect(mockUpdater.getLatest).toHaveBeenCalledTimes(1)
+
+        mockUpdater.getLatest.mockResolvedValue({ url: 'https://bundles/beta', version: '1.1.10846' })
+        mockUpdater.download.mockResolvedValue({ id: 'beta-bundle' })
+        const joined = joinBetaOtaChannel()
+        await jest.advanceTimersByTimeAsync(0)
+        expect(mockUpdater.getLatest).toHaveBeenCalledTimes(1)
+
+        releaseLaunchCheck({})
+        await expect(joined).resolves.toBe('staged')
+        expect(mockUpdater.getLatest).toHaveBeenCalledTimes(2)
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'beta-bundle' })
+    })
+
     it('joins the staging channel and stages its bundle straight away', async () => {
         const { joinBetaOtaChannel, BETA_OTA_CHANNEL } = await import('../capgo-updater')
         mockUpdater.getLatest.mockResolvedValue({ url: 'https://bundles/1.1.10846', version: '1.1.10846' })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -1,7 +1,8 @@
 /**
  * Log-level contract for OTA update-check failures: transient failures stay at
  * info (invisible to Sentry's captureConsoleIntegration), known-fatal patterns
- * and persistent streaks escalate to error.
+ * and persistent streaks escalate to error. Plus the beta-channel opt-in, which
+ * must never strand a tester on a bundle production can no longer replace.
  */
 const mockUpdater = {
     notifyAppReady: jest.fn().mockResolvedValue(undefined),
@@ -9,6 +10,9 @@ const mockUpdater = {
     getLatest: jest.fn(),
     download: jest.fn(),
     next: jest.fn().mockResolvedValue(undefined),
+    setChannel: jest.fn(),
+    unsetChannel: jest.fn().mockResolvedValue(undefined),
+    reset: jest.fn().mockResolvedValue(undefined),
 }
 
 jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
@@ -80,4 +84,41 @@ it('restarts the streak when the failure message changes', async () => {
     mockUpdater.getLatest.mockRejectedValue(new Error('Request timed out'))
     await launch()
     expect(error).not.toHaveBeenCalled()
+})
+
+describe('beta channel opt-in', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUpdater.setChannel.mockResolvedValue({ status: 'ok' })
+        mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
+    })
+
+    it('joins the staging channel and pulls its bundle straight away', async () => {
+        const { joinBetaOtaChannel, BETA_OTA_CHANNEL } = await import('../capgo-updater')
+        await joinBetaOtaChannel()
+        expect(mockUpdater.setChannel).toHaveBeenCalledWith({ channel: BETA_OTA_CHANNEL })
+        expect(mockUpdater.getLatest).toHaveBeenCalled()
+    })
+
+    it('reports a channel that does not accept self-assignment', async () => {
+        const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
+        mockUpdater.setChannel.mockRejectedValue(new Error('channel_not_found'))
+        await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)
+        expect(mockUpdater.getLatest).not.toHaveBeenCalled()
+    })
+
+    it('treats an error field in the response as a rejection', async () => {
+        const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
+        mockUpdater.setChannel.mockResolvedValue({ status: 'error', error: 'disabled_by_config' })
+        await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)
+    })
+
+    // A staging bundle outranks every production one, so unsetting the channel
+    // alone would leave the tester stuck on beta code forever.
+    it('drops back to the store bundle when leaving', async () => {
+        const { leaveBetaOtaChannel } = await import('../capgo-updater')
+        await leaveBetaOtaChannel()
+        expect(mockUpdater.unsetChannel).toHaveBeenCalled()
+        expect(mockUpdater.reset).toHaveBeenCalled()
+    })
 })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -93,11 +93,26 @@ describe('beta channel opt-in', () => {
         mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
     })
 
-    it('joins the staging channel and pulls its bundle straight away', async () => {
+    it('joins the staging channel and stages its bundle straight away', async () => {
         const { joinBetaOtaChannel, BETA_OTA_CHANNEL } = await import('../capgo-updater')
-        await joinBetaOtaChannel()
+        mockUpdater.getLatest.mockResolvedValue({ url: 'https://bundles/1.1.10846', version: '1.1.10846' })
+        mockUpdater.download.mockResolvedValue({ id: 'beta-bundle' })
+        await expect(joinBetaOtaChannel()).resolves.toBe('staged')
         expect(mockUpdater.setChannel).toHaveBeenCalledWith({ channel: BETA_OTA_CHANNEL })
-        expect(mockUpdater.getLatest).toHaveBeenCalled()
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'beta-bundle' })
+    })
+
+    // The tester is on the channel, but nothing is pending — telling them to
+    // restart would send them looking for a build that was never downloaded.
+    it('separates "joined, nothing new" from "joined, bundle waiting"', async () => {
+        const { joinBetaOtaChannel } = await import('../capgo-updater')
+        await expect(joinBetaOtaChannel()).resolves.toBe('up-to-date')
+    })
+
+    it('reports a failed download rather than a staged bundle', async () => {
+        const { joinBetaOtaChannel } = await import('../capgo-updater')
+        mockUpdater.getLatest.mockRejectedValue(new Error('disable_auto_update_under_native'))
+        await expect(joinBetaOtaChannel()).resolves.toBe('failed')
     })
 
     it('reports a channel that does not accept self-assignment', async () => {
@@ -107,7 +122,25 @@ describe('beta channel opt-in', () => {
         expect(mockUpdater.getLatest).not.toHaveBeenCalled()
     })
 
-    it('treats an error field in the response as a rejection', async () => {
+    it('reads the reason off a CapacitorException data code', async () => {
+        const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
+        mockUpdater.setChannel.mockRejectedValue(
+            Object.assign(new Error('setChannel failed'), {
+                data: { error: 'channel_private' },
+            })
+        )
+        await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)
+    })
+
+    // A timeout must not send the tester chasing a dashboard toggle that is
+    // already correct.
+    it('leaves a network failure as an ordinary error', async () => {
+        const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
+        mockUpdater.setChannel.mockRejectedValue(new Error('Failed to fetch'))
+        await expect(joinBetaOtaChannel()).rejects.not.toBeInstanceOf(OtaChannelClosedError)
+    })
+
+    it('treats a closed-channel code in the response as a rejection', async () => {
         const { joinBetaOtaChannel, OtaChannelClosedError } = await import('../capgo-updater')
         mockUpdater.setChannel.mockResolvedValue({ status: 'error', error: 'disabled_by_config' })
         await expect(joinBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelClosedError)

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -90,6 +90,10 @@ it('restarts the streak when the failure message changes', async () => {
 describe('beta channel opt-in', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        // clearAllMocks wipes calls, not implementations: a rejection set by one
+        // test leaks into the next one that expects the happy path.
+        mockUpdater.reset.mockResolvedValue(undefined)
+        mockUpdater.unsetChannel.mockResolvedValue(undefined)
         mockUpdater.setChannel.mockResolvedValue({ status: 'ok' })
         mockUpdater.getChannel.mockResolvedValue({ channel: null, status: 'default' })
         mockUpdater.getLatest.mockRejectedValue(new Error('No new version available'))
@@ -230,6 +234,30 @@ describe('beta channel opt-in', () => {
         arrange()
         await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelUnknownError)
         expect(mockUpdater.reset).not.toHaveBeenCalled()
+    })
+
+    // The state this marker exists for: channel cleared, beta bundle still running,
+    // and — for a tester outside the cohort — no card left to retry from.
+    it('records the owed exit before it clears anything', async () => {
+        const { leaveBetaOtaChannel, hasPendingBetaExit } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockRejectedValue(new Error('Failed to fetch'))
+        await expect(leaveBetaOtaChannel()).rejects.toBeTruthy()
+        expect(hasPendingBetaExit()).toBe(true)
+    })
+
+    it('keeps the marker when the reset itself fails', async () => {
+        const { leaveBetaOtaChannel, hasPendingBetaExit } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockResolvedValue({ channel: '', status: 'default' })
+        mockUpdater.reset.mockRejectedValue(new Error('reset failed'))
+        await expect(leaveBetaOtaChannel()).rejects.toBeTruthy()
+        expect(hasPendingBetaExit()).toBe(true)
+    })
+
+    it('clears the marker on a reset that resolves without reloading', async () => {
+        const { leaveBetaOtaChannel, hasPendingBetaExit } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockResolvedValue({ channel: '', status: 'default' })
+        await leaveBetaOtaChannel()
+        expect(hasPendingBetaExit()).toBe(false)
     })
 
     it('resets once Capgo confirms no channel is assigned', async () => {

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -56,7 +56,7 @@ export async function initCapgoUpdater(
     let updateCheckTimer: ReturnType<typeof setTimeout> | undefined
     if (!isDemoMode()) {
         updateCheckTimer = setTimeout(
-            () => void checkAndStageUpdate(onUpdateAvailable, onUpdateFailed),
+            () => void queueUpdateCheck(onUpdateAvailable, onUpdateFailed),
             UPDATE_CHECK_DELAY_MS
         )
     }
@@ -73,6 +73,26 @@ const UPDATE_CHECK_DELAY_MS = 5_000
 // opt-in needs it, because "channel switched" and "beta bundle waiting" are not
 // the same thing and a tester told to restart for nothing chases a ghost.
 export type OtaCheckOutcome = 'staged' | 'up-to-date' | 'failed'
+
+// One check at a time, whoever asks. The launch check can still be downloading
+// when a tester joins the beta channel, and two overlapping checks both call
+// next(): the bundle that boots is whichever write lands last, which may be the
+// one resolved against the channel the device just left. Queueing rather than
+// sharing the in-flight promise matters — the join needs a check made AFTER its
+// setChannel, not the launch check's verdict on the old channel.
+let pendingCheck: Promise<void> = Promise.resolve()
+
+function queueUpdateCheck(
+    onUpdateAvailable?: (bundle: BundleInfo) => void,
+    onUpdateFailed?: (error: string) => void
+): Promise<OtaCheckOutcome> {
+    const outcome = pendingCheck.then(() => checkAndStageUpdate(onUpdateAvailable, onUpdateFailed))
+    pendingCheck = outcome.then(
+        () => undefined,
+        () => undefined
+    )
+    return outcome
+}
 
 async function checkAndStageUpdate(
     onUpdateAvailable?: (bundle: BundleInfo) => void,
@@ -212,7 +232,7 @@ export async function joinBetaOtaChannel(): Promise<OtaCheckOutcome> {
         if (isClosedChannel(result.error)) throw new OtaChannelClosedError(result.error)
         throw new Error(result.error)
     }
-    return checkAndStageUpdate()
+    return queueUpdateCheck()
 }
 
 // A device that unset its channel but kept the beta bundle is the worst state of

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -163,10 +163,18 @@ export interface OtaChannelStatus {
 // sends people chasing a dashboard toggle that is already correct.
 export class OtaChannelClosedError extends Error {}
 
-const CLOSED_CHANNEL_CODES = ['channel_private', 'disabled_by_config', 'channel_not_found', 'cannot_set_channel']
+// Both platforms reject setChannel() with a CapacitorException carrying
+// `data.error`: iOS normalises the private-channel case to `channel_private`,
+// Android passes the backend's own code straight through. `disabled_by_config`
+// (allowSetDefaultChannel off) and `channel_not_found` arrive in the message.
+const CLOSED_CHANNEL_CODES = [
+    'channel_private',
+    'cannot_update_via_private_channel',
+    'channel_self_set_not_allowed',
+    'disabled_by_config',
+    'channel_not_found',
+]
 
-// The plugin reports the reason as a CapacitorException `data.error` code on iOS
-// and folds it into the message on Android; check both.
 function isClosedChannel(reason: unknown): boolean {
     const code = (reason as { data?: { error?: unknown } } | null)?.data?.error
     const message = reason instanceof Error ? reason.message : String(reason ?? '')
@@ -207,11 +215,26 @@ export async function joinBetaOtaChannel(): Promise<OtaCheckOutcome> {
     return checkAndStageUpdate()
 }
 
+// A device that unset its channel but kept the beta bundle is the worst state of
+// the two: production versions sort below it, so nothing will ever replace it.
+export class OtaResetFailedError extends Error {}
+
 // Beta bundles carry a higher version than production's, so no production OTA
 // can ever overwrite one: reset() back to the store bundle is the only way out,
-// and it reloads the app on the spot.
+// and it reloads the app on the spot. reset() resolving is therefore the unusual
+// path (the device was already on the builtin bundle) — a rejection means the
+// channel is gone but the beta code is still running, so retry once and say so
+// rather than reporting a clean exit.
 export async function leaveBetaOtaChannel(): Promise<void> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     await CapacitorUpdater.unsetChannel({})
-    await CapacitorUpdater.reset()
+    try {
+        await CapacitorUpdater.reset()
+    } catch {
+        try {
+            await CapacitorUpdater.reset()
+        } catch (err) {
+            throw new OtaResetFailedError(err instanceof Error ? err.message : String(err ?? ''))
+        }
+    }
 }

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -74,24 +74,31 @@ const UPDATE_CHECK_DELAY_MS = 5_000
 // the same thing and a tester told to restart for nothing chases a ghost.
 export type OtaCheckOutcome = 'staged' | 'up-to-date' | 'failed'
 
-// One check at a time, whoever asks. The launch check can still be downloading
-// when a tester joins the beta channel, and two overlapping checks both call
-// next(): the bundle that boots is whichever write lands last, which may be the
-// one resolved against the channel the device just left. Queueing rather than
-// sharing the in-flight promise matters — the join needs a check made AFTER its
-// setChannel, not the launch check's verdict on the old channel.
-let pendingCheck: Promise<void> = Promise.resolve()
+// One OTA operation at a time, whoever asks. The launch check can still be
+// downloading when a tester flips the beta switch, and an unserialized check
+// calls next() with a bundle chosen for the channel the device is leaving —
+// which is how a device ends up booting beta code with the channel already
+// unset, the one state no production OTA can repair.
+//
+// Queueing rather than sharing the in-flight promise matters: the join needs a
+// check made AFTER its setChannel, not the launch check's verdict on the old
+// channel.
+let pendingOtaWork: Promise<void> = Promise.resolve()
+
+function queueOtaWork<T>(task: () => Promise<T>): Promise<T> {
+    const result = pendingOtaWork.then(task, task)
+    pendingOtaWork = result.then(
+        () => undefined,
+        () => undefined
+    )
+    return result
+}
 
 function queueUpdateCheck(
     onUpdateAvailable?: (bundle: BundleInfo) => void,
     onUpdateFailed?: (error: string) => void
 ): Promise<OtaCheckOutcome> {
-    const outcome = pendingCheck.then(() => checkAndStageUpdate(onUpdateAvailable, onUpdateFailed))
-    pendingCheck = outcome.then(
-        () => undefined,
-        () => undefined
-    )
-    return outcome
+    return queueOtaWork(() => checkAndStageUpdate(onUpdateAvailable, onUpdateFailed))
 }
 
 async function checkAndStageUpdate(
@@ -245,16 +252,21 @@ export class OtaResetFailedError extends Error {}
 // path (the device was already on the builtin bundle) — a rejection means the
 // channel is gone but the beta code is still running, so retry once and say so
 // rather than reporting a clean exit.
+//
+// Queued with the checks: a check still in flight would otherwise stage the beta
+// bundle it had already chosen right after the reset cleared it.
 export async function leaveBetaOtaChannel(): Promise<void> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
-    await CapacitorUpdater.unsetChannel({})
-    try {
-        await CapacitorUpdater.reset()
-    } catch {
+    return queueOtaWork(async () => {
+        await CapacitorUpdater.unsetChannel({})
         try {
             await CapacitorUpdater.reset()
-        } catch (err) {
-            throw new OtaResetFailedError(err instanceof Error ? err.message : String(err ?? ''))
+        } catch {
+            try {
+                await CapacitorUpdater.reset()
+            } catch (err) {
+                throw new OtaResetFailedError(err instanceof Error ? err.message : String(err ?? ''))
+            }
         }
-    }
+    })
 }

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -253,6 +253,11 @@ export class OtaResetFailedError extends Error {}
 // and nothing in the app can undo it.
 export class OtaChannelOverrideError extends Error {}
 
+// Capgo could not say which channel it will serve. Resetting on that guess is how
+// a forced tester gets reloaded onto the store bundle and quietly routed back to
+// beta on the next check, with the reload having eaten the explanation.
+export class OtaChannelUnknownError extends Error {}
+
 // Beta bundles carry a higher version than production's, so no production OTA
 // can ever overwrite one: reset() back to the store bundle is the only way out,
 // and it reloads the app on the spot. reset() resolving is therefore the unusual
@@ -267,12 +272,14 @@ export async function leaveBetaOtaChannel(): Promise<void> {
     return queueOtaWork(async () => {
         await CapacitorUpdater.unsetChannel({})
 
-        // getChannel() asks the backend what it will actually serve. Still the
-        // beta channel means a server-side assignment survived the unset, so
-        // resetting here would undo itself on the next launch — and take the
-        // explanation with it, since reset() reloads the app.
+        // getChannel() asks the backend what it will actually serve, and only a
+        // successful, channel-bearing answer licenses the reset. Offline, rate
+        // limited, or an error field means indeterminate — not "clear".
         const effective = await CapacitorUpdater.getChannel().catch(() => null)
-        if (effective?.channel === BETA_OTA_CHANNEL) {
+        if (!effective || effective.error) {
+            throw new OtaChannelUnknownError(effective?.error ?? 'the effective channel could not be read')
+        }
+        if (effective.channel === BETA_OTA_CHANNEL) {
             throw new OtaChannelOverrideError(`${BETA_OTA_CHANNEL} is still assigned to this device`)
         }
 

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -246,6 +246,13 @@ export async function joinBetaOtaChannel(): Promise<OtaCheckOutcome> {
 // the two: production versions sort below it, so nothing will ever replace it.
 export class OtaResetFailedError extends Error {}
 
+// A device Capgo itself routes to the beta channel — forced from the dashboard,
+// which is the documented way to enrol someone outside the cohort. unsetChannel()
+// only clears the plugin's local preference (verified in the plugin source: both
+// platforms just drop a stored key and return ok), so this assignment outlives it
+// and nothing in the app can undo it.
+export class OtaChannelOverrideError extends Error {}
+
 // Beta bundles carry a higher version than production's, so no production OTA
 // can ever overwrite one: reset() back to the store bundle is the only way out,
 // and it reloads the app on the spot. reset() resolving is therefore the unusual
@@ -259,6 +266,16 @@ export async function leaveBetaOtaChannel(): Promise<void> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     return queueOtaWork(async () => {
         await CapacitorUpdater.unsetChannel({})
+
+        // getChannel() asks the backend what it will actually serve. Still the
+        // beta channel means a server-side assignment survived the unset, so
+        // resetting here would undo itself on the next launch — and take the
+        // explanation with it, since reset() reloads the app.
+        const effective = await CapacitorUpdater.getChannel().catch(() => null)
+        if (effective?.channel === BETA_OTA_CHANNEL) {
+            throw new OtaChannelOverrideError(`${BETA_OTA_CHANNEL} is still assigned to this device`)
+        }
+
         try {
             await CapacitorUpdater.reset()
         } catch {

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -69,10 +69,15 @@ export async function initCapgoUpdater(
 
 const UPDATE_CHECK_DELAY_MS = 5_000
 
+// What one update check actually achieved. The launch path ignores it; the beta
+// opt-in needs it, because "channel switched" and "beta bundle waiting" are not
+// the same thing and a tester told to restart for nothing chases a ghost.
+export type OtaCheckOutcome = 'staged' | 'up-to-date' | 'failed'
+
 async function checkAndStageUpdate(
     onUpdateAvailable?: (bundle: BundleInfo) => void,
     onUpdateFailed?: (error: string) => void
-): Promise<void> {
+): Promise<OtaCheckOutcome> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     try {
         const latest = await CapacitorUpdater.getLatest()
@@ -90,14 +95,17 @@ async function checkAndStageUpdate(
             // UI out from under the user). set() reloads IMMEDIATELY; next()
             // is the deferred variant.
             await CapacitorUpdater.next({ id: bundle.id })
+            removeStoredValue(FAILURE_STREAK_KEY)
+            return 'staged'
         }
         removeStoredValue(FAILURE_STREAK_KEY)
+        return 'up-to-date'
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err ?? '')
         // "No new version available" is the normal up-to-date path, not a failure.
         if (message === 'No new version available') {
             removeStoredValue(FAILURE_STREAK_KEY)
-            return
+            return 'up-to-date'
         }
         // captureConsoleIntegration turns console.error into a Sentry event, and
         // this updater runs on every launch — transient CDN/network failures that
@@ -114,6 +122,7 @@ async function checkAndStageUpdate(
             console.info('[capgo] update check failed:', message)
         }
         onUpdateFailed?.(message)
+        return 'failed'
     }
 }
 
@@ -148,10 +157,21 @@ export interface OtaChannelStatus {
     deviceId: string | null
 }
 
-// Capgo rejects setChannel() unless the channel allows self-assignment, and the
-// plugin surfaces that as a plain Error. Distinguish it so the UI can say what
-// has to change instead of "something went wrong".
+// Capgo rejects setChannel() unless the channel allows self-assignment. That is
+// a standing configuration fact the tester can act on ("ask an admin"), unlike a
+// timeout — so it must not swallow every other rejection, or a flaky network
+// sends people chasing a dashboard toggle that is already correct.
 export class OtaChannelClosedError extends Error {}
+
+const CLOSED_CHANNEL_CODES = ['channel_private', 'disabled_by_config', 'channel_not_found', 'cannot_set_channel']
+
+// The plugin reports the reason as a CapacitorException `data.error` code on iOS
+// and folds it into the message on Android; check both.
+function isClosedChannel(reason: unknown): boolean {
+    const code = (reason as { data?: { error?: unknown } } | null)?.data?.error
+    const message = reason instanceof Error ? reason.message : String(reason ?? '')
+    return CLOSED_CHANNEL_CODES.some((closed) => code === closed || message.includes(closed))
+}
 
 export async function readOtaChannelStatus(): Promise<OtaChannelStatus> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
@@ -168,17 +188,23 @@ export async function readOtaChannelStatus(): Promise<OtaChannelStatus> {
 }
 
 // Join the beta channel and pull its bundle straight away. The bundle applies on
-// the next launch, like every other OTA — next() rather than set().
-export async function joinBetaOtaChannel(): Promise<void> {
+// the next launch, like every other OTA — next() rather than set(). The returned
+// outcome is what the switch reports: a device whose binary already outranks the
+// beta bundle joins the channel and downloads nothing.
+export async function joinBetaOtaChannel(): Promise<OtaCheckOutcome> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     let result
     try {
         result = await CapacitorUpdater.setChannel({ channel: BETA_OTA_CHANNEL })
     } catch (err) {
-        throw new OtaChannelClosedError(err instanceof Error ? err.message : String(err ?? ''))
+        if (isClosedChannel(err)) throw new OtaChannelClosedError(err instanceof Error ? err.message : String(err))
+        throw err
     }
-    if (result.error) throw new OtaChannelClosedError(result.error)
-    await checkAndStageUpdate()
+    if (result.error) {
+        if (isClosedChannel(result.error)) throw new OtaChannelClosedError(result.error)
+        throw new Error(result.error)
+    }
+    return checkAndStageUpdate()
 }
 
 // Beta bundles carry a higher version than production's, so no production OTA

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -136,3 +136,56 @@ function recordFailureStreak(message: string): number {
     writeStoredValue(FAILURE_STREAK_KEY, JSON.stringify({ message, count }))
     return count
 }
+
+// The channel every merge to `dev` publishes to (capgo-deploy.yml). Testers opt
+// in from the About screen; every other install stays on the app's default
+// channel (production) and never sees these bundles.
+export const BETA_OTA_CHANNEL = 'staging'
+
+export interface OtaChannelStatus {
+    channel: string | null
+    bundleVersion: string | null
+    deviceId: string | null
+}
+
+// Capgo rejects setChannel() unless the channel allows self-assignment, and the
+// plugin surfaces that as a plain Error. Distinguish it so the UI can say what
+// has to change instead of "something went wrong".
+export class OtaChannelClosedError extends Error {}
+
+export async function readOtaChannelStatus(): Promise<OtaChannelStatus> {
+    const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+    const [channel, current, device] = await Promise.all([
+        CapacitorUpdater.getChannel().catch(() => null),
+        CapacitorUpdater.current().catch(() => null),
+        CapacitorUpdater.getDeviceId().catch(() => null),
+    ])
+    return {
+        channel: channel?.channel ?? null,
+        bundleVersion: current?.bundle?.version ?? null,
+        deviceId: device?.deviceId ?? null,
+    }
+}
+
+// Join the beta channel and pull its bundle straight away. The bundle applies on
+// the next launch, like every other OTA — next() rather than set().
+export async function joinBetaOtaChannel(): Promise<void> {
+    const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+    let result
+    try {
+        result = await CapacitorUpdater.setChannel({ channel: BETA_OTA_CHANNEL })
+    } catch (err) {
+        throw new OtaChannelClosedError(err instanceof Error ? err.message : String(err ?? ''))
+    }
+    if (result.error) throw new OtaChannelClosedError(result.error)
+    await checkAndStageUpdate()
+}
+
+// Beta bundles carry a higher version than production's, so no production OTA
+// can ever overwrite one: reset() back to the store bundle is the only way out,
+// and it reloads the app on the spot.
+export async function leaveBetaOtaChannel(): Promise<void> {
+    const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+    await CapacitorUpdater.unsetChannel({})
+    await CapacitorUpdater.reset()
+}

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -182,6 +182,24 @@ export interface OtaChannelStatus {
     channel: string | null
     bundleVersion: string | null
     deviceId: string | null
+    // The exit is only finished when the store bundle is the one running: the
+    // channel alone cannot say so, and a half-finished exit leaves a device on
+    // beta code with a default channel.
+    onBuiltinBundle: boolean
+}
+
+// A leave that started but was never confirmed. Written before the channel is
+// cleared, because after that the device looks like it is on the default channel
+// while it still runs the beta bundle — invisible, and unreachable by any
+// production OTA.
+const PENDING_EXIT_KEY = 'capgoPendingBetaExit'
+
+export function hasPendingBetaExit(): boolean {
+    return readStoredValue(PENDING_EXIT_KEY) === '1'
+}
+
+export function clearPendingBetaExit(): void {
+    removeStoredValue(PENDING_EXIT_KEY)
 }
 
 // Capgo rejects setChannel() unless the channel allows self-assignment. That is
@@ -219,6 +237,7 @@ export async function readOtaChannelStatus(): Promise<OtaChannelStatus> {
         channel: channel?.channel ?? null,
         bundleVersion: current?.bundle?.version ?? null,
         deviceId: device?.deviceId ?? null,
+        onBuiltinBundle: current?.bundle?.id === 'builtin',
     }
 }
 
@@ -270,6 +289,9 @@ export class OtaChannelUnknownError extends Error {}
 export async function leaveBetaOtaChannel(): Promise<void> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     return queueOtaWork(async () => {
+        // Before the unset, not after: everything below can fail, and once the
+        // channel is cleared nothing else records that an exit is owed.
+        writeStoredValue(PENDING_EXIT_KEY, '1')
         await CapacitorUpdater.unsetChannel({})
 
         // getChannel() asks the backend what it will actually serve, and only a
@@ -285,9 +307,13 @@ export async function leaveBetaOtaChannel(): Promise<void> {
 
         try {
             await CapacitorUpdater.reset()
+            // Usually unreachable — reset() reloads the app. The next launch
+            // clears the marker instead, once the builtin bundle is running.
+            clearPendingBetaExit()
         } catch {
             try {
                 await CapacitorUpdater.reset()
+                clearPendingBetaExit()
             } catch (err) {
                 throw new OtaResetFailedError(err instanceof Error ? err.message : String(err ?? ''))
             }


### PR DESCRIPTION
## Why

Every merge to `dev` publishes a bundle to the Capgo `staging` channel and **no device ever reads it**: `production` is the app's default download channel, the app never calls `setChannel()`, and `staging` has self-assignment turned off. So an OTA today is all-or-nothing — internal testing on a real device has no path at all.

## What

**Profile → About → five taps on the version line** reveals a Beta-updates switch:

- **on** → `setChannel('staging')` + an immediate update check, so the next launch runs the beta bundle;
- **off** → `unsetChannel()` **and** `reset()` back to the store bundle. Staging versions (commit-count band) outrank every production one, so no production OTA could ever replace a beta bundle — dropping to builtin is the only exit, and leaving it out would strand testers on beta forever;
- the row also prints the running bundle and the Capgo device ID (tap to copy), which is what someone needs to force a device onto a channel from the dashboard.

Hidden behind the tap gesture and behind `isNativeBridge()`, so it never renders on web and can't be reached by accident.

A refused channel is reported as its own case (`OtaChannelClosedError`) with a message naming the fix, because until an admin flips the toggle below, **that is what every tester will hit**.

## Dashboard prerequisite (not in this PR)

`staging` → Information → **"Allow devices to self dissociate/associate"** must be enabled in Capgo; it is off today, and changing it needs a Super Admin. Until then the switch shows "ask an admin to allow self-assignment".

Unrelated but adjacent, also for a Super Admin: the app's **default upload channel is `ios-mobile-release`**, a dead lane from the retired `feat/mobile-release` branch. Nothing in CI uploads without `--channel`, so it is inert, but it should point at `staging` before that channel and `android-mobile-release` are deleted. Default *download* channel is correctly `production`.

## Tests

- `capgo-updater`: join stages a bundle, a rejected/`error`-carrying `setChannel` surfaces as a closed channel, leave unsets **and** resets.
- `About.view`: four taps reveal nothing, the fifth does, and a lapsed window forgets the streak.
- `BetaUpdatesCard`: hidden off native, closed-channel and restart-needed toasts.

`docs/NATIVE-RELEASE.md` §9 gains the tester path and its two prerequisites.