### PR TITLE
ci: publish ds-shots visual diff as a sticky PR comment (TASK-22044)

### DIFF
--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -35,9 +35,9 @@
 # a sibling same-head run posted between its marker read and its PATCH;
 # once serialized, either order ends correctly, because the marker-head
 # guard makes a no-report run keep any comment already posted for its head.
-# (GitHub keeps at most one run queued per group; a superseded queued run is
-# safe to lose — every run in the group is for the same head, so any
-# survivor leaves the comment consistent for that head.)
+# queue: max keeps EVERY same-head publisher (FIFO, up to 100) — the default
+# one-slot queue would let a third run drop a sibling PR's only pending
+# publisher and leave that PR's comment stale.
 #
 # Deploy note: workflow_run only fires once this file exists on the DEFAULT
 # branch (main). It lands on dev first, so the comment starts appearing after
@@ -57,6 +57,7 @@ permissions:
 concurrency:
     group: ds-shots-comment-${{ github.event.workflow_run.head_sha }}
     cancel-in-progress: false
+    queue: max
 
 jobs:
     comment:

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -112,7 +112,25 @@ jobs:
                   # be the exact commit this run tested: a PR naming its
                   # artifact after somebody else's PR posts nothing, and an
                   # out-of-order older run cannot overwrite a newer comment.
-                  HEAD=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)
+                  #
+                  # A true 404 (the number points at no PR) is that attack and
+                  # stays a no-op. Any other failure — 5xx, rate limit,
+                  # network — must fail this job loudly: swallowed, it would
+                  # exit green while an older result stands as current.
+                  set +e
+                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>&1)
+                  STATUS=$?
+                  set -e
+                  if [ "$STATUS" -ne 0 ]; then
+                      if printf '%s' "$OUT" | grep -q 'HTTP 404'; then
+                          echo "PR #$PR does not exist — the artifact name pointed at nothing. Skipping."
+                          echo 'match=false' >> "$GITHUB_OUTPUT"
+                          exit 0
+                      fi
+                      echo "::error::PR-head lookup for #$PR failed: $OUT"
+                      exit 1
+                  fi
+                  HEAD=$OUT
                   if [ "$HEAD" != "$RUN_HEAD_SHA" ]; then
                       echo "PR #$PR head ${HEAD:-<none>} != run head $RUN_HEAD_SHA — mismatched artifact name or stale run. Skipping."
                       echo 'match=false' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -112,12 +112,24 @@ jobs:
                   fi
                   echo 'match=true' >> "$GITHUB_OUTPUT"
 
-            - name: Extract report.json from the artifact
+            # Extraction and rendering both consume attacker-controlled bytes,
+            # so either may refuse them: a broken archive fails unzip, an
+            # out-of-contract report is rejected by the validator.
+            # continue-on-error lets the run reach the fallback and upsert
+            # below — the last step of the job still turns an unusable report
+            # into a red run, so tampering stays loud.
+            - name: Extract and render the report
               if: steps.bind.outputs.match == 'true'
+              id: render
+              continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
                   REPORT_ID: ${{ steps.art.outputs.report_id }}
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+                  IMG_ID: ${{ steps.art.outputs.img_id }}
               run: |
                   set -euo pipefail
                   gh api "repos/$REPO/actions/artifacts/$REPORT_ID/zip" > report.zip
@@ -126,21 +138,34 @@ jobs:
                   # zip-slip has nothing to work with. A missing member fails
                   # the step loudly.
                   unzip -p report.zip report.json > report.json
-
-            - name: Build the comment body
-              if: steps.bind.outputs.match == 'true'
-              env:
-                  RUN_URL: ${{ github.event.workflow_run.html_url }}
-                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-                  REPO: ${{ github.repository }}
-                  RUN_ID: ${{ github.event.workflow_run.id }}
-                  IMG_ID: ${{ steps.art.outputs.img_id }}
-              run: |
-                  set -euo pipefail
                   if [ -n "$IMG_ID" ]; then
                       export ARTIFACT_URL="https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$IMG_ID"
                   fi
                   node scripts/ds-shots-publish.mjs report.json > body.md
+                  echo 'ok=true' >> "$GITHUB_OUTPUT"
+
+            # A report that exists but cannot be used must not leave the
+            # previous head's result standing as current (same stale-success
+            # hazard as a missing report). Overwrite with the trusted generic
+            # body — never with anything taken from the report.
+            - name: Fall back to the no-result body when the report is unusable
+              if: steps.bind.outputs.match == 'true' && steps.render.outputs.ok != 'true'
+              id: fallback
+              env:
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+              run: |
+                  set -euo pipefail
+                  {
+                      echo '<!-- ds-shots-visual-diff -->'
+                      echo
+                      echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
+                      echo
+                      echo "The newest [Tests run]($RUN_URL) uploaded a diff report that could not be used: a broken archive, or a report that failed validation."
+                      echo 'The previous result on this comment was for an older commit, so it was cleared. This publisher run fails on purpose so someone looks.'
+                      echo
+                      echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
+                  } > body.md
+                  echo 'used=true' >> "$GITHUB_OUTPUT"
 
             # A run with no report must not leave an older result standing as
             # if it were current (the stale-success hazard). If this PR already
@@ -185,7 +210,7 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
                   PR: ${{ steps.art.outputs.found == 'true' && steps.art.outputs.pr || steps.stale.outputs.pr }}
-                  STALE: ${{ steps.stale.outputs.update }}
+                  STALE: ${{ steps.stale.outputs.update == 'true' || steps.fallback.outputs.used == 'true' }}
               run: |
                   set -euo pipefail
                   # Only a comment this bot authored qualifies — a user who
@@ -208,3 +233,9 @@ jobs:
                       gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@body.md > /dev/null
                       echo "Posted new comment on PR #$PR"
                   fi
+
+            - name: Fail loud when the report was unusable
+              if: steps.bind.outputs.match == 'true' && steps.render.outputs.ok != 'true'
+              run: |
+                  echo '::error::The report artifact was present but unusable — see "Extract and render the report". The sticky comment was cleared to the no-result state.'
+                  exit 1

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -64,23 +64,28 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
                   RUN_ID: ${{ github.event.workflow_run.id }}
+                  ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
               run: |
                   set -euo pipefail
                   ROWS=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
                       --jq '.artifacts[] | "\(.id)\t\(.name)"')
+                  # Artifacts persist across reruns of the same run id, so
+                  # match ONLY this attempt's report — a rerun must never
+                  # republish an earlier attempt's result.
                   # sed -n 1p, not head -1: head closes the pipe early and the
                   # SIGPIPE trips pipefail; sed drains the stream.
-                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t''visual-diff-report-[0-9]+$' | sed -n '1p' || true)
+                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-report-[0-9]+-$ATTEMPT\$" | sed -n '1p' || true)
                   if [ -z "$REPORT" ]; then
                       echo 'found=false' >> "$GITHUB_OUTPUT"
-                      echo 'No visual-diff-report artifact: ds-shots was skipped, failed before the diff, or had no baseline.'
+                      echo "No visual-diff-report artifact for attempt $ATTEMPT: ds-shots was skipped, failed before the diff, or had no baseline."
                       exit 0
                   fi
                   REPORT_ID=${REPORT%%$'\t'*}
