### PR TITLE
fix(ios): current sentry-cli, DSN check that survives a key rotation

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -294,25 +294,6 @@ jobs:
                       -exportPath build/ios \
                       -exportOptionsPlist /tmp/ExportOptions.plist
 
-            - name: Upload dSYMs to Sentry
-              # Without debug symbols every native crash arrives as hex offsets.
-              # `uploadSymbols` in ExportOptions.plist goes to App Store Connect only —
-              # Sentry sunset its ASC fetch in 2024. Needs a SENTRY_AUTH_TOKEN repo
-              # secret (org peanut-c34d84c05, project peanut-ui, scope project:releases).
-              # Until it exists this step warns and the release still ships. sentry-cli
-              # is a pinned devDependency so it comes from the lockfile, not a fresh
-              # registry fetch inside the signing job.
-              env:
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_ORG: peanut-c34d84c05
-                  SENTRY_PROJECT: peanut-ui
-              run: |
-                  if [ -z "$SENTRY_AUTH_TOKEN" ]; then
-                      echo "::warning::SENTRY_AUTH_TOKEN not set — dSYMs not uploaded; native iOS crashes will be unsymbolicated in Sentry"
-                      exit 0
-                  fi
-                  pnpm exec sentry-cli debug-files upload build/ios/App.xcarchive/dSYMs
-
             - name: Verify push entitlements + Sentry DSN in exported IPA
               run: |
                   unzip -q build/ios/App.ipa -d /tmp/ipa-check
@@ -324,14 +305,51 @@ jobs:
                       exit 1
                   fi
                   # An empty, unexpanded, or malformed SentryDSN ships a build with native
-                  # crash reporting silently off (sentry-cocoa disables itself on a DSN it
-                  # cannot parse) — the iOS analogue of the gradle warning.
+                  # crash reporting silently off — sentry-cocoa disables itself on a DSN it
+                  # cannot parse, and nothing downstream would tell us. Stricter than the
+                  # gradle equivalent, which only logs: this runs on the actual artifact,
+                  # so it can be certain rather than advisory.
+                  #
+                  # Matched on the shape sentry-cocoa itself requires — scheme, key, host,
+                  # numeric project id — and NOT on how today's DSN happens to look. An
+                  # earlier draft required a hex key and a *.sentry.io host; both are true
+                  # of the current DSN and neither is guaranteed, so rotating the key or
+                  # moving region would have failed every iOS release for no reason.
                   DSN=$(plutil -extract SentryDSN raw -o - /tmp/ipa-check/Payload/App.app/Info.plist 2>/dev/null || true)
-                  if ! printf '%s' "$DSN" | grep -Eq '^https://[0-9a-f]+@[a-z0-9.-]+\.sentry\.io/[0-9]+$'; then
+                  case "$DSN" in
+                      '$(SENTRY_DSN)')
+                          echo "::error::exported ipa SentryDSN is the literal \$(SENTRY_DSN) — the build setting never reached xcodebuild, so this build ships blind"
+                          exit 1
+                          ;;
+                  esac
+                  if ! printf '%s' "$DSN" | grep -Eq '^https://[^@/]+@[^/]+/[0-9]+$'; then
                       echo "::error::exported ipa SentryDSN is ${DSN:+malformed}${DSN:-missing} — native crash reporting would be dead in this build"
                       exit 1
                   fi
                   echo "SentryDSN present and well-formed"
+
+            - name: Upload dSYMs to Sentry
+              # Without debug symbols every native crash arrives as hex offsets.
+              # `uploadSymbols` in ExportOptions.plist goes to App Store Connect only —
+              # Sentry sunset its ASC fetch in 2024. Needs a SENTRY_AUTH_TOKEN repo
+              # secret (org peanut-c34d84c05, project peanut-ui, scope project:releases).
+              # Until it exists this step warns and the release still ships. sentry-cli
+              # is a pinned devDependency so it comes from the lockfile, not a fresh
+              # registry fetch inside the signing job.
+              #
+              # Runs after the IPA verification: a build that fails that gate is never
+              # shipped, so uploading its symbols first only leaves orphaned debug files
+              # in the project.
+              env:
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_ORG: peanut-c34d84c05
+                  SENTRY_PROJECT: peanut-ui
+              run: |
+                  if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+                      echo "::warning::SENTRY_AUTH_TOKEN not set — dSYMs not uploaded; native iOS crashes will be unsymbolicated in Sentry"
+                      exit 0
+                  fi
+                  pnpm exec sentry-cli debug-files upload build/ios/App.xcarchive/dSYMs
 
             - name: Upload to TestFlight
               uses: apple-actions/upload-testflight-build@1ad58030672057aa084b4e96beb6f7a8c627f9e6 # v5

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -296,6 +296,13 @@ jobs:
 
             - name: Verify push entitlements + Sentry DSN in exported IPA
               run: |
