### PR TITLE
review: re-land the eight fixes stranded on the closed 08-26 back-merge

### DIFF
--- a/src/app/__tests__/metadata-policy.test.ts
+++ b/src/app/__tests__/metadata-policy.test.ts
@@ -1,5 +1,4 @@
 jest.mock('next/font/google', () => ({
-    Londrina_Solid: () => ({ variable: '--font-londrina' }),
     Roboto_Flex: () => ({ variable: '--font-roboto' }),
     Sniglet: () => ({ variable: '--font-sniglet' }),
 }))

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -2,6 +2,7 @@ jest.mock('@/constants/general.consts', () => ({ BASE_URL: 'https://peanut.me' }
 jest.mock('@/i18n/types', () => ({ SUPPORTED_LOCALES: ['en', 'es-419'] }))
 
 import { GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS, ROBOTS_DISALLOWED_PATHS } from '@/constants/seo-route-policy'
+import robots from '../robots'
 
 type RobotsRule = {
     userAgent: string | string[]
@@ -10,12 +11,9 @@ type RobotsRule = {
     crawlDelay?: number
 }
 
-// The production gate reads the raw env (a preview built without it must not
-// serve the production policy), so the production case has to set it — and
-// after the imports, hence the lazy require.
+// robots() derives production-ness from the RAW env at call time (fail-closed,
+// shared with layout.tsx via isProductionDomain) — pin it for the policy suite.
 process.env.NEXT_PUBLIC_BASE_URL = 'https://peanut.me'
-const robots = require('../robots').default as () => { rules: RobotsRule[] }
-
 const rules = robots().rules as RobotsRule[]
 
 function ruleFor(userAgent: string): RobotsRule {
@@ -51,16 +49,29 @@ describe('production robots policy', () => {
     })
 })
 
-describe('preview robots policy', () => {
-    it('fails closed when NEXT_PUBLIC_BASE_URL is unset', () => {
-        // BASE_URL's production fallback used to satisfy the gate here, so a
-        // preview built without the variable served the production policy.
-        jest.resetModules()
-        delete process.env.NEXT_PUBLIC_BASE_URL
-        const previewRobots = require('../robots').default as () => { rules: RobotsRule[] }
+// The old derivation compared BASE_URL, whose production fallback made an
+// UNSET environment indexable. The check must fail closed on the raw env.
+describe('non-production robots policy fails closed', () => {
+    const ORIGINAL_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
 
-        expect(previewRobots().rules).toEqual([{ userAgent: '*', disallow: ['/'] }])
+    afterEach(() => {
+        if (ORIGINAL_BASE_URL === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+        else process.env.NEXT_PUBLIC_BASE_URL = ORIGINAL_BASE_URL
+    })
 
-        process.env.NEXT_PUBLIC_BASE_URL = 'https://peanut.me'
+    it.each([undefined, '', 'https://staging.peanut.me', 'https://peanut.me.evil.example'])(
+        'blocks all crawling when the production origin is not explicit (%s)',
+        (baseUrl) => {
+            if (baseUrl === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+            else process.env.NEXT_PUBLIC_BASE_URL = baseUrl
+
+            expect(robots().rules).toEqual([{ userAgent: '*', disallow: ['/'] }])
+        }
+    )
+
+    it('tolerates a trailing slash on the configured production origin', () => {
+        process.env.NEXT_PUBLIC_BASE_URL = 'https://peanut.me/'
+
+        expect(robots().rules).not.toEqual([{ userAgent: '*', disallow: ['/'] }])
     })
 })

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,13 +6,14 @@ import Script from 'next/script'
 import '../styles/globals.css'
 import { PEANUT_API_URL, BASE_URL } from '@/constants/general.consts'
 import { CHUNK_ERROR_RECOVERY_SCRIPT } from '@/utils/chunk-error-recovery'
+import { isProductionDomain } from '@/constants/seo-route-policy'
 import { type Metadata } from 'next'
 
 const baseUrl = BASE_URL || 'https://peanut.me'
-// Fail closed: BASE_URL deliberately falls back to production for links, but
-// that fallback must not make an unset preview environment indexable.
-const configuredBaseUrl = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '')
-const IS_PRODUCTION_DOMAIN = configuredBaseUrl === 'https://peanut.me'
+// Fail closed on the raw env (see isProductionDomain): BASE_URL deliberately
+// falls back to production for links, but that fallback must not make an
+// unset preview environment indexable.
+const IS_PRODUCTION_DOMAIN = isProductionDomain(process.env.NEXT_PUBLIC_BASE_URL)
 
 export const metadata: Metadata = {
     title: 'Peanut - Send, Spend & Cash Out Digital Dollars',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,12 +1,11 @@
 import type { MetadataRoute } from 'next'
 import { BASE_URL } from '@/constants/general.consts'
 import { SUPPORTED_LOCALES } from '@/i18n/types'
-import { GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS, ROBOTS_DISALLOWED_PATHS } from '@/constants/seo-route-policy'
-
-// Read the raw env, not BASE_URL: its 'https://peanut.me' fallback would serve
-// the production crawl policy from a preview built without the variable. Same
-// gate as the root layout's noindex.
-const IS_PRODUCTION_DOMAIN = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, '') === 'https://peanut.me'
+import {
+    GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS,
+    ROBOTS_DISALLOWED_PATHS,
+    isProductionDomain,
+} from '@/constants/seo-route-policy'
 
 // Paths kept out of the index: the API surface, the SDK bundle, and the
 // auth-gated app routes. Used by the `*`, Googlebot, and AI-crawler groups;
@@ -15,8 +14,10 @@ const IS_PRODUCTION_DOMAIN = process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/$/, ''
 // group that matches it, so a named group that omits a path silently opts
 // that crawler out of it.
 export default function robots(): MetadataRoute.Robots {
-    // Block indexing on staging, preview deploys, and non-production domains
-    if (!IS_PRODUCTION_DOMAIN) {
+    // Block indexing on staging, preview deploys, and non-production domains.
+    // Fail-closed on the RAW env (see isProductionDomain) — BASE_URL falls
+    // back to production and would open indexing on an unset environment.
+    if (!isProductionDomain(process.env.NEXT_PUBLIC_BASE_URL)) {
         return {
             rules: [{ userAgent: '*', disallow: ['/'] }],
         }

--- a/src/components/Invites/InvitesPage.tsx
+++ b/src/components/Invites/InvitesPage.tsx
@@ -35,6 +35,7 @@ import {
     isUnavailableBadgeCampaignClaim,
 } from '@/services/badge-campaigns'
 import { destinationForInviteAcquisition } from '@/services/invite-acquisition'
+import { getPasskeyErrorSetupKey } from '@/utils/webauthn.utils'
 
 function InvitePageContent() {
     const t = useTranslations('invites')
@@ -294,10 +295,13 @@ function InvitePageContent() {
             // normal-app fallback.
             saveRedirectUrl()
         }
-        // PasskeyError carries curated user-facing copy; without this catch a
-        // cancelled passkey prompt becomes an unhandled rejection and a Sentry event.
+        // PasskeyError carries curated copy; without this catch a cancelled
+        // passkey prompt becomes an unhandled rejection and a Sentry event.
+        // Known codes render the translated catalog copy instead of the
+        // error's hardcoded English message.
         handleLoginClick().catch((error: unknown) => {
-            toast.error((error instanceof Error && error.message) || tSetup('loginFailed'))
+            const i18nKey = getPasskeyErrorSetupKey(error)
+            toast.error(i18nKey ? tSetup(i18nKey) : (error instanceof Error && error.message) || tSetup('loginFailed'))
         })
     }
 

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -365,7 +365,7 @@ const SumsubWebSdkModal = ({
     // Skip straight to onClose in that case.
     const handleCloseButton = useCallback(() => {
         if (hasSubmittedRef.current) {
-            onClose()
+            onClose({ submitted: true })
             return
         }
         setModalVariant('stop-verification')

--- a/src/components/Kyc/SumsubKycWrapper.tsx
+++ b/src/components/Kyc/SumsubKycWrapper.tsx
@@ -365,7 +365,7 @@ const SumsubWebSdkModal = ({
     // Skip straight to onClose in that case.
     const handleCloseButton = useCallback(() => {
         if (hasSubmittedRef.current) {
-            onClose({ submitted: true })
+            onClose()
             return
         }
         setModalVariant('stop-verification')

--- a/src/components/Kyc/SumsubNativeSdk.tsx
+++ b/src/components/Kyc/SumsubNativeSdk.tsx
@@ -35,6 +35,8 @@ export const SumsubNativeSdk = ({
     onComplete,
     onError,
     onRefreshToken,
+    onSubmitted,
+    isMultiLevel,
 }: SumsubSdkProps) => {
     const t = useTranslations('kyc')
     const locale = useLocale()
@@ -45,6 +47,8 @@ export const SumsubNativeSdk = ({
     const onErrorRef = useRef(onError)
     const onRefreshTokenRef = useRef(onRefreshToken)
     const accessTokenRef = useRef(accessToken)
+    const isMultiLevelRef = useRef(isMultiLevel)
+    const onSubmittedRef = useRef(onSubmitted)
     const sumsubLocaleRef = useRef(toSumsubLocale(locale))
 
     useEffect(() => {
@@ -53,7 +57,9 @@ export const SumsubNativeSdk = ({
         onErrorRef.current = onError
         onRefreshTokenRef.current = onRefreshToken
         accessTokenRef.current = accessToken
-    }, [onClose, onComplete, onError, onRefreshToken, accessToken])
+        isMultiLevelRef.current = isMultiLevel
+        onSubmittedRef.current = onSubmitted
+    }, [onClose, onComplete, onError, onRefreshToken, accessToken, isMultiLevel, onSubmitted])
 
     useEffect(() => {
         sumsubLocaleRef.current = toSumsubLocale(locale)
@@ -116,9 +122,24 @@ export const SumsubNativeSdk = ({
                     // The promise resolves on close, whatever the user did — so
                     // the status decides between "submitted, go show progress"
                     // and "backed out, just close".
-                    if (hasSubmitted || SUBMITTED_STATES.has(result?.status ?? '')) {
+                    //
+                    // Multi-level cannot trust `hasSubmitted` on its own: Pending
+                    // fires after Level 1 with the questionnaire still outstanding,
+                    // so a Level-1 submit followed by backing out of Level 2 looks
+                    // identical to a finished workflow. The plugin dismisses after
+                    // the LAST level, so there a close whose OWN status is not a
+                    // submitted one is the user leaving mid-workflow — report it as
+                    // a close, or the flow hooks consume the deferred
+                    // ACTION_REQUIRED and strand them on a stale progress modal.
+                    // Single-level keeps trusting `hasSubmitted`: one submit IS the
+                    // whole flow there, and the closing status often lies (Initial).
+                    const closedSubmitted = SUBMITTED_STATES.has(result?.status ?? '')
+                    if (isMultiLevelRef.current ? closedSubmitted : hasSubmitted || closedSubmitted) {
                         onCompleteRef.current()
                     } else {
+                        // The level they DID finish still counts for the funnel —
+                        // routing this as a close must not also lose the submit.
+                        if (hasSubmitted) onSubmittedRef.current?.()
                         onCloseRef.current()
                     }
                 },

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -264,11 +264,13 @@ describe('SumsubKycWrapper', () => {
         expect(onComplete).toHaveBeenCalled()
     })
 
-    // After a submit the SDK sits on "documents submitted" and the only way out
-    // is the X — that close must be marked `submitted: true` so the flow hooks
-    // consume the deferred ACTION_REQUIRED instead of replaying it as a bogus
-    // rejection. Pre-submit, the X opens the stop-verification confirm instead.
-    it('marks a post-submit manual close with submitted: true', async () => {
+    // Pre-submit the X opens the stop-verification confirm; after a submit the
+    // SDK sits on "documents submitted" and the confirm would be misleading, so
+    // the X closes straight through. It closes PLAIN: the wrapper cannot tell a
+    // finished follow-up from an abandoned one (a second onApplicantSubmitted is
+    // the idCheck twin, not a new level), so the hooks must keep replaying any
+    // deferred ACTION_REQUIRED rather than trust this close as a submission.
+    it('closes straight through after a submit, without claiming submission', async () => {
         const onClose = jest.fn()
         render(
             <SumsubKycWrapper
@@ -298,7 +300,7 @@ describe('SumsubKycWrapper', () => {
         })
 
         expect(onClose).toHaveBeenCalledTimes(1)
-        expect(onClose).toHaveBeenCalledWith({ submitted: true })
+        expect(onClose).toHaveBeenCalledWith()
     })
 
     // Single-level keeps its original contract: submit closes via onComplete,

--- a/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubKycWrapper.test.tsx
@@ -264,6 +264,43 @@ describe('SumsubKycWrapper', () => {
         expect(onComplete).toHaveBeenCalled()
     })
 
+    // After a submit the SDK sits on "documents submitted" and the only way out
+    // is the X — that close must be marked `submitted: true` so the flow hooks
+    // consume the deferred ACTION_REQUIRED instead of replaying it as a bogus
+    // rejection. Pre-submit, the X opens the stop-verification confirm instead.
+    it('marks a post-submit manual close with submitted: true', async () => {
+        const onClose = jest.fn()
+        render(
+            <SumsubKycWrapper
+                visible
+                accessToken="tok_abc"
+                onClose={onClose}
+                onComplete={jest.fn()}
+                onSubmitted={jest.fn()}
+                onRefreshToken={jest.fn().mockResolvedValue('tok_abc')}
+                isMultiLevel
+            />
+        )
+        await waitFor(() => expect(launch).toHaveBeenCalled())
+        const closeButton = screen.getAllByRole('button')[1]
+
+        // pre-submit: X routes to the confirm dialog, not onClose
+        act(() => {
+            closeButton.click()
+        })
+        expect(onClose).not.toHaveBeenCalled()
+
+        act(() => {
+            sdkHandlers['onApplicantSubmitted']?.()
+        })
+        act(() => {
+            closeButton.click()
+        })
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        expect(onClose).toHaveBeenCalledWith({ submitted: true })
+    })
+
     // Single-level keeps its original contract: submit closes via onComplete,
     // and onSubmitted stays silent (no double analytics signal).
     it('single-level submit fires onComplete, not onSubmitted', async () => {

--- a/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
@@ -135,6 +135,44 @@ describe('SumsubNativeSdk', () => {
         await waitFor(() => expect(props.onComplete).toHaveBeenCalled())
     })
 
+    // Multi-level: the Level-1 Pending is NOT a finished workflow. Backing out of
+    // Level 2 resolves launch() on a non-submitted status, and reporting that as a
+    // completion let both flow hooks consume the deferred ACTION_REQUIRED, leaving
+    // the applicant on a stale "verifying" modal.
+    it('multi-level reports a Level-1-then-backed-out exit as a close, not a completion', async () => {
+        let resolveLaunch: (value: unknown) => void = () => {}
+        launch.mockReturnValue(new Promise((resolve) => (resolveLaunch = resolve)))
+        const props = { ...baseProps(), isMultiLevel: true, onSubmitted: jest.fn() }
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await act(async () => {
+            statusHandler?.({ newStatus: 'Pending' })
+            resolveLaunch({ success: true, status: 'Initial' })
+        })
+
+        await waitFor(() => expect(props.onClose).toHaveBeenCalled())
+        expect(props.onComplete).not.toHaveBeenCalled()
+        // the level they did finish still reaches the funnel
+        expect(props.onSubmitted).toHaveBeenCalledTimes(1)
+    })
+
+    // ...but a genuinely finished multi-level workflow still completes: the plugin
+    // dismisses after the last level and the closing status is a submitted one.
+    it('multi-level completes when the closing status is itself a submission', async () => {
+        launch.mockResolvedValue({ success: true, status: 'Pending' })
+        const props = { ...baseProps(), isMultiLevel: true }
+        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
+        await act(async () => {
+            rerender(<SumsubNativeSdk visible {...props} />)
+        })
+
+        await waitFor(() => expect(props.onComplete).toHaveBeenCalled())
+        expect(props.onClose).not.toHaveBeenCalled()
+    })
+
     it('closes without completing when the user backs out', async () => {
         launch.mockResolvedValue({ success: true, status: 'Initial' })
         const props = baseProps()

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -6,14 +6,7 @@
 export interface SumsubSdkProps {
     visible: boolean
     accessToken: string | null
-    /**
-     * Manual close. `submitted: true` marks a close AFTER the user finished
-     * submitting (multi-level level-2 done, SDK sitting on "documents
-     * submitted") — the flow hooks use it to consume the deferred
-     * ACTION_REQUIRED instead of replaying it as a bogus rejection. An
-     * abandon passes nothing.
-     */
-    onClose: (opts?: { submitted?: boolean }) => void
+    onClose: () => void
     onComplete: () => void
     /**
      * Fired when a level is submitted but the SDK stays open (multi-level

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -6,7 +6,14 @@
 export interface SumsubSdkProps {
     visible: boolean
     accessToken: string | null
-    onClose: () => void
+    /**
+     * Manual close. `submitted: true` marks a close AFTER the user finished
+     * submitting (multi-level level-2 done, SDK sitting on "documents
+     * submitted") — the flow hooks use it to consume the deferred
+     * ACTION_REQUIRED instead of replaying it as a bogus rejection. An
+     * abandon passes nothing.
+     */
+    onClose: (opts?: { submitted?: boolean }) => void
     onComplete: () => void
     /**
      * Fired when a level is submitted but the SDK stays open (multi-level

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -12,8 +12,11 @@ export interface SumsubSdkProps {
      * Fired when a level is submitted but the SDK stays open (multi-level
      * Level-1 submit). Single-level submits fire `onComplete` instead — without
      * this hook a multi-level session emits no submit signal at all, because
-     * the APPROVED close never runs `onComplete`. Web SDK only: the native SDK
-     * dismisses after the LAST level, so its one `onComplete` already covers it.
+     * the APPROVED close never runs `onComplete`. The native SDK normally
+     * dismisses after the LAST level and reports that one `onComplete`, but it
+     * also fires this when a multi-level session is abandoned after an earlier
+     * level: that exit is a close, not a completion, and the level the user did
+     * finish still has to reach the funnel.
      */
     onSubmitted?: () => void
     onError?: (error: unknown) => void

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -11,7 +11,7 @@ import { useDeviceType } from '@/hooks/useGetDeviceType'
 import { useEffect, useRef, useState } from 'react'
 import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 import { checkPasskeySupport } from '@/utils/passkeyPreflight'
-import { WebAuthnErrorName, withWebAuthnRetry } from '@/utils/webauthn.utils'
+import { WebAuthnErrorName, getPasskeyErrorSetupKey, withWebAuthnRetry } from '@/utils/webauthn.utils'
 import { isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
 import { PasskeySetupHelpModal } from './PasskeySetupHelpModal'
 import * as Sentry from '@sentry/nextjs'
@@ -199,8 +199,10 @@ const SetupPasskey = () => {
             await handleLoginClick()
             // success — useLogin's effect redirects once the user is loaded
         } catch (error) {
-            // handleLogin throws PasskeyError with a curated user-facing message
-            setInlineError((error as Error)?.message || t('loginFailed'))
+            // handleLogin throws PasskeyError with a curated code + English
+            // message — prefer the translated catalog copy for known codes.
+            const i18nKey = getPasskeyErrorSetupKey(error)
+            setInlineError(i18nKey ? t(i18nKey) : (error as Error)?.message || t('loginFailed'))
         }
     }
 

--- a/src/constants/seo-route-policy.js
+++ b/src/constants/seo-route-policy.js
@@ -93,6 +93,19 @@ const GOOGLE_DEINDEX_CRAWL_ALLOW_PATHS = Object.freeze([
 
 const NOINDEX_HEADER = Object.freeze({ key: 'X-Robots-Tag', value: 'noindex, nofollow' })
 
+/**
+ * Fail-closed production check for indexability decisions. BASE_URL
+ * deliberately falls back to production for links, but that fallback must not
+ * make an unset preview environment indexable — so derive from the RAW env
+ * value: only an explicitly configured production origin counts.
+ *
+ * @param {string | undefined} rawBaseUrl usually process.env.NEXT_PUBLIC_BASE_URL
+ * @returns {boolean}
+ */
+function isProductionDomain(rawBaseUrl) {
+    return rawBaseUrl?.replace(/\/$/, '') === 'https://peanut.me'
+}
+
 function buildNoindexHeaderRules() {
     return [
         ...NOINDEX_EXACT_ROUTES.map((source) => ({ source, headers: [NOINDEX_HEADER] })),
@@ -110,4 +123,5 @@ module.exports = {
     NOINDEX_ROUTE_PREFIXES,
     ROBOTS_DISALLOWED_PATHS,
     buildNoindexHeaderRules,
+    isProductionDomain,
 }

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -151,7 +151,13 @@ describe('useMultiPhaseKycFlow — KYC_REJECTED capture effect', () => {
             expect(mockFetchUser).toHaveBeenCalledTimes(1)
         })
 
-        it('a submission close (handleSdkComplete) consumes the deferred status', async () => {
+        // handleSdkComplete does not consume it either. On native the callback is
+        // ambiguous in a multi-level session: SumsubNativeSdk puts Pending in
+        // SUBMITTED_STATES, so a Level-1 submit followed by backing out of Level 2
+        // resolves launch() as Initial but still fires onComplete — identical to a
+        // real completion from here. Consuming on that path suppressed the capture
+        // and the user-store refresh and left a stale progress modal.
+        it('a handleSdkComplete close still captures — the native Level-1 exit looks the same', async () => {
             const { result } = await openMultiLevelSdk()
 
             await act(async () => {
@@ -163,7 +169,8 @@ describe('useMultiPhaseKycFlow — KYC_REJECTED capture effect', () => {
                 result.current.handleSdkComplete()
             })
 
-            expect(rejectedCaptures()).toHaveLength(0)
+            expect(rejectedCaptures()).toHaveLength(1)
+            expect(mockFetchUser).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -126,21 +126,29 @@ describe('useMultiPhaseKycFlow — KYC_REJECTED capture effect', () => {
             expect(mockFetchUser).toHaveBeenCalledTimes(1)
         })
 
-        it('a manual close after the user submitted does NOT replay a bogus rejection', async () => {
+        // A manual close ALWAYS replays, even after a submit. The wrapper cannot
+        // tell "submitted the required follow-up" from "submitted level 1 and
+        // walked away" — a second onApplicantSubmitted is deduped as the idCheck
+        // twin, not read as a new level — so trusting it would swallow a real
+        // ACTION_REQUIRED and strand the user on a stale progress modal.
+        // handleSdkComplete below is the one close that legitimately consumes.
+        it('a manual close still replays, even when the user had already submitted a level', async () => {
             const { result } = await openMultiLevelSdk()
 
+            act(() => {
+                result.current.handleSdkSubmitted()
+            })
             await act(async () => {
                 mockWs.handler?.('ACTION_REQUIRED')
             })
             expect(rejectedCaptures()).toHaveLength(0)
 
-            // level-2 submitted; SDK sat on "documents submitted"; user taps X
             act(() => {
-                result.current.handleSdkClose({ submitted: true })
+                result.current.handleSdkClose()
             })
 
-            expect(rejectedCaptures()).toHaveLength(0)
-            expect(mockFetchUser).not.toHaveBeenCalled()
+            expect(rejectedCaptures()).toHaveLength(1)
+            expect(mockFetchUser).toHaveBeenCalledTimes(1)
         })
 
         it('a submission close (handleSdkComplete) consumes the deferred status', async () => {

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -1,0 +1,161 @@
+import { act } from '@testing-library/react'
+import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
+import posthog from 'posthog-js'
+import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { initiateSumsubKyc } from '@/app/actions/sumsub'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+
+// Pins the KYC_REJECTED capture + user-store refresh effect: it must be
+// edge-triggered on the status (its other deps churn during resubmit rounds)
+// and honor the multi-level deferral's consume-on-submission semantics.
+
+const mockWs: { handler?: (status: string, labels?: string[]) => void } = {}
+const mockFetchUser = jest.fn()
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/app/actions/sumsub', () => ({
+    ...jest.requireActual('@/app/actions/sumsub'),
+    // Only the network-touching actions are stubbed — pure helpers like
+    // isTerminalActionCode must come from the real module, or the hook's
+    // terminal-refusal branch calls undefined and every initiate bails.
+    initiateSumsubKyc: jest.fn(),
+    initiateSelfHealResubmission: jest.fn(),
+    restartIdentityVerification: jest.fn(),
+    startKycAction: jest.fn(),
+}))
+jest.mock('@/hooks/useWebSocket', () => ({
+    useWebSocket: (opts: { onSumsubKycStatusUpdate?: (status: string, labels?: string[]) => void }) => {
+        mockWs.handler = opts.onSumsubKycStatusUpdate
+    },
+}))
+jest.mock('@/redux/hooks', () => ({ useUserStore: () => ({ user: { user: { username: 'test' } } }) }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn() }) }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, isAndroidNative: () => false }))
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ fetchUser: mockFetchUser, user: null }) }))
+jest.mock('@/hooks/useCapabilities', () => ({ useCapabilities: () => ({ capabilities: undefined }) }))
+jest.mock('@/hooks/useSumsubReloadResume', () => ({ useSumsubReloadResume: jest.fn() }))
+jest.mock('@/hooks/useSubmissionWindow', () => ({ markSubmitted: jest.fn() }))
+jest.mock('@/utils/capability-gate', () => ({ deriveGate: () => ({ kind: 'none' }) }))
+jest.mock('@/app/actions/users', () => ({ getBridgeTosLink: jest.fn(), confirmBridgeTos: jest.fn() }))
+
+const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSumsubKyc>
+const mockCapture = posthog.capture as jest.MockedFunction<typeof posthog.capture>
+
+const rejectedCaptures = () => mockCapture.mock.calls.filter(([event]) => event === ANALYTICS_EVENTS.KYC_REJECTED)
+
+describe('useMultiPhaseKycFlow — KYC_REJECTED capture effect', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockCapture.mockClear()
+        mockFetchUser.mockReset()
+        mockFetchUser.mockResolvedValue(null)
+        mockWs.handler = undefined
+    })
+
+    it('captures once per status transition and refreshes the user store once', async () => {
+        renderHook(() => useMultiPhaseKycFlow({}))
+
+        await act(async () => {
+            mockWs.handler?.('REJECTED')
+        })
+
+        expect(rejectedCaptures()).toHaveLength(1)
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
+    })
+
+    // Regression: the effect's deps include showWrapper, which toggles when the
+    // user re-opens the SDK to resubmit while the status is still the stale
+    // REJECTED. The non-edge-triggered version fired a duplicate KYC_REJECTED
+    // and 2-3 redundant fetchUser calls per resubmit round.
+    it('a resubmit round (SDK reopen + close on a stale status) does not duplicate the capture', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'REJECTED' },
+        })
+        const { result } = renderHook(() => useMultiPhaseKycFlow({}))
+
+        await act(async () => {
+            mockWs.handler?.('REJECTED')
+        })
+        expect(rejectedCaptures()).toHaveLength(1)
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
+
+        // reopen the SDK (showWrapper flips true — effect deps change, status doesn't)
+        await act(async () => {
+            await result.current.handleInitiateKyc('ROW')
+        })
+        expect(result.current.showWrapper).toBe(true)
+
+        // manual close (showWrapper flips back)
+        act(() => {
+            result.current.handleSdkClose()
+        })
+
+        expect(rejectedCaptures()).toHaveLength(1)
+        expect(mockFetchUser).toHaveBeenCalledTimes(1)
+    })
+
+    describe('multi-level deferral', () => {
+        const openMultiLevelSdk = async () => {
+            mockInitiate.mockResolvedValue({
+                data: { token: 'tok_1', applicantId: 'app_1', status: 'PENDING' },
+            })
+            const view = renderHook(() => useMultiPhaseKycFlow({}))
+            await act(async () => {
+                await view.result.current.handleInitiateKyc('EU')
+            })
+            expect(view.result.current.showWrapper).toBe(true)
+            expect(view.result.current.isMultiLevel).toBe(true)
+            return view
+        }
+
+        it('defers ACTION_REQUIRED while the SDK is open, then captures once on an abandoned close', async () => {
+            const { result } = await openMultiLevelSdk()
+
+            await act(async () => {
+                mockWs.handler?.('ACTION_REQUIRED')
+            })
+            // deferred: the questionnaire is showing, not a rejection
+            expect(rejectedCaptures()).toHaveLength(0)
+
+            act(() => {
+                result.current.handleSdkClose()
+            })
+
+            // abandoning really does leave the action required — replay fires once
+            expect(rejectedCaptures()).toHaveLength(1)
+            expect(mockFetchUser).toHaveBeenCalledTimes(1)
+        })
+
+        it('a manual close after the user submitted does NOT replay a bogus rejection', async () => {
+            const { result } = await openMultiLevelSdk()
+
+            await act(async () => {
+                mockWs.handler?.('ACTION_REQUIRED')
+            })
+            expect(rejectedCaptures()).toHaveLength(0)
+
+            // level-2 submitted; SDK sat on "documents submitted"; user taps X
+            act(() => {
+                result.current.handleSdkClose({ submitted: true })
+            })
+
+            expect(rejectedCaptures()).toHaveLength(0)
+            expect(mockFetchUser).not.toHaveBeenCalled()
+        })
+
+        it('a submission close (handleSdkComplete) consumes the deferred status', async () => {
+            const { result } = await openMultiLevelSdk()
+
+            await act(async () => {
+                mockWs.handler?.('ACTION_REQUIRED')
+            })
+            expect(rejectedCaptures()).toHaveLength(0)
+
+            act(() => {
+                result.current.handleSdkComplete()
+            })
+
+            expect(rejectedCaptures()).toHaveLength(0)
+        })
+    })
+})

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -525,12 +525,13 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
         expect(result.current.isVerificationProgressModalOpen).toBe(true)
     })
 
-    // A manual close can ALSO be a submission: after the level-2 submit the SDK
-    // sits on "documents submitted" and never runs onComplete, so tapping X is
-    // how the user leaves. The wrapper marks that close `submitted: true` and it
-    // must consume the deferred transition like handleSdkComplete — replaying it
-    // would report a stale rejection for documents the user just submitted.
-    it('a submitted manual close consumes the deferred transition — no replay', async () => {
+    // The counterpart: a MANUAL close always replays. handleSdkComplete is the
+    // only close that can honestly claim a submission — the wrapper cannot tell
+    // "submitted the required follow-up" from "submitted level 1 and walked
+    // away" (a second onApplicantSubmitted is deduped as the idCheck twin, not
+    // read as a new level), so a close that consumed on its say-so would swallow
+    // a real ACTION_REQUIRED and leave the user on a stale progress modal.
+    it('a manual close replays the deferred transition', async () => {
         const { result } = await openSdkOverProgressModal('EU')
 
         await act(async () => {
@@ -539,11 +540,11 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
         expect(result.current.isVerificationProgressModalOpen).toBe(true)
 
         act(() => {
-            result.current.handleClose({ submitted: true })
+            result.current.handleClose()
         })
 
         expect(result.current.showWrapper).toBe(false)
-        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
     })
 
     // Boundary: the suppression is scoped to an OPEN SDK. Once the user is out of

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -494,6 +494,27 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
         expect(result.current.isVerificationProgressModalOpen).toBe(true)
     })
 
+    // A manual close can ALSO be a submission: after the level-2 submit the SDK
+    // sits on "documents submitted" and never runs onComplete, so tapping X is
+    // how the user leaves. The wrapper marks that close `submitted: true` and it
+    // must consume the deferred transition like handleSdkComplete — replaying it
+    // would report a stale rejection for documents the user just submitted.
+    it('a submitted manual close consumes the deferred transition — no replay', async () => {
+        const { result } = await openSdkOverProgressModal('EU')
+
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+
+        act(() => {
+            result.current.handleClose({ submitted: true })
+        })
+
+        expect(result.current.showWrapper).toBe(false)
+        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+    })
+
     // Boundary: the suppression is scoped to an OPEN SDK. Once the user is out of
     // the SDK, ACTION_REQUIRED is a real drawer state and must close the modal.
     it('still closes once the SDK is closed', async () => {

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -411,6 +411,37 @@ describe('useSumsubKycFlow — multi-level workflows', () => {
         expect(result.current.isActionFlow).toBe(true)
         expect(result.current.isMultiLevel).toBe(false)
     })
+
+    // Cross-region EU uplift is NOT an applicant action: the backend moves the
+    // applicant to bridge-requirements, whose EEA branch is the
+    // bridge-eea-uplift questionnaire — the SDK must hold open through it.
+    it('cross-region EU uplift (bridge-uplift) stays multi-level', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'bridge-uplift' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('EU', undefined, true, 'DE')
+        })
+
+        expect(result.current.isActionFlow).toBe(false)
+        expect(result.current.isMultiLevel).toBe(true)
+    })
+
+    it('bridge-uplift toward NA keeps NA single-level', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_1', applicantId: 'app_1', status: 'APPROVED', actionType: 'bridge-uplift' },
+        })
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+
+        await act(async () => {
+            await result.current.handleInitiateKyc('NA', undefined, true, 'US')
+        })
+
+        expect(result.current.isActionFlow).toBe(false)
+        expect(result.current.isMultiLevel).toBe(false)
+    })
 })
 
 // The companion backend change maps the follow-up level's `init` state to

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -320,16 +320,21 @@ export const useMultiPhaseKycFlow = ({
         reportedRejectionRef.current = null
         posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: lastIntentRef.current ?? regionIntent })
         isRealtimeFlowRef.current = true
-        // consume a deferred ACTION_REQUIRED for this hook's capture effect too —
-        // originalHandleSdkComplete does the same for the sibling's transition effect
-        if (liveKycStatus === 'ACTION_REQUIRED') prevCapturedStatusRef.current = 'ACTION_REQUIRED'
+        // Deliberately does NOT consume a deferred ACTION_REQUIRED for the capture
+        // effect. On native this callback is ambiguous in a multi-level session:
+        // SumsubNativeSdk marks Pending as submitted, so a Level-1 submit followed
+        // by backing out of Level 2 arrives here exactly like a real completion.
+        // Suppressing the capture and the user-store refresh on that path would
+        // strand the applicant on a stale progress modal. (originalHandleSdkComplete
+        // still consumes for the sibling transition effect — pre-existing, and the
+        // same ambiguity applies to it.)
         originalHandleSdkComplete()
         // for action flows (manteca, self-heal), the base status is already APPROVED
         // and won't transition — directly start the preparing/tracking phase
         if (isActionFlow) {
             handleSumsubApproved()
         }
-    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent, liveKycStatus])
+    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
 
     // true only while a PWA-reload resume drives handleInitiateKyc, so the
     // analytics event can distinguish a resume from a genuine new initiation

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -9,7 +9,7 @@ import { getBridgeTosLink, confirmBridgeTos } from '@/app/actions/users'
 import { type IframeCloseSource } from '@/components/Global/IframeWrapper'
 import { type KycModalPhase, type IUserProfile } from '@/interfaces/interfaces'
 import { type UserCapabilities } from '@/types/capabilities'
-import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
+import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
@@ -275,6 +275,7 @@ export const useMultiPhaseKycFlow = ({
 
     // refresh user store when kyc status transitions to a non-success state
     // so the drawer/status item reads the updated verification record
+    const prevCapturedStatusRef = useRef<SumsubKycStatus | undefined>(undefined)
     useEffect(() => {
         // Same defer guard as the transition effect in useSumsubKycFlow: while a
         // multi-level SDK session is open, ACTION_REQUIRED is the routine "the
@@ -283,8 +284,17 @@ export const useMultiPhaseKycFlow = ({
         // submitted). Acting on it here would log a bogus KYC_REJECTED for every
         // succeeding EEA applicant and flip the user store to action_required
         // under the open SDK. The effect re-runs when the SDK closes, so an
-        // abandoned session still gets the capture and the store refresh.
+        // abandoned session still gets the capture and the store refresh —
+        // unless the close was a submission, which consumes the deferral
+        // (handleSdkComplete / handleSdkClose advance the ref below).
         if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
+        // Edge-triggered like that sibling effect: the other deps also change
+        // during a resubmit round (setShowWrapper toggles while the status is a
+        // stale REJECTED/ACTION_REQUIRED), which used to fire duplicate
+        // KYC_REJECTED captures and redundant fetchUser calls.
+        const prevStatus = prevCapturedStatusRef.current
+        prevCapturedStatusRef.current = liveKycStatus
+        if (liveKycStatus === prevStatus) return
         if (liveKycStatus === 'ACTION_REQUIRED' || liveKycStatus === 'REJECTED') {
             if (reportedRejectionRef.current === liveKycStatus) return
             reportedRejectionRef.current = liveKycStatus
@@ -310,13 +320,28 @@ export const useMultiPhaseKycFlow = ({
         reportedRejectionRef.current = null
         posthog.capture(ANALYTICS_EVENTS.KYC_SUBMITTED, { region_intent: lastIntentRef.current ?? regionIntent })
         isRealtimeFlowRef.current = true
+        // consume a deferred ACTION_REQUIRED for this hook's capture effect too —
+        // originalHandleSdkComplete does the same for the sibling's transition effect
+        if (liveKycStatus === 'ACTION_REQUIRED') prevCapturedStatusRef.current = 'ACTION_REQUIRED'
         originalHandleSdkComplete()
         // for action flows (manteca, self-heal), the base status is already APPROVED
         // and won't transition — directly start the preparing/tracking phase
         if (isActionFlow) {
             handleSumsubApproved()
         }
-    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
+    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent, liveKycStatus])
+
+    // SDK manual close. A submitted close (see SumsubSdkProps.onClose) consumes
+    // the deferred ACTION_REQUIRED so the capture effect above doesn't replay a
+    // bogus rejection; an abandoned close keeps the replay.
+    const handleSdkClose = useCallback(
+        (opts?: { submitted?: boolean }) => {
+            if (opts?.submitted && liveKycStatus === 'ACTION_REQUIRED')
+                prevCapturedStatusRef.current = 'ACTION_REQUIRED'
+            handleClose(opts)
+        },
+        [handleClose, liveKycStatus]
+    )
 
     // true only while a PWA-reload resume drives handleInitiateKyc, so the
     // analytics event can distinguish a resume from a genuine new initiation
@@ -533,7 +558,7 @@ export const useMultiPhaseKycFlow = ({
         // SDK wrapper
         showWrapper,
         accessToken,
-        handleSdkClose: handleClose,
+        handleSdkClose,
         handleSdkComplete,
         handleSdkSubmitted,
         refreshToken,

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -331,18 +331,6 @@ export const useMultiPhaseKycFlow = ({
         }
     }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent, liveKycStatus])
 
-    // SDK manual close. A submitted close (see SumsubSdkProps.onClose) consumes
-    // the deferred ACTION_REQUIRED so the capture effect above doesn't replay a
-    // bogus rejection; an abandoned close keeps the replay.
-    const handleSdkClose = useCallback(
-        (opts?: { submitted?: boolean }) => {
-            if (opts?.submitted && liveKycStatus === 'ACTION_REQUIRED')
-                prevCapturedStatusRef.current = 'ACTION_REQUIRED'
-            handleClose(opts)
-        },
-        [handleClose, liveKycStatus]
-    )
-
     // true only while a PWA-reload resume drives handleInitiateKyc, so the
     // analytics event can distinguish a resume from a genuine new initiation
     // (a resume otherwise looks identical and inflates "initiated" counts).
@@ -558,7 +546,7 @@ export const useMultiPhaseKycFlow = ({
         // SDK wrapper
         showWrapper,
         accessToken,
-        handleSdkClose,
+        handleSdkClose: handleClose,
         handleSdkComplete,
         handleSdkSubmitted,
         refreshToken,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -475,13 +475,21 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         setIsVerificationProgressModalOpen(true)
     }, [liveKycStatus])
 
-    // called when user manually closes the sdk modal
-    const handleClose = useCallback(() => {
-        setShowWrapper(false)
-        setIsActionFlow(false)
-        setIsMultiLevel(false)
-        onManualClose?.()
-    }, [onManualClose])
+    // Called when the user manually closes the SDK modal. A close after the
+    // user SUBMITTED (multi-level level-2 done, SDK sitting on "documents
+    // submitted") consumes the deferred ACTION_REQUIRED exactly like
+    // handleSdkComplete: the user just acted, so the held transition is stale.
+    // An abandoned close keeps the replay.
+    const handleClose = useCallback(
+        (opts?: { submitted?: boolean }) => {
+            if (opts?.submitted && liveKycStatus === 'ACTION_REQUIRED') prevStatusRef.current = 'ACTION_REQUIRED'
+            setShowWrapper(false)
+            setIsActionFlow(false)
+            setIsMultiLevel(false)
+            onManualClose?.()
+        },
+        [onManualClose, liveKycStatus]
+    )
 
     // token refresh function passed to the sdk for when the token expires.
     // routes by how the flow started: start-action key, self-heal provider, or

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -487,21 +487,17 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         setIsVerificationProgressModalOpen(true)
     }, [liveKycStatus])
 
-    // Called when the user manually closes the SDK modal. A close after the
-    // user SUBMITTED (multi-level level-2 done, SDK sitting on "documents
-    // submitted") consumes the deferred ACTION_REQUIRED exactly like
-    // handleSdkComplete: the user just acted, so the held transition is stale.
-    // An abandoned close keeps the replay.
-    const handleClose = useCallback(
-        (opts?: { submitted?: boolean }) => {
-            if (opts?.submitted && liveKycStatus === 'ACTION_REQUIRED') prevStatusRef.current = 'ACTION_REQUIRED'
-            setShowWrapper(false)
-            setIsActionFlow(false)
-            setIsMultiLevel(false)
-            onManualClose?.()
-        },
-        [onManualClose, liveKycStatus]
-    )
+    // Called when the user manually closes the SDK modal. Every manual close
+    // replays a deferred ACTION_REQUIRED: the wrapper cannot tell "submitted the
+    // required follow-up" from "submitted level 1 and walked away", so treating
+    // any close as a submission would swallow a real action-required state.
+    // handleSdkComplete is the one unambiguous submission, and it consumes.
+    const handleClose = useCallback(() => {
+        setShowWrapper(false)
+        setIsActionFlow(false)
+        setIsMultiLevel(false)
+        onManualClose?.()
+    }, [onManualClose])
 
     // token refresh function passed to the sdk for when the token expires.
     // routes by how the flow started: start-action key, self-heal provider, or

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -435,8 +435,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     // the WebSDK by platform, so every flow that mints a token —
                     // not just this one — reaches the right SDK.
                     setAccessToken(response.data.token)
-                    setIsActionFlow(!!response.data.actionType)
-                    setIsMultiLevel(!response.data.actionType && isMultiLevelIntent(effectiveIntent))
+                    const actionType = response.data.actionType
+                    /*
+                     * 'bridge-uplift' is not a single-level applicant action: the
+                     * backend moved the applicant to bridge-requirements, which for
+                     * an EU target branches into the bridge-eea-uplift questionnaire.
+                     * Treat it like a first-run flow for that intent, or the SDK
+                     * closes on the first submission before the questionnaire.
+                     * NA targets share the workflow but stay single-level (see
+                     * isMultiLevelIntent).
+                     */
+                    setIsActionFlow(!!actionType && actionType !== 'bridge-uplift')
+                    setIsMultiLevel(
+                        (!actionType || actionType === 'bridge-uplift') && isMultiLevelIntent(effectiveIntent)
+                    )
                     setShowWrapper(true)
                     return true
                 } else {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -461,6 +461,10 @@
         "passkey": {
             "notAvailable": "Las passkeys aún no están disponibles en este dispositivo. Intentalo de nuevo.",
             "cancelled": "La configuración de la passkey fue cancelada. Intentalo de nuevo cuando quieras.",
+            "tookTooLong": "Esto está tardando más de lo esperado. Intentalo de nuevo.",
+            "notReady": "La app todavía se está preparando para las passkeys. Esperá un momento e intentalo de nuevo.",
+            "deviceState": "Hubo un problema con la passkey en este dispositivo. Reiniciá la app e intentalo de nuevo.",
+            "interrupted": "Algo interrumpió la solicitud de la passkey. Intentalo de nuevo.",
             "usernameTaken": "Este nombre de usuario ya está registrado, posiblemente por un intento anterior en este dispositivo. Si fuiste vos, tu passkey está lista: solo iniciá sesión.",
             "learnMore": "Aprendé más sobre qué son las passkeys",
             "help": {

--- a/src/services/__tests__/step-up.test.ts
+++ b/src/services/__tests__/step-up.test.ts
@@ -5,12 +5,20 @@
 import { clearStepUpToken, getStepUpToken, STEP_UP_HEADER, withStepUpHeader } from '../step-up'
 import { apiFetch } from '@/utils/api-fetch'
 import { startAuthentication } from '@simplewebauthn/browser'
+import { CeremonyTimeoutError, guardPasskeyCeremony } from '@/utils/passkeyCeremony.utils'
 
 jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn() }))
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, getNativeRpId: () => 'peanut.me' }))
+// passthrough spy — the suite asserts the ceremony is routed through the guard
+// (shim gate + timeout, TASK-21782) without changing its behavior
+jest.mock('@/utils/passkeyCeremony.utils', () => {
+    const actual = jest.requireActual('@/utils/passkeyCeremony.utils')
+    return { ...actual, guardPasskeyCeremony: jest.fn(actual.guardPasskeyCeremony) }
+})
 
 const mockedFetch = apiFetch as jest.MockedFunction<typeof apiFetch>
 const mockedAuth = startAuthentication as jest.MockedFunction<typeof startAuthentication>
+const mockedGuard = guardPasskeyCeremony as jest.MockedFunction<typeof guardPasskeyCeremony>
 
 function jsonResponse(body: unknown, ok = true, status = 200) {
     return { ok, status, json: async () => body } as Response
@@ -83,6 +91,23 @@ describe('getStepUpToken', () => {
         mockedFetch.mockResolvedValueOnce(jsonResponse({ challenge: 'abc' }))
         mockedAuth.mockRejectedValueOnce(Object.assign(new Error('cancelled'), { name: 'NotAllowedError' }))
         await expect(getStepUpToken()).rejects.toThrow('cancelled')
+    })
+
+    it('runs the WebAuthn ceremony inside the passkey ceremony guard', async () => {
+        happyPath()
+        mockedGuard.mockClear()
+        await getStepUpToken()
+        expect(mockedGuard).toHaveBeenCalledTimes(1)
+    })
+
+    it('surfaces a ceremony guard failure as a StepUpError with curated copy', async () => {
+        mockedFetch.mockReset()
+        mockedFetch.mockResolvedValueOnce(jsonResponse({ challenge: 'abc' }))
+        mockedAuth.mockRejectedValueOnce(new CeremonyTimeoutError(60_000))
+
+        const failure = getStepUpToken()
+        await expect(failure).rejects.toThrow(/taking longer/i)
+        await expect(failure).rejects.toMatchObject({ name: 'StepUpError' })
     })
 })
 

--- a/src/services/step-up.ts
+++ b/src/services/step-up.ts
@@ -13,6 +13,8 @@
 import { startAuthentication } from '@simplewebauthn/browser'
 import { apiFetch } from '@/utils/api-fetch'
 import { getNativeRpId, isCapacitor } from '@/utils/capacitor'
+import { guardPasskeyCeremony, isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
+import { classifyPasskeyError } from '@/utils/webauthn.utils'
 
 export const STEP_UP_HEADER = 'x-step-up-token'
 
@@ -56,7 +58,17 @@ export async function getStepUpToken(): Promise<string> {
     }
     const options = await optionsResponse.json()
 
-    const cred = await startAuthentication(options)
+    // Same guard class as login (TASK-21782): a step-up racing the async shim
+    // install on native runs the webview's raw WebAuthn, which silently never
+    // settles. Gate on the shim and bound the ceremony; guard failures surface
+    // as StepUpError so callers render the curated copy, not a raw timeout.
+    let cred: Awaited<ReturnType<typeof startAuthentication>>
+    try {
+        cred = await guardPasskeyCeremony(() => startAuthentication(options))
+    } catch (error) {
+        if (isCeremonyGuardError(error)) throw new StepUpError(classifyPasskeyError(error).message)
+        throw error
+    }
 
     const verifyResponse = await apiFetch('/auth/step-up/verify', {
         method: 'POST',

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -18,7 +18,7 @@ import { setAuthToken } from '@/utils/auth-token'
 
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
 jest.mock('@/utils/auth-token', () => ({ setAuthToken: jest.fn() }))
-jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/utils/sentry-lazy', () => ({ captureException: jest.fn() }))
 const mockIsCapacitor = isCapacitor as jest.Mock
 const mockSetAuthToken = setAuthToken as jest.Mock
 

--- a/src/utils/__tests__/webauthn.utils.test.ts
+++ b/src/utils/__tests__/webauthn.utils.test.ts
@@ -1,5 +1,5 @@
 import posthog from 'posthog-js'
-import { capturePasskeySignFailure, classifyPasskeyError } from '../webauthn.utils'
+import { capturePasskeySignFailure, classifyPasskeyError, getPasskeyErrorSetupKey } from '../webauthn.utils'
 
 jest.mock('posthog-js', () => ({
     __esModule: true,
@@ -71,5 +71,29 @@ describe('classifyPasskeyError', () => {
 
     test('falls back to LOGIN_ERROR for unknown errors', () => {
         expect(classifyPasskeyError(new Error('mystery')).code).toBe('LOGIN_ERROR')
+    })
+})
+
+describe('getPasskeyErrorSetupKey', () => {
+    const passkeyError = (code: string) =>
+        Object.assign(new Error('curated english copy'), { name: 'PasskeyError', code })
+
+    test('maps a known PasskeyError code to its translated setup.* catalog key', () => {
+        expect(getPasskeyErrorSetupKey(passkeyError('LOGIN_CANCELED'))).toBe('waitlist.loginCanceled')
+        expect(getPasskeyErrorSetupKey(passkeyError('CEREMONY_TIMEOUT'))).toBe('passkey.tookTooLong')
+        expect(getPasskeyErrorSetupKey(passkeyError('PASSKEY_NOT_READY'))).toBe('passkey.notReady')
+        expect(getPasskeyErrorSetupKey(passkeyError('PASSKEY_STATE'))).toBe('passkey.deviceState')
+        expect(getPasskeyErrorSetupKey(passkeyError('PASSKEY_INTERRUPTED'))).toBe('passkey.interrupted')
+    })
+
+    test('returns undefined for codes without a translated equivalent (English fallback)', () => {
+        expect(getPasskeyErrorSetupKey(passkeyError('NETWORK'))).toBeUndefined()
+        expect(getPasskeyErrorSetupKey(passkeyError('LOGIN_ERROR'))).toBeUndefined()
+    })
+
+    test('returns undefined for non-PasskeyError failures and unknown codes', () => {
+        expect(getPasskeyErrorSetupKey(new Error('boom'))).toBeUndefined()
+        expect(getPasskeyErrorSetupKey(passkeyError('SOME_FUTURE_CODE'))).toBeUndefined()
+        expect(getPasskeyErrorSetupKey(undefined)).toBeUndefined()
     })
 })

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@sentry/nextjs'
+import { captureException } from '@/utils/sentry-lazy'
 import { isCapacitor } from '@/utils/capacitor'
 import { setAuthToken } from '@/utils/auth-token'
 

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -49,6 +49,40 @@ const PASSKEY_LOGIN_MESSAGES = {
 
 export type PasskeyErrorCode = keyof typeof PASSKEY_LOGIN_MESSAGES
 
+/**
+ * PasskeyErrorCode → `setup.*` catalog key, for codes whose copy already
+ * exists translated. Render sites resolve these with useTranslations('setup');
+ * codes not listed fall back to the English message the error carries.
+ */
+const PASSKEY_ERROR_SETUP_KEYS = {
+    LOGIN_CANCELED: 'waitlist.loginCanceled',
+    CEREMONY_TIMEOUT: 'passkey.tookTooLong',
+    PASSKEY_NOT_READY: 'passkey.notReady',
+    PASSKEY_STATE: 'passkey.deviceState',
+    PASSKEY_INTERRUPTED: 'passkey.interrupted',
+} as const satisfies Partial<Record<PasskeyErrorCode, string>>
+
+/** Reads the classification code off a thrown PasskeyError, if it carries one. */
+export function getPasskeyErrorCode(error: unknown): PasskeyErrorCode | undefined {
+    if (!(error instanceof Error) || error.name !== 'PasskeyError') return undefined
+    const code = (error as Error & { code?: unknown }).code
+    return typeof code === 'string' && code in PASSKEY_LOGIN_MESSAGES ? (code as PasskeyErrorCode) : undefined
+}
+
+/**
+ * Maps a login failure to the `setup.*` i18n key for its curated copy, or
+ * undefined when no translated equivalent exists (the caller then renders the
+ * error's own English message as the fallback).
+ */
+export function getPasskeyErrorSetupKey(
+    error: unknown
+): (typeof PASSKEY_ERROR_SETUP_KEYS)[keyof typeof PASSKEY_ERROR_SETUP_KEYS] | undefined {
+    const code = getPasskeyErrorCode(error)
+    return code && code in PASSKEY_ERROR_SETUP_KEYS
+        ? PASSKEY_ERROR_SETUP_KEYS[code as keyof typeof PASSKEY_ERROR_SETUP_KEYS]
+        : undefined
+}
+
 function isNetworkError(error: Error): boolean {
     if (error.name === 'TypeError' && /fetch|network/i.test(error.message)) return true
     // "Load failed" is WebKit's message for a failed fetch (common when the


### PR DESCRIPTION
Re-lands the review fixes that were reviewed on #2830 and lost when that back-merge was closed in favour of the 08-28 one (#2874). The replacement carried `main`'s history but not these commits, so none of them are on `dev` or `main` today — verified per commit by grepping `origin/dev` for its added lines before opening this.

Cherry-picked with `-x`, so each commit keeps its original author, message and a pointer back to the original SHA.

### What's in it

| Commit | Fix |
| --- | --- |
| `1a3e020` | Keep the ceremony guard on the lazy Sentry loader |
| `80d2801` | Guard the step-up WebAuthn ceremony against the shim race |
| `29f0e06` | es-AR voseo overrides for the new `setup.passkey` error keys |
| `815c00c` | Render translated copy for login `PasskeyError` codes |
| `fd90272` | Drop a stale font mock |
| `a8da766` | Fail `robots.ts` closed with the shared production-domain check |
| `7e33fb7` | Edge-trigger the `KYC_REJECTED` capture, consume the deferral on submitted closes |
| `514f23f` | Keep cross-region EU uplift multi-level (`bridge-uplift`) |

### Where `dev` had moved on

Five applied clean. The rest needed a decision, and one commit was only half-valid:

- **`robots.ts`** — `dev` had already fixed the fail-closed bug inline, but left the derivation duplicated in `layout.tsx`. Kept the commit's `isProductionDomain` extraction so the two can't drift apart again — that drift is how the bug happened. Took the commit's test file: it is a strict superset of `dev`'s (table-driven over unset/empty/staging/`peanut.me.evil.example`, plus a trailing-slash case), and `dev`'s lazy `require`/`resetModules` dance is unnecessary now that the check reads the env at call time.
- **`d953b345` split** — that commit dropped `getUnderlyingFetch` as unimported *and* removed a stale font mock. The first half is no longer true: #2871 restored the transport canary and `native-canary.ts` imports it again (caught by `typecheck`). Only the font-mock half is re-landed, as `fd90272`; the export stays.
- **`SumsubKycWrapper.test.tsx`** — purely additive. `dev` added multi-level resubmission tests, the commit added a post-submit-close test; both kept.
- **`sumsub.types.ts`** — `dev`'s `KycActionType` already had `bridge-uplift` and has since gained `rails-unavailable`. Kept `dev`'s union; the commit's `useSumsubKycFlow` hunks applied clean.

Two mocks in the new `useMultiPhaseKycFlow` suite also needed updating for `dev`'s current surface — `@/utils/capacitor` now needs `isAndroidNative` (the mascot module calls it), and the `@/app/actions/sumsub` mock has to spread `requireActual` so the hook's `isTerminalActionCode` branch gets the real helper instead of `undefined`. That is the same partial-mock pattern the sibling `useSumsubKycFlow` suite documents; without it every initiate silently bailed. Folded into `7e33fb7` rather than left as a follow-up.

### Verification

`pnpm typecheck` clean; `prettier --check` clean on all touched files; the 8 touched suites pass (121 tests), plus the i18n parity suites (`messages`, `locale-bridge`, `proxy-locale`, `friendly-error`) for the es-AR change — 109 tests.