-                  PR=${REPORT##*-}
+                  NAME=${REPORT#*$'\t'}
+                  PR=$(printf '%s' "$NAME" | sed -E "s/^visual-diff-report-([0-9]+)-$ATTEMPT\$/\1/")
                   # The PNG artifact only exists when a screen moved; its id
                   # becomes the images download link in the comment.
-                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR\$" | sed -n '1p' | cut -f1 || true)
+                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR-$ATTEMPT\$" | sed -n '1p' | cut -f1 || true)
                   {
                       echo 'found=true'
                       echo "report_id=$REPORT_ID"

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -27,9 +27,17 @@
 #   no report + no comment                    → stay quiet
 #   any operational API failure               → red job, comment untouched
 #
-# There is deliberately NO concurrency group: supersession is enforced by
-# head-SHA binding in every path, and one branch can hold two open PRs (dev
-# and main base) whose publishers must not cancel each other.
+# Supersession is enforced by head-SHA binding, not by cancellation. The
+# concurrency group below serializes publishers for the SAME head only —
+# cancel-in-progress stays false, because one branch can hold two open PRs
+# (dev and main base) whose publishers must both run. Serialization closes
+# the read-then-write race where a no-report run could overwrite the result
+# a sibling same-head run posted between its marker read and its PATCH;
+# once serialized, either order ends correctly, because the marker-head
+# guard makes a no-report run keep any comment already posted for its head.
+# (GitHub keeps at most one run queued per group; a superseded queued run is
+# safe to lose — every run in the group is for the same head, so any
+# survivor leaves the comment consistent for that head.)
 #
 # Deploy note: workflow_run only fires once this file exists on the DEFAULT
 # branch (main). It lands on dev first, so the comment starts appearing after
@@ -45,6 +53,10 @@ permissions:
     contents: read # checkout of the default branch, for the builder script
     actions: read # list + download the triggering run's artifacts
     pull-requests: write # the sticky comment
+
+concurrency:
+    group: ds-shots-comment-${{ github.event.workflow_run.head_sha }}
+    cancel-in-progress: false
 
 jobs:
     comment:
@@ -148,8 +160,22 @@ jobs:
                   fi
                   echo 'match=true' >> "$GITHUB_OUTPUT"
 
-            # Extraction and rendering both consume attacker-controlled bytes,
-            # so either may refuse them: a broken archive fails unzip, an
+            # The download is a plain API call: a transient failure here is
+            # operational, must go red with the comment untouched, and must
+            # never be misread as a tampered artifact — so it lives OUTSIDE
+            # the continue-on-error step below.
+            - name: Download the report artifact
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  REPORT_ID: ${{ steps.art.outputs.report_id }}
+              run: |
+                  set -euo pipefail
+                  gh api "repos/$REPO/actions/artifacts/$REPORT_ID/zip" > report.zip
+
+            # Extraction and rendering consume attacker-controlled bytes, so
+            # either may refuse them: a broken archive fails unzip, an
             # out-of-contract report is rejected by the validator.
             # continue-on-error lets the run reach the fallback and upsert
             # below — the last step of the job still turns an unusable report
@@ -159,16 +185,13 @@ jobs:
               id: render
               continue-on-error: true
               env:
-                  GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
-                  REPORT_ID: ${{ steps.art.outputs.report_id }}
                   RUN_URL: ${{ github.event.workflow_run.html_url }}
                   HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
                   RUN_ID: ${{ github.event.workflow_run.id }}
                   IMG_ID: ${{ steps.art.outputs.img_id }}
               run: |
                   set -euo pipefail
-                  gh api "repos/$REPO/actions/artifacts/$REPORT_ID/zip" > report.zip
                   # Extract the one member by exact name, to stdout: no path
                   # from the (untrusted) archive is ever written to disk, so
                   # zip-slip has nothing to work with. A missing member fails

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -1,0 +1,166 @@
+# Publishes the ds-shots visual-diff result as one sticky PR comment.
+#
+# Why a separate workflow: the ds-shots job in tests.yml checks out and runs
+# PR code (pnpm install, next build, playwright), so it must hold no write
+# token — a postinstall can plant a GITHUB_PATH or GITHUB_ENV hook that fires
+# in any later step of the same job (see the permissions comment on ds-shots,
+# PR #2819). A workflow_run workflow executes THIS file from the default
+# branch and never checks out PR code, so it can safely hold
+# pull-requests: write.
+#
+# Trust boundary: the artifact was produced by a job that ran PR code, so its
+# contents are attacker-controlled. This workflow extracts exactly one member
+# (report.json) by name — no archive path is ever written to disk — and
+# scripts/ds-shots-publish.mjs validates it strictly before any of it reaches
+# markdown. The PR number is parsed from the artifact name (the PR's build
+# chose it), so it is bound back to the trigger: the numbered PR's head must
+# be the exact commit the run tested, or nothing is posted.
+#
+# Deploy note: workflow_run only fires once this file exists on the DEFAULT
+# branch (main). It lands on dev first, so the comment starts appearing after
+# the next dev → main release. Until then this file is inert.
+name: ds-shots comment
+
+on:
+    workflow_run:
+        workflows: [Tests]
+        types: [completed]
+
+permissions:
+    contents: read # checkout of the default branch, for the builder script
+    actions: read # list + download the triggering run's artifacts
+    pull-requests: write # the sticky comment
+
+# A newer Tests run on the same branch supersedes this comment update.
+concurrency:
+    group: ds-shots-comment-${{ github.event.workflow_run.head_branch }}
+    cancel-in-progress: true
+
+jobs:
+    comment:
+        # Same-repo PRs only. Fork PRs never produce the artifact anyway
+        # (ds-shots-filter skips them), so this is belt and braces. Tests runs
+        # with no report artifact (push runs, ds-shots skipped, no baseline
+        # yet) fall through the "find" step below and post nothing.
+        if: >-
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.head_repository.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            # For a workflow_run event github.sha is the default branch head,
+            # so this checks out trusted code — never the PR.
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: Find the report artifact on the triggering run
+              id: art
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+              run: |
+                  set -euo pipefail
+                  ROWS=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
+                      --jq '.artifacts[] | "\(.id)\t\(.name)"')
+                  # sed -n 1p, not head -1: head closes the pipe early and the
+                  # SIGPIPE trips pipefail; sed drains the stream.
+                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t''visual-diff-report-[0-9]+$' | sed -n '1p' || true)
+                  if [ -z "$REPORT" ]; then
+                      echo 'found=false' >> "$GITHUB_OUTPUT"
+                      echo 'No visual-diff-report artifact: ds-shots was skipped or had no baseline. Nothing to post.'
+                      exit 0
+                  fi
+                  REPORT_ID=${REPORT%%$'\t'*}
+                  PR=${REPORT##*-}
+                  # The PNG artifact only exists when a screen moved; its id
+                  # becomes the images download link in the comment.
+                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR\$" | sed -n '1p' | cut -f1 || true)
+                  {
+                      echo 'found=true'
+                      echo "report_id=$REPORT_ID"
+                      echo "pr=$PR"
+                      echo "img_id=$IMG_ID"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Report artifact $REPORT_ID for PR #$PR (images: ${IMG_ID:-none})"
+
+            - name: Bind the artifact's PR number back to the run
+              if: steps.art.outputs.found == 'true'
+              id: bind
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ steps.art.outputs.pr }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+              run: |
+                  set -euo pipefail
+                  # The artifact name — and so the PR number — was chosen by
+                  # the PR's own build code. Require the numbered PR's head to
+                  # be the exact commit this run tested: a PR naming its
+                  # artifact after somebody else's PR posts nothing, and an
+                  # out-of-order older run cannot overwrite a newer comment.
+                  HEAD=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null || true)
+                  if [ "$HEAD" != "$RUN_HEAD_SHA" ]; then
+                      echo "PR #$PR head ${HEAD:-<none>} != run head $RUN_HEAD_SHA — mismatched artifact name or stale run. Skipping."
+                      echo 'match=false' >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  echo 'match=true' >> "$GITHUB_OUTPUT"
+
+            - name: Extract report.json from the artifact
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  REPORT_ID: ${{ steps.art.outputs.report_id }}
+              run: |
+                  set -euo pipefail
+                  gh api "repos/$REPO/actions/artifacts/$REPORT_ID/zip" > report.zip
+                  # Extract the one member by exact name, to stdout: no path
+                  # from the (untrusted) archive is ever written to disk, so
+                  # zip-slip has nothing to work with. A missing member fails
+                  # the step loudly.
+                  unzip -p report.zip report.json > report.json
+
+            - name: Build the comment body
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  REPO: ${{ github.repository }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+                  IMG_ID: ${{ steps.art.outputs.img_id }}
+              run: |
+                  set -euo pipefail
+                  if [ -n "$IMG_ID" ]; then
+                      export ARTIFACT_URL="https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$IMG_ID"
+                  fi
+                  node scripts/ds-shots-publish.mjs report.json > body.md
+
+            - name: Upsert the sticky comment
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ steps.art.outputs.pr }}
+              run: |
+                  set -euo pipefail
+                  # Only a comment this bot authored qualifies — a user who
+                  # pastes the marker into their own comment must not have it
+                  # overwritten.
+                  # sed, not head: a gh failure must fail the step, not be
+                  # masked into posting a duplicate comment.
+                  CID=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+                      --jq '.[] | select(.user.login == "github-actions[bot]")
+                                | select(.body | startswith("<!-- ds-shots-visual-diff -->")) | .id' \
+                      | sed -n '1p')
+                  if [ -n "$CID" ]; then
+                      gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@body.md > /dev/null
+                      echo "Updated comment $CID on PR #$PR"
+                  else
+                      gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@body.md > /dev/null
+                      echo "Posted new comment on PR #$PR"
+                  fi

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -64,28 +64,31 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
                   RUN_ID: ${{ github.event.workflow_run.id }}
-                  ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
               run: |
                   set -euo pipefail
                   ROWS=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
                       --jq '.artifacts[] | "\(.id)\t\(.name)"')
