### PR TITLE
fix(claim): stop claim page crashing on links with no events relation

### DIFF
--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -181,7 +181,10 @@ export const Claim = ({}) => {
             initials: getInitialsFromName(recipientName),
             memo: claimLinkData.textContent,
             attachmentUrl: claimLinkData.fileUrl,
-            cancelledDate: status === 'cancelled' ? new Date(claimLinkData.events[0]?.timestamp) : undefined,
+            cancelledDate:
+                status === 'cancelled' && claimLinkData.events?.[0]
+                    ? new Date(claimLinkData.events[0].timestamp)
+                    : undefined,
             txHash: claimLinkData.claim?.txHash,
             extraDataForDrawer: {
                 isLinkTransaction: true,

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -374,7 +374,8 @@ export type SendLink = {
             }[]
         }
     }
-    events: {
+    /** Absent post-ledger-collapse: the API no longer selects the `events` relation. */
+    events?: {
         timestamp: Date
         status: SendLinkStatus
         reason?: string


### PR DESCRIPTION
## Problem

Opening a send link on production shows **"Application error: a client-side exception has occurred"** — the page never renders.

Sentry: [PEANUT-UI-SJ0](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SJ0) — `TypeError: Cannot read properties of undefined (reading '0')` at `src/components/Claim/Claim.tsx:184`, on release `85079d7e` (current `main`, from the dev→main merge #2879). 2 users so far, plus the same crash in the `native` env.

## Cause

`peanut-api-ts` dropped the `events` relation from `SEND_LINK_SELECT` ("Post-ledger-collapse: SendLink no longer has `claim`/`claimAttempts`/`events` relations"), so `GET /send-links/:id` no longer returns an `events` field at all.

`Claim.tsx` still dereferenced it:

```ts
cancelledDate: status === 'cancelled' ? new Date(claimLinkData.events[0]?.timestamp) : undefined,
```

The optional chain sits on the wrong side of the index — `events[0]?.timestamp` still throws when `events` itself is undefined. (`3b6055bc7` patched this same line but placed the `?.` after the subscript.)

It throws inside a `useMemo` during render, so React unwinds the tree and Next.js paints the generic client-exception screen rather than anything actionable.

Note the trigger is the `status === 'cancelled'` branch — the ternary short-circuits for other statuses, so this hits **cancelled** links.

## Fix

- Guard the array itself, not the element.
- Mark `events` optional on the `SendLink` type. It was declared **required**, which is exactly why the compiler never flagged the dereference.

## Scope check

Swept every remaining access to the removed relations. `Claim.tsx:169` (`events?.find`), `useClaimSuccessPolling.ts:28` (`events?.[…]`) and all five `claim?.` sites were already guarded — line 184 was the only unguarded one. `tsc --noEmit` is clean with `events` now optional, which confirms nothing else relied on it being present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cancelled date handling so dates are only displayed for cancelled transactions.
  * Improved compatibility with responses where transaction event details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->