### PR TITLE
test(claim): cover the unprojected send-link payload that crashed the claim page

### DIFF
--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -407,6 +407,32 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
         })
     })
 
+    // GET /send-links/:pubKey answers a cache hit with the raw Prisma row, which
+    // carries `intents` instead of the projected `claim` + `events`. Claim.tsx read
+    // `events[0]` unguarded and took the whole page down (PEANUT-UI-SJ0).
+    test('CANCELLED link renders when the API omits claim/events (cache-hit shape)', async () => {
+        const { events: _events, claim: _claim, ...unprojected } = makeSendLink({ status: 'CANCELLED' })
+        mockSendLinksApi.get.mockResolvedValue(unprojected)
+
+        const openTransactionDetails = jest.fn()
+        mockUseTransactionDetailsDrawer.mockReturnValue({
+            openTransactionDetails,
+            selectedTransaction: { amount: 10, tokenSymbol: 'USDC' },
+            isDrawerOpen: false,
+            closeTransactionDetails: jest.fn(),
+        })
+
+        renderClaim()
+
+        // Gates on the drawer effect, which only fires once the transaction memo
+        // has produced a value — asserting on the view alone settles too early to
+        // catch a throw inside the memo.
+        await waitFor(() => {
+            expect(openTransactionDetails).toHaveBeenCalled()
+        })
+        expect(screen.getByTestId('claimed-view')).toBeInTheDocument()
+    })
+
     test('CLAIMING link (in progress) shows as already claimed', async () => {
         const link = makeSendLink({ status: 'CLAIMING' })
         mockSendLinksApi.get.mockResolvedValue(link)


### PR DESCRIPTION
Follow-up to #2889 (already merged) — adds the regression coverage that fix lacked.

## Why the existing test didn't catch it

`claim-states.test.tsx` already had the right test — "CANCELLED link shows ClaimedView", rendering the real `Claim` component with `status: 'CANCELLED'`. It passed anyway, because of one line in the fixture factory:

```ts
function makeSendLink(overrides = {}) {
    return { …, claim: null, events: [], ...overrides }
}
```

`[][0]` is `undefined` and `undefined?.timestamp` is safe. Production sends **no `events` key at all**, and `undefined[0]` throws. The fixture modelled a shape the endpoint doesn't return.

## Where the unprojected shape comes from

`GET /send-links/:pubKey` has two response paths:

- **DB path** → `reply.send(sanitizeSendLink(sendLink))` — projects `intents` into the legacy `claim` + `events` shape.
- **Cache path** (`send-links/index.ts:905`, 30s TTL) → `reply.send(cached.sendLink)` — the **raw Prisma row**, with `intents` and no `claim`/`events`.

So the crash needed a cache hit on a cancelled link, which is why it was rare and intermittent rather than constant.

I've filed the backend half separately — that side also skips `toWireUser`, so the cache path is a data-exposure issue, not just a shape mismatch.

## The test

Builds the payload by stripping `claim` and `events`, matching the cache-hit response.

It gates on the **drawer effect** rather than the rendered view. That matters: `claimLinkData` is populated by an async effect that awaits `fetchTokenDetails`, so the view settles *before* the transaction memo ever runs — asserting on `claimed-view` alone passes even against the crashing code. Gating on `openTransactionDetails` forces the wait until the memo has produced a value.

## Verified

- Against pre-fix `Claim.tsx` (`c020f6b57^1`): **fails** with `TypeError: Cannot read properties of undefined (reading '0')`, in isolation as well as in the full suite.
- Against current `main`: **16/16 pass**.

The default fixture keeps `events: []` so the projected shape stays covered too — this adds the second shape rather than swapping one blind spot for another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled send links when transaction details are opened.
  * Ensured the claimed view renders successfully for cancelled links with limited cached data.

* **Tests**
  * Added regression coverage for cancelled send link scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->