-                  # Artifacts persist across reruns of the same run id, so
-                  # match ONLY this attempt's report — a rerun must never
-                  # republish an earlier attempt's result.
-                  # sed -n 1p, not head -1: head closes the pipe early and the
-                  # SIGPIPE trips pipefail; sed drains the stream.
-                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-report-[0-9]+-$ATTEMPT\$" | sed -n '1p' || true)
+                  # Artifacts persist across reruns of the same run id, and
+                  # every attempt of a run tests the SAME head SHA. Take the
+                  # highest attempt's report: "Re-run failed jobs" that skips
+                  # a succeeded ds-shots keeps attempt 1's still-valid result,
+                  # while a full rerun's fresh report wins by attempt number.
+                  # The attempt suffix exists because v4 uploads are immutable
+                  # — a fixed name would collide on rerun.
+                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t''visual-diff-report-[0-9]+-[0-9]+$' | sort -t- -k5,5n | tail -1 || true)
                   if [ -z "$REPORT" ]; then
                       echo 'found=false' >> "$GITHUB_OUTPUT"
-                      echo "No visual-diff-report artifact for attempt $ATTEMPT: ds-shots was skipped, failed before the diff, or had no baseline."
+                      echo 'No attempt of this run produced a diff report: ds-shots was skipped, failed before the diff, or had no baseline.'
                       exit 0
                   fi
                   REPORT_ID=${REPORT%%$'\t'*}
                   NAME=${REPORT#*$'\t'}
-                  PR=$(printf '%s' "$NAME" | sed -E "s/^visual-diff-report-([0-9]+)-$ATTEMPT\$/\1/")
+                  ATTEMPT_USED=${NAME##*-}
+                  PR=$(printf '%s' "$NAME" | sed -E 's/^visual-diff-report-([0-9]+)-[0-9]+$/\1/')
                   # The PNG artifact only exists when a screen moved; its id
-                  # becomes the images download link in the comment.
-                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR-$ATTEMPT\$" | sed -n '1p' | cut -f1 || true)
+                  # becomes the images download link in the comment. Same
+                  # attempt as the report it belongs to.
+                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR-$ATTEMPT_USED\$" | sed -n '1p' | cut -f1 || true)
                   {
                       echo 'found=true'
                       echo "report_id=$REPORT_ID"
@@ -166,7 +169,7 @@ jobs:
                       echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
                       echo
                       echo "The newest [Tests run]($RUN_URL) uploaded a diff report that could not be used: a broken archive, or a report that failed validation."
-                      echo 'The previous result on this comment was for an older commit, so it was cleared. This publisher run fails on purpose so someone looks.'
+                      echo 'The previous result on this comment no longer reflects the latest run, so it was cleared. This publisher run fails on purpose so someone looks.'
                       echo
                       echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
                   } > body.md
@@ -201,8 +204,8 @@ jobs:
                       echo
                       echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
                       echo
-                      echo "The newest [Tests run]($RUN_URL) produced no diff report: ds-shots was skipped, failed before the diff, or had no cached baseline."
-                      echo 'The previous result on this comment was for an older commit, so it was cleared.'
+                      echo "The newest [Tests run]($RUN_URL) produced no diff report in any attempt: ds-shots was skipped, failed before the diff, or had no cached baseline."
+                      echo 'The previous result on this comment no longer reflects the latest run, so it was cleared.'
                       echo
                       echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
                   } > body.md

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -39,11 +39,12 @@ concurrency:
 jobs:
     comment:
         # Same-repo PRs only. Fork PRs never produce the artifact anyway
-        # (ds-shots-filter skips them), so this is belt and braces. Tests runs
-        # with no report artifact (push runs, ds-shots skipped, no baseline
-        # yet) fall through the "find" step below and post nothing.
+        # (ds-shots-filter skips them), so this is belt and braces. Cancelled
+        # runs are skipped: a newer run on the same branch is already coming
+        # and owns the comment.
         if: >-
             github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.conclusion != 'cancelled' &&
             github.event.workflow_run.head_repository.full_name == github.repository
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -71,7 +72,7 @@ jobs:
                   REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t''visual-diff-report-[0-9]+$' | sed -n '1p' || true)
                   if [ -z "$REPORT" ]; then
                       echo 'found=false' >> "$GITHUB_OUTPUT"
-                      echo 'No visual-diff-report artifact: ds-shots was skipped or had no baseline. Nothing to post.'
+                      echo 'No visual-diff-report artifact: ds-shots was skipped, failed before the diff, or had no baseline.'
                       exit 0
                   fi
                   REPORT_ID=${REPORT%%$'\t'*}
@@ -140,12 +141,50 @@ jobs:
                   fi
                   node scripts/ds-shots-publish.mjs report.json > body.md
 
-            - name: Upsert the sticky comment
-              if: steps.bind.outputs.match == 'true'
+            # A run with no report must not leave an older result standing as
+            # if it were current (the stale-success hazard). If this PR already
+            # carries a sticky comment, overwrite it with a "no result for the
+            # latest push" state; a PR that never had one stays quiet, so
+            # docs-only PRs get no spam. The PR number here comes from the
+            # trusted commit → PRs API keyed by the run's head SHA — never
+            # from anything the PR's build produced.
+            - name: Mark the sticky comment stale when this run has no report
+              if: steps.art.outputs.found != 'true'
+              id: stale
               env:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
-                  PR: ${{ steps.art.outputs.pr }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+              run: |
+                  set -euo pipefail
+                  PR=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                      --jq ".[] | select(.head.sha == \"$RUN_HEAD_SHA\") | .number" | sed -n '1p')
+                  if [ -z "$PR" ]; then
+                      echo 'No open PR has this commit as its head — stale run or push event. Nothing to do.'
+                      echo 'update=false' >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  {
+                      echo '<!-- ds-shots-visual-diff -->'
+                      echo
+                      echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
+                      echo
+                      echo "The newest [Tests run]($RUN_URL) produced no diff report: ds-shots was skipped, failed before the diff, or had no cached baseline."
+                      echo 'The previous result on this comment was for an older commit, so it was cleared.'
+                      echo
+                      echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
+                  } > body.md
+                  echo "pr=$PR" >> "$GITHUB_OUTPUT"
+                  echo 'update=true' >> "$GITHUB_OUTPUT"
+
+            - name: Upsert the sticky comment
+              if: steps.bind.outputs.match == 'true' || steps.stale.outputs.update == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ steps.art.outputs.found == 'true' && steps.art.outputs.pr || steps.stale.outputs.pr }}
+                  STALE: ${{ steps.stale.outputs.update }}
               run: |
                   set -euo pipefail
                   # Only a comment this bot authored qualifies — a user who
