### PR TITLE
ci: bot provenance gate — chip-authored PRs with a human owner (TASK-22051)

### DIFF
--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -1,0 +1,128 @@
+# Ownership gate for bot-authored PRs — the second half of the provenance
+# policy whose first half (per-commit Ordered-By / Order trailers) lives in
+# the human-authors job in tests.yml. That job proves every bot commit cites
+# the team member who ordered it; this one proves that human owns the PR:
+#
+#   - the PR is assigned to every cited orderer, and
+#   - base != main: an APPROVED review of the CURRENT head from an orderer —
+#     the accountability click; bot PRs never merge on green gates alone,
+#     dev included, and
+#   - base == main: an APPROVED review of the current head from a team member
+#     who is NOT an orderer, so main always gets a second human.
+#
+# Human-authored PRs pass immediately — nothing changes for people. This is a
+# separate workflow because approval state changes on pull_request_review
+# events, which must not re-run the test matrix (a review-event ci-success run
+# would report green with every test job skipped). Enforced by adding the
+# `bot-approval` context to the org ruleset that already requires ci-success —
+# until that flip, this check is advisory.
+name: Bot approval
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, ready_for_review, assigned, unassigned]
+    pull_request_review:
+        types: [submitted, dismissed]
+
+permissions:
+    pull-requests: read
+    contents: read
+
+concurrency:
+    group: bot-approval-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    bot-approval:
+        name: bot-approval
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify a human owns and approved this bot-authored PR
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const ALLOWED_BOTS = ['chip-peanut-bot[bot]'];
+                      const pr = context.payload.pull_request;
+                      if (!ALLOWED_BOTS.includes(pr.user.login)) {
+                        console.log(`✅ PR author ${pr.user.login} is not an allowlisted bot — no ownership gate to apply`);
+                        return;
+                      }
+                      const memberCache = new Map();
+                      async function hasWriteAccess(login) {
+                        if (memberCache.has(login)) return memberCache.get(login);
+                        let ok = false;
+                        try {
+                          const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            username: login,
+                          });
+                          ok = ['admin', 'maintain', 'write'].includes(data.permission);
+                        } catch (e) {
+                          ok = false;
+                        }
+                        memberCache.set(login, ok);
+                        return ok;
+                      }
+                      // The humans who ordered this work, from the commit trailers. Trailer
+                      // validity (presence, write access, order link) is human-authors' job in
+                      // tests.yml; here the trailers only name whose ownership to demand.
+                      const commits = await github.paginate(github.rest.pulls.listCommits, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr.number,
+                        per_page: 100,
+                      });
+                      const orderers = new Set();
+                      for (const c of commits) {
+                        const login = c.author && c.author.login;
+                        if (!login || !ALLOWED_BOTS.includes(login)) continue;
+                        const m = c.commit.message.match(/^Ordered-By: @?([A-Za-z0-9-]+)\s*$/m);
+                        if (m) orderers.add(m[1]);
+                      }
+                      if (orderers.size === 0) {
+                        console.log('✅ No bot-authored commits carry trailers — human-authors gates the commits themselves');
+                        return;
+                      }
+                      const assignees = (pr.assignees || []).map((a) => a.login);
+                      const unassigned = [...orderers].filter((o) => !assignees.includes(o));
+                      if (unassigned.length) {
+                        core.setFailed(`The PR must be assigned to the human(s) who ordered it — missing assignee(s): ${unassigned.join(', ')}. The assignee owns the findings and the merge.`);
+                        return;
+                      }
+                      // Latest review state per human. COMMENTED never overwrites an earlier
+                      // APPROVED / CHANGES_REQUESTED — the same semantics GitHub itself uses.
+                      // An approval only counts on the exact current head: a bot push after
+                      // the click is new, unapproved work.
+                      const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr.number,
+                        per_page: 100,
+                      });
+                      const latest = new Map();
+                      for (const r of reviews) {
+                        if (!r.user || r.user.type === 'Bot') continue;
+                        if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(r.state)) continue;
+                        latest.set(r.user.login, { state: r.state, commit: r.commit_id });
+                      }
+                      const approvers = [];
+                      for (const [login, r] of latest) {
+                        if (r.state !== 'APPROVED' || r.commit !== pr.head.sha) continue;
+                        if (await hasWriteAccess(login)) approvers.push(login);
+                      }
+                      if (pr.base.ref === 'main') {
+                        const second = approvers.filter((a) => !orderers.has(a));
+                        if (!second.length) {
+                          core.setFailed(`Bot PR into main needs an APPROVED review of the current head from a team member other than the orderer(s) (${[...orderers].join(', ')}) — main always gets a second human.`);
+                          return;
+                        }
+                        console.log(`✅ Second-human approval by ${second.join(', ')} (ordered by ${[...orderers].join(', ')})`);
+                      } else {
+                        const owner = approvers.filter((a) => orderers.has(a));
+                        if (!owner.length) {
+                          core.setFailed(`Bot PR needs an APPROVED review of the current head from the human who ordered it (${[...orderers].join(' or ')}) — their approval is the accountability act; bot PRs never merge on green gates alone.`);
+                          return;
+                        }
+                        console.log(`✅ Owner approval by ${owner.join(', ')}`);
+                      }

