### PR TITLE
fix(kyc): yellow unlock bubble, and one alignment for prep prose

### DIFF
--- a/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
+++ b/src/components/AddMoney/components/MantecaPixQrDeposit.tsx
@@ -58,7 +58,7 @@ const MantecaPixQrDeposit: FC<{
             <PageStack>
                 <NavHeader title={t('title')} onPrev={onDone} />
                 <div className="my-auto flex flex-col items-center gap-4 text-center">
-                    <IconBubble icon="check" size="m" color="green" />
+                    <IconBubble icon="check" size="l" color="green" />
                     <h2 className="text-heading-s text-foreground-primary">{t('pix.depositReceived')}</h2>
                     <p className="text-body-s text-foreground-secondary">{t('pix.balanceUpdated')}</p>
                     <Button variant="purple" shadowSize="4" className="w-full" onClick={onDone}>

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -73,8 +73,11 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
         <div className="flex w-full flex-col gap-6">
             <NavHeader title={t('title')} onPrev={onBack} />
 
-            <div className="flex flex-col items-center gap-3 text-center">
-                <IconBubble icon="user-id" size="l" color="yellow" />
+            {/* Bubble centered, prose not: the checklist right below is
+                left-aligned, and a centered paragraph above it reads as a
+                second column. */}
+            <div className="flex flex-col gap-3">
+                <IconBubble icon="user-id" size="l" color="yellow" className="self-center" />
                 <p className="text-body-s text-foreground-secondary">
                     {isAdvisory ? t('descriptionAdvisory') : t('description')}
                 </p>

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -210,8 +210,10 @@ export const InitiateKycModal = ({
     // vendor without it. Every other variant is an error/action state where the
     // list would be noise.
     const showPrepChecklist = (variant === 'default' || variant === 'cross_region') && !error
+    // The checklist is left-aligned, so the paragraph introducing it is too:
+    // centered prose stacked on a left-aligned list reads as two columns.
     const description = showPrepChecklist ? (
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 text-left">
             <p>{getDescription()}</p>
             <KycPrepChecklist path={prepPath} />
         </div>
@@ -219,7 +221,6 @@ export const InitiateKycModal = ({
         getDescription()
     )
     const iconName = (error || isBlocked || isRestartIdentity || isRegionUnavailable ? 'alert' : 'badge') as IconName
-    const iconBubbleClass = isBlocked || isRestartIdentity || isRegionUnavailable ? 'bg-action-secondary' : ''
     const footer =
         isProviderRejection || isBlocked || isRestartIdentity || isRegionUnavailable ? undefined : (
             <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
@@ -243,7 +244,11 @@ export const InitiateKycModal = ({
                     heading at all whenever the visible one is dropped. */}
                 {titleIsGeneric && <h1 className="sr-only">{headerTitle}</h1>}
                 <div className="flex flex-col items-center gap-4 text-center">
-                    <IconBubble icon={iconName} size="l" className={iconBubbleClass} />
+                    {/* Yellow, never green: every variant of this screen is
+                        waiting on the user. Green is the bubble the app uses
+                        for a finished state, and a green shield over "we need
+                        extra documents" reads as already-verified. */}
+                    <IconBubble icon={iconName} size="l" color="yellow" />
                     {!titleIsGeneric && <h1 className="text-heading-xs text-foreground-primary">{getTitle()}</h1>}
                     <div className="w-full text-body-s text-foreground-secondary">{description}</div>
                 </div>
@@ -270,7 +275,7 @@ export const InitiateKycModal = ({
             description={description}
             preventClose
             icon={iconName}
-            iconContainerClassName={iconBubbleClass}
+            iconContainerClassName="bg-background-icon-bubble-yellow"
             modalPanelClassName="max-w-full m-2"
             ctaClassName="grid grid-cols-1 gap-3"
             ctas={[


### PR DESCRIPTION
The unlock screen showed a **green** icon bubble on every variant, including "We need extra documents". Green is the bubble this app uses for a finished state — the hosted-prep done panel, the PIX deposit-received screen — so a green shield over a request for documents reads as *already verified*. `error` was worse: an alert icon in a green bubble.

Every variant of this screen is waiting on the user, so it is yellow throughout and the per-variant override goes away.

The prep checklist is `text-left`, but the paragraph introducing it sat inside a `text-center` block, so the two read as separate columns. Both screens that stack prose on that checklist now share one edge; the bubble and heading stay centered.

### Changes

- `InitiateKycModal` — `color="yellow"` on the hero bubble (and on the sheet presentation), `iconBubbleClass` removed; description block is `text-left` when it carries the checklist. One node, so page and sheet fix together.
- `AdditionalVerificationView` — same alignment fix, bubble centered via `self-center`.
- `MantecaPixQrDeposit` — deposit-received bubble `m` → `l`. `IconBubble` documents `l` (72px) as the page hero and every other bare page hero already uses it; this was the last one at `m`.

### Checked, deliberately unchanged

- `CardPinSetupFlow` — centered title/body then a `text-left` list of PIN rules. Same shape, but the centered PIN pad sits between them and the list is left only so the bullets align; left-aligning the intro would throw the pad off-centre.
- `UnlockMethodModal` — pink `shield` bubble (`bg-action-primary`), so the same journey shows pink in the sheet and yellow on the page. Not green, so out of scope here, but it is the remaining inconsistency in that flow.

### Verification

`pnpm typecheck` clean, prettier clean, `AdditionalVerificationView` (20) and `UnlockPayments` (15) suites pass.
