### PR TITLE
fix(claim): stop claim page crashing on links with no events relation

### DIFF
--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -179,7 +179,10 @@ export const Claim = ({}) => {
             initials: getInitialsFromName(recipientName),
             memo: claimLinkData.textContent,
             attachmentUrl: claimLinkData.fileUrl,
-            cancelledDate: status === 'cancelled' ? new Date(claimLinkData.events[0]?.timestamp) : undefined,
+            cancelledDate:
+                status === 'cancelled' && claimLinkData.events?.[0]
+                    ? new Date(claimLinkData.events[0].timestamp)
+                    : undefined,
             txHash: claimLinkData.claim?.txHash,
             extraDataForDrawer: {
                 isLinkTransaction: true,

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -385,6 +385,36 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
         })
     })
 
+    // GET /send-links/:pubKey answers a cache hit with the raw Prisma row, which
+    // carries `intents` instead of the projected `claim` + `events`. Claim.tsx read
+    // `events[0]` unguarded and took the whole page down (PEANUT-UI-SJ0).
+    test('CANCELLED link renders when the API omits claim/events (cache-hit shape)', async () => {
+        mockUseAuth.mockReturnValue({
+            user: { user: { userId: 'sender-123' } },
+            isFetchingUser: false,
+            fetchUser: jest.fn(),
+        })
+
+        const {
+            events: _events,
+            claim: _claim,
+            ...unprojected
+        } = makeSendLink({
+            status: 'CANCELLED',
+            sender: { userId: 'sender-123', username: 'alice' },
+        })
+        mockSendLinksApi.get.mockResolvedValue(unprojected)
+
+        renderClaim()
+
+        // Gates on the receipt, which only renders once the transaction memo has
+        // produced a value — asserting on ClaimedView settles too early to catch
+        // a throw inside the memo.
+        await waitFor(() => {
+            expect(screen.getByTestId('transaction-details-receipt')).toBeInTheDocument()
+        })
+    })
+
     test('CLAIMING link (in progress) shows as already claimed', async () => {
         const link = makeSendLink({ status: 'CLAIMING' })
         mockSendLinksApi.get.mockResolvedValue(link)

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -374,7 +374,8 @@ export type SendLink = {
             }[]
         }
     }
-    events: {
+    /** Absent post-ledger-collapse: the API no longer selects the `events` relation. */
+    events?: {
         timestamp: Date
         status: SendLinkStatus
         reason?: string


### PR DESCRIPTION
Re-targets #2889 (merged to `main`) and #2892 onto `dev`. **`dev` never received the fix** — the crashing line is still live there:

```ts
// src/components/Claim/Claim.tsx (dev)
cancelledDate: status === 'cancelled' ? new Date(claimLinkData.events[0]?.timestamp) : undefined,
```

Without this, the next `dev` → `main` release re-introduces the crash. Carries both the fix and its regression test, since `dev` has neither.

## The bug

Opening a cancelled send link showed **"Application error: a client-side exception has occurred"** — `TypeError: Cannot read properties of undefined (reading '0')` thrown inside a render-phase `useMemo` (Sentry PEANUT-UI-SJ0).

The optional chain sits on the wrong side of the subscript: `events[0]?.timestamp` still throws when `events` itself is missing.

## Why `events` goes missing

`GET /send-links/:pubKey` has two response paths. The DB path returns `sanitizeSendLink(sendLink)`, which projects `intents` into the legacy `claim` + `events` shape. The **cache path** (30s TTL) returns the raw Prisma row, which has neither. So the crash needed a cache hit on a cancelled link — which is why it was intermittent.

The backend half is peanutprotocol/peanut-api-ts#1473 (also re-targeted to `dev`). This PR is still worth landing on its own: the guard is correct regardless of which shape the API sends.

## Changes

- Guard the array, not the element.
- Mark `events` optional on the `SendLink` type. It was declared **required**, which is exactly why the compiler never flagged the dereference — and why the existing test fixture couldn't be corrected.

## The test

`dev` already had the right test — "CANCELLED link shows ClaimedView", rendering the real `Claim` component. It passed anyway because the fixture hard-codes `events: []`, and `[][0]?.timestamp` is safe where `undefined[0]` throws.

The new case builds the cache-hit shape by stripping `claim` and `events`. It gates on the **receipt** rather than `ClaimedView`: `claimLinkData` is populated by an async effect that awaits `fetchTokenDetails`, so the view settles *before* the memo runs — asserting on `ClaimedView` alone passes even against the crashing code.

Note this gate differs from #2892's, which used the transaction-details drawer. That hook doesn't exist on `dev`; here the same memo feeds `selectedTransaction` and the receipt instead.

## Verified on this base

- Against `origin/dev`'s `Claim.tsx`: **fails** with `TypeError: Cannot read properties of undefined (reading '0')`.
- With the fix: **16/16 pass**.
- `tsc --noEmit` reports only the pre-existing `src/utils/tw.ts(58,5)` error, which is present on clean `origin/dev`.

The default fixture keeps `events: []` so the projected shape stays covered too.