### PR TITLE
feat(card): self-serve identity re-upload CTA via Rain card portal (TASK-21687)

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -27,6 +27,7 @@ import { rainApi, type ApplyForCardResponse } from '@/services/rain'
 import { cardConsentDocuments } from '@/services/consent'
 import { useGrantSessionKey } from '@/hooks/wallet/useGrantSessionKey'
 import { useCapabilities } from '@/hooks/useCapabilities'
+import { useHostedVerification } from '@/hooks/useHostedVerification'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useSumsubReloadResume } from '@/hooks/useSumsubReloadResume'
@@ -270,6 +271,17 @@ const CardPage: FC = () => {
         }
     }, [])
     const onUploadProofOfAddress = poaAction && !poaSubmitted ? () => void startPoaUpload() : undefined
+
+    // The rain rail's identity-document re-upload action, emitted when Rain
+    // rejected the card application on a proof-of-identity document. Rather than
+    // a Sumsub token we own, this hands off to Rain's card-member portal (which
+    // runs and re-adjudicates its own Sumsub flow) via the shared hosted-
+    // verification handoff — same gesture-bound tab reservation as bridge-hosted.
+    const identityAction = cardRail
+        ? nextActionsForRail(cardRail.id).find((action) => action.kind === 'rain-hosted')
+        : undefined
+    const { start: startIdentityUpload, error: identityUploadError } = useHostedVerification('rain-hosted')
+    const onUploadIdentity = identityAction ? () => void startIdentityUpload() : undefined
 
     // Once the backend's own state takes over (the rail's sumsub action gives
     // way to the review-wait state, an approval, or a different ask), drop the
@@ -737,7 +749,8 @@ const CardPage: FC = () => {
                         reasonCode={cardRailReasonCode}
                         onContactSupport={() => setIsSupportModalOpen(true)}
                         onUploadProofOfAddress={onUploadProofOfAddress}
-                        uploadError={poaError ?? undefined}
+                        onUploadIdentity={onUploadIdentity}
+                        uploadError={poaError ?? identityUploadError ?? undefined}
                         onPrev={onBack}
                     />
                 )

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -178,16 +178,19 @@ export const initiateSelfHealResubmission = async (
 }
 
 /**
- * Exchange the `bridge-hosted` capability action for Bridge's hosted
- * verification URL (same POST /users/kyc/start-action endpoint as
- * {@link startKycAction}, different response shape: that path mints Sumsub
- * tokens, this one returns a URL — hence its own guard).
+ * Exchange a hosted-verification capability action for its provider's hosted
+ * URL (same POST /users/kyc/start-action endpoint as {@link startKycAction},
+ * different response shape: that path mints Sumsub tokens, this one returns a
+ * URL — hence its own guard). Serves both `bridge-hosted` (Bridge/Persona) and
+ * `rain-hosted` (Rain's card-member portal); the key selects the provider.
  */
