### PR TITLE
fix: three UI behavior guards (TASK-21886, TASK-21930, TASK-21967)

### DIFF
--- a/src/app/(mobile-ui)/card/add-to-wallet/__tests__/add-to-wallet-nav.test.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/__tests__/add-to-wallet-nav.test.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { __testing } from '@/hooks/useSafeBack'
 
+const back = jest.fn()
 const push = jest.fn()
 const replace = jest.fn()
-const onBack = jest.fn()
 
-jest.mock('next/navigation', () => ({ useRouter: () => ({ push, replace }) }))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ back, push, replace, prefetch: jest.fn() }) }))
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
 jest.mock('@/hooks/useWalletPlatform', () => ({ useWalletPlatform: () => 'ios' }))
-jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => onBack }))
 jest.mock('@/components/0_Bruddle/PageContainer', () => {
     return function MockPageContainer(p: { children?: React.ReactNode }) {
         return <div>{p.children}</div>
     }
 })
 // Surface the carousel's two exits as buttons so the test drives the real page callbacks.
+// useSafeBack is deliberately NOT mocked — the whole defect lives in which branch it takes.
 jest.mock('@/components/Card/AddToWalletCarousel', () => {
     return function MockCarousel(p: { onDone: () => void; onPrev?: () => void }) {
         return (
@@ -28,29 +29,46 @@ jest.mock('@/components/Card/AddToWalletCarousel', () => {
 
 import AddToWalletPage from '../page'
 
+// Regression (TASK-21930): Done used router.push, so Back popped the user straight back
+// into the tutorial they had just finished. The only in-app entry is the link on /card
+// (YourCardScreen), so the realistic history is [..., /card, /card/add-to-wallet].
 describe('card add-to-wallet navigation', () => {
     beforeEach(() => {
-        push.mockClear()
-        replace.mockClear()
-        onBack.mockClear()
+        back.mockReset()
+        push.mockReset()
+        replace.mockReset()
+        __testing.reset()
     })
 
-    // Regression (TASK-21930): Done used router.push, so browser/native Back
-    // popped the user straight back into the tutorial they had just finished.
-    it('replaces the tutorial entry on Done so Back cannot re-enter it', () => {
+    it('backs out of the tutorial on Done when entered in-app, leaving no tutorial entry', () => {
+        act(() => {
+            window.history.pushState({}, '', '/card/add-to-wallet')
+        })
         render(<AddToWalletPage />)
+
+        fireEvent.click(screen.getByText('done'))
+
+        expect(back).toHaveBeenCalledTimes(1)
+        // A push here is the original bug; a replace would strand the user on /card.
+        expect(push).not.toHaveBeenCalled()
+        expect(replace).not.toHaveBeenCalled()
+    })
+
+    it('replaces rather than pushes on Done from a cold deep link', () => {
+        render(<AddToWalletPage />)
+
         fireEvent.click(screen.getByText('done'))
 
         expect(replace).toHaveBeenCalledWith('/card')
         expect(push).not.toHaveBeenCalled()
     })
 
-    it('routes Back through useSafeBack', () => {
+    it('leaves Back on the push fallback, so Done and Back differ only there', () => {
         render(<AddToWalletPage />)
+
         fireEvent.click(screen.getByText('prev'))
 
-        expect(onBack).toHaveBeenCalled()
-        expect(push).not.toHaveBeenCalled()
+        expect(push).toHaveBeenCalledWith('/card')
         expect(replace).not.toHaveBeenCalled()
     })
 })

--- a/src/app/(mobile-ui)/card/add-to-wallet/__tests__/add-to-wallet-nav.test.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/__tests__/add-to-wallet-nav.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+const push = jest.fn()
+const replace = jest.fn()
+const onBack = jest.fn()
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push, replace }) }))
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+jest.mock('@/hooks/useWalletPlatform', () => ({ useWalletPlatform: () => 'ios' }))
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => onBack }))
+jest.mock('@/components/0_Bruddle/PageContainer', () => {
+    return function MockPageContainer(p: { children?: React.ReactNode }) {
+        return <div>{p.children}</div>
+    }
+})
+// Surface the carousel's two exits as buttons so the test drives the real page callbacks.
+jest.mock('@/components/Card/AddToWalletCarousel', () => {
+    return function MockCarousel(p: { onDone: () => void; onPrev?: () => void }) {
+        return (
+            <div>
+                <button onClick={p.onDone}>done</button>
+                <button onClick={p.onPrev}>prev</button>
+            </div>
+        )
+    }
+})
+
+import AddToWalletPage from '../page'
+
+describe('card add-to-wallet navigation', () => {
+    beforeEach(() => {
+        push.mockClear()
+        replace.mockClear()
+        onBack.mockClear()
+    })
+
+    // Regression (TASK-21930): Done used router.push, so browser/native Back
+    // popped the user straight back into the tutorial they had just finished.
+    it('replaces the tutorial entry on Done so Back cannot re-enter it', () => {
+        render(<AddToWalletPage />)
+        fireEvent.click(screen.getByText('done'))
+
+        expect(replace).toHaveBeenCalledWith('/card')
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    it('routes Back through useSafeBack', () => {
+        render(<AddToWalletPage />)
+        fireEvent.click(screen.getByText('prev'))
+
+        expect(onBack).toHaveBeenCalled()
+        expect(push).not.toHaveBeenCalled()
+        expect(replace).not.toHaveBeenCalled()
+    })
+})

--- a/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
@@ -17,7 +17,8 @@ const AddToWalletPage: FC = () => {
     }, [platform])
     return (
         <PageContainer>
-            <AddToWalletCarousel onDone={() => router.push('/card')} onPrev={onBack} />
+            {/* Done replaces: pushing would leave the tutorial in history, so Back re-enters it. */}
+            <AddToWalletCarousel onDone={() => router.replace('/card')} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
+++ b/src/app/(mobile-ui)/card/add-to-wallet/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { type FC, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
@@ -9,16 +8,18 @@ import { useWalletPlatform } from '@/hooks/useWalletPlatform'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
 const AddToWalletPage: FC = () => {
-    const router = useRouter()
     const platform = useWalletPlatform()
     const onBack = useSafeBack('/card')
+    // Done must not leave the finished tutorial in history. The only in-app entry is the
+    // link on /card, so backing out lands there; `replace` covers the cold-deep-link
+    // fallback, where pushing /card would strand the tutorial one Back away.
+    const onDone = useSafeBack('/card', { replace: true })
     useEffect(() => {
         posthog.capture(ANALYTICS_EVENTS.CARD_ADD_TO_WALLET_VIEWED, { platform: platform ?? 'unknown' })
     }, [platform])
     return (
         <PageContainer>
-            {/* Done replaces: pushing would leave the tutorial in history, so Back re-enters it. */}
-            <AddToWalletCarousel onDone={() => router.replace('/card')} onPrev={onBack} />
+            <AddToWalletCarousel onDone={onDone} onPrev={onBack} />
         </PageContainer>
     )
 }

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -946,20 +946,39 @@ describe('GROUP 2: Payment Form States', () => {
         })
     })
 
-    test('Provider maintenance shows maintenance banner', async () => {
+    test('Provider maintenance shows maintenance banner and never calls /init', async () => {
         const maintenanceConfig = require('@/config/underMaintenance.config').default
         maintenanceConfig.disabledPaymentProviders = ['MANTECA']
 
         setupMantecaPayment()
 
+        try {
+            renderQrPay({ qrCode: 'pix://payment?id=123', type: 'PIX', t: '1' })
+
+            await waitFor(() => {
+                expect(screen.getByText('Service Temporarily Unavailable')).toBeInTheDocument()
+            })
+
+            // The kill-switch used to be render-only: the banner showed while the lock
+            // query still fired a doomed /init on every scan during the outage. The
+            // banner assertion alone passes with the guard removed, so assert the call.
+            expect(mockMantecaApi.initiateQrPayment).not.toHaveBeenCalled()
+        } finally {
+            // finally, not a trailing statement: a failed assertion above would otherwise
+            // leak MANTECA into every later test through this module singleton.
+            maintenanceConfig.disabledPaymentProviders = []
+        }
+    })
+
+    test('With the provider enabled the same QR does call /init', async () => {
+        setupMantecaPayment()
+
         renderQrPay({ qrCode: 'pix://payment?id=123', type: 'PIX', t: '1' })
 
         await waitFor(() => {
-            expect(screen.getByText('Service Temporarily Unavailable')).toBeInTheDocument()
+            expect(mockMantecaApi.initiateQrPayment).toHaveBeenCalled()
         })
-
-        // Clean up
-        maintenanceConfig.disabledPaymentProviders = []
+        expect(screen.queryByText('Service Temporarily Unavailable')).not.toBeInTheDocument()
     })
 })
 

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -607,7 +607,10 @@ export default function QRPayPage() {
             // this the entry guard shows its error but the doomed init still fires.
             !isPixRecurringCode(qrCode) &&
             !paymentLock &&
-            !shouldBlockPay,
+            !shouldBlockPay &&
+            // The maintenance kill-switch is render-only below; without this the
+            // doomed /init still fires on every scan during a provider outage.
+            !isProviderDisabled,
         retry: (failureCount, error) => {
             // Don't retry provider-specific errors
             if (NON_RETRYABLE_QR_PAY_ERRORS.some((code) => error?.message?.includes(code))) {

--- a/src/components/LandingPage/CurrencySelect.tsx
+++ b/src/components/LandingPage/CurrencySelect.tsx
@@ -59,6 +59,9 @@ const CurrencySelect = ({
                     <PopoverPanel
                         anchor="bottom end"
                         className="z-50 mt-4 h-72 w-72 overflow-scroll rounded-sm border border-black bg-white shadow-lg sm:w-80 md:w-96"
+                        // usePullToRefresh listens on `document` and only bails on window.scrollY > 0,
+                        // so scrolling this panel at page top reads as a pull. Same guard as Global/Drawer.
+                        onTouchMove={(e: React.TouchEvent) => e.stopPropagation()}
                     >
                         <div className="flex max-h-full w-full flex-col gap-4 overflow-hidden p-4">
                             <div className="relative w-full">

--- a/src/components/LandingPage/__tests__/CurrencySelect.pull-to-refresh.test.tsx
+++ b/src/components/LandingPage/__tests__/CurrencySelect.pull-to-refresh.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+import CurrencySelect from '../CurrencySelect'
+
+// usePullToRefresh binds touchmove on `document` and only bails on window.scrollY > 0,
+// so a scrollable overlay sitting at page top reads as a pull-to-refresh. This asserts
+// the panel's onTouchMove guard keeps the gesture from ever reaching that listener.
+describe('CurrencySelect pull-to-refresh guard (TASK-21967)', () => {
+    const onDocumentTouchMove = jest.fn()
+
+    beforeEach(() => {
+        onDocumentTouchMove.mockClear()
+        document.addEventListener('touchmove', onDocumentTouchMove)
+    })
+
+    afterEach(() => {
+        document.removeEventListener('touchmove', onDocumentTouchMove)
+    })
+
+    const open = () => {
+        render(
+            <CurrencySelect selectedCurrency="USD" setSelectedCurrency={jest.fn()} trigger={<button>pick</button>} />
+        )
+        fireEvent.click(screen.getByText('pick'))
+    }
+
+    it('does not let a touchmove inside the open panel reach the document listener', () => {
+        open()
+
+        // A row deep inside the scroll area — the element a finger actually drags.
+        fireEvent.touchMove(screen.getByText('Popular currencies'), { touches: [{ clientX: 0, clientY: 40 }] })
+
+        expect(onDocumentTouchMove).not.toHaveBeenCalled()
+    })
+
+    it('still lets a touchmove outside the panel reach the document listener', () => {
+        open()
+
+        fireEvent.touchMove(screen.getByText('pick'), { touches: [{ clientX: 0, clientY: 40 }] })
+
+        expect(onDocumentTouchMove).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary

Three one-line behavior guards. Each is a guard that was missing, not a redesign — no refactors, no drive-by cleanups.

**TASK-21886 — QR pay still POSTs `/init` during a Manteca outage.**
`isProviderDisabled` gated only the render path (`qr-pay/page.tsx`, maintenance card). The `useQuery` that fires `mantecaApi.initiateQrPayment` had it missing from its `enabled` predicate, so every scan during an outage still sent a doomed `/init` before the user saw the maintenance card. Added `&& !isProviderDisabled`.

**TASK-21930 — Card tutorial "Done" reappears on Back.**
`card/add-to-wallet/page.tsx` passed `onDone={() => router.push('/card')}`. Pushing leaves the tutorial in history, so Back drops the user straight back into the tutorial they just finished. Done now uses `useSafeBack('/card', { replace: true })`: the only in-app entry is the link on `/card` (`YourCardScreen`), so it backs out to where the user came from, and `replace` covers the cold-deep-link fallback. A plain `router.replace` was the first fix and was wrong in a smaller way — it turned the history into `[..., /card, /card]`, so Back stayed on the card screen and needed a second press. `onPrev` keeps the push fallback and is otherwise unchanged.

**TASK-21967 — Currency picker triggers pull-to-refresh.**
`usePullToRefresh` listens on `document` and only bails on `window.scrollY > 0`. Scrolling the `CurrencySelect` popover at page top therefore reads as a pull and reloads the screen. Added the same `onTouchMove` stopPropagation guard `Global/Drawer` already uses. `CurrencySelect` is rendered twice by `ExchangeRateWidget`, which serves both `(mobile-ui)/profile/exchange-rate` and the public landing page — one guard in the shared component covers every mount point.

## Task

- TASK-21886, TASK-21930, TASK-21967
- Scoped by the Issue Inbox Sweep report: https://claude.ai/code/artifact/4d953a35-cab2-4f12-8f4d-bb7aaa5790ac — all three verified there against `origin/dev`, then re-confirmed line by line on this branch before editing.

## Risks / breaking changes

Low, and frontend-only. No cross-repo impact, no API contract change, no schema change.

- TASK-21886: the query now stays disabled while the kill-switch is on. That is the intent — the maintenance card is the only reachable surface in that state, and `handleMantecaPayment` (the second `/init` call site) needs a `paymentLock` that this query is the only producer of, so it is already unreachable while disabled.
- TASK-21930: Done no longer leaves a history entry. Back from `/card` now goes wherever the user was before entering the tutorial, which is the point.
- TASK-21967: `stopPropagation` on the panel's touchmove stops pull-to-refresh only while the picker is open. Page scroll and the picker's own scrolling are unaffected. Note the guard reaches the public landing page too, since `ExchangeRateWidget` is shared — wider than the ticket's framing, and harmless there.

## QA

- `npm run typecheck` clean, `pnpm prettier --check .` clean, `npm test` 392 suites / 4689 tests pass.
- Every guard has a test, and every test was mutation-checked — reintroduce the defect and it fails:
  - `card/add-to-wallet/__tests__/add-to-wallet-nav.test.tsx` drives the real `useSafeBack` (not a mock, since the defect is which branch it takes) and covers in-app entry, cold deep link, and Back. Fails against both `router.push` and a bare `router.replace`.
  - `qr-pay/__tests__/qr-pay-states.test.tsx` — the existing provider-maintenance test asserted only the banner, so it passed with the guard removed. It now asserts `/init` is never called during an outage, with an enabled counterpart. Fails with the predicate reverted.
  - `components/LandingPage/__tests__/CurrencySelect.pull-to-refresh.test.tsx` proves an inner touchmove never reaches a `document` listener while an outside one still does. Fails with the guard removed.

## Screenshots

N/A — no visible change. All three are behavior guards: a network-request predicate, a history-entry mode, and a touch-event guard. Nothing renders differently in any state.

## Design notes / accepted trade-offs

**The pull-to-refresh guard treats the symptom on purpose.** The root cause is in `usePullToRefresh`: it decides "the user is at the top of the page" from `window.scrollY > 0` alone, so any nested scroll container at page top reads as a pull. Three components now work around the hook rather than the hook knowing about them — `Global/Drawer` and `LandingPage/CurrencySelect` (both `onTouchMove` stopPropagation) and `PeanutRagdoll` (`touch-none`). Fixing the hook touches every `(mobile-ui)` and `(setup)` screen, which is far outside a one-line guard's blast radius, so it is filed as a follow-up in mono `TODO.md` instead of bundled here.

**`CurrencySelect` gets the guard once, not twice.** `ExchangeRateWidget` renders it in both the from- and to-currency slots; putting the guard in the shared component covers both and cannot drift.

**The maintenance test now restores the config in a `finally`.** It mutates the `underMaintenance.config` module singleton; the old trailing-statement cleanup would have leaked `MANTECA` into every later test in the file if an assertion above it threw.

**No other smells added.** `qr-pay/page.tsx` being a ~1600-line component with a six-term `enabled` predicate is pre-existing and out of scope; the DS audit already tracks promoting `CurrencySelect` into a `Global/Combobox` (`dev/ds/audit/audit-data.ts`), which is likewise not this PR's job.

## Docs / legal impact

No customer-facing mono doc goes stale, and no legal impact (privacy policy read in full; Manteca is already a named processor and this PR strictly reduces calls to it). Two internal `product/feedback/` records are worth a decision-log line but no status change, and both are separate follow-ups, not part of this PR:

- `product/feedback/problems/flow-state-stale-on-back.md` — its `2026-07-30 · crisp · Fabricio Jallaza` line is exactly TASK-21930. The file covers ~30 other back/stale-state reports this PR does not touch, so its `status: open` stays.
- `product/feedback/problems/qr-scanner-camera-focus-detection.md` — also a pull-to-refresh complaint, but on the QR scan view, a different surface. Noted so the two are not read as one fix.