+                  # Extract into a clean directory. `macos-15` is ephemeral so a stale
+                  # /tmp/ipa-check cannot survive today, but unzip without -o prompts on
+                  # existing files and skips them when stdin is at EOF — which on any
+                  # reused runner would leave the PREVIOUS build's Payload in place and
+                  # quietly verify the wrong artifact. A release gate that can pass while
+                  # reading the wrong IPA is worse than no gate.
+                  rm -rf /tmp/ipa-check
                   unzip -q build/ios/App.ipa -d /tmp/ipa-check
                   APS=$(codesign -d --entitlements :- /tmp/ipa-check/Payload/App.app 2>/dev/null \
                         | plutil -extract aps-environment raw -o - - || true)

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
         "@next/bundle-analyzer": "^16.1.1",
         "@next/eslint-plugin-next": "^16.2.4",
         "@playwright/test": "^1.58.0",
-        "@sentry/cli": "2.39.1",
+        "@sentry/cli": "3.6.2",
         "@size-limit/preset-app": "^11.2.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/dom": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,8 +287,8 @@ importers:
         specifier: ^1.58.0
         version: 1.58.2
       '@sentry/cli':
-        specifier: 2.39.1
-        version: 2.39.1
+        specifier: 3.6.2
+        version: 3.6.2
       '@size-limit/preset-app':
         specifier: ^11.2.0
         version: 11.2.0(bufferutil@4.1.0)(size-limit@11.2.0)(utf-8-validate@5.0.10)