-export const startBridgeHostedVerification = async (): Promise<{ url?: string; error?: string }> => {
+export const startHostedVerification = async (
+    key: 'bridge-hosted' | 'rain-hosted' = 'bridge-hosted'
+): Promise<{ url?: string; error?: string }> => {
     try {
         const response = await serverFetch('/users/kyc/start-action', {
             method: 'POST',
-            body: JSON.stringify({ key: 'bridge-hosted' }),
+            body: JSON.stringify({ key }),
         })
         const responseJson = await response.json()
         if (!response.ok) {

--- a/src/components/Card/ApplicationStatusScreen.tsx
+++ b/src/components/Card/ApplicationStatusScreen.tsx
@@ -27,6 +27,10 @@ interface Props {
      *  the Sumsub upload flow — rendered as the primary CTA so users fix it
      *  themselves instead of messaging support. */
     onUploadProofOfAddress?: () => void
+    /** When the rail carries a `rain-hosted` action (identity document rejected),
+     *  this opens Rain's card-member portal to re-upload — the primary CTA so
+     *  users fix it themselves instead of hitting the contact-support dead end. */
+    onUploadIdentity?: () => void
     /** Inline failure from starting the upload (a silent primary CTA on a
      *  stuck-application screen reads as broken). */
     uploadError?: string
@@ -65,6 +69,7 @@ const ApplicationStatusScreen: FC<Props> = ({
     reasonCode,
     onContactSupport,
     onUploadProofOfAddress,
+    onUploadIdentity,
     uploadError,
     onPrev,
 }) => {
@@ -104,6 +109,14 @@ const ApplicationStatusScreen: FC<Props> = ({
                     <div className="flex w-full flex-col gap-2">
                         <Button variant="purple" shadowSize="4" className="w-full" onClick={onUploadProofOfAddress}>
                             {t('uploadProofOfAddress')}
+                        </Button>
+                        {uploadError && <p className="text-body-s text-foreground-error">{uploadError}</p>}
+                    </div>
+                )}
+                {SUPPORT_VARIANTS.has(variant) && onUploadIdentity && (
+                    <div className="flex w-full flex-col gap-2">
+                        <Button variant="purple" shadowSize="4" className="w-full" onClick={onUploadIdentity}>
+                            {t('uploadIdentityDocuments')}
                         </Button>
                         {uploadError && <p className="text-body-s text-foreground-error">{uploadError}</p>}
                     </div>

--- a/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
+++ b/src/components/Card/__tests__/ApplicationStatusScreen.test.tsx
@@ -128,6 +128,39 @@ describe('ApplicationStatusScreen — proof-of-address upload CTA', () => {
     })
 })
 
+describe('ApplicationStatusScreen — identity-document upload CTA (TASK-21687)', () => {
+    it('renders the identity upload CTA as primary when the rail carries a rain-hosted action', () => {
+        const onUpload = jest.fn()
+        render(
+            <ApplicationStatusScreen
+                variant="requires-info"
+                reasonMessage="We couldn't verify the identity documents on your card application."
+                onContactSupport={jest.fn()}
+                onUploadIdentity={onUpload}
+            />
+        )
+        fireEvent.click(screen.getByText('Upload identity documents'))
+        expect(onUpload).toHaveBeenCalledTimes(1)
+        // Contact support stays available as the fallback path.
+        expect(screen.getByText('Contact support')).toBeInTheDocument()
+    })
+
+    it('renders the identity upload CTA on the rejected variant too', () => {
+        render(<ApplicationStatusScreen variant="rejected" onContactSupport={jest.fn()} onUploadIdentity={jest.fn()} />)
+        expect(screen.getByText('Upload identity documents')).toBeInTheDocument()
+    })
+
+    it('omits the identity upload CTA when no rain-hosted action exists', () => {
+        render(<ApplicationStatusScreen variant="requires-info" onContactSupport={jest.fn()} />)
+        expect(screen.queryByText('Upload identity documents')).not.toBeInTheDocument()
+    })
+
+    it('never renders the identity upload CTA on non-support variants', () => {
+        render(<ApplicationStatusScreen variant="pending" onUploadIdentity={jest.fn()} />)
+        expect(screen.queryByText('Upload identity documents')).not.toBeInTheDocument()
+    })
+})
+
 describe('ApplicationStatusScreen — pending', () => {
     // The pending variant carries no CTA of its own, so its back button is the
     // screen's ONLY control. A caller that omits onPrev leaves the user with a

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -8,7 +8,7 @@ import { Notification } from '@/components/0_Bruddle/Notification'
 import NavHeader from '@/components/Global/NavHeader'
 import KycPrepChecklist from '@/components/Kyc/KycPrepChecklist'
 import { PeanutDoesntStoreAnyPersonalInformation } from '@/components/Kyc/PeanutDoesntStoreAnyPersonalInformation'
-import { useBridgeHostedVerification } from '@/hooks/useBridgeHostedVerification'
+import { useHostedVerification } from '@/hooks/useHostedVerification'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
@@ -22,7 +22,7 @@ import { useSafeBack } from '@/hooks/useSafeBack'
  * an interruption, not as the step it actually is.
  *
  * The CTA calls `start` straight out of the click: the reserved tab depends on
- * that user gesture (see useBridgeHostedVerification).
+ * that user gesture (see useHostedVerification).
  *
  * The task DISAPPEARING is the success signal — nothing else reports it, since
  * nothing polls a requires-info rail. The card this replaced got that for free
@@ -45,7 +45,7 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
     const router = useRouter()
     const onBack = useSafeBack(IDENTITY_ROUTE)
     const { nextActions, isLoading: isLoadingCapabilities } = useCapabilities()
-    const { start, isStarting, error } = useBridgeHostedVerification()
+    const { start, isStarting, error } = useHostedVerification('bridge-hosted')
     const hostedTask = nextActions.find((action) => action.kind === 'bridge-hosted')
     // A future-dated action is advisory: those rails still work today, and this
     // screen must not tell that user their transfers are blocked.

--- a/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
+++ b/src/components/Kyc/__tests__/AdditionalVerificationView.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@/context/authContext', () => ({
     useAuth: () => ({ user: { user: { userId: 'user-1' } }, fetchUser: mockFetchUser, logoutUser: jest.fn() }),
 }))
 jest.mock('@/app/actions/sumsub', () => ({
-    startBridgeHostedVerification: () => mockStartHosted(),
+    startHostedVerification: () => mockStartHosted(),
 }))
 const mockOpenExternalUrl = jest.fn<Promise<void>, [string]>()
 let mockIsCapacitor = false

--- a/src/hooks/useHostedVerification.ts
+++ b/src/hooks/useHostedVerification.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { startHostedVerification } from '@/app/actions/sumsub'
 import { useAuth } from '@/context/authContext'
 import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
@@ -29,83 +29,94 @@ export function useHostedVerification(
     const [isStarting, setIsStarting] = useState(false)
     const [awaitingReturn, setAwaitingReturn] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    // Synchronous re-entry guard. `isStarting` is React state, set a tick later,
+    // so a fast second tap (Capacitor especially) re-enters start() before the
+    // disable takes effect and reserves/opens a SECOND portal tab. The ref
+    // blocks the duplicate in the same tick; reset on every exit path via finally.
+    const startingRef = useRef(false)
 
     const start = useCallback(async () => {
-        setError(null)
-        // NOT an iframe: `bridge.withpersona.com` serves
-        // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
-        // "refused to connect" for EVERY user. It has to be a real
-        // top-level page (native: the in-app browser). Bridge's ToS link
-        // (`compliance.bridge.xyz`) sends no framing header, which is why
-        // BridgeTosStep keeps its iframe.
-        //
-        // On web, reserve the tab HERE — synchronously, inside the click's
-        // user-activation window. Fetching the link takes ~800ms, and a
-        // window.open() after that await is no longer gesture-initiated,
-        // so Safari/Firefox block it — the same "nothing happens" symptom
-        // this PR exists to fix. The reserved tab is navigated once the
-        // URL lands, and closed if it never does.
-        // isNativeBridge(), not isCapacitor(): the latter is also true for
-        // any build carrying NEXT_PUBLIC_CAPACITOR_BUILD (vercel previews),
-        // where the native apis don't exist and we'd skip the reservation
-        // in a real browser.
-        const native = isNativeBridge()
-        const reservedTab = native ? null : window.open('', '_blank')
-        // The reserved tab can't carry `noopener` (that returns null and
-        // defeats the reservation), so sever the back-reference by hand —
-        // otherwise Persona, and anything it redirects to, holds a handle
-        // that can navigate the signed-in tab (reverse tabnabbing).
-        if (reservedTab) reservedTab.opener = null
+        if (startingRef.current) return
+        startingRef.current = true
+        try {
+            setError(null)
+            // NOT an iframe: `bridge.withpersona.com` serves
+            // `X-Frame-Options: SAMEORIGIN`, so embedding it rendered
+            // "refused to connect" for EVERY user. It has to be a real
+            // top-level page (native: the in-app browser). Bridge's ToS link
+            // (`compliance.bridge.xyz`) sends no framing header, which is why
+            // BridgeTosStep keeps its iframe.
+            //
+            // On web, reserve the tab HERE — synchronously, inside the click's
+            // user-activation window. Fetching the link takes ~800ms, and a
+            // window.open() after that await is no longer gesture-initiated,
+            // so Safari/Firefox block it — the same "nothing happens" symptom
+            // this PR exists to fix. The reserved tab is navigated once the
+            // URL lands, and closed if it never does.
+            // isNativeBridge(), not isCapacitor(): the latter is also true for
+            // any build carrying NEXT_PUBLIC_CAPACITOR_BUILD (vercel previews),
+            // where the native apis don't exist and we'd skip the reservation
+            // in a real browser.
+            const native = isNativeBridge()
+            const reservedTab = native ? null : window.open('', '_blank')
+            // The reserved tab can't carry `noopener` (that returns null and
+            // defeats the reservation), so sever the back-reference by hand —
+            // otherwise Persona, and anything it redirects to, holds a handle
+            // that can navigate the signed-in tab (reverse tabnabbing).
+            if (reservedTab) reservedTab.opener = null
 
-        setIsStarting(true)
-        let url: string | undefined
-        try {
-            ;({ url } = await startHostedVerification(actionKey))
-        } catch (error) {
-            // The action body catches its own errors, but a server action
-            // can still REJECT at the transport layer — a dropped network,
-            // or a deploy invalidating the action id mid-flight. Without
-            // this the button stays on "Loading..." forever and the blank
-            // reserved tab is orphaned.
-            reservedTab?.close()
-            console.error(`[hosted:${actionKey}] start-action rejected`, error)
-            setError("We couldn't start the verification. Please try again in a moment.")
-            return
-        } finally {
-            setIsStarting(false)
-        }
-        if (!url) {
-            // Friendly copy regardless of the server detail (a 403 here just
-            // means the action aged out); refetch so a stale entry point
-            // self-corrects.
-            reservedTab?.close()
-            setError("We couldn't start the verification. Please try again in a moment.")
-            void fetchUser().catch(() => undefined)
-            return
-        }
-        try {
-            if (native) {
-                await openExternalUrl(url)
-            } else if (reservedTab && !reservedTab.closed) {
-                // `.closed` matters: assigning href to a closed window is a
-                // silent no-op, so without this the user would tap and see
-                // nothing — the very failure this PR removes.
-                reservedTab.location.href = url
-            } else {
-                // No usable tab: pop-ups blocked, a standalone PWA, or the
-                // user closed the blank tab while we fetched. Same-tab
-                // navigation is never gesture-gated, so it always lands.
+            setIsStarting(true)
+            let url: string | undefined
+            try {
+                ;({ url } = await startHostedVerification(actionKey))
+            } catch (error) {
+                // The action body catches its own errors, but a server action
+                // can still REJECT at the transport layer — a dropped network,
+                // or a deploy invalidating the action id mid-flight. Without
+                // this the button stays on "Loading..." forever and the blank
+                // reserved tab is orphaned.
                 reservedTab?.close()
-                window.location.href = url
+                console.error(`[hosted:${actionKey}] start-action rejected`, error)
+                setError("We couldn't start the verification. Please try again in a moment.")
+                return
+            } finally {
+                setIsStarting(false)
+            }
+            if (!url) {
+                // Friendly copy regardless of the server detail (a 403 here just
+                // means the action aged out); refetch so a stale entry point
+                // self-corrects.
+                reservedTab?.close()
+                setError("We couldn't start the verification. Please try again in a moment.")
+                void fetchUser().catch(() => undefined)
                 return
             }
-        } catch (error) {
-            reservedTab?.close()
-            console.error(`[hosted:${actionKey}] failed to open hosted verification`, error)
-            setError("We couldn't open the verification. Please try again in a moment.")
-            return
+            try {
+                if (native) {
+                    await openExternalUrl(url)
+                } else if (reservedTab && !reservedTab.closed) {
+                    // `.closed` matters: assigning href to a closed window is a
+                    // silent no-op, so without this the user would tap and see
+                    // nothing — the very failure this PR removes.
+                    reservedTab.location.href = url
+                } else {
+                    // No usable tab: pop-ups blocked, a standalone PWA, or the
+                    // user closed the blank tab while we fetched. Same-tab
+                    // navigation is never gesture-gated, so it always lands.
+                    reservedTab?.close()
+                    window.location.href = url
+                    return
+                }
+            } catch (error) {
+                reservedTab?.close()
+                console.error(`[hosted:${actionKey}] failed to open hosted verification`, error)
+                setError("We couldn't open the verification. Please try again in a moment.")
+                return
+            }
+            setAwaitingReturn(true)
+        } finally {
+            startingRef.current = false
         }
-        setAwaitingReturn(true)
     }, [fetchUser, actionKey])
 
     // The same-tab fallback navigates THIS tab away, so the listener below is

--- a/src/hooks/useHostedVerification.ts
+++ b/src/hooks/useHostedVerification.ts
@@ -1,18 +1,20 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { startBridgeHostedVerification } from '@/app/actions/sumsub'
+import { startHostedVerification } from '@/app/actions/sumsub'
 import { useAuth } from '@/context/authContext'
 import { isNativeBridge, openExternalUrl } from '@/utils/capacitor'
 
 /**
- * Drives the handoff to Bridge's hosted verification (Persona) and the wait
- * for the user to come back from it.
+ * Drives the handoff to a provider's hosted verification page and the wait for
+ * the user to come back from it. Serves both `bridge-hosted` (Bridge/Persona)
+ * and `rain-hosted` (Rain's card-member portal) — the same top-level-tab
+ * handoff applies to any third-party page that can't be iframed.
  *
  * `start` must be called STRAIGHT out of a click handler — it reserves the tab
  * synchronously, inside the user-activation window (see below).
  */
-interface BridgeHostedVerification {
+interface HostedVerification {
     /** Call STRAIGHT out of a click — the tab reservation needs the gesture. */
     start: () => Promise<void>
     isStarting: boolean
@@ -20,7 +22,9 @@ interface BridgeHostedVerification {
     error: string | null
 }
 
-export function useBridgeHostedVerification(): BridgeHostedVerification {
+export function useHostedVerification(
+    actionKey: 'bridge-hosted' | 'rain-hosted' = 'bridge-hosted'
+): HostedVerification {
     const { fetchUser } = useAuth()
     const [isStarting, setIsStarting] = useState(false)
     const [awaitingReturn, setAwaitingReturn] = useState(false)
@@ -56,7 +60,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
         setIsStarting(true)
         let url: string | undefined
         try {
-            ;({ url } = await startBridgeHostedVerification())
+            ;({ url } = await startHostedVerification(actionKey))
         } catch (error) {
             // The action body catches its own errors, but a server action
             // can still REJECT at the transport layer — a dropped network,
@@ -64,7 +68,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
             // this the button stays on "Loading..." forever and the blank
             // reserved tab is orphaned.
             reservedTab?.close()
-            console.error('[bridge-hosted] start-action rejected', error)
+            console.error(`[hosted:${actionKey}] start-action rejected`, error)
             setError("We couldn't start the verification. Please try again in a moment.")
             return
         } finally {
@@ -97,12 +101,12 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
             }
         } catch (error) {
             reservedTab?.close()
-            console.error('[bridge-hosted] failed to open Bridge hosted verification', error)
+            console.error(`[hosted:${actionKey}] failed to open hosted verification`, error)
             setError("We couldn't open the verification. Please try again in a moment.")
             return
         }
         setAwaitingReturn(true)
-    }, [fetchUser])
+    }, [fetchUser, actionKey])
 
     // The same-tab fallback navigates THIS tab away, so the listener below is
     // never armed for it — and a Back that restores from BFCache re-runs no
@@ -146,7 +150,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
                     if (disposed) handle.remove()
                     else remove = () => handle.remove()
                 })
-                .catch((error) => console.error('[bridge-hosted] browserFinished listener failed', error))
+                .catch((error) => console.error(`[hosted:${actionKey}] browserFinished listener failed`, error))
             return () => {
                 disposed = true
                 remove?.()
@@ -158,7 +162,7 @@ export function useBridgeHostedVerification(): BridgeHostedVerification {
         }
         document.addEventListener('visibilitychange', onReturn)
         return () => document.removeEventListener('visibilitychange', onReturn)
-    }, [awaitingReturn, fetchUser])
+    }, [awaitingReturn, fetchUser, actionKey])
 
     return { start, isStarting, error }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1569,6 +1569,7 @@
             "cta": "Recover funds"
         },
         "uploadProofOfAddress": "Upload proof of address",
+        "uploadIdentityDocuments": "Upload identity documents",
         "fixSignature": {
             "navTitle": "Fix card signature",
             "intro": "This tool repairs a wallet state issue that stops your card from funding itself automatically. It takes up to two quick passkey confirmations.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1569,6 +1569,7 @@
             "cta": "Recuperar fondos"
         },
         "uploadProofOfAddress": "Subir comprobante de domicilio",
+        "uploadIdentityDocuments": "Subir documentos de identidad",
         "fixSignature": {
             "navTitle": "Reparar la firma de la tarjeta",
             "intro": "Esta herramienta repara un problema de estado de la billetera que impide que tu tarjeta se recargue automáticamente. Requiere hasta dos confirmaciones rápidas con tu passkey.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1569,6 +1569,7 @@
             "cta": "Recuperar fundos"
         },
         "uploadProofOfAddress": "Enviar comprovante de endereço",
+        "uploadIdentityDocuments": "Enviar documentos de identidade",
         "fixSignature": {
             "navTitle": "Reparar a assinatura do cartão",
             "intro": "Esta ferramenta repara um problema no estado da carteira que impede o seu cartão de se recarregar automaticamente. Leva até duas confirmações rápidas com a passkey.",

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -137,7 +137,12 @@ export interface ResolvedRail {
  *   - `bridge-hosted`     — open Bridge's hosted verification flow (the
  *                           catch-all for requirements with no native Sumsub
  *                           mapping); exchange the key for a URL via
- *                           startBridgeHostedVerification().
+ *                           startHostedVerification().
+ *   - `rain-hosted`       — open Rain's card-member portal to re-upload an
+ *                           identity document a card application was rejected
+ *                           on; exchange the key for a URL via
+ *                           startHostedVerification(), same handoff as
+ *                           bridge-hosted.
  */
 export type NextActionKind =
     | 'sumsub'
@@ -147,6 +152,7 @@ export type NextActionKind =
     | 'restart-identity'
     | 'provide-email'
     | 'bridge-hosted'
+    | 'rain-hosted'
 
 export interface NextAction {
     key: string // stable id, referenced by RailCapability.blockingActions


### PR DESCRIPTION
## Problem

A card application Rain rejected on an identity document (`BAD_PROOF_OF_IDENTITY` / `DOCUMENT_MISSING`) showed only the contact-support dead end — no way for the user to fix it themselves.

## Change

Pairs with peanut-api-ts #1482, which reclassifies these rails as fixable and emits a new `rain-hosted` next-action. This PR renders that action as an **"Upload identity documents"** CTA that opens Rain's card-member portal — where the user re-uploads and Rain re-adjudicates (verified live: the portal mints a fresh Sumsub token for a rejected applicant).

- **Generalize the hosted-verification handoff** (it was Bridge-only but the top-level-tab handoff — gesture-bound tab reservation, reverse-tabnabbing guard, native in-app browser — applies to any un-iframeable third-party page):
  - `useBridgeHostedVerification()` → `useHostedVerification(actionKey)` (file renamed)
  - `startBridgeHostedVerification()` → `startHostedVerification(key)`
- **card page**: surface the rain rail's `rain-hosted` action as `onUploadIdentity`, opening the portal via the hook.
- **ApplicationStatusScreen**: render the identity-upload CTA as primary on the support variants (mirrors the existing proof-of-address CTA), contact-support kept as the fallback.
- **types/i18n**: add `rain-hosted` to `NextActionKind`; `card.uploadIdentityDocuments` copy in en / es-419 / pt-BR.

## Notes

- `selectBridgeTasks` (home carousel) matches only `accept-tos`/`bridge-hosted`, so `rain-hosted` is not swept into the Bridge flow — it surfaces on the card status screen where the user already is.
- Uses the hand-mirrored `src/types/capabilities.ts` (the FE source of truth for the capabilities contract), so the generated `api.openapi.json`/`api.generated.ts` are untouched and `check:api` stays green; the generated spec syncs from the API repo separately.

## Test

- `ApplicationStatusScreen`: new cases for the identity CTA (renders on support/rejected variants, omitted otherwise and on non-support variants).
- `AdditionalVerificationView`: updated for the renamed action; still green.
- `tsc` clean.