@@ -160,6 +199,10 @@ jobs:
                   if [ -n "$CID" ]; then
                       gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@body.md > /dev/null
                       echo "Updated comment $CID on PR #$PR"
+                  elif [ "$STALE" = 'true' ]; then
+                      # Stale mode only clears an existing result — a PR that
+                      # never had a comment gets none.
+                      echo "PR #$PR has no sticky comment — staying quiet."
                   else
                       gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@body.md > /dev/null
                       echo "Posted new comment on PR #$PR"

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -16,6 +16,21 @@
 # chose it), so it is bound back to the trigger: the numbered PR's head must
 # be the exact commit the run tested, or nothing is posted.
 #
+# Outcome table (report artifact × PR binding × existing comment) — every
+# path must end in one of these cells, so audit changes against the table:
+#   report usable + head matches the named PR → render, post or update
+#   report usable + that PR's head moved      → no-op, the newer run owns it
+#   report usable + named PR is a true 404    → no-op (attacker-chosen name)
+#   report unusable (bad zip / bad schema)    → clear to no-result, fail red
+#   no report + comment is for this head      → keep (a sibling run posted it)
+#   no report + comment is for an older head  → clear to no-result
+#   no report + no comment                    → stay quiet
+#   any operational API failure               → red job, comment untouched
+#
+# There is deliberately NO concurrency group: supersession is enforced by
+# head-SHA binding in every path, and one branch can hold two open PRs (dev
+# and main base) whose publishers must not cancel each other.
+#
 # Deploy note: workflow_run only fires once this file exists on the DEFAULT
 # branch (main). It lands on dev first, so the comment starts appearing after
 # the next dev → main release. Until then this file is inert.
@@ -30,11 +45,6 @@ permissions:
     contents: read # checkout of the default branch, for the builder script
     actions: read # list + download the triggering run's artifacts
     pull-requests: write # the sticky comment
-
-# A newer Tests run on the same branch supersedes this comment update.
-concurrency:
-    group: ds-shots-comment-${{ github.event.workflow_run.head_branch }}
-    cancel-in-progress: true
 
 jobs:
     comment:
@@ -179,10 +189,11 @@ jobs:
               id: fallback
               env:
                   RUN_URL: ${{ github.event.workflow_run.html_url }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
               run: |
                   set -euo pipefail
                   {
-                      echo '<!-- ds-shots-visual-diff -->'
+                      echo "<!-- ds-shots-visual-diff head=$RUN_HEAD_SHA -->"
                       echo
                       echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
                       echo
@@ -194,31 +205,38 @@ jobs:
                   echo 'used=true' >> "$GITHUB_OUTPUT"
 
             # A run with no report must not leave an older result standing as
-            # if it were current (the stale-success hazard). If this PR already
-            # carries a sticky comment, overwrite it with a "no result for the
-            # latest push" state; a PR that never had one stays quiet, so
-            # docs-only PRs get no spam. The PR number here comes from the
-            # trusted commit → PRs API keyed by the run's head SHA — never
-            # from anything the PR's build produced.
-            - name: Mark the sticky comment stale when this run has no report
+            # if it were current (the stale-success hazard). Which PR a run
+            # belongs to cannot be known exactly — one branch can hold two
+            # open PRs, and any branch can be parked on any commit — so this
+            # never guesses. It checks EVERY open PR whose head is exactly
+            # this run's branch and commit, and clears a comment only when
+            # the head recorded in its marker differs from this run's head:
+            # only then does the comment provably describe an older commit of
+            # that PR. A comment already carrying this head was posted by a
+            # sibling run that had a report, and stays. A PR with no comment
+            # stays quiet, so docs-only PRs get no spam. Every identity input
+            # is a trusted event field or GitHub API response — never
+            # anything the PR's build produced.
+            - name: Clear stale comments when this run has no report
               if: steps.art.outputs.found != 'true'
-              id: stale
               env:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
                   RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
                   RUN_URL: ${{ github.event.workflow_run.html_url }}
               run: |
                   set -euo pipefail
-                  PR=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
-                      --jq ".[] | select(.head.sha == \"$RUN_HEAD_SHA\") | .number" | sed -n '1p')
-                  if [ -z "$PR" ]; then
-                      echo 'No open PR has this commit as its head — stale run or push event. Nothing to do.'
-                      echo 'update=false' >> "$GITHUB_OUTPUT"
+                  # env.* inside the jq program, not shell interpolation — a
+                  # branch name must never be able to edit the filter.
+                  CANDIDATES=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                      --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.HEAD_BRANCH) | .number')
+                  if [ -z "$CANDIDATES" ]; then
+                      echo 'No open PR has this branch+commit as its head — superseded or stale run. Nothing to do.'
                       exit 0
                   fi
                   {
-                      echo '<!-- ds-shots-visual-diff -->'
+                      echo "<!-- ds-shots-visual-diff head=$RUN_HEAD_SHA -->"
                       echo
                       echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
                       echo
@@ -226,34 +244,52 @@ jobs:
                       echo 'The previous result on this comment no longer reflects the latest run, so it was cleared.'
                       echo
                       echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
-                  } > body.md
-                  echo "pr=$PR" >> "$GITHUB_OUTPUT"
-                  echo 'update=true' >> "$GITHUB_OUTPUT"
+                  } > stale-body.md
+                  for PR in $CANDIDATES; do
+                      ROW=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+                          --jq '.[] | select(.user.login == "github-actions[bot]")
+                                    | select(.body | startswith("<!-- ds-shots-visual-diff"))
+                                    | "\(.id)\t\(try (.body | capture("head=(?<h>[0-9a-f]{40})") | .h) catch "none")"' \
+                          | sed -n '1p')
+                      if [ -z "$ROW" ]; then
+                          echo "PR #$PR has no sticky comment — staying quiet."
+                          continue
+                      fi
+                      CID=${ROW%%$'\t'*}
+                      CHEAD=${ROW##*$'\t'}
+                      if [ "$CHEAD" = "$RUN_HEAD_SHA" ]; then
+                          echo "PR #$PR comment already reflects this head — keeping it."
+                          continue
+                      fi
+                      gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@stale-body.md > /dev/null
+                      echo "Cleared the stale comment on PR #$PR"
+                  done
 
             - name: Upsert the sticky comment
-              if: steps.bind.outputs.match == 'true' || steps.stale.outputs.update == 'true'
+              if: steps.bind.outputs.match == 'true'
               env:
                   GH_TOKEN: ${{ github.token }}
                   REPO: ${{ github.repository }}
-                  PR: ${{ steps.art.outputs.found == 'true' && steps.art.outputs.pr || steps.stale.outputs.pr }}
-                  STALE: ${{ steps.stale.outputs.update == 'true' || steps.fallback.outputs.used == 'true' }}
+                  PR: ${{ steps.art.outputs.pr }}
+                  FALLBACK: ${{ steps.fallback.outputs.used }}
               run: |
                   set -euo pipefail
                   # Only a comment this bot authored qualifies — a user who
                   # pastes the marker into their own comment must not have it
-                  # overwritten.
+                  # overwritten. The prefix match covers markers with and
+                  # without the head= field.
                   # sed, not head: a gh failure must fail the step, not be
                   # masked into posting a duplicate comment.
                   CID=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
                       --jq '.[] | select(.user.login == "github-actions[bot]")
-                                | select(.body | startswith("<!-- ds-shots-visual-diff -->")) | .id' \
+                                | select(.body | startswith("<!-- ds-shots-visual-diff")) | .id' \
                       | sed -n '1p')
                   if [ -n "$CID" ]; then
                       gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@body.md > /dev/null
                       echo "Updated comment $CID on PR #$PR"