@@ -2748,11 +2748,22 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
+  '@sentry/cli-darwin@3.6.2':
+    resolution: {integrity: sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   '@sentry/cli-linux-arm64@2.39.1':
     resolution: {integrity: sha512-5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux, freebsd]
+
+  '@sentry/cli-linux-arm64@3.6.2':
+    resolution: {integrity: sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
 
   '@sentry/cli-linux-arm@2.39.1':
     resolution: {integrity: sha512-DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==}
@@ -2760,11 +2771,23 @@ packages:
     cpu: [arm]
     os: [linux, freebsd]
 
+  '@sentry/cli-linux-arm@3.6.2':
+    resolution: {integrity: sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-linux-i686@2.39.1':
     resolution: {integrity: sha512-pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [linux, freebsd]
+
+  '@sentry/cli-linux-i686@3.6.2':
+    resolution: {integrity: sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
 
   '@sentry/cli-linux-x64@2.39.1':
     resolution: {integrity: sha512-IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==}
@@ -2772,9 +2795,27 @@ packages:
     cpu: [x64]
     os: [linux, freebsd]
 
+  '@sentry/cli-linux-x64@3.6.2':
+    resolution: {integrity: sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@3.6.2':
+    resolution: {integrity: sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@sentry/cli-win32-i686@2.39.1':
     resolution: {integrity: sha512-NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==}
     engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@3.6.2':
+    resolution: {integrity: sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [win32]
 
@@ -2784,9 +2825,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry/cli-win32-x64@3.6.2':
+    resolution: {integrity: sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@sentry/cli@2.39.1':
     resolution: {integrity: sha512-JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==}
     engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/cli@3.6.2':
+    resolution: {integrity: sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==}
+    engines: {node: '>= 18'}
     hasBin: true
 
   '@sentry/core@8.55.0':
@@ -8043,6 +8095,10 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
 
@@ -11698,22 +11754,46 @@ snapshots:
   '@sentry/cli-darwin@2.39.1':
     optional: true
 
+  '@sentry/cli-darwin@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-arm64@2.39.1':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.6.2':
     optional: true
 
   '@sentry/cli-linux-arm@2.39.1':
     optional: true
 
+  '@sentry/cli-linux-arm@3.6.2':
+    optional: true
+
   '@sentry/cli-linux-i686@2.39.1':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.6.2':
     optional: true
 
   '@sentry/cli-linux-x64@2.39.1':
     optional: true
 
+  '@sentry/cli-linux-x64@3.6.2':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-i686@2.39.1':
     optional: true
 
+  '@sentry/cli-win32-i686@3.6.2':
+    optional: true
+
   '@sentry/cli-win32-x64@2.39.1':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.6.2':
     optional: true
 
   '@sentry/cli@2.39.1':
@@ -11734,6 +11814,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@sentry/cli@3.6.2':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.28.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.6.2
+      '@sentry/cli-linux-arm': 3.6.2
+      '@sentry/cli-linux-arm64': 3.6.2
+      '@sentry/cli-linux-i686': 3.6.2
+      '@sentry/cli-linux-x64': 3.6.2
+      '@sentry/cli-win32-arm64': 3.6.2
+      '@sentry/cli-win32-i686': 3.6.2
+      '@sentry/cli-win32-x64': 3.6.2
 
   '@sentry/core@8.55.0': {}
 
@@ -18442,6 +18538,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici@6.28.0: {}
 
   unicode-properties@1.4.1:
     dependencies:


### PR DESCRIPTION
Follow-up to [#2884](https://github.com/peanutprotocol/peanut-ui/pull/2884) — these three were raised in review but the PR merged before they landed. No behaviour change to the app itself; all three are release-pipeline correctness.

## 1. `@sentry/cli` 2.39.1 → 3.6.2

2.39.1 was published **2024-11-26** — 21 months old and a major version behind. `check-min-release-age` stayed green because it enforces a *floor*, not currency.

3.6.2 rather than the newest: 3.7.0 landed 2026-08-28, three days ago, and hasn't cleared the 14-day cooldown. 3.6.2 (2026-07-22) is the newest that has.

Verified the major bump is safe for this call site rather than assuming:

- `debug-files upload [OPTIONS] [PATH]...` — confirmed unchanged by running the 3.6.2 binary
- 3.0's removals are `files` / `releases files`, `sourcemaps explain`, `send-metric`, and legacy API-key auth. We use none of them and authenticate with an auth token, which is the supported method
- new Node ≥18 floor is met by the job's Node 22
- the JS-wrapper breakages (named exports, `live` semantics) don't apply — we invoke the binary via `pnpm exec`, not the JS API

`sentry-cocoa` deliberately **stays at 9.26.0**: 9.26.1 is four days old, so 9.26.0 is already the correct pick under the cooldown rule.

## 2. The DSN check no longer breaks on a key rotation

The check required `^https://[0-9a-f]+@[a-z0-9.-]+\.sentry\.io/[0-9]+$`. Both of those are true of the current DSN and guaranteed by neither — a rotated key with a non-hex character, or a region move off `*.sentry.io`, would have failed **every iOS release** for no reason, on a step whose failure mode is a hard `exit 1`.

Now matched on the shape sentry-cocoa itself requires — scheme, key, host, numeric project id:

```
^https://[^@/]+@[^/]+/[0-9]+$
```

Verified against 8 cases: the real DSN, a rotated mixed-case key, a `de.sentry.io` host and a self-hosted host all accepted; empty, unexpanded, non-numeric project id and missing key all rejected.

It stays a hard failure — that is the right call on a release artifact, even though the gradle equivalent only logs, because this one runs on the actual IPA and can be certain rather than advisory. An unexpanded `$(SENTRY_DSN)` now gets its own message naming the real cause (the build setting never reached `xcodebuild`) instead of a generic "malformed".

## 3. dSYM upload moved after the IPA verification

A build that fails the entitlements/DSN gate never ships, so uploading its symbols first only leaves orphaned debug files in the project.

## Still outstanding from that review

Neither is addressed here, both are actions rather than code:

- **`SENTRY_AUTH_TOKEN` is still unset.** I checked repo secrets and the `Production` environment — it exists in neither, so the dSYM step currently warns and skips, and native crashes will arrive as unsymbolicated hex offsets.
- **Nothing has compiled the iOS project yet.** `ios-release.yml` only runs on tag/dispatch, so no CI job builds it. I statically validated the hand-written pbxproj as far as is possible without Xcode — valid plist, 43/43 object ids resolve with zero dangling references, both new `isa` values correct, and all six package links (build file → product → remote package, target frameworks phase, target `packageProductDependencies`, project `packageReferences`) wired correctly. What that cannot prove is SPM resolving sentry-cocoa and `import Sentry` compiling.

⚠️ When dispatching to validate, pass a `versionName` **not newer** than the version production already serves (1.1.0). Anything higher also fires the "Publish matching production OTA bundle" step, which pushes that branch's static export to the Capgo `production` channel for all users. The `Production` environment has no protection rules or branch policy, so there is no approval gate to catch it.

## Testing

Workflow YAML parses and step order verified (Archive → Verify → dSYMs → TestFlight). DSN matcher exercised against the 8 cases above. `debug-files upload --help` run against the real 3.6.2 binary. Prettier clean.