### PR TITLE
fix(ci): give the OTA resolver the deps the Capgo CLI needs

### DIFF
--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -76,16 +76,41 @@ jobs:
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
               run: |
-                  # Keep the raw output: piping the CLI straight into grep discards
-                  # its diagnostics, so a config-load or auth failure is
+                  # Keep the raw output rather than piping the CLI into grep, which
+                  # discarded its diagnostics and made a config-load or auth failure
                   # indistinguishable from an empty channel.
+                  #
+                  # Streams stay separate and the EXIT STATUS is the gate. The CLI
+                  # mirrors its errors onto stdout as well as stderr, so "did any
+                  # version-shaped text appear" is not a safe success test: npx's
+                  # install warning names `@capgo/cli@8.42.4`, and npm prints its
+                  # own "new version available" notice at exit — either can satisfy
+                  # the version grep and be read as the current bundle.
+                  set +e
                   npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet >"$RUNNER_TEMP/capgo-current.txt" 2>&1 || true
-                  CURRENT="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' "$RUNNER_TEMP/capgo-current.txt" | tail -n1 || true)"
+                    --apikey "$CAPGO_API_KEY" --quiet >"$RUNNER_TEMP/capgo-out.txt" 2>"$RUNNER_TEMP/capgo-err.txt"
+                  STATUS=$?
+                  set -e
+
+                  dump_capgo() {
+                      echo "--- capgo stdout ---" >&2
+                      cat "$RUNNER_TEMP/capgo-out.txt" >&2
+                      echo "--- capgo stderr ---" >&2
+                      cat "$RUNNER_TEMP/capgo-err.txt" >&2
+                      echo "--------------------" >&2
+                  }
+
+                  if [ "$STATUS" -ne 0 ]; then
+                      dump_capgo
+                      echo "::error::the Capgo CLI failed (exit $STATUS) reading the production channel" >&2
+                      exit 1
+                  fi
+
+                  # stdout only: npm's notices land on stderr after the CLI output,
+                  # where `tail -n1` would pick one up as if it were the version.
+                  CURRENT="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' "$RUNNER_TEMP/capgo-out.txt" | tail -n1 || true)"
                   if [ -z "$CURRENT" ]; then
-                      echo "--- capgo cli output ---" >&2
-                      cat "$RUNNER_TEMP/capgo-current.txt" >&2
-                      echo "------------------------" >&2
+                      dump_capgo
                       echo "::error::cannot read the production channel's current bundle from Capgo — refusing to guess the next OTA version" >&2
                       exit 1
                   fi

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -53,18 +53,39 @@ jobs:
                   # Full history + tags: the resolver reads the v<major>.<build>.0 tags.
                   fetch-depth: 0
 
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
             - uses: actions/setup-node@v6
               with:
                   node-version: '22'
+                  cache: 'pnpm'
+
+            # The Capgo CLI reads `capacitor.config.ts` to resolve the appId on
+            # every command, and parsing a .ts config needs the project's own
+            # TypeScript. Without it the CLI aborts at config load and prints the
+            # failure on STDOUT — straight into the version grep below, which
+            # matches nothing and leaves CURRENT empty. That reads exactly like
+            # "Capgo has no bundle for this channel", which is what the first two
+            # runs of this workflow looked like. Passing the appId positionally
+            # does not help: the config is loaded regardless.
+            - name: Install dependencies
+              run: pnpm install
 
             - name: Resolve next OTA version
               id: resolve
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
               run: |
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  # Keep the raw output: piping the CLI straight into grep discards
+                  # its diagnostics, so a config-load or auth failure is
+                  # indistinguishable from an empty channel.
+                  npx @capgo/cli@8.42.4 channel currentBundle production \
+                    --apikey "$CAPGO_API_KEY" --quiet >"$RUNNER_TEMP/capgo-current.txt" 2>&1 || true
+                  CURRENT="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' "$RUNNER_TEMP/capgo-current.txt" | tail -n1 || true)"
                   if [ -z "$CURRENT" ]; then
+                      echo "--- capgo cli output ---" >&2
+                      cat "$RUNNER_TEMP/capgo-current.txt" >&2
+                      echo "------------------------" >&2
                       echo "::error::cannot read the production channel's current bundle from Capgo — refusing to guess the next OTA version" >&2
                       exit 1
                   fi


### PR DESCRIPTION
`Release OTA` has never completed a run. Its first two attempts (runs [33505472241](https://github.com/peanutprotocol/peanut-ui/actions/runs/33505472241) and [33506616522](https://github.com/peanutprotocol/peanut-ui/actions/runs/33506616522)) both failed with:

```
::error::cannot read the production channel's current bundle from Capgo — refusing to guess the next OTA version
```

That message is misleading. The production channel is fine — the Capgo console shows bundle `1.1.0` assigned to it, misconfigured `no`, comment "6bbb98c — auto-published with the 1.1.0 native release". The resolver would have computed `1.1.1`.

## Root cause

The `resolve` job is `checkout` → `setup-node` → run the CLI. **It never installs dependencies.**

The Capgo CLI loads `capacitor.config.ts` on *every* command to resolve the appId, and parsing a `.ts` config requires the project's own TypeScript. With no `node_modules` it aborts at config load:

```
■  No capacitor config file found, run `cap init` first Could not find installation of TypeScript.
   To use capacitor.config.ts files, you must install TypeScript in your project | Code: FATAL
```

It writes that on **stdout**, and the step piped stdout straight into `grep -oE '[0-9]+\.[0-9]+\.[0-9]+…'`. The error contains no version-shaped string, so grep matched nothing, `CURRENT` came back empty, and the CLI's actual complaint never reached the log — the job looked silent. That is why two runs showed no CLI output at all.

`capgo-deploy` makes a byte-identical call (`channel currentBundle "$CHANNEL" --apikey … --quiet`) with the same key and the same pinned CLI, and it has always worked — because `pnpm install` runs earlier in that job. Dependencies were the only difference between the working call and the broken one.

Reproduced locally with a dummy key, against a copy of `capacitor.config.ts` and no `node_modules`. Passing the appId positionally (`channel currentBundle production me.peanut.wallet`) does **not** help — the config is loaded regardless of whether the appId was supplied.

## The fix

1. Add `pnpm/action-setup` + `pnpm install` to `resolve`, matching `capgo-deploy`.
2. Stop discarding the CLI's diagnostics: capture its output, parse the version from the file, and print the raw output when nothing parses. A config-load or auth failure is otherwise indistinguishable from an empty channel — which is what cost the time here.

## Verification

- YAML parses; `bash -n` clean on the rewritten step.
- The empty-output path was exercised directly: given output with no version in it, the guard trips and dumps the CLI text.
- `postinstall` is only `node scripts/copy-flags.mjs`, so the added install needs nothing this job doesn't already check out (no submodule).
- Unchanged: the `dev`-only ref guard, the `production-release` concurrency mutex, and the resolve-then-tag ordering that avoids burning a version on a failed deploy.

Merging this does not ship an OTA — `Release OTA` still has to be dispatched deliberately.