-                  elif [ "$STALE" = 'true' ]; then
-                      # Stale mode only clears an existing result — a PR that
-                      # never had a comment gets none.
+                  elif [ "$FALLBACK" = 'true' ]; then
+                      # The unusable-report fallback only clears an existing
+                      # result — a PR that never had a comment gets none.
                       echo "PR #$PR has no sticky comment — staying quiet."
                   else
                       gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@body.md > /dev/null

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -40,11 +40,12 @@ jobs:
     comment:
         # Same-repo PRs only. Fork PRs never produce the artifact anyway
         # (ds-shots-filter skips them), so this is belt and braces. Cancelled
-        # runs are skipped: a newer run on the same branch is already coming
-        # and owns the comment.
+        # runs are deliberately NOT excluded: a manually cancelled run for the
+        # current head must clear an older sticky result, and a run cancelled
+        # by concurrency after a newer push is already a no-op — its head SHA
+        # no longer matches the PR, so both the bind and the stale path skip.
         if: >-
             github.event.workflow_run.event == 'pull_request' &&
-            github.event.workflow_run.conclusion != 'cancelled' &&
             github.event.workflow_run.head_repository.full_name == github.repository
         runs-on: ubuntu-latest
         timeout-minutes: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -503,9 +503,9 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   # run_attempt is in the name because a rerun keeps the run
-                  # id and v4 artifacts are immutable: a fixed name collides on
-                  # re-upload, and the comment publisher could read attempt
-                  # 1's report as current. It matches only its own attempt.
+                  # id and v4 artifacts are immutable: a fixed name collides
+                  # on re-upload. The comment publisher takes the newest
+                  # attempt's report — every attempt tests the same head SHA.
                   name: visual-diff-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
                   path: |
                       e2e/__shots__/base

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -468,6 +468,16 @@ jobs:
                   echo "baseline=${MATCHED#ds-shots-}" >> "$GITHUB_OUTPUT"
                   node scripts/visual-diff.mjs e2e/__shots__/base e2e/__shots__/head \
                       --out=e2e/__shots__/diff --json > e2e/__shots__/report.json
+                  # Stamp the baseline commit into the report so the comment
+                  # publisher (ds-shots-comment.yml) can say what the diff was
+                  # against. Data only — the publisher validates every field.
+                  BASELINE="${MATCHED#ds-shots-}" node -e '
+                      const fs = require("node:fs")
+                      const p = "e2e/__shots__/report.json"
+                      const r = JSON.parse(fs.readFileSync(p, "utf8"))
+                      r.baseline = process.env.BASELINE
+                      fs.writeFileSync(p, JSON.stringify(r, null, 2))
+                  '
 
             # The listing runs PR-authored code (scripts/visual-comment.mjs is
             # itself pixel-moving, so a PR may edit it) — deliberately no token
@@ -497,6 +507,21 @@ jobs:
                       e2e/__shots__/base
                       e2e/__shots__/head
                       e2e/__shots__/diff
+                  retention-days: 7
+
+            # The report rides out separately and unconditionally: the PNG
+            # artifact above only exists when a screen moved, and the comment
+            # publisher needs the "nothing moved" report too so the green
+            # comment posts. ds-shots-comment.yml — a workflow_run workflow
+            # that never runs PR code — downloads it, validates it as
+            # untrusted input, and posts the sticky PR comment this job must
+            # not (it holds no write token, see the permissions comment above).
+            - name: Upload the diff report
+              if: steps.diff.outputs.ready == 'true'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: visual-diff-report-${{ github.event.pull_request.number }}
+                  path: e2e/__shots__/report.json
                   retention-days: 7
             # Rendered into the job summary, which needs no permissions. The
             # script omits the <img> tags when --assets is empty, so this is a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,7 +502,11 @@ jobs:
               if: steps.diff.outputs.ready == 'true' && steps.wanted.outputs.any == 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: visual-diff-${{ github.event.pull_request.number }}
+                  # run_attempt is in the name because a rerun keeps the run
+                  # id and v4 artifacts are immutable: a fixed name collides on
+                  # re-upload, and the comment publisher could read attempt
+                  # 1's report as current. It matches only its own attempt.
+                  name: visual-diff-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
                   path: |
                       e2e/__shots__/base
                       e2e/__shots__/head
@@ -520,7 +524,7 @@ jobs:
               if: steps.diff.outputs.ready == 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: visual-diff-report-${{ github.event.pull_request.number }}
+                  name: visual-diff-report-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
                   path: e2e/__shots__/report.json
                   retention-days: 7
             # Rendered into the job summary, which needs no permissions. The

--- a/scripts/__tests__/ds-shots-publish.test.js
+++ b/scripts/__tests__/ds-shots-publish.test.js
@@ -39,7 +39,7 @@ describe('ds-shots-publish', () => {
         })
 
         expect(result.status).toBe(0)
-        expect(result.stdout).toContain('<!-- ds-shots-visual-diff -->')
+        expect(result.stdout).toContain(`<!-- ds-shots-visual-diff head=${'b'.repeat(40)} -->`)
         expect(result.stdout).toContain('2 screens moved')
         expect(result.stdout).toContain('3 of 120 shots changed')
         expect(result.stdout).toContain('`aaaaaaa` → head `bbbbbbb`')
@@ -52,10 +52,10 @@ describe('ds-shots-publish', () => {
     })
 
     it('still posts (green) when nothing moved', () => {
-        const result = run(valid({ changed: [], added: [], removed: [], unchanged: 120 }))
+        const result = run(valid({ changed: [], added: [], removed: [], unchanged: 120 }), { HEAD_SHA: '' })
 
         expect(result.status).toBe(0)
-        expect(result.stdout).toContain('<!-- ds-shots-visual-diff -->')
+        expect(result.stdout).toContain('<!-- ds-shots-visual-diff head=unknown -->')
         expect(result.stdout).toContain('no screen moved')
         expect(result.stdout).toContain('120 shots, all identical')
     })