--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -15,9 +15,12 @@
 #
 # Bot involvement is decided from commit authorship, never from who opened
 # the PR — a human opening a PR that carries bot commits must not skip the
-# gate. Commits already reachable from main/dev are exempt, exactly like
-# human-authors' already-landed clause: a promotion or back-merge that carries
-# historical bot commits must not wedge on ceremony that already happened.
+# gate. Commits that already went through this base's ceremony are exempt:
+# base main exempts only commits already ON main — the dev path never
+# required a second human, so a dev->main promotion must still collect one —
+# while any other base exempts main+dev, so back-merges carrying historical
+# bot commits don't wedge. PRs past GitHub's 250-commit listing cap fail
+# closed: a gate that cannot see every commit must not pass.
 #
 # PRs with no unlanded bot commits pass immediately — nothing changes for
 # people. This is a separate workflow because approval state changes on
@@ -75,14 +78,16 @@ jobs:
                         memberCache.set(key, ok);
                         return ok;
                       }
-                      // Same exemption as human-authors: a commit already reachable from
-                      // main/dev was gated by the PR that first proposed it; judging it again
-                      // only wedges the promotion or back-merge that carries it.
+                      // Landed exemption, base-aware. Into main, only main reachability
+                      // counts — commits merged to dev were never second-human approved, so
+                      // the promotion PR is where that ceremony happens. Into anything else,
+                      // main+dev reachability exempts, so back-merges don't wedge.
+                      const LANDED_BRANCHES = pr.base.ref === 'main' ? ['main'] : ['main', 'dev'];
                       const landedCache = new Map();
                       async function alreadyLanded(sha) {
                         if (landedCache.has(sha)) return landedCache.get(sha);
                         let landed = false;
-                        for (const branch of ['main', 'dev']) {
+                        for (const branch of LANDED_BRANCHES) {
                           try {
                             const { data } = await github.rest.repos.compareCommitsWithBasehead({
                               owner: context.repo.owner,
@@ -110,7 +115,15 @@ jobs:
                         pull_number: pr.number,
                         per_page: 100,
                       });
+                      // Fail closed when the listing is truncated: the API caps PR commit
+                      // listings at 250, and a gate blind to even one commit must not pass.
+                      const total = typeof pr.commits === 'number' ? pr.commits : null;
+                      if ((total !== null && commits.length < total) || (total === null && commits.length >= 250)) {
+                        core.setFailed(`The PR has ${total ?? '250+'} commits but the API enumerated ${commits.length} — the gate cannot see every commit. Split the PR or merge in stages.`);
+                        return;
+                      }
                       const orderers = new Set();
+                      const untrailed = [];
                       let unlandedBotCommits = 0;
                       for (const c of commits) {
                         const login = lc(c.author && c.author.login);
@@ -119,13 +132,16 @@ jobs:
                         unlandedBotCommits++;
                         const m = c.commit.message.match(/^Ordered-By: @?([A-Za-z0-9-]+)\s*$/m);
                         if (m) orderers.add(lc(m[1]));
+                        else untrailed.push(c.sha.slice(0, 7));
                       }
                       if (unlandedBotCommits === 0) {
                         console.log('✅ No unlanded bot-authored commits — no ownership gate to apply');
                         return;
                       }
-                      if (orderers.size === 0) {
-                        console.log('✅ Bot commits carry no trailers — human-authors fails them; nothing for this gate to own');
+                      // Never fail open: an ownership gate with no owner is red, even though
+                      // human-authors flags the same commits through ci-success.
+                      if (untrailed.length) {
+                        core.setFailed(`Unlanded bot commit(s) without an Ordered-By trailer: ${untrailed.join(', ')} — no owner, no green.`);
                         return;
                       }
                       const assignees = (pr.assignees || []).map((a) => lc(a.login));

--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -7,9 +7,9 @@
 #   - the PR is assigned to every cited orderer, and
 #   - base != main: an APPROVED review of the CURRENT head from an orderer —
 #     the accountability click; bot work never merges on green gates alone,
-#     dev included. A PR the orderer opened themselves counts as owned: they
-#     cannot approve their own PR, and adopting bot commits under your own PR
-#     is the same accountability as authoring them. And
+#     dev included. When the orderer opened the PR themselves (adopting bot
+#     commits), GitHub blocks self-approval, so any other team member's
+#     approval of the current head satisfies the rule instead. And
 #   - base == main: an APPROVED review of the current head from a team member
 #     who is NOT an orderer, so main always gets a second human.
 #
@@ -160,6 +160,10 @@ jobs:
                         pull_number: pr.number,
                         per_page: 100,
                       });
+                      // Fold oldest-first so the newest review per human wins — the API does
+                      // not document an ordering, and last-write-wins on an undocumented
+                      // order could let a stale APPROVED shadow a newer CHANGES_REQUESTED.
+                      reviews.sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at) || a.id - b.id);
                       const latest = new Map();
                       for (const r of reviews) {
                         if (!r.user || r.user.type === 'Bot') continue;
@@ -178,11 +182,16 @@ jobs:
                           return;
                         }
                         console.log(`✅ Second-human approval by ${second.join(', ')} (ordered by ${[...orderers].join(', ')})`);
-                      } else {
-                        if (orderers.has(lc(pr.user.login))) {
-                          console.log(`✅ PR opened by orderer ${pr.user.login} — their own PR is their owned work`);
+                      } else if (orderers.has(lc(pr.user.login))) {
+                        // The orderer opened the PR themselves and cannot self-approve, so
+                        // any other team member's approval of the head stands in — bot work
+                        // still never merges reviewless.
+                        if (!approvers.length) {
+                          core.setFailed(`PR opened by orderer ${pr.user.login}, who cannot approve their own PR — needs an APPROVED review of the current head from any other team member; bot work never merges on green gates alone.`);
                           return;
                         }
+                        console.log(`✅ Approval by ${approvers.join(', ')} for orderer-opened PR`);
+                      } else {
                         const owner = approvers.filter((a) => orderers.has(a));
                         if (!owner.length) {
                           core.setFailed(`Bot work needs an APPROVED review of the current head from the human who ordered it (${[...orderers].join(' or ')}) — their approval is the accountability act; bot PRs never merge on green gates alone.`);

--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -1,26 +1,37 @@
-# Ownership gate for bot-authored PRs — the second half of the provenance
-# policy whose first half (per-commit Ordered-By / Order trailers) lives in
-# the human-authors job in tests.yml. That job proves every bot commit cites
-# the team member who ordered it; this one proves that human owns the PR:
+# Ownership gate for PRs carrying bot-authored commits — the second half of
+# the provenance policy whose first half (per-commit Ordered-By / Order
+# trailers) lives in the human-authors job in tests.yml. That job proves every
+# bot commit cites the team member who ordered it; this one proves that human
+# owns the PR:
 #
 #   - the PR is assigned to every cited orderer, and
 #   - base != main: an APPROVED review of the CURRENT head from an orderer —
-#     the accountability click; bot PRs never merge on green gates alone,
-#     dev included, and
+#     the accountability click; bot work never merges on green gates alone,
+#     dev included. A PR the orderer opened themselves counts as owned: they
+#     cannot approve their own PR, and adopting bot commits under your own PR
+#     is the same accountability as authoring them. And
 #   - base == main: an APPROVED review of the current head from a team member
 #     who is NOT an orderer, so main always gets a second human.
 #
-# Human-authored PRs pass immediately — nothing changes for people. This is a
-# separate workflow because approval state changes on pull_request_review
-# events, which must not re-run the test matrix (a review-event ci-success run
-# would report green with every test job skipped). Enforced by adding the
-# `bot-approval` context to the org ruleset that already requires ci-success —
-# until that flip, this check is advisory.
+# Bot involvement is decided from commit authorship, never from who opened
+# the PR — a human opening a PR that carries bot commits must not skip the
+# gate. Commits already reachable from main/dev are exempt, exactly like
+# human-authors' already-landed clause: a promotion or back-merge that carries
+# historical bot commits must not wedge on ceremony that already happened.
+#
+# PRs with no unlanded bot commits pass immediately — nothing changes for
+# people. This is a separate workflow because approval state changes on
+# pull_request_review events, which must not re-run the test matrix (a
+# review-event ci-success run would report green with every test job skipped).
+# The `edited` trigger matters: it is the event a base-branch retarget fires,
+# and retargeting dev -> main must re-evaluate the second-human rule.
+# Enforced by adding the `bot-approval` context to the org ruleset that
+# already requires ci-success — until that flip, this check is advisory.
 name: Bot approval
 
 on:
     pull_request:
-        types: [opened, reopened, synchronize, ready_for_review, assigned, unassigned]
+        types: [opened, reopened, synchronize, ready_for_review, assigned, unassigned, edited]
     pull_request_review:
         types: [submitted, dismissed]
 
@@ -37,19 +48,19 @@ jobs:
         name: bot-approval
         runs-on: ubuntu-latest
         steps:
-            - name: Verify a human owns and approved this bot-authored PR
+            - name: Verify a human owns and approved the bot-authored commits
               uses: actions/github-script@v7
               with:
                   script: |
                       const ALLOWED_BOTS = ['chip-peanut-bot[bot]'];
+                      // GitHub logins are case-insensitive; compare lowercased everywhere.
+                      const lc = (s) => (s || '').toLowerCase();
+                      const BOT_SET = new Set(ALLOWED_BOTS.map(lc));
                       const pr = context.payload.pull_request;
-                      if (!ALLOWED_BOTS.includes(pr.user.login)) {
-                        console.log(`✅ PR author ${pr.user.login} is not an allowlisted bot — no ownership gate to apply`);
-                        return;
-                      }
                       const memberCache = new Map();
                       async function hasWriteAccess(login) {
-                        if (memberCache.has(login)) return memberCache.get(login);
+                        const key = lc(login);
+                        if (memberCache.has(key)) return memberCache.get(key);
                         let ok = false;
                         try {
                           const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -61,12 +72,38 @@ jobs:
                         } catch (e) {
                           ok = false;
                         }
-                        memberCache.set(login, ok);
+                        memberCache.set(key, ok);
                         return ok;
                       }
-                      // The humans who ordered this work, from the commit trailers. Trailer
-                      // validity (presence, write access, order link) is human-authors' job in
-                      // tests.yml; here the trailers only name whose ownership to demand.
+                      // Same exemption as human-authors: a commit already reachable from
+                      // main/dev was gated by the PR that first proposed it; judging it again
+                      // only wedges the promotion or back-merge that carries it.
+                      const landedCache = new Map();
+                      async function alreadyLanded(sha) {
+                        if (landedCache.has(sha)) return landedCache.get(sha);
+                        let landed = false;
+                        for (const branch of ['main', 'dev']) {
+                          try {
+                            const { data } = await github.rest.repos.compareCommitsWithBasehead({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              basehead: `${branch}...${sha}`,
+                            });
+                            if (data.status === 'identical' || data.status === 'behind') {
+                              landed = true;
+                              break;
+                            }
+                          } catch (e) {
+                            core.warning(`already-landed check failed for ${sha} against ${branch}: ${e.message}`);
+                          }
+                        }
+                        landedCache.set(sha, landed);
+                        return landed;
+                      }
+                      // Bot involvement and the orderers come from the commits, not from the
+                      // PR opener. Trailer validity (presence, write access, order link) is
+                      // human-authors' job in tests.yml; here the trailers only name whose
+                      // ownership to demand.
                       const commits = await github.paginate(github.rest.pulls.listCommits, {
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -74,17 +111,24 @@ jobs:
                         per_page: 100,
                       });
                       const orderers = new Set();
+                      let unlandedBotCommits = 0;
                       for (const c of commits) {
-                        const login = c.author && c.author.login;
-                        if (!login || !ALLOWED_BOTS.includes(login)) continue;
+                        const login = lc(c.author && c.author.login);
+                        if (!login || !BOT_SET.has(login)) continue;
+                        if (await alreadyLanded(c.sha)) continue;
+                        unlandedBotCommits++;
                         const m = c.commit.message.match(/^Ordered-By: @?([A-Za-z0-9-]+)\s*$/m);
-                        if (m) orderers.add(m[1]);
+                        if (m) orderers.add(lc(m[1]));
                       }
-                      if (orderers.size === 0) {
-                        console.log('✅ No bot-authored commits carry trailers — human-authors gates the commits themselves');
+                      if (unlandedBotCommits === 0) {
+                        console.log('✅ No unlanded bot-authored commits — no ownership gate to apply');
                         return;
                       }
-                      const assignees = (pr.assignees || []).map((a) => a.login);
+                      if (orderers.size === 0) {
+                        console.log('✅ Bot commits carry no trailers — human-authors fails them; nothing for this gate to own');
+                        return;
+                      }
+                      const assignees = (pr.assignees || []).map((a) => lc(a.login));
                       const unassigned = [...orderers].filter((o) => !assignees.includes(o));
                       if (unassigned.length) {
                         core.setFailed(`The PR must be assigned to the human(s) who ordered it — missing assignee(s): ${unassigned.join(', ')}. The assignee owns the findings and the merge.`);
@@ -104,7 +148,7 @@ jobs:
                       for (const r of reviews) {
                         if (!r.user || r.user.type === 'Bot') continue;
                         if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(r.state)) continue;
-                        latest.set(r.user.login, { state: r.state, commit: r.commit_id });
+                        latest.set(lc(r.user.login), { state: r.state, commit: r.commit_id });
                       }
                       const approvers = [];
                       for (const [login, r] of latest) {
@@ -114,14 +158,18 @@ jobs:
                       if (pr.base.ref === 'main') {
                         const second = approvers.filter((a) => !orderers.has(a));
                         if (!second.length) {
-                          core.setFailed(`Bot PR into main needs an APPROVED review of the current head from a team member other than the orderer(s) (${[...orderers].join(', ')}) — main always gets a second human.`);
+                          core.setFailed(`Bot work into main needs an APPROVED review of the current head from a team member other than the orderer(s) (${[...orderers].join(', ')}) — main always gets a second human.`);
                           return;
                         }
                         console.log(`✅ Second-human approval by ${second.join(', ')} (ordered by ${[...orderers].join(', ')})`);
                       } else {
+                        if (orderers.has(lc(pr.user.login))) {
+                          console.log(`✅ PR opened by orderer ${pr.user.login} — their own PR is their owned work`);
+                          return;
+                        }
                         const owner = approvers.filter((a) => orderers.has(a));
                         if (!owner.length) {
-                          core.setFailed(`Bot PR needs an APPROVED review of the current head from the human who ordered it (${[...orderers].join(' or ')}) — their approval is the accountability act; bot PRs never merge on green gates alone.`);
+                          core.setFailed(`Bot work needs an APPROVED review of the current head from the human who ordered it (${[...orderers].join(' or ')}) — their approval is the accountability act; bot PRs never merge on green gates alone.`);
                           return;
                         }
                         console.log(`✅ Owner approval by ${owner.join(', ')}`);

--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -137,8 +137,10 @@ jobs:
                       if (unlandedBotCommits === 0) {
                         // A bot-opened PR whose commits all claim human authors is either
                         // authorship laundering (API commits carry caller-supplied author
-                        // metadata) or a fully superseded branch — red either way.
-                        if (BOT_SET.has(lc(pr.user.login))) {
+                        // metadata) or a fully superseded branch — red either way. ANY bot
+                        // opener counts, not just allowlisted ones: an unlisted bot opening
+                        // forged-human commits must not slip past both gates.
+                        if (pr.user.type === 'Bot' || lc(pr.user.login).endsWith('[bot]')) {
                           core.setFailed(`Bot-opened PR carries no unlanded bot-authored commits — a bot PR must consist of its own provenance-trailed commits.`);
                           return;
                         }

--- a/.github/workflows/bot-approval.yml
+++ b/.github/workflows/bot-approval.yml
@@ -135,6 +135,13 @@ jobs:
                         else untrailed.push(c.sha.slice(0, 7));
                       }
                       if (unlandedBotCommits === 0) {
+                        // A bot-opened PR whose commits all claim human authors is either
+                        // authorship laundering (API commits carry caller-supplied author
+                        // metadata) or a fully superseded branch — red either way.
+                        if (BOT_SET.has(lc(pr.user.login))) {
+                          core.setFailed(`Bot-opened PR carries no unlanded bot-authored commits — a bot PR must consist of its own provenance-trailed commits.`);
+                          return;
+                        }
                         console.log('✅ No unlanded bot-authored commits — no ownership gate to apply');
                         return;
                       }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -703,17 +703,23 @@ jobs:
                           });
                       }
 
-    # Human-only authorship gate. Every commit on the PR must be authored by a
-    # repo collaborator's own GitHub account — no `*[bot]` authors (claude[bot],
-    # github-actions[bot], …) and no emails that GitHub cannot map to an
-    # account. Policy set 2026-08-24: AI is a tool, not an owner; every commit
-    # has a human who is accountable for it. Cloud coding sessions that commit
-    # as claude[bot] are exactly what this blocks. Content-publish PRs pass:
-    # update-content.yml authors and signs its commit as a human account.
+    # Authorship + provenance gate. Every commit on the PR must be either
+    # (a) authored by a repo collaborator's own GitHub account, or
+    # (b) authored by an allowlisted bot and carry provenance trailers naming
+    #     the team member who ordered the work:
+    #         Ordered-By: <github-login>   (must have write access to this repo)
+    #         Order: <https link to the order — Discord message, PR comment,
+    #                Notion task>
+    # Policy set 2026-08-24, amended 2026-09-01: AI is a tool, not an owner;
+    # every commit has a human who is accountable for it. Unknown bots
+    # (claude[bot] cloud sessions, …) and emails GitHub cannot map to an
+    # account still fail. The ownership half of the policy — the orderer is
+    # assignee and approves the merge — lives in bot-approval.yml, a separate
+    # required check.
     #
-    # No allowlist to maintain: "has write access to this repo" IS the team
-    # roster, and GitHub org/repo access management keeps it current. The
-    # per-user permission endpoint works with the default GITHUB_TOKEN.
+    # No allowlist of humans to maintain: "has write access to this repo" IS
+    # the team roster, and GitHub org/repo access management keeps it current.
+    # The per-user permission endpoint works with the default GITHUB_TOKEN.
     human-authors:
         name: human-authors
         if: github.event_name == 'pull_request'
@@ -723,10 +729,11 @@ jobs:
         permissions:
             pull-requests: read
         steps:
-            - name: Verify every commit is authored by a team member
+            - name: Verify every commit is authored by a team member or a provenance-trailed bot
               uses: actions/github-script@v7
               with:
                   script: |
+                      const ALLOWED_BOTS = ['chip-peanut-bot[bot]'];
                       const memberCache = new Map();
                       async function hasWriteAccess(login) {
                         if (memberCache.has(login)) return memberCache.get(login);
@@ -786,8 +793,16 @@ jobs:
                         let problem = null;
                         if (!login) {
                           problem = `author email <${email}> is not linked to a GitHub account — commit from your own account (git config user.email must be an email verified on your GitHub profile)`;
+                        } else if (ALLOWED_BOTS.includes(login)) {
+                          const orderedBy = (c.commit.message.match(/^Ordered-By: @?([A-Za-z0-9-]+)\s*$/m) || [])[1];
+                          const orderUrl = (c.commit.message.match(/^Order: (https:\/\/\S+)\s*$/m) || [])[1];
+                          if (!orderedBy || !orderUrl) {
+                            problem = `authored by ${login} without provenance trailers — a bot commit must carry "Ordered-By: <github-login>" and "Order: <https link to the human's order>"`;
+                          } else if (!(await hasWriteAccess(orderedBy))) {
+                            problem = `cites Ordered-By: ${orderedBy}, who has no write access to this repo — a bot commit must cite the team member who ordered it`;
+                          }
                         } else if (login.endsWith('[bot]')) {
-                          problem = `authored by ${login} — bot-authored commits are not allowed; commit as yourself`;
+                          problem = `authored by ${login} — this bot is not allowlisted; bot commits are only accepted from ${ALLOWED_BOTS.join(', ')}, with provenance trailers`;
                         } else if (!(await hasWriteAccess(login))) {
                           problem = `authored by ${login}, who has no write access to this repo`;
                         }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -784,6 +784,13 @@ jobs:
                         pull_number: context.payload.pull_request.number,
                         per_page: 100,
                       });
+                      // Fail closed when the listing is truncated: the API caps PR commit
+                      // listings at 250, and a gate blind to even one commit must not pass.
+                      const total = context.payload.pull_request.commits;
+                      if ((typeof total === 'number' && commits.length < total) || (typeof total !== 'number' && commits.length >= 250)) {
+                        core.setFailed(`The PR has ${typeof total === 'number' ? total : '250+'} commits but the API enumerated ${commits.length} — the gate cannot see every commit. Split the PR or merge in stages.`);
+                        return;
+                      }
                       const bad = [];
                       const landed = [];
                       for (const c of commits) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -800,7 +800,7 @@ jobs:
                         let problem = null;
                         if (!login) {
                           problem = `author email <${email}> is not linked to a GitHub account — commit from your own account (git config user.email must be an email verified on your GitHub profile)`;
-                        } else if (ALLOWED_BOTS.includes(login)) {
+                        } else if (ALLOWED_BOTS.includes(login.toLowerCase())) {
                           const orderedBy = (c.commit.message.match(/^Ordered-By: @?([A-Za-z0-9-]+)\s*$/m) || [])[1];
                           const orderUrl = (c.commit.message.match(/^Order: (https:\/\/\S+)\s*$/m) || [])[1];
                           if (!orderedBy || !orderUrl) {
@@ -808,7 +808,7 @@ jobs:
                           } else if (!(await hasWriteAccess(orderedBy))) {
                             problem = `cites Ordered-By: ${orderedBy}, who has no write access to this repo — a bot commit must cite the team member who ordered it`;
                           }
-                        } else if (login.endsWith('[bot]')) {
+                        } else if (login.toLowerCase().endsWith('[bot]')) {
                           problem = `authored by ${login} — this bot is not allowlisted; bot commits are only accepted from ${ALLOWED_BOTS.join(', ')}, with provenance trailers`;
                         } else if (!(await hasWriteAccess(login))) {
                           problem = `authored by ${login}, who has no write access to this repo`;


### PR DESCRIPTION
## Summary

Replaces the blanket bot-author ban with an ownership gate. The `human-authors` job (ui#2805) enforced *authorship* when the 2026-08-24 policy asked for *accountability* — chip's green #2891 died on ceremony, while `update-content.yml` commits as a human account and local AI sessions ship under human git identities all day. This PR makes the accountable human machine-readable instead:

- `human-authors` now also passes commits authored by an **allowlisted bot** (`chip-peanut-bot[bot]`) when each bot commit carries provenance trailers: `Ordered-By: <github-login>` (must have write access — same live roster as before, nothing to maintain) and `Order: <https link>` to the human's order (Discord message, PR comment, Notion task). Unknown bots (cloud `claude[bot]`) and unlinked emails still fail.
- New **`bot-approval.yml`**: applies to any PR carrying **unlanded bot-authored commits** — decided from commit authorship, never from who opened the PR; commits already on main/dev are exempt (human-authors' landed clause), so promotions and back-merges don't wedge. The cited orderer(s) must be PR **assignees**, and the PR needs an APPROVED review **of the current head** — from an orderer when base ≠ `main` (a PR the orderer opened themselves instead needs any other team member's approval — GitHub blocks self-approval, so bot work still never merges reviewless), from a **non-orderer team member** when base = `main` (second human). Re-runs on `edited`, so a dev→main retarget re-evaluates the second-human rule; logins compare case-insensitively. PRs with no bot commits pass instantly; Chip still never approves.

Separate workflow because approval state changes on `pull_request_review` events, which must not re-run the test matrix (a review-event `ci-success` run would report green with every test job skipped).

## Task

TASK-22051 — https://app.notion.com/p/3ce838117579817e97c3f0727095ac40

## Deploy order (org-admin step at the end)

1. Merge this to `dev`; twin PR in peanut-api-ts.
2. Promote to `main` in both repos (next release / back-merge).
3. Only then add required context `bot-approval` to org ruleset **"Require ci-success on api + ui (main, dev)"** (id 15666903) — **name-context mode (`required_status_checks`), not the pinned "Require workflows" rule**. Chip's review established that ruleset-run workflows ignore the `types` filter and never run on `pull_request_review`, so under pinning an approval could not flip the check green nor a dismissal invalidate it. Name-context mode honors this workflow's own triggers; its forgery residual is bounded by step 4 and by the standing trust in write-access humans (identical to `ci-success` today). Hardening path if ever wanted: a trusted GitHub App (chip's box) re-evaluating review webhooks and posting the required status — infra beyond this PR. Until the flip the check runs but is advisory. Flipping earlier wedges PRs whose merge ref predates the workflow file. Pre-flip sanity check (both repos): `git log origin/main..origin/dev --format='%ae' | grep -c '\[bot\]'` must be 0 — a pre-policy untrailered bot commit on dev would wedge the next promotion; none exist today (verified 2026-09-01), and post-merge `human-authors` stops new ones landing untrailered.
4. Verify the `chip-peanut-bot` GitHub App has **no `workflows` permission** (org settings → GitHub Apps → chip → Repository permissions): without it, GitHub rejects any bot push touching `.github/workflows/**` at the git layer. While there, **audit which installed apps hold `contents: write`** — each one can author-spoof commits (Security, last bullet). Needs `admin:org`; this session's token has none.

## Security — who can edit the gate that judges them

Chip's review correctly notes `pull_request`/`pull_request_review` workflows run from the PR merge ref, so a PR can carry a no-op copy of its own gate. Three things bound that risk:

- **This property is pre-existing and shared by the whole `ci-success` suite** (`human-authors` included, since ui#2805): any same-repo PR could already no-op `tests.yml`. The org's standing trust model accepts it because a same-repo branch implies write access — an already-trusted human — and `main` additionally requires human review of the diff (a deleted gate is loud in a diff).
- **The genuinely new surface is the bot.** That is closed at the platform layer, not in YAML: the chip app must lack the `workflows` permission (deploy step 4), which makes a bot push that touches any workflow file un-pushable, regardless of what the workflow says.
- **The name-forgery residual** (any PR-defined job can claim the `bot-approval` name — fork PRs included, since job-name check runs need no token permissions) remains open exactly as it does for `ci-success` itself today: every name-context required check in the suite is forgeable this way, bounded by the fact that only write-access humans can click merge, and a fork PR gets human eyes by construction. Unreachable for bots via step 4. A pinned "Require workflows" binding would close it but cannot re-run on review events (deploy step 3), so it is deliberately not used; the trusted-App dispatcher is the hardening path.
- **Author-metadata forgery residual**: commit APIs accept caller-supplied author metadata, and GitHub signs API-created commits as web-flow, so `required_signatures` passes them — a contents-write bot can therefore author commits that resolve to a human login and read as human work to any author-keyed gate, **including the pre-PR `human-authors`** (this is not new surface). In-gate mitigation: a bot-opened PR with zero unlanded trailed bot commits now fails, closing the bot-opened laundering path. The residual (forged-author commits pushed onto a human-opened branch) is not detectable at the YAML layer — chip's legitimate commits and forged ones are indistinguishable there (both web-flow-signed) — and needs actor attestation: the trusted-App dispatcher (step 3's hardening path) attesting push actors. Exposure is bounded to `dev` (main gets human diff review) and to the audited `contents: write` app inventory (step 4).


## Risks / breaking changes

- No behavior change for human-authored PRs (`bot-approval` short-circuits; `human-authors` human path untouched).
- The `alreadyLanded` grandfather clause applies to trailer problems the same way it applies to authorship problems (shared `problem` path), so historical commits can't wedge back-merges.
- A stale approval never merges a newer bot head: approvals count only when `review.commit_id == head.sha`.
- Chip-side: chip must start stamping trailers + assignee (chip AGENTS.md PR, separate). Until then chip PRs correctly fail this gate — same net effect as today.

## Design notes / accepted trade-offs

- The `Order:` link is presence+format checked only; CI has no Discord credentials to verify the message. The link lands in an independent audit log (Discord/Notion), which is the point.
- `Co-Authored-By: Claude` stays banned as a repo convention (mono CONTRIBUTING.md) — deliberately not CI-enforced by this gate. Producer truth lives in the git author field; ownership in the trailers/assignee.
- Follow-up (not here): un-launder `update-content.yml` — commit as the bot with `Ordered-By:` from a lane owner instead of authoring as Hugo0.

## QA

- Both embedded scripts syntax-checked via `AsyncFunction` construction (github-script's own wrapper).
- Prettier clean.
- This PR itself exercises both paths live: human-authored → `human-authors` passes, `bot-approval` short-circuits green.
- Real bot-path test after chip's protocol lands: re-run of the #2891 scenario.

Screenshots: N/A (no visible change)