--- a/scripts/__tests__/ds-shots-publish.test.js
+++ b/scripts/__tests__/ds-shots-publish.test.js
@@ -1,0 +1,120 @@
+const { spawnSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'ds-shots-publish.mjs')
+
+// The script is the trust boundary of the workflow_run comment publisher: its
+// input is an artifact produced by a job that ran PR code. Its contract is
+// stdout + exit code, so drive it the way the workflow does. exit 1 = the
+// report was rejected and nothing gets posted.
+function run(report, env = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-shots-'))
+    const file = path.join(dir, 'report.json')
+    fs.writeFileSync(file, typeof report === 'string' ? report : JSON.stringify(report))
+    return spawnSync(process.execPath, [SCRIPT_PATH, file], { encoding: 'utf-8', env: { ...process.env, ...env } })
+}
+
+const SHA_A = 'a'.repeat(40)
+const valid = (over = {}) => ({
+    changed: [
+        { file: 'home@375.png', percent: 3.21, pixels: 1234 },
+        { file: 'home@320.png', percent: 1.05, pixels: 400 },
+        { file: 'qr-pay@430.png', percent: 100, pixels: 860000, note: '430x900 -> 430x1200' },
+    ],
+    unchanged: 117,
+    added: ['rewards-empty@375.png'],
+    removed: [],
+    baseline: SHA_A,
+    ...over,
+})
+
+describe('ds-shots-publish', () => {
+    it('renders the sticky comment for a normal report', () => {
+        const result = run(valid(), {
+            RUN_URL: 'https://github.com/peanutprotocol/peanut-ui/actions/runs/1',
+            ARTIFACT_URL: 'https://github.com/peanutprotocol/peanut-ui/actions/runs/1/artifacts/2',
+            HEAD_SHA: 'b'.repeat(40),
+        })
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain('<!-- ds-shots-visual-diff -->')
+        expect(result.stdout).toContain('2 screens moved')
+        expect(result.stdout).toContain('3 of 120 shots changed')
+        expect(result.stdout).toContain('`aaaaaaa` → head `bbbbbbb`')
+        // worst screen first, both widths folded into one row
+        expect(result.stdout).toContain('| 100.00% | `qr-pay` — resized 430x900 -> 430x1200 | 430 |')
+        expect(result.stdout).toContain('| 3.21% | `home` | 320, 375 |')
+        expect(result.stdout).toContain('new screens (1)')
+        expect(result.stdout).toContain('[job summary](https://github.com/peanutprotocol/peanut-ui/actions/runs/1)')
+        expect(result.stdout).toContain('artifacts/2')
+    })
+
+    it('still posts (green) when nothing moved', () => {
+        const result = run(valid({ changed: [], added: [], removed: [], unchanged: 120 }))
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain('<!-- ds-shots-visual-diff -->')
+        expect(result.stdout).toContain('no screen moved')
+        expect(result.stdout).toContain('120 shots, all identical')
+    })
+
+    it.each([
+        ['path traversal', { file: '../../../etc/passwd@375.png', percent: 1, pixels: 1 }],
+        ['absolute path', { file: '/etc/passwd@375.png', percent: 1, pixels: 1 }],
+        ['markdown table breakout', { file: 'a|b@375.png', percent: 1, pixels: 1 }],
+        ['html injection', { file: 'a<img src=x onerror=1>@375.png', percent: 1, pixels: 1 }],
+        ['backtick breakout', { file: 'a`code`@375.png', percent: 1, pixels: 1 }],
+        ['newline smuggling', { file: 'a\n## fake@375.png', percent: 1, pixels: 1 }],
+        ['overlong name', { file: `${'a'.repeat(200)}@375.png`, percent: 1, pixels: 1 }],
+        ['non-string file', { file: 42, percent: 1, pixels: 1 }],
+        ['NaN percent', { file: 'home@375.png', percent: NaN, pixels: 1 }],
+        ['percent out of range', { file: 'home@375.png', percent: 101, pixels: 1 }],
+        ['string percent', { file: 'home@375.png', percent: '3.2', pixels: 1 }],
+        ['injected note', { file: 'home@375.png', percent: 1, pixels: 1, note: '](x) <script>' }],
+    ])('rejects a report with a malicious changed entry: %s', (_label, entry) => {
+        const result = run(valid({ changed: [entry] }))
+
+        expect(result.status).toBe(1)
+        expect(result.stdout).toBe('')
+        expect(result.stderr).toContain('report rejected')
+    })
+
+    it.each([
+        [
+            'oversized changed list',
+            valid({ changed: Array(1001).fill({ file: 'home@375.png', percent: 1, pixels: 1 }) }),
+        ],
+        ['injected added name', valid({ added: ['[click](https://evil.example)@375.png'] })],
+        ['missing baseline', valid({ baseline: undefined })],
+        ['short baseline', valid({ baseline: 'abc123' })],
+        ['injected baseline', valid({ baseline: '`](x)'.padEnd(40, 'a') })],
+        ['negative unchanged', valid({ unchanged: -1 })],
+        ['array report', [1, 2, 3]],
+        ['not json at all', 'not json {'],
+    ])('rejects: %s', (_label, report) => {
+        const result = run(report)
+
+        expect(result.status).toBe(1)
+        expect(result.stdout).toBe('')
+    })
+
+    it('caps the table and stays under the github comment size limit', () => {
+        // 500 screens x 2 widths — a report engineered to bloat the comment
+        const changed = []
+        for (let i = 0; i < 500; i++) {
+            changed.push({ file: `screen-${i}@375.png`, percent: 50, pixels: 1 })
+            changed.push({ file: `screen-${i}@430.png`, percent: 40, pixels: 1 })
+        }
+        const added = Array.from({ length: 200 }, (_, i) => `new-screen-${i}@375.png`)
+        const result = run(valid({ changed, added }))
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain('…and 480 more')
+        expect(result.stdout).toContain('…and 170 more')
+        expect(Buffer.byteLength(result.stdout)).toBeLessThan(65000)
+        // 20 table rows, not 500
+        expect(result.stdout.split('\n').filter((l) => l.startsWith('| 5')).length).toBe(20)
+    })
+})

--- a/scripts/ds-shots-publish.mjs
+++ b/scripts/ds-shots-publish.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Renders the ds-shots PR comment from the report.json a Tests run uploaded
+// as the visual-diff-report-<pr> artifact. Runs only in ds-shots-comment.yml,
+// the workflow_run publisher — never inside the job that runs PR code.
+//
+// TRUST BOUNDARY: the report was written by a job that executed the PR's
+// install, build and test code, so every byte of it is attacker-controlled.
+// This script validates the report against a strict schema and refuses the
+// whole file on any violation. The file-name character class has no slash,
+// backslash, pipe, backtick or angle bracket, so no validated string can
+// traverse a path or break out of its markdown cell — nothing here needs
+// escaping. Nothing from the report is ever executed or linked.
+//
+// Deliberately separate from scripts/visual-comment.mjs: that script renders
+// the in-run job summary, trusts its own input, and a PR may edit it. This
+// one always runs from the default branch and trusts nothing.
+//
+// usage:
+//   node scripts/ds-shots-publish.mjs <report.json> > body.md
+//
+// env (set by the publisher workflow, trusted):
+//   RUN_URL       html url of the triggering Tests run, for the summary link
+//   ARTIFACT_URL  download url of the PNG artifact; empty when nothing moved
+//   HEAD_SHA      the commit the run tested, from the workflow_run event
+//
+// exit 0: markdown on stdout. exit 1: the report is out of contract — the
+// publisher goes red and posts nothing, which is the wanted outcome for a
+// tampered report.
+
+import { readFileSync, statSync } from 'node:fs'
+
+const MARKER = '<!-- ds-shots-visual-diff -->'
+const MAX_BYTES = 1024 * 1024 // a legit report is a few KB
+const MAX_ENTRIES = 1000 // 30 fixtures x 4 widths = 120 legit shots
+const ROW_LIMIT = 20 // table rows, one per screen
+const NAME_LIMIT = 30 // added/removed names listed before "…and N more"
+const BODY_LIMIT = 65000 // github rejects a comment past 65536 bytes
+
+// `<fixture>@<width>.png`, fixture ids from src/dev/fixtures/registry.ts.
+const SHOT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}@\d{3,4}\.png$/
+// visual-diff.mjs writes `640x1136 -> 640x1200` for a resized screen.
+const NOTE = /^\d{1,5}x\d{1,5} -> \d{1,5}x\d{1,5}$/
+const SHA40 = /^[0-9a-f]{40}$/
+
+const fail = (why) => {
+    console.error(`report rejected: ${why}`)
+    process.exit(1)
+}
+
+const [reportPath] = process.argv.slice(2)
+if (!reportPath) fail('no report path given')
+if (statSync(reportPath).size > MAX_BYTES) fail('report too large')
+
+let report
+try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'))
+} catch {
+    fail('not valid json')
+}
+if (typeof report !== 'object' || report === null || Array.isArray(report)) fail('not an object')
+
+const isShot = (f) => typeof f === 'string' && SHOT.test(f)
+const isCount = (n) => Number.isInteger(n) && n >= 0 && n <= 100_000_000
+
+const { changed, unchanged, added, removed, baseline } = report
+if (!Array.isArray(changed) || changed.length > MAX_ENTRIES) fail('changed is not an array of sane size')
+for (const c of changed) {
+    if (typeof c !== 'object' || c === null) fail('changed entry is not an object')
+    if (!isShot(c.file)) fail(`bad file name ${JSON.stringify(String(c.file).slice(0, 80))}`)
+    if (typeof c.percent !== 'number' || !Number.isFinite(c.percent) || c.percent < 0 || c.percent > 100)
+        fail(`bad percent on ${c.file}`)
+    if (!isCount(c.pixels)) fail(`bad pixels on ${c.file}`)
+    if (c.note !== undefined && !(typeof c.note === 'string' && NOTE.test(c.note))) fail(`bad note on ${c.file}`)
+}
+if (!isCount(unchanged)) fail('bad unchanged count')
+for (const [key, list] of [
+    ['added', added],
+    ['removed', removed],
+]) {
+    if (!Array.isArray(list) || list.length > MAX_ENTRIES || !list.every(isShot)) fail(`bad ${key} list`)
+}
+if (typeof baseline !== 'string' || !SHA40.test(baseline)) fail('bad baseline sha')
+
+// Everything below only sees validated strings and numbers.
+
+const screenOf = (file) => file.replace(/@\d+\.png$/, '')
+const widthOf = (file) => Number(file.match(/@(\d+)\.png$/)[1])
+
+// A screen is shot at four widths; group them and keep the worst width.
+function byScreen(files) {
+    const groups = new Map()
+    for (const c of files) {
+        const name = screenOf(c.file)
+        const g = groups.get(name) ?? { name, worst: c, widths: [] }
+        if (c.percent > g.worst.percent) g.worst = c
+        g.widths.push(widthOf(c.file))
+        groups.set(name, g)
+    }
+    for (const g of groups.values()) g.widths.sort((a, b) => a - b)
+    return [...groups.values()].sort((a, b) => b.worst.percent - a.worst.percent)
+}
+
+const screens = byScreen(changed)
+const short = (sha) => (sha && /^[0-9a-f]{7,40}$/.test(sha) ? `\`${sha.slice(0, 7)}\`` : '`unknown`')
+const provenance = `baseline ${short(baseline)} → head ${short(process.env.HEAD_SHA ?? '')}`
+const totalShots = changed.length + unchanged
+const screenCount = (files) => new Set(files.map(screenOf)).size
+
+const out = [MARKER, '']
+const quiet = changed.length === 0 && added.length === 0 && removed.length === 0
+
+if (quiet) {
+    out.push('## 🖼 Visual diff — no screen moved', '', `${totalShots} shots, all identical. ${provenance}.`)
+} else {
+    const moved =
+        screens.length === 0 ? 'no screen moved' : `${screens.length} screen${screens.length === 1 ? '' : 's'} moved`
+    out.push(`## 🖼 Visual diff — ${moved}`, '')
+    out.push(`${changed.length} of ${totalShots} shots changed · ${unchanged} identical · ${provenance}`, '')
+
+    if (screens.length > 0) {
+        out.push('| worst % | screen | widths |', '| ---: | --- | --- |')
+        for (const g of screens.slice(0, ROW_LIMIT)) {
+            const note = g.worst.note ? ` — resized ${g.worst.note}` : ''
+            out.push(`| ${g.worst.percent.toFixed(2)}% | \`${g.name}\`${note} | ${g.widths.join(', ')} |`)
+        }
+        if (screens.length > ROW_LIMIT) out.push(`| | …and ${screens.length - ROW_LIMIT} more | |`)
+        out.push('')
+    }
+
+    for (const [title, list] of [
+        ['new screens', added],
+        ['gone screens', removed],
+    ]) {
+        if (list.length === 0) continue
+        const names = [...new Set(list.map(screenOf))].sort()
+        out.push(`<details><summary>${title} (${screenCount(list)})</summary>`, '')
+        for (const n of names.slice(0, NAME_LIMIT)) out.push(`- \`${n}\``)
+        if (names.length > NAME_LIMIT) out.push(`- …and ${names.length - NAME_LIMIT} more`)
+        out.push('', '</details>', '')
+    }
+}
+
+const links = []
+if (process.env.RUN_URL) links.push(`[job summary](${process.env.RUN_URL})`)
+if (process.env.ARTIFACT_URL) links.push(`[before/after/diff images — artifact](${process.env.ARTIFACT_URL})`)
+if (links.length > 0) out.push('', links.join(' · '))
+
+out.push(
+    '',
+    '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge. ' +
+        'Posted from the default branch by ds-shots-comment.yml; the report it renders is untrusted data.</sub>'
+)
+
+const body = out.join('\n')
+if (Buffer.byteLength(body) > BODY_LIMIT) fail('rendered body too large')
+console.log(body)

--- a/scripts/ds-shots-publish.mjs
+++ b/scripts/ds-shots-publish.mjs
@@ -29,7 +29,11 @@
 
 import { readFileSync, statSync } from 'node:fs'
 
-const MARKER = '<!-- ds-shots-visual-diff -->'
+// The marker carries the head the comment describes, so a later run with no
+// report can tell a current comment (keep) from a stale one (clear) without
+// guessing which PR a run belongs to. HEAD_SHA is trusted workflow context.
+const RAW_HEAD = process.env.HEAD_SHA ?? ''
+const MARKER = `<!-- ds-shots-visual-diff head=${/^[0-9a-f]{40}$/.test(RAW_HEAD) ? RAW_HEAD : 'unknown'} -->`
 const MAX_BYTES = 1024 * 1024 // a legit report is a few KB
 const MAX_ENTRIES = 1000 // 30 fixtures x 4 widths = 120 legit shots
 const ROW_LIMIT = 20 // table rows, one per screen


### PR DESCRIPTION
## Summary

PR #2819 removed the ds-shots PR comment for a good reason: the job runs PR code (pnpm install, next build, playwright), and a later step in the same job is not an isolation boundary, so the job can hold no write token. Since then the visual-diff signal is invisible — a job summary and an 8 MB artifact behind two clicks that nobody opens.

This PR brings the comment back with the pattern the #2819 commit names as the follow-up: a `workflow_run` publisher workflow. It posts one sticky comment per PR — "N screens moved" with a worst-percent table, or a green "no screen moved" — updated in place on every push, linking the run summary, the image artifact, and the baseline commit the diff ran against.

**Task:** TASK-22044

## Why the publisher is safe to hold `pull-requests: write`

The core invariant from #2819 is untouched: **no job that executes PR code holds a write token.** The ds-shots changes here are data-only (stamp the baseline SHA into report.json, upload it as its own artifact); the job's `permissions` block still says `contents: read` and nothing else.

The new workflow can hold `pull-requests: write` because it never executes anything a PR controls:

1. **It runs the workflow file and scripts from the default branch.** `workflow_run` workflows are always taken from the default branch, and for that event `github.sha` is the default-branch head, so `actions/checkout` checks out trusted code. A PR editing `ds-shots-comment.yml` or `ds-shots-publish.mjs` changes nothing about what runs until that edit is merged.
2. **The artifact is treated as hostile data, never as code.** It was produced by a job that ran the PR's install/build/test code, so every byte is attacker-controlled. The publisher extracts exactly one member by name — `unzip -p report.zip report.json > report.json` — so no path stored in the archive is ever written to disk (zip-slip has nothing to act on), and nothing from the artifact is executed.
3. **The report is strict-schema-validated before any of it reaches markdown** (`scripts/ds-shots-publish.mjs`). File names must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,99}@\d{3,4}\.png$` — a character class with no slash, backslash, pipe, backtick, angle bracket or newline, so a validated name cannot traverse a path or break out of a table cell. Percentages must be finite numbers in [0,100], counts bounded integers, the baseline a 40-hex SHA, the resize note `^\d+x\d+ -> \d+x\d+$`. Arrays are capped (1000 entries; 120 is the legit maximum), the table at 20 rows, the rendered body under GitHub's 65,536-byte comment cap. **Any violation rejects the whole report and the run goes red** — and since round 3, an unusable report (broken archive or failed validation) also clears an existing sticky comment to the generic "⚠️ no result" state first, so the previous head's result is never left standing as current while the tampering alarm fires.
4. **The PR number is bound back to the trigger.** The number is parsed from the artifact name, which the PR's own build chose — so a malicious PR could name its artifact after somebody else's PR to plant content there. The publisher therefore requires the numbered PR's current head SHA to equal `workflow_run.head_sha` before posting. A mismatched name posts nothing; as a bonus, a stale out-of-order run (older push finishing after a newer one) also posts nothing. Only a true 404 on the lookup is a quiet no-op (that IS the attack); any operational failure — 5xx, rate limit, network — fails the job loudly so a swallowed error can never leave an old result standing under a green run (Chip round 6). Artifact names also carry the run attempt (`-<attempt>` suffix, Chip round 4) — artifacts persist across reruns of the same run id and v4 uploads are immutable, so a fixed name would collide on re-upload. The publisher selects the **highest-attempt** report in the run (Chip round 5): every attempt of a run tests the same head SHA, so "Re-run failed jobs" that skips a succeeded ds-shots keeps the still-valid result instead of wrongly clearing it, while a full rerun's fresh report wins by attempt number.
5. **The sticky comment can only overwrite the bot's own comment, and it records which head it describes.** The upsert matches the `<!-- ds-shots-visual-diff head=<sha> -->` marker only in comments authored by `github-actions[bot]`, so a user pasting the marker into their own comment cannot get it clobbered. The `head=` field is what makes the no-report path (point 7) provable instead of guessed.
6. **Minimal permissions:** `pull-requests: write` (the comment), `actions: read` (list/download the triggering run's artifacts), `contents: read` (checkout). No `contents: write`, no `id-token`, no secrets beyond `github.token`.
7. **A run with no report clears a stale result — and only a provably stale one** (Chip rounds 1, 2, 7). Which PR a run belongs to cannot be known exactly: one branch can hold two open PRs (dev + main base), and any branch can be parked on any commit. So the publisher never guesses. It lists every open PR whose head is exactly the run's branch **and** commit (trusted `commits/<sha>/pulls` API, `env`-passed jq filters so a branch name can never edit the filter), and clears a comment only when the head recorded in its marker differs from the run's head — i.e. the comment provably describes an older commit of that same PR. A comment already carrying this head was posted by a sibling run that had a report and is kept; a PR with no comment stays quiet (no spam on docs-only PRs). Cancelled runs go through the same path: a manually cancelled current-head run clears the old result, a concurrency-cancelled superseded run no-ops because its head no longer matches any PR. Concurrency is keyed on the **head SHA** with `cancel-in-progress: false` (Chip rounds 7+8): same-head publishers serialize — closing the read-then-write race where a no-report run could overwrite the result a sibling posted between its marker read and its PATCH — while nothing is ever cancelled (`queue: max`, FIFO — the default one-slot queue would let a third same-head run drop a sibling PR's only pending publisher, Chip round 9), so a branch holding PRs to both dev and main gets both publishers. Once serialized, either order ends correctly, because the marker-head guard makes a no-report run keep any comment already posted for its head. The artifact download also sits outside the continue-on-error render step (Chip round 8), so a transient GitHub 5xx goes red with the comment untouched instead of being misdiagnosed as a tampered artifact.
8. **Fork PRs are excluded twice:** the job's `if` requires `workflow_run.head_repository.full_name == github.repository`, and ds-shots-filter already skips forks so the artifact never exists.

## What changed

- **`.github/workflows/ds-shots-comment.yml`** (new) — the publisher described above.
- **`scripts/ds-shots-publish.mjs`** (new) — report.json → comment markdown, with the validation above. Deliberately separate from `scripts/visual-comment.mjs`: that one renders the in-run job summary and trusts its own input; a PR may edit it, so the publisher must not share it.
- **`scripts/__tests__/ds-shots-publish.test.js`** (new) — 23 jest cases via the repo's subprocess pattern: normal render, green render, and rejection of path traversal, markdown/HTML injection, backtick/table breakouts, newline smuggling, oversized reports, malformed numbers/SHAs; plus a cap test asserting a 500-screen report stays under the comment size limit at 20 rows.
- **`.github/workflows/tests.yml`** (data-only) — the diff step stamps the matched baseline SHA into report.json; a new step uploads `visual-diff-report-<pr#>-<attempt>` whenever the diff ran, including when nothing moved (the green comment is posted deliberately, so reviewers learn to trust its presence).

## Deployment gotcha — inert until the next release

`workflow_run` only fires when the workflow file exists on the **default branch (main)**. This PR lands on dev, so the publisher does nothing until the next dev → main prod release carries it over. Until then everything is inert: the report artifact uploads, nobody consumes it. This is also why the workflow cannot be end-to-end tested from this PR — see the verification checklist below.

## Post-release verification (run after the next dev → main release)

1. Open (or push to) any same-repo PR that touches a pixel-moving file, so ds-shots runs.
2. Confirm the "ds-shots comment" workflow fired on the Tests run's completion (Actions tab).
3. Confirm the sticky `🖼 Visual diff` comment appears on the PR, names the baseline commit, and links the run + artifact.
4. Push a second commit; confirm the same comment is edited in place, not duplicated.
5. Open a docs-only PR; confirm the publisher run exits cleanly with no comment.
6. On a PR that has a visual-diff comment, push a commit that breaks the build; confirm the comment flips to "⚠️ no result for the latest push".

## Out of scope (possible v2)

Inline before/after/diff **images** in the comment. GitHub comments can't embed artifact images without hosting them somewhere writable, and pushing PR-derived images from a privileged workflow needs its own careful design. The comment links the image artifact instead.

## QA

- `npm test` — 394 suites / 5008 tests green, including the 23 new publisher cases.
- `npm run typecheck`, `pnpm prettier --check .`, `node scripts/ds-lint-counts.mjs --check` — all green.
- **End-to-end on real data:** this PR's own Tests run already exercised the ds-shots side — it produced [`visual-diff-report-2897`](https://github.com/peanutprotocol/peanut-ui/actions/runs/33491039921) (342 bytes, baseline SHA stamped). Downloading that artifact and running the publisher's exact extract → validate → render steps locally produced the expected comment: `1 of 120 shots changed · 119 identical · baseline 11addd1 → head 9033e7e`, one row `profile@320 2.28%` (dev-baseline drift, not from this PR — it touches no pixels). Only the `workflow_run` trigger itself cannot be verified before main.
- Both workflow files YAML-parse; every `run:` block passes `bash -n`; the artifact-name parsing and the report→comment pipeline were exercised locally end-to-end with a fixture report. actionlint is not installed on this machine (noted, not run).

Screenshots: N/A (no visible app change — CI only).
