### PR TITLE
fix(ds): sweep composition drift against design.md + ratchet five new metrics

### DIFF
--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -173,6 +173,10 @@ describe('iconOffScale', () => {
             '<Icon name="x" size={iconSize} />',
             '<Icon name="x" size={small ? 16 : 20} />',
             'iconSize={resolved}',
+            '<Icon name="x" size="18" />',
+            'iconSize="18"',
+            'iconSize="2"',
+            'iconSize="8"',
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
         }
@@ -184,6 +188,10 @@ describe('iconOffScale', () => {
             '<Icon size={20} />',
             '<Icon size={24} />',
             'iconSize={20}',
+            '<Icon name="x" size="16" />',
+            'iconSize="4"',
+            'iconSize="6"',
+            'iconSize="24"',
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBe(0)
         }

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -92,6 +92,17 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
         expect(countWeightStacks(jsx)).toBe(1)
     })
 
+    it('counts extracted multiline class builders assigned to variables', () => {
+        const code = [
+            'const classes = twMerge(',
+            "    'text-body-m',",
+            "    active && 'font-semibold'",
+            ')',
+            'return <p className={classes} />',
+        ].join('\n')
+        expect(countWeightStacks(code)).toBe(1)
+    })
+
     it('does not count a token and a weight living in different elements', () => {
         const jsx = [
             '<p className="text-body-m">a</p>',
@@ -113,6 +124,8 @@ describe('iconOffScale', () => {
             '<Icon name="paste" className="h-3.5 w-3.5" />',
             '<Icon name="chevron-up" className={`h-4 w-4 transition-transform ${open ? "" : "rotate-180"}`} />',
             "<Icon name={icon} className={twMerge('size-6', extra)} />",
+            '<Icon name="x" className="size-[18px]" />',
+            "<Icon name={icon} className={twMerge('h-[18px] w-[18px]', extra)} />",
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
         }

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -1,0 +1,107 @@
+import { countOffScaleSpacing, OFF_SCALE_ICON_RE, OFF_SCALE_RADIUS_RE, RAW_DURATION_RE } from '../ds-lint-rules.cjs'
+
+const countMatches = (text: string, re: RegExp) => (text.match(re) ?? []).length
+
+describe('offScaleSpacing', () => {
+    it('flags off-scale steps across every spacing family, logical ps/pe/ms/me included', () => {
+        for (const cls of ['p-5', 'px-7', 'py-2.5', 'gap-11', 'p-4.5', 'pr-18', 'ps-5', 'pe-18', 'ms-2.5', 'me-7']) {
+            expect(countOffScaleSpacing(`<div className="${cls}" />`)).toBe(1)
+        }
+    })
+
+    it('flags negative and variant-prefixed forms', () => {
+        expect(countOffScaleSpacing('className="-m-2.5"')).toBe(1)
+        expect(countOffScaleSpacing('className="-mt-5"')).toBe(1)
+        expect(countOffScaleSpacing('className="md:pr-18"')).toBe(1)
+        expect(countOffScaleSpacing('className="first:ps-7"')).toBe(1)
+    })
+
+    it('accepts every documented scale step, negatives and variants included', () => {
+        for (const cls of [
+            'p-0',
+            'p-0.5',
+            'gap-1',
+            'px-2',
+            'py-3',
+            'p-4',
+            'gap-6',
+            'p-8',
+            'mt-10',
+            'pb-12',
+            'ps-4',
+            'me-2',
+            '-mt-4',
+            'md:gap-6',
+            'space-y-8',
+            'gap-x-16',
+        ]) {
+            expect(countOffScaleSpacing(`<div className="${cls}" />`)).toBe(0)
+        }
+    })
+
+    it('does not misread longer utilities or words as spacing classes', () => {
+        for (const text of [
+            'className="max-p-5"',
+            'theme-3',
+            'frame-2',
+            'className="p-[13px]"',
+            'className="ms-auto"',
+        ]) {
+            expect(countOffScaleSpacing(text)).toBe(0)
+        }
+    })
+})
+
+describe('iconOffScale', () => {
+    it('flags off-step size, width/height props, and class-sized Icons', () => {
+        for (const text of [
+            '<Icon name="info" size={18} />',
+            '<Icon name={logo} width={18} height={18} />',
+            '<Icon name="swap" width={32} height={32} />',
+            'iconSize={13}',
+            '<Icon name="check" className="size-4" />',
+            '<Icon name="paste" className="h-3.5 w-3.5" />',
+        ]) {
+            expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
+        }
+    })
+
+    it('accepts the 16/20/24 steps', () => {
+        for (const text of [
+            '<Icon name="info" size={16} />',
+            '<Icon size={20} />',
+            '<Icon size={24} />',
+            'iconSize={20}',
+        ]) {
+            expect(countMatches(text, OFF_SCALE_ICON_RE)).toBe(0)
+        }
+    })
+})
+
+describe('offScaleRadius', () => {
+    it('flags radii off the none/2/4/full scale, sides included', () => {
+        for (const cls of ['rounded-md', 'rounded-lg', 'rounded-t-2xl', 'rounded-3xl']) {
+            expect(countMatches(`className="${cls}"`, OFF_SCALE_RADIUS_RE)).toBe(1)
+        }
+    })
+
+    it('accepts the scale classes', () => {
+        for (const cls of ['rounded-sm', 'rounded-round', 'rounded-full', 'rounded-none']) {
+            expect(countMatches(`className="${cls}"`, OFF_SCALE_RADIUS_RE)).toBe(0)
+        }
+    })
+})
+
+describe('rawDuration', () => {
+    it('flags any numeric or arbitrary duration', () => {
+        for (const cls of ['duration-100', 'duration-250', 'duration-75', 'duration-[250ms]']) {
+            expect(countMatches(`className="${cls}"`, RAW_DURATION_RE)).toBe(1)
+        }
+    })
+
+    it('accepts the motion tokens', () => {
+        for (const cls of ['duration-instant', 'duration-fast', 'duration-moderate', 'duration-slow']) {
+            expect(countMatches(`className="${cls}"`, RAW_DURATION_RE)).toBe(0)
+        }
+    })
+})

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -101,11 +101,22 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
     })
 
     it('counts every weight utility, not just the bold family', () => {
-        for (const w of ['font-thin', 'font-light', 'font-normal', 'font-medium', 'font-black', 'font-[550]']) {
+        for (const w of [
+            'font-thin',
+            'font-light',
+            'font-normal',
+            'font-medium',
+            'font-black',
+            'font-extraBlack',
+            'font-[550]',
+            'font-[650.5]',
+            'font-(weight:--my-weight)',
+        ]) {
             expect(countWeightStacks(`<p className="text-body-s ${w}" />`)).toBe(1)
         }
-        expect(countWeightStacks('<p className="text-body-s font-sans" />')).toBe(0)
-        expect(countWeightStacks('<p className="text-body-s font-roboto" />')).toBe(0)
+        for (const notWeight of ['font-sans', 'font-roboto', 'font-(--brand-face)', 'font-blackout']) {
+            expect(countWeightStacks(`<p className="text-body-s ${notWeight}" />`)).toBe(0)
+        }
     })
 
     it('counts stacks carried through *ClassName props, not just className', () => {

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -82,6 +82,14 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
         expect(countWeightStacks("const style = 'text-body-s font-bold underline'")).toBe(1)
     })
 
+    it('counts every weight utility, not just the bold family', () => {
+        for (const w of ['font-thin', 'font-light', 'font-normal', 'font-medium', 'font-black', 'font-[550]']) {
+            expect(countWeightStacks(`<p className="text-body-s ${w}" />`)).toBe(1)
+        }
+        expect(countWeightStacks('<p className="text-body-s font-sans" />')).toBe(0)
+        expect(countWeightStacks('<p className="text-body-s font-roboto" />')).toBe(0)
+    })
+
     it('counts stacks carried through *ClassName props, not just className', () => {
         const jsx = [
             '<TitleBlock',

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -1,8 +1,8 @@
 import {
     countOffScaleSpacing,
     countWeightStacks,
+    countOffScaleRadius,
     OFF_SCALE_ICON_RE,
-    OFF_SCALE_RADIUS_RE,
     RAW_DURATION_RE,
 } from '../ds-lint-rules.cjs'
 
@@ -82,6 +82,16 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
         expect(countWeightStacks("const style = 'text-body-s font-bold underline'")).toBe(1)
     })
 
+    it('counts stacks carried through *ClassName props, not just className', () => {
+        const jsx = [
+            '<TitleBlock',
+            "    titleClassName={twMerge('text-body-m',",
+            "        'font-semibold')}",
+            '/>',
+        ].join('\n')
+        expect(countWeightStacks(jsx)).toBe(1)
+    })
+
     it('does not count a token and a weight living in different elements', () => {
         const jsx = [
             '<p className="text-body-m">a</p>',
@@ -101,6 +111,8 @@ describe('iconOffScale', () => {
             'iconSize={13}',
             '<Icon name="check" className="size-4" />',
             '<Icon name="paste" className="h-3.5 w-3.5" />',
+            '<Icon name="chevron-up" className={`h-4 w-4 transition-transform ${open ? "" : "rotate-180"}`} />',
+            "<Icon name={icon} className={twMerge('size-6', extra)} />",
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
         }
@@ -118,16 +130,33 @@ describe('iconOffScale', () => {
     })
 })
 
-describe('offScaleRadius', () => {
-    it('flags radii off the none/2/4/full scale, sides included', () => {
-        for (const cls of ['rounded-md', 'rounded-lg', 'rounded-t-2xl', 'rounded-3xl']) {
-            expect(countMatches(`className="${cls}"`, OFF_SCALE_RADIUS_RE)).toBe(1)
+describe('offScaleRadius (countOffScaleRadius)', () => {
+    it('flags radii off the scale — named steps, sides, and arbitrary values', () => {
+        for (const cls of [
+            'rounded-md',
+            'rounded-lg',
+            'rounded-t-2xl',
+            'rounded-3xl',
+            'rounded-[1px]',
+            'rounded-[5px]',
+            'rounded-t-[10px]',
+            'rounded-xs',
+        ]) {
+            expect(countOffScaleRadius(`className="${cls}"`)).toBe(1)
         }
     })
 
-    it('accepts the scale classes', () => {
-        for (const cls of ['rounded-sm', 'rounded-round', 'rounded-full', 'rounded-none']) {
-            expect(countMatches(`className="${cls}"`, OFF_SCALE_RADIUS_RE)).toBe(0)
+    it('accepts the scale classes, bare rounded and sides included', () => {
+        for (const cls of [
+            'rounded-sm',
+            'rounded-round',
+            'rounded-full',
+            'rounded-none',
+            'rounded',
+            'rounded-t-sm',
+            'rounded-e-full',
+        ]) {
+            expect(countOffScaleRadius(`className="${cls}"`)).toBe(0)
         }
     })
 })

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -111,6 +111,7 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
             'font-[550]',
             'font-[650.5]',
             'font-(weight:--my-weight)',
+            'font-[weight:var(--my-font-weight)]',
         ]) {
             expect(countWeightStacks(`<p className="text-body-s ${w}" />`)).toBe(1)
         }
@@ -140,6 +141,11 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
         expect(countWeightStacks(code)).toBe(1)
     })
 
+    it('counts multiline template-literal class constants outside builders', () => {
+        const code = ['const classes = `text-body-m', '    font-semibold underline`', 'use(classes)'].join('\n')
+        expect(countWeightStacks(code)).toBe(1)
+    })
+
     it('does not count a token and a weight living in different elements', () => {
         const jsx = [
             '<p className="text-body-m">a</p>',
@@ -164,6 +170,9 @@ describe('iconOffScale', () => {
             '<Icon name="x" className="size-[18px]" />',
             '<Icon name="x" className="size-(--icon)" />',
             "<Icon name={icon} className={twMerge('h-[18px] w-[18px]', extra)} />",
+            '<Icon name="x" size={iconSize} />',
+            '<Icon name="x" size={small ? 16 : 20} />',
+            'iconSize={resolved}',
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
         }

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -1,4 +1,10 @@
-import { countOffScaleSpacing, OFF_SCALE_ICON_RE, OFF_SCALE_RADIUS_RE, RAW_DURATION_RE } from '../ds-lint-rules.cjs'
+import {
+    countOffScaleSpacing,
+    countWeightStacks,
+    OFF_SCALE_ICON_RE,
+    OFF_SCALE_RADIUS_RE,
+    RAW_DURATION_RE,
+} from '../ds-lint-rules.cjs'
 
 const countMatches = (text: string, re: RegExp) => (text.match(re) ?? []).length
 
@@ -39,16 +45,50 @@ describe('offScaleSpacing', () => {
         }
     })
 
+    it('flags arbitrary spacing values wholesale — the bracket form is always drift', () => {
+        for (const cls of ['p-[5px]', 'gap-[20px]', 'p-[13px]', '-m-[3px]', 'md:ps-[10%]']) {
+            expect(countOffScaleSpacing(`<div className="${cls}" />`)).toBe(1)
+        }
+    })
+
     it('does not misread longer utilities or words as spacing classes', () => {
         for (const text of [
             'className="max-p-5"',
             'theme-3',
             'frame-2',
-            'className="p-[13px]"',
+            'className="w-[13px]"',
             'className="ms-auto"',
         ]) {
             expect(countOffScaleSpacing(text)).toBe(0)
         }
+    })
+})
+
+describe('fontWeightOnTypeToken (countWeightStacks)', () => {
+    it('counts a token and weight split across lines inside one className expression', () => {
+        const jsx = [
+            '<span',
+            '    className={`text-body-m ${twMerge(',
+            "        'font-semibold text-foreground-primary capitalize',",
+            '        titleClassName',
+            '    )}`}',
+            '>',
+        ].join('\n')
+        expect(countWeightStacks(jsx)).toBe(1)
+    })
+
+    it('counts same-line stacks in plain strings and const class strings', () => {
+        expect(countWeightStacks('<p className="text-body-s font-bold" />')).toBe(1)
+        expect(countWeightStacks("const style = 'text-body-s font-bold underline'")).toBe(1)
+    })
+
+    it('does not count a token and a weight living in different elements', () => {
+        const jsx = [
+            '<p className="text-body-m">a</p>',
+            '<p className="font-semibold">b</p>',
+            '<p className={twMerge("text-label-l", cls)}>c</p>',
+        ].join('\n')
+        expect(countWeightStacks(jsx)).toBe(0)
     })
 })
 

--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -22,6 +22,24 @@ describe('offScaleSpacing', () => {
         expect(countOffScaleSpacing('className="first:ps-7"')).toBe(1)
     })
 
+    it('flags the 1px -px suffix on every family', () => {
+        for (const cls of ['p-px', 'gap-px', '-m-px', 'md:pt-px']) {
+            expect(countOffScaleSpacing(`<div className="${cls}" />`)).toBe(1)
+        }
+    })
+
+    it('flags the logical block-axis families', () => {
+        expect(countOffScaleSpacing('<div className="pbs-5 mbe-7" />')).toBe(2)
+        expect(countOffScaleSpacing('<div className="-mbs-2.5 pbe-[3px]" />')).toBe(2)
+        expect(countOffScaleSpacing('<div className="pbs-4 mbe-8" />')).toBe(0)
+    })
+
+    it('flags custom-property shorthand values', () => {
+        for (const cls of ['p-(--gutter)', 'gap-(--space)', '-m-(--x)', 'md:ps-(--pad)']) {
+            expect(countOffScaleSpacing(`<div className="${cls}" />`)).toBe(1)
+        }
+    })
+
     it('accepts every documented scale step, negatives and variants included', () => {
         for (const cls of [
             'p-0',
@@ -133,6 +151,7 @@ describe('iconOffScale', () => {
             '<Icon name="chevron-up" className={`h-4 w-4 transition-transform ${open ? "" : "rotate-180"}`} />',
             "<Icon name={icon} className={twMerge('size-6', extra)} />",
             '<Icon name="x" className="size-[18px]" />',
+            '<Icon name="x" className="size-(--icon)" />',
             "<Icon name={icon} className={twMerge('h-[18px] w-[18px]', extra)} />",
         ]) {
             expect(countMatches(text, OFF_SCALE_ICON_RE)).toBeGreaterThan(0)
@@ -184,7 +203,7 @@ describe('offScaleRadius (countOffScaleRadius)', () => {
 
 describe('rawDuration', () => {
     it('flags any numeric or arbitrary duration', () => {
-        for (const cls of ['duration-100', 'duration-250', 'duration-75', 'duration-[250ms]']) {
+        for (const cls of ['duration-100', 'duration-250', 'duration-75', 'duration-[250ms]', 'duration-(--speed)']) {
             expect(countMatches(`className="${cls}"`, RAW_DURATION_RE)).toBe(1)
         }
     })

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -12,8 +12,8 @@
     "deadLegacyTokens": 0,
     "consumedUndefinedTokens": 0,
     "classNameSitesInPages": 314,
-    "fontWeightOnTypeToken": 13,
-    "offScaleSpacing": 181,
+    "fontWeightOnTypeToken": 14,
+    "offScaleSpacing": 198,
     "iconOffScale": 64,
     "offScaleRadius": 33,
     "rawDuration": 9

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -14,7 +14,7 @@
     "classNameSitesInPages": 314,
     "fontWeightOnTypeToken": 47,
     "offScaleSpacing": 204,
-    "iconOffScale": 64,
+    "iconOffScale": 81,
     "offScaleRadius": 37,
     "rawDuration": 9,
     "_meta": [
@@ -22,6 +22,11 @@
             "date": "2026-09-01",
             "metrics": ["offScaleSpacing 199 -> 204"],
             "reason": "chip round 7 on #2905: spacing metric adds the -px suffix, block-axis logical families, and custom-property shorthand; the +5 are marketing hairline gap-px dividers and one 1px nudge"
+        },
+        {
+            "date": "2026-09-01",
+            "metrics": ["iconOffScale 64 -> 81"],
+            "reason": "chip round 9 on #2905: icon metric now counts non-literal size expressions conservatively — the +17 are dynamic size maps (Button/IconBubble resolve to board steps) and variable-sized call sites held for static resolution"
         }
     ]
 }

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -12,7 +12,7 @@
     "deadLegacyTokens": 0,
     "consumedUndefinedTokens": 0,
     "classNameSitesInPages": 314,
-    "fontWeightOnTypeToken": 14,
+    "fontWeightOnTypeToken": 47,
     "offScaleSpacing": 199,
     "iconOffScale": 64,
     "offScaleRadius": 37,

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -13,7 +13,7 @@
     "consumedUndefinedTokens": 0,
     "classNameSitesInPages": 314,
     "fontWeightOnTypeToken": 14,
-    "offScaleSpacing": 198,
+    "offScaleSpacing": 199,
     "iconOffScale": 64,
     "offScaleRadius": 37,
     "rawDuration": 9

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -13,8 +13,15 @@
     "consumedUndefinedTokens": 0,
     "classNameSitesInPages": 314,
     "fontWeightOnTypeToken": 47,
-    "offScaleSpacing": 199,
+    "offScaleSpacing": 204,
     "iconOffScale": 64,
     "offScaleRadius": 37,
-    "rawDuration": 9
+    "rawDuration": 9,
+    "_meta": [
+        {
+            "date": "2026-09-01",
+            "metrics": ["offScaleSpacing 199 -> 204"],
+            "reason": "chip round 7 on #2905: spacing metric adds the -px suffix, block-axis logical families, and custom-property shorthand; the +5 are marketing hairline gap-px dividers and one 1px nudge"
+        }
+    ]
 }

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -2,7 +2,7 @@
     "rawHex": 65,
     "rawHexFiles": 41,
     "inlineStyle": 50,
-    "stockTextSize": 362,
+    "stockTextSize": 361,
     "dsTextScale": 10,
     "nonDsClassesInViews": 138,
     "useSearchParamsFiles": 47,
@@ -11,5 +11,10 @@
     "offRampPalette": 0,
     "deadLegacyTokens": 0,
     "consumedUndefinedTokens": 0,
-    "classNameSitesInPages": 314
+    "classNameSitesInPages": 314,
+    "fontWeightOnTypeToken": 13,
+    "offScaleSpacing": 124,
+    "iconOffScale": 42,
+    "offScaleRadius": 33,
+    "rawDuration": 9
 }

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -13,8 +13,8 @@
     "consumedUndefinedTokens": 0,
     "classNameSitesInPages": 314,
     "fontWeightOnTypeToken": 13,
-    "offScaleSpacing": 124,
-    "iconOffScale": 42,
+    "offScaleSpacing": 181,
+    "iconOffScale": 64,
     "offScaleRadius": 33,
     "rawDuration": 9
 }

--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -15,6 +15,6 @@
     "fontWeightOnTypeToken": 14,
     "offScaleSpacing": 198,
     "iconOffScale": 64,
-    "offScaleRadius": 33,
+    "offScaleRadius": 37,
     "rawDuration": 9
 }

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -266,22 +266,20 @@ counts.classNameSitesInPages = files
 // pending a ruling) live inside the baseline, not an allowlist — a ruling
 // drives the count down, new drift pushes it up and fails.
 counts.fontWeightOnTypeToken = files
-    .filter((f) => isTsx(f) && !allowed(f.path))
+    .filter((f) => !allowed(f.path))
     .reduce((sum, f) => sum + countWeightStacks(f.text), 0)
 // matchers live in ds-lint-rules.cjs (imported at the top) so the regression
 // tests in scripts/__tests__/ds-lint-rules.test.ts exercise the exact rules
-// this script counts with, without running the src/ scan.
-counts.offScaleSpacing = files
-    .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce((sum, f) => sum + countOffScaleSpacing(f.text), 0)
+// this script counts with, without running the src/ scan. these five scan
+// .ts as well as .tsx — class constants exported from plain modules
+// (Marketing/mdx/constants.ts) carry the same drift.
+counts.offScaleSpacing = files.filter((f) => !allowed(f.path)).reduce((sum, f) => sum + countOffScaleSpacing(f.text), 0)
 counts.iconOffScale = files
-    .filter((f) => isTsx(f) && !allowed(f.path))
+    .filter((f) => !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_ICON_RE), 0)
-counts.offScaleRadius = files
-    .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce((sum, f) => sum + countOffScaleRadius(f.text), 0)
+counts.offScaleRadius = files.filter((f) => !allowed(f.path)).reduce((sum, f) => sum + countOffScaleRadius(f.text), 0)
 counts.rawDuration = files
-    .filter((f) => isTsx(f) && !allowed(f.path))
+    .filter((f) => !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, RAW_DURATION_RE), 0)
 
 // dsTextScale and nuqsFiles are adoption counts (should go UP) — everything

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -312,8 +312,13 @@ if (mode === '--json') {
     // ever runs --check, so the flag cannot be abused there.
     const allowIdx = process.argv.indexOf('--allow-increase')
     const allowReason = allowIdx !== -1 ? process.argv[allowIdx + 1] : null
+    // _meta is the durable audit trail: every allowed increase appends its
+    // reason into the baseline file itself, so a bump is visible in the diff
+    // reviewers read, not just in the terminal of whoever ran the command.
+    let meta = []
     try {
         const prev = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
+        if (Array.isArray(prev._meta)) meta = prev._meta
         const raised = DEBT_KEYS.filter((k) => typeof prev[k] === 'number' && counts[k] > prev[k])
         if (raised.length && !allowReason) {
             console.error(
@@ -323,12 +328,19 @@ if (mode === '--json') {
             console.error('  --write-baseline --allow-increase "<why>"')
             process.exit(1)
         }
-        if (raised.length) console.log(`baseline increase allowed: ${allowReason}`)
+        if (raised.length) {
+            console.log(`baseline increase allowed: ${allowReason}`)
+            meta.push({
+                date: new Date().toISOString().slice(0, 10),
+                metrics: raised.map((k) => `${k} ${prev[k]} -> ${counts[k]}`),
+                reason: allowReason,
+            })
+        }
     } catch (e) {
         if (e.code !== 'ENOENT') throw e // no previous baseline: first write is free
     }
     // 4-space indent matches prettier (tabWidth 4) so a regen never fails the format gate
-    writeFileSync(BASELINE_PATH, JSON.stringify(counts, null, 4) + '\n')
+    writeFileSync(BASELINE_PATH, JSON.stringify(meta.length ? { ...counts, _meta: meta } : counts, null, 4) + '\n')
     console.log(`baseline written to ${relative(ROOT, BASELINE_PATH)}`)
     console.log(JSON.stringify(counts, null, 2))
 } else if (mode === '--check') {

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -13,6 +13,7 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, relative, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { countOffScaleSpacing, OFF_SCALE_ICON_RE, OFF_SCALE_RADIUS_RE, RAW_DURATION_RE } from './ds-lint-rules.cjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SRC = join(ROOT, 'src')
@@ -266,35 +267,18 @@ counts.fontWeightOnTypeToken = files
         (sum, f) => sum + f.text.split('\n').filter((l) => TYPE_TOKEN_RE.test(l) && WEIGHT_STACK_RE.test(l)).length,
         0
     )
-// allowlist inversion, not a blocklist: tailwind v4 compiles ANY numeric step
-// (p-4.5, pr-18, -mt-5), so the metric flags every numeric spacing utility —
-// negative forms and variant prefixes included — whose magnitude is not a
-// documented scale step, instead of enumerating known-bad values.
-const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
-const NUMERIC_SPACING_RE =
-    /(?<![a-z0-9-])-?(?:px|py|pt|pb|pl|pr|p|mx|my|mt|mb|ml|mr|m|gap-x|gap-y|gap|space-y|space-x)-([0-9]+(?:\.[0-9]+)?)(?![0-9.a-z%\]])/g
+// matchers live in ds-lint-rules.mjs (imported at the top) so the regression
+// tests in scripts/__tests__/ds-lint-rules.test.ts exercise the exact rules
+// this script counts with, without running the src/ scan.
 counts.offScaleSpacing = files
     .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce((sum, f) => {
-        let n = 0
-        for (const m of f.text.matchAll(NUMERIC_SPACING_RE)) if (!SPACING_STEPS.has(m[1])) n++
-        return sum + n
-    }, 0)
-// three ways an Icon gets sized: the size prop (also width/height, which the
-// component forwards), Button's iconSize, and — banned outright by the icon
-// law — tailwind size-/h-/w- classes on the Icon itself.
-const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?className="[^"]*\b(?:size|h|w)-[0-9]/g
+    .reduce((sum, f) => sum + countOffScaleSpacing(f.text), 0)
 counts.iconOffScale = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_ICON_RE), 0)
-const OFF_SCALE_RADIUS_RE = /\brounded(?:-[trbl]{1,2})?-(?:md|lg|xl|2xl|3xl)\b/g
 counts.offScaleRadius = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_RADIUS_RE), 0)
-// any numeric duration is off-token (the motion scale is instant/fast/
-// moderate/slow); arbitrary values (duration-[250ms]) count too.
-const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\])/g
 counts.rawDuration = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, RAW_DURATION_RE), 0)

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -252,6 +252,38 @@ counts.classNameSitesInPages = files
     .filter((f) => /^app\/\(mobile-ui\)\//.test(f.path) && /(^|\/)page\.tsx$/.test(f.path) && !f.path.includes('/dev/'))
     .reduce((sum, f) => sum + countMatches(f.text, /className=/g), 0)
 
+// composition-drift metrics (2026-09-01 sweep). design.md laws the token
+// metrics above cannot see: stacked weights mint off-ramp type styles, the
+// spacing/radius/motion scales ban off-scale values, icons have three sizes.
+// deliberate holds (geometry-driven indents like Notification's pl-7, boards
+// pending a ruling) live inside the baseline, not an allowlist — a ruling
+// drives the count down, new drift pushes it up and fails.
+const WEIGHT_STACK_RE = /\bfont-(?:bold|semibold|extrabold)\b/
+const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
+counts.fontWeightOnTypeToken = files
+    .filter((f) => isTsx(f) && !allowed(f.path))
+    .reduce(
+        (sum, f) => sum + f.text.split('\n').filter((l) => TYPE_TOKEN_RE.test(l) && WEIGHT_STACK_RE.test(l)).length,
+        0
+    )
+const OFF_SCALE_SPACING_RE =
+    /(?<![a-z0-9-])(?:p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-y|space-x)-(?:1\.5|2\.5|3\.5|5|7|9|11|13|15)(?![0-9.])/g
+counts.offScaleSpacing = files
+    .filter((f) => isTsx(f) && !allowed(f.path))
+    .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_SPACING_RE), 0)
+const OFF_SCALE_ICON_RE = /(?:<Icon\s[^>]*\bsize|\biconSize)=\{(?!16\}|20\}|24\})[0-9]+\}/g
+counts.iconOffScale = files
+    .filter((f) => isTsx(f) && !allowed(f.path))
+    .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_ICON_RE), 0)
+const OFF_SCALE_RADIUS_RE = /\brounded(?:-[trbl]{1,2})?-(?:md|lg|xl|2xl|3xl)\b/g
+counts.offScaleRadius = files
+    .filter((f) => isTsx(f) && !allowed(f.path))
+    .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_RADIUS_RE), 0)
+const RAW_DURATION_RE = /\bduration-(?:75|100|150|200|300|500|700|1000)\b/g
+counts.rawDuration = files
+    .filter((f) => isTsx(f) && !allowed(f.path))
+    .reduce((sum, f) => sum + countMatches(f.text, RAW_DURATION_RE), 0)
+
 // dsTextScale and nuqsFiles are adoption counts (should go UP) — everything
 // else is debt (must only go DOWN). the ratchet only enforces the debt keys.
 const DEBT_KEYS = [
@@ -266,6 +298,11 @@ const DEBT_KEYS = [
     'classNameSitesInPages',
     'deadLegacyTokens',
     'consumedUndefinedTokens',
+    'fontWeightOnTypeToken',
+    'offScaleSpacing',
+    'iconOffScale',
+    'offScaleRadius',
+    'rawDuration',
 ]
 
 const mode = process.argv[2] ?? ''

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -13,7 +13,13 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, relative, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { countOffScaleSpacing, OFF_SCALE_ICON_RE, OFF_SCALE_RADIUS_RE, RAW_DURATION_RE } from './ds-lint-rules.cjs'
+import {
+    countOffScaleSpacing,
+    countWeightStacks,
+    OFF_SCALE_ICON_RE,
+    OFF_SCALE_RADIUS_RE,
+    RAW_DURATION_RE,
+} from './ds-lint-rules.cjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SRC = join(ROOT, 'src')
@@ -259,15 +265,10 @@ counts.classNameSitesInPages = files
 // deliberate holds (geometry-driven indents like Notification's pl-7, boards
 // pending a ruling) live inside the baseline, not an allowlist — a ruling
 // drives the count down, new drift pushes it up and fails.
-const WEIGHT_STACK_RE = /\bfont-(?:bold|semibold|extrabold)\b/
-const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 counts.fontWeightOnTypeToken = files
     .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce(
-        (sum, f) => sum + f.text.split('\n').filter((l) => TYPE_TOKEN_RE.test(l) && WEIGHT_STACK_RE.test(l)).length,
-        0
-    )
-// matchers live in ds-lint-rules.mjs (imported at the top) so the regression
+    .reduce((sum, f) => sum + countWeightStacks(f.text), 0)
+// matchers live in ds-lint-rules.cjs (imported at the top) so the regression
 // tests in scripts/__tests__/ds-lint-rules.test.ts exercise the exact rules
 // this script counts with, without running the src/ scan.
 counts.offScaleSpacing = files

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -16,8 +16,8 @@ import { fileURLToPath } from 'node:url'
 import {
     countOffScaleSpacing,
     countWeightStacks,
+    countOffScaleRadius,
     OFF_SCALE_ICON_RE,
-    OFF_SCALE_RADIUS_RE,
     RAW_DURATION_RE,
 } from './ds-lint-rules.cjs'
 
@@ -279,7 +279,7 @@ counts.iconOffScale = files
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_ICON_RE), 0)
 counts.offScaleRadius = files
     .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_RADIUS_RE), 0)
+    .reduce((sum, f) => sum + countOffScaleRadius(f.text), 0)
 counts.rawDuration = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, RAW_DURATION_RE), 0)

--- a/scripts/ds-lint-counts.mjs
+++ b/scripts/ds-lint-counts.mjs
@@ -266,12 +266,25 @@ counts.fontWeightOnTypeToken = files
         (sum, f) => sum + f.text.split('\n').filter((l) => TYPE_TOKEN_RE.test(l) && WEIGHT_STACK_RE.test(l)).length,
         0
     )
-const OFF_SCALE_SPACING_RE =
-    /(?<![a-z0-9-])(?:p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-y|space-x)-(?:1\.5|2\.5|3\.5|5|7|9|11|13|15)(?![0-9.])/g
+// allowlist inversion, not a blocklist: tailwind v4 compiles ANY numeric step
+// (p-4.5, pr-18, -mt-5), so the metric flags every numeric spacing utility —
+// negative forms and variant prefixes included — whose magnitude is not a
+// documented scale step, instead of enumerating known-bad values.
+const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
+const NUMERIC_SPACING_RE =
+    /(?<![a-z0-9-])-?(?:px|py|pt|pb|pl|pr|p|mx|my|mt|mb|ml|mr|m|gap-x|gap-y|gap|space-y|space-x)-([0-9]+(?:\.[0-9]+)?)(?![0-9.a-z%\]])/g
 counts.offScaleSpacing = files
     .filter((f) => isTsx(f) && !allowed(f.path))
-    .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_SPACING_RE), 0)
-const OFF_SCALE_ICON_RE = /(?:<Icon\s[^>]*\bsize|\biconSize)=\{(?!16\}|20\}|24\})[0-9]+\}/g
+    .reduce((sum, f) => {
+        let n = 0
+        for (const m of f.text.matchAll(NUMERIC_SPACING_RE)) if (!SPACING_STEPS.has(m[1])) n++
+        return sum + n
+    }, 0)
+// three ways an Icon gets sized: the size prop (also width/height, which the
+// component forwards), Button's iconSize, and — banned outright by the icon
+// law — tailwind size-/h-/w- classes on the Icon itself.
+const OFF_SCALE_ICON_RE =
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?className="[^"]*\b(?:size|h|w)-[0-9]/g
 counts.iconOffScale = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_ICON_RE), 0)
@@ -279,7 +292,9 @@ const OFF_SCALE_RADIUS_RE = /\brounded(?:-[trbl]{1,2})?-(?:md|lg|xl|2xl|3xl)\b/g
 counts.offScaleRadius = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, OFF_SCALE_RADIUS_RE), 0)
-const RAW_DURATION_RE = /\bduration-(?:75|100|150|200|300|500|700|1000)\b/g
+// any numeric duration is off-token (the motion scale is instant/fast/
+// moderate/slow); arbitrary values (duration-[250ms]) count too.
+const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\])/g
 counts.rawDuration = files
     .filter((f) => isTsx(f) && !allowed(f.path))
     .reduce((sum, f) => sum + countMatches(f.text, RAW_DURATION_RE), 0)

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -7,17 +7,19 @@
 
 // allowlist inversion, not a blocklist: tailwind v4 compiles ANY numeric step
 // (p-4.5, pr-18, -mt-5, ps-5), so the metric flags every numeric spacing
-// utility — negative forms, variant prefixes, and the logical ps/pe/ms/me
-// families included — whose magnitude is not a documented scale step.
-// arbitrary values (p-[5px], gap-[20%]) are rejected wholesale: a value that
-// equals a scale step has a numeric class, so the bracket form is always drift.
+// utility — negative forms, variant prefixes, the logical inline (ps/pe/ms/me)
+// and block-axis (pbs/pbe/mbs/mbe) families, and the 1px `-px` suffix — whose
+// magnitude is not a documented scale step. arbitrary values (p-[5px]) and
+// custom-property shorthand (p-(--gutter)) are rejected wholesale: a value
+// that equals a scale step has a numeric class, so those forms are always drift.
 const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
-const SPACING_FAMILIES = 'px|py|pt|pb|pl|pr|ps|pe|p|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x'
+const SPACING_FAMILIES =
+    'pbs|pbe|px|py|pt|pb|pl|pr|ps|pe|p|mbs|mbe|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x'
 const NUMERIC_SPACING_RE = new RegExp(
-    `(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-([0-9]+(?:\\.[0-9]+)?)(?![0-9.a-z%\\]])`,
+    `(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-([0-9]+(?:\\.[0-9]+)?|px)(?![0-9.a-z%\\]])`,
     'g'
 )
-const ARBITRARY_SPACING_RE = new RegExp(`(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-\\[[^\\]]+\\]`, 'g')
+const ARBITRARY_SPACING_RE = new RegExp(`(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-(?:\\[[^\\]]+\\]|\\(--[^)]+\\))`, 'g')
 
 function countOffScaleSpacing(text) {
     let n = 0
@@ -115,13 +117,16 @@ function countWeightStacks(text) {
 // className syntax (string, template literal, or brace expression): any
 // size-/h-/w- numeric class inside an <Icon …> tag span counts.
 const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[)/g
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[|\(--)/g
 
 // allowlist inversion like spacing: any rounded suffix outside the documented
 // scale (bare rounded = 4px/xs, none, sm = 2px, round, full) is drift —
 // named steps (md/lg/xl…) and arbitrary values (rounded-[1px]) alike.
 const RADIUS_SIDES = '(?:t|r|b|l|tl|tr|bl|br|s|e|ss|se|es|ee)'
-const RADIUS_RE = new RegExp(`\\brounded(?:-${RADIUS_SIDES})?(?:-(\\[[^\\]]+\\]|[a-z0-9.]+))?(?![a-z0-9-])`, 'g')
+const RADIUS_RE = new RegExp(
+    `\\brounded(?:-${RADIUS_SIDES})?(?:-(\\[[^\\]]+\\]|\\(--[^)]+\\)|[a-z0-9.]+))?(?![a-z0-9-])`,
+    'g'
+)
 const RADIUS_ALLOWED = new Set([undefined, 'none', 'sm', 'round', 'full'])
 
 function countOffScaleRadius(text) {
@@ -132,7 +137,7 @@ function countOffScaleRadius(text) {
 
 // any numeric duration is off-token (the motion scale is instant/fast/
 // moderate/slow); arbitrary values (duration-[250ms]) count too.
-const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\])/g
+const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\]|\(--[^)]+\))/g
 
 module.exports = {
     SPACING_STEPS,

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -64,9 +64,34 @@ function classNameExpressions(text) {
     return regions
 }
 
+// class-builder calls (twMerge('text-body-m', active && 'font-semibold')
+// assigned to a variable) produce class lists outside any *ClassName
+// attribute, so their paren-balanced argument spans are regions too.
+function builderCallRegions(text) {
+    const regions = []
+    const re = /\b(?:twMerge|clsx|cn|classNames|cva|tw)\s*\(/g
+    let m
+    while ((m = re.exec(text))) {
+        let depth = 1
+        let j = re.lastIndex
+        while (j < text.length && depth > 0) {
+            if (text[j] === '(') depth++
+            else if (text[j] === ')') depth--
+            j++
+        }
+        regions.push({ start: m.index, end: j })
+        re.lastIndex = j
+    }
+    return regions
+}
+
 function countWeightStacks(text) {
     let n = 0
-    const regions = classNameExpressions(text)
+    const attrRegions = classNameExpressions(text)
+    const inAttr = (r) => attrRegions.some((a) => r.start >= a.start && r.end <= a.end)
+    const regions = [...attrRegions, ...builderCallRegions(text).filter((r) => !inAttr(r))].sort(
+        (a, b) => a.start - b.start
+    )
     for (const r of regions) {
         const expr = text.slice(r.start, r.end)
         if (TYPE_TOKEN_RE.test(expr) && WEIGHT_STACK_RE.test(expr)) n++
@@ -74,6 +99,7 @@ function countWeightStacks(text) {
     let rest = ''
     let cursor = 0
     for (const r of regions) {
+        if (r.start < cursor) continue
         rest += text.slice(cursor, r.start)
         cursor = r.end
     }
@@ -88,7 +114,7 @@ function countWeightStacks(text) {
 // className syntax (string, template literal, or brace expression): any
 // size-/h-/w- numeric class inside an <Icon …> tag span counts.
 const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-[0-9]/g
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[)/g
 
 // allowlist inversion like spacing: any rounded suffix outside the documented
 // scale (bare rounded = 4px/xs, none, sm = 2px, round, full) is drift —

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -9,13 +9,74 @@
 // (p-4.5, pr-18, -mt-5, ps-5), so the metric flags every numeric spacing
 // utility — negative forms, variant prefixes, and the logical ps/pe/ms/me
 // families included — whose magnitude is not a documented scale step.
+// arbitrary values (p-[5px], gap-[20%]) are rejected wholesale: a value that
+// equals a scale step has a numeric class, so the bracket form is always drift.
 const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
-const NUMERIC_SPACING_RE =
-    /(?<![a-z0-9-])-?(?:px|py|pt|pb|pl|pr|ps|pe|p|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x)-([0-9]+(?:\.[0-9]+)?)(?![0-9.a-z%\]])/g
+const SPACING_FAMILIES = 'px|py|pt|pb|pl|pr|ps|pe|p|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x'
+const NUMERIC_SPACING_RE = new RegExp(
+    `(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-([0-9]+(?:\\.[0-9]+)?)(?![0-9.a-z%\\]])`,
+    'g'
+)
+const ARBITRARY_SPACING_RE = new RegExp(`(?<![a-z0-9-])-?(?:${SPACING_FAMILIES})-\\[[^\\]]+\\]`, 'g')
 
 function countOffScaleSpacing(text) {
     let n = 0
     for (const m of text.matchAll(NUMERIC_SPACING_RE)) if (!SPACING_STEPS.has(m[1])) n++
+    n += (text.match(ARBITRARY_SPACING_RE) ?? []).length
+    return n
+}
+
+// a type token carries its own weight, so a weight utility stacked next to one
+// mints an off-ramp style. matching happens per className expression (the
+// attribute's full string or brace-balanced JSX expression), so a token and a
+// weight split across formatted lines inside one twMerge/clsx call still
+// count; class strings held in variables outside className= are caught by a
+// per-line pass over the remaining text.
+const WEIGHT_STACK_RE = /\bfont-(?:bold|semibold|extrabold)\b/
+const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
+
+function classNameExpressions(text) {
+    const regions = []
+    const re = /className\s*=\s*/g
+    let m
+    while ((m = re.exec(text))) {
+        const i = re.lastIndex
+        const c = text[i]
+        if (c === '"' || c === "'") {
+            const end = text.indexOf(c, i + 1)
+            if (end === -1) continue
+            regions.push({ start: i, end: end + 1 })
+            re.lastIndex = end + 1
+        } else if (c === '{') {
+            let depth = 1
+            let j = i + 1
+            while (j < text.length && depth > 0) {
+                if (text[j] === '{') depth++
+                else if (text[j] === '}') depth--
+                j++
+            }
+            regions.push({ start: i, end: j })
+            re.lastIndex = j
+        }
+    }
+    return regions
+}
+
+function countWeightStacks(text) {
+    let n = 0
+    const regions = classNameExpressions(text)
+    for (const r of regions) {
+        const expr = text.slice(r.start, r.end)
+        if (TYPE_TOKEN_RE.test(expr) && WEIGHT_STACK_RE.test(expr)) n++
+    }
+    let rest = ''
+    let cursor = 0
+    for (const r of regions) {
+        rest += text.slice(cursor, r.start)
+        cursor = r.end
+    }
+    rest += text.slice(cursor)
+    for (const line of rest.split('\n')) if (TYPE_TOKEN_RE.test(line) && WEIGHT_STACK_RE.test(line)) n++
     return n
 }
 
@@ -34,7 +95,9 @@ const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\])/g
 module.exports = {
     SPACING_STEPS,
     NUMERIC_SPACING_RE,
+    ARBITRARY_SPACING_RE,
     countOffScaleSpacing,
+    countWeightStacks,
     OFF_SCALE_ICON_RE,
     OFF_SCALE_RADIUS_RE,
     RAW_DURATION_RE,

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -32,7 +32,8 @@ function countOffScaleSpacing(text) {
 // weight split across formatted lines inside one twMerge/clsx call still
 // count; class strings held in variables outside className= are caught by a
 // per-line pass over the remaining text.
-const WEIGHT_STACK_RE = /\bfont-(?:bold|semibold|extrabold)\b/
+const WEIGHT_STACK_RE =
+    /\bfont-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black|\[[0-9]+\])(?![a-z-])/
 const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 
 function classNameExpressions(text) {

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -1,0 +1,41 @@
+// composition-drift matchers shared by ds-lint-counts.mjs and its regression
+// tests (scripts/__tests__/ds-lint-rules.test.ts). the counting script has
+// top-level side effects (it walks src/), so the rules live here where a test
+// can import them without running the scan. CommonJS on purpose: node's ESM
+// loader named-imports it statically, and jest's CJS runtime requires it with
+// no transform.
+
+// allowlist inversion, not a blocklist: tailwind v4 compiles ANY numeric step
+// (p-4.5, pr-18, -mt-5, ps-5), so the metric flags every numeric spacing
+// utility — negative forms, variant prefixes, and the logical ps/pe/ms/me
+// families included — whose magnitude is not a documented scale step.
+const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
+const NUMERIC_SPACING_RE =
+    /(?<![a-z0-9-])-?(?:px|py|pt|pb|pl|pr|ps|pe|p|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x)-([0-9]+(?:\.[0-9]+)?)(?![0-9.a-z%\]])/g
+
+function countOffScaleSpacing(text) {
+    let n = 0
+    for (const m of text.matchAll(NUMERIC_SPACING_RE)) if (!SPACING_STEPS.has(m[1])) n++
+    return n
+}
+
+// three ways an Icon gets sized: the size prop (also width/height, which the
+// component forwards), Button's iconSize, and — banned outright by the icon
+// law — tailwind size-/h-/w- classes on the Icon itself.
+const OFF_SCALE_ICON_RE =
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?className="[^"]*\b(?:size|h|w)-[0-9]/g
+
+const OFF_SCALE_RADIUS_RE = /\brounded(?:-[trbl]{1,2})?-(?:md|lg|xl|2xl|3xl)\b/g
+
+// any numeric duration is off-token (the motion scale is instant/fast/
+// moderate/slow); arbitrary values (duration-[250ms]) count too.
+const RAW_DURATION_RE = /\bduration-(?:[0-9]+\b|\[[^\]]+\])/g
+
+module.exports = {
+    SPACING_STEPS,
+    NUMERIC_SPACING_RE,
+    countOffScaleSpacing,
+    OFF_SCALE_ICON_RE,
+    OFF_SCALE_RADIUS_RE,
+    RAW_DURATION_RE,
+}

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -39,7 +39,7 @@ function countOffScaleSpacing(text) {
 // (decimals included) + the font-(weight:…) custom-property form. bare
 // font-(--x) is a font-FAMILY custom property, not a weight — excluded.
 const WEIGHT_STACK_RE =
-    /\bfont-(?:thin|extralight|light|normal|medium|semibold|extrabold|extraBlack|bold|black|\[[0-9]+(?:\.[0-9]+)?\]|\(weight:[^)]+\))(?![a-zA-Z0-9-])/
+    /\bfont-(?:thin|extralight|light|normal|medium|semibold|extrabold|extraBlack|bold|black|\[[0-9]+(?:\.[0-9]+)?\]|\[weight:[^\]]+\]|\(weight:[^)]+\))(?![a-zA-Z0-9-])/
 const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 
 function classNameExpressions(text) {
@@ -92,13 +92,35 @@ function builderCallRegions(text) {
     return regions
 }
 
+// a multiline template-literal class constant (text-body-m on one line,
+// font-semibold on the next, no builder call around it) renders one class
+// list, so backtick spans are regions of their own.
+function templateLiteralRegions(text) {
+    const regions = []
+    let i = text.indexOf('`')
+    while (i !== -1) {
+        let j = i + 1
+        while (j < text.length && text[j] !== '`') {
+            if (text[j] === '\\') j++
+            j++
+        }
+        if (j >= text.length) break
+        regions.push({ start: i, end: j + 1 })
+        i = text.indexOf('`', j + 1)
+    }
+    return regions
+}
+
 function countWeightStacks(text) {
     let n = 0
     const attrRegions = classNameExpressions(text)
-    const inAttr = (r) => attrRegions.some((a) => r.start >= a.start && r.end <= a.end)
-    const regions = [...attrRegions, ...builderCallRegions(text).filter((r) => !inAttr(r))].sort(
-        (a, b) => a.start - b.start
-    )
+    const outer = [...attrRegions, ...builderCallRegions(text)]
+    const contained = (r) =>
+        outer.some((a) => (a.start < r.start || a.end > r.end) && r.start >= a.start && r.end <= a.end)
+    const regions = [
+        ...outer.filter((r, idx) => !outer.some((a, ai) => ai !== idx && r.start >= a.start && r.end <= a.end)),
+        ...templateLiteralRegions(text).filter((r) => !contained(r)),
+    ].sort((a, b) => a.start - b.start)
     for (const r of regions) {
         const expr = text.slice(r.start, r.end)
         if (TYPE_TOKEN_RE.test(expr) && WEIGHT_STACK_RE.test(expr)) n++
@@ -120,8 +142,11 @@ function countWeightStacks(text) {
 // law — tailwind size-/h-/w- classes on the Icon itself, whatever the
 // className syntax (string, template literal, or brace expression): any
 // size-/h-/w- numeric class inside an <Icon …> tag span counts.
+// non-literal size expressions (size={iconSize}, size={a ? 16 : 20}) are
+// counted conservatively: the matcher cannot resolve them, and an unresolved
+// size is a hold to justify in the baseline, not a free pass.
 const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[|\(--)/g
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|width|height)=\{(?![0-9]+\})[^}]*\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?![0-9]+\})[^}]*\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[|\(--)/g
 
 // allowlist inversion like spacing: any rounded suffix outside the documented
 // scale (bare rounded = 4px/xs, none, sm = 2px, round, full) is drift —

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -37,7 +37,9 @@ const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 
 function classNameExpressions(text) {
     const regions = []
-    const re = /className\s*=\s*/g
+    // any JSX prop ending in ClassName (titleClassName, iconClassName, …)
+    // carries classes into an element, so all of them are scanned.
+    const re = /\b[a-zA-Z]*[cC]lassName\s*=\s*/g
     let m
     while ((m = re.exec(text))) {
         const i = re.lastIndex
@@ -82,11 +84,24 @@ function countWeightStacks(text) {
 
 // three ways an Icon gets sized: the size prop (also width/height, which the
 // component forwards), Button's iconSize, and — banned outright by the icon
-// law — tailwind size-/h-/w- classes on the Icon itself.
+// law — tailwind size-/h-/w- classes on the Icon itself, whatever the
+// className syntax (string, template literal, or brace expression): any
+// size-/h-/w- numeric class inside an <Icon …> tag span counts.
 const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?className="[^"]*\b(?:size|h|w)-[0-9]/g
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|h|w)-[0-9]/g
 
-const OFF_SCALE_RADIUS_RE = /\brounded(?:-[trbl]{1,2})?-(?:md|lg|xl|2xl|3xl)\b/g
+// allowlist inversion like spacing: any rounded suffix outside the documented
+// scale (bare rounded = 4px/xs, none, sm = 2px, round, full) is drift —
+// named steps (md/lg/xl…) and arbitrary values (rounded-[1px]) alike.
+const RADIUS_SIDES = '(?:t|r|b|l|tl|tr|bl|br|s|e|ss|se|es|ee)'
+const RADIUS_RE = new RegExp(`\\brounded(?:-${RADIUS_SIDES})?(?:-(\\[[^\\]]+\\]|[a-z0-9.]+))?(?![a-z0-9-])`, 'g')
+const RADIUS_ALLOWED = new Set([undefined, 'none', 'sm', 'round', 'full'])
+
+function countOffScaleRadius(text) {
+    let n = 0
+    for (const m of text.matchAll(RADIUS_RE)) if (!RADIUS_ALLOWED.has(m[1])) n++
+    return n
+}
 
 // any numeric duration is off-token (the motion scale is instant/fast/
 // moderate/slow); arbitrary values (duration-[250ms]) count too.
@@ -98,7 +113,7 @@ module.exports = {
     ARBITRARY_SPACING_RE,
     countOffScaleSpacing,
     countWeightStacks,
+    countOffScaleRadius,
     OFF_SCALE_ICON_RE,
-    OFF_SCALE_RADIUS_RE,
     RAW_DURATION_RE,
 }

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -34,8 +34,12 @@ function countOffScaleSpacing(text) {
 // weight split across formatted lines inside one twMerge/clsx call still
 // count; class strings held in variables outside className= are caught by a
 // per-line pass over the remaining text.
+// stock weight names + the theme's own extraBlack (globals.css
+// --font-weight-extraBlack, registered in tw.ts) + arbitrary numeric brackets
+// (decimals included) + the font-(weight:…) custom-property form. bare
+// font-(--x) is a font-FAMILY custom property, not a weight — excluded.
 const WEIGHT_STACK_RE =
-    /\bfont-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black|\[[0-9]+\])(?![a-z-])/
+    /\bfont-(?:thin|extralight|light|normal|medium|semibold|extrabold|extraBlack|bold|black|\[[0-9]+(?:\.[0-9]+)?\]|\(weight:[^)]+\))(?![a-zA-Z0-9-])/
 const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 
 function classNameExpressions(text) {

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -4,6 +4,14 @@
 // can import them without running the scan. CommonJS on purpose: node's ESM
 // loader named-imports it statically, and jest's CJS runtime requires it with
 // no transform.
+//
+// heuristic boundary: these are regex matchers over source text, scanning
+// class attributes, builder calls, and string/template literals. class lists
+// assembled through other static expressions (array .join, string
+// concatenation, lookup maps) are out of scope here — that long tail is the
+// AST-scanner follow-up (Notion: "AST-based ds-lint composition scanner").
+// the ratchet still catches such drift indirectly the moment any covered
+// form touches the same file, and baselines cap every covered form.
 
 // allowlist inversion, not a blocklist: tailwind v4 compiles ANY numeric step
 // (p-4.5, pr-18, -mt-5, ps-5), so the metric flags every numeric spacing
@@ -12,6 +20,11 @@
 // magnitude is not a documented scale step. arbitrary values (p-[5px]) and
 // custom-property shorthand (p-(--gutter)) are rejected wholesale: a value
 // that equals a scale step has a numeric class, so those forms are always drift.
+// positioning and scroll offsets (inset/top/right/bottom/left/start/end,
+// scroll-m*/scroll-p*) are deliberately OUT of scope: the spacing board
+// governs box rhythm (padding/margin/gap), while offsets are geometry tied
+// to what they overlap, and flagging them would drown the metric in
+// coordinate math that has no scale-step answer.
 const SPACING_STEPS = new Set(['0', '0.5', '1', '2', '3', '4', '6', '8', '10', '12', '14', '16'])
 const SPACING_FAMILIES =
     'pbs|pbe|px|py|pt|pb|pl|pr|ps|pe|p|mbs|mbe|mx|my|mt|mb|ml|mr|ms|me|m|gap-x|gap-y|gap|space-y|space-x'
@@ -145,8 +158,11 @@ function countWeightStacks(text) {
 // non-literal size expressions (size={iconSize}, size={a ? 16 : 20}) are
 // counted conservatively: the matcher cannot resolve them, and an unresolved
 // size is a hold to justify in the baseline, not a free pass.
+// quoted forms count too. iconSize carries two denominations: pixel props
+// (Button et al: "16"/"20"/"24" ok) and CopyToClipboard's tailwind-unit enum
+// ("4"=16px, "5"=20px, "6"=24px ok) — anything outside both sets is off-step.
 const OFF_SCALE_ICON_RE =
-    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|width|height)=\{(?![0-9]+\})[^}]*\}|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?![0-9]+\})[^}]*\}|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[|\(--)/g
+    /<Icon\s[^>]*?\b(?:size|width|height)=\{(?!16\}|20\}|24\})[0-9]+\}|<Icon\s[^>]*?\b(?:size|width|height)=\{(?![0-9]+\})[^}]*\}|<Icon\s[^>]*?\b(?:size|width|height)=["'](?!16["']|20["']|24["'])[0-9]+["']|\biconSize=\{(?!16\}|20\}|24\})[0-9]+\}|\biconSize=\{(?![0-9]+\})[^}]*\}|\biconSize=["'](?!4["']|5["']|6["']|16["']|20["']|24["'])[0-9]+["']|<Icon\s[^>]*?\b(?:size|h|w)-(?:[0-9]|\[|\(--)/g
 
 // allowlist inversion like spacing: any rounded suffix outside the documented
 // scale (bare rounded = 4px/xs, none, sm = 2px, round, full) is drift —

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -476,7 +476,7 @@ function BridgeBankOnrampPage() {
             <div className="space-y-8 flex flex-col justify-start">
                 <NavHeader title={t('title')} onPrev={onBack} />
                 <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
-                    <div className="text-body-s font-bold">{t('howMuchToAdd')}</div>
+                    <div className="text-label-l">{t('howMuchToAdd')}</div>
                     <AmountInput
                         initialAmount={rawTokenAmount}
                         setPrimaryAmount={handleTokenAmountChange}

--- a/src/app/(mobile-ui)/card-recovery/page.tsx
+++ b/src/app/(mobile-ui)/card-recovery/page.tsx
@@ -180,7 +180,7 @@ function Row({ label, value }: { label: string; value: string }) {
     return (
         <div className="flex items-center justify-between">
             <span className="text-body-s text-foreground-secondary">{label}</span>
-            <span className="text-body-s font-medium text-foreground-primary">{value}</span>
+            <span className="text-body-s text-foreground-primary">{value}</span>
         </div>
     )
 }

--- a/src/app/(mobile-ui)/dev/_components/DevSegmented.tsx
+++ b/src/app/(mobile-ui)/dev/_components/DevSegmented.tsx
@@ -31,8 +31,8 @@ export default function DevSegmented<T extends string>({
                     aria-pressed={value === option.value}
                     onClick={() => onChange(option.value)}
                     className={twMerge(
-                        'rounded-sm font-bold transition-colors',
-                        size === 'sm' ? 'px-2 py-1 text-[11px]' : 'px-3 py-1.5 text-body-xs',
+                        'rounded-sm transition-colors',
+                        size === 'sm' ? 'px-2 py-1 text-[11px] font-bold' : 'px-3 py-1.5 text-label-m',
                         value === option.value
                             ? 'bg-action-primary text-foreground-primary'
                             : 'text-foreground-secondary hover:bg-purple-200/40'

--- a/src/app/(mobile-ui)/profile/backup/page.tsx
+++ b/src/app/(mobile-ui)/profile/backup/page.tsx
@@ -52,7 +52,7 @@ export default function BackupPage() {
 
                 <Section title={t('enableNow')}>
                     <Card>
-                        <ol className="space-y-4 list-decimal py-2 pl-5">
+                        <ol className="space-y-4 list-decimal py-2 pl-6">
                             {backupSteps.map((step, index) => (
                                 <li key={index}>
                                     <p className="font-bold text-foreground-primary">{step.title}</p>
@@ -104,7 +104,7 @@ export default function BackupPage() {
                 titleClassName="text-heading-xs"
                 content={
                     <div className="space-y-3 w-full">
-                        <ol className="list-decimal pl-5 text-left text-body-s text-foreground-primary">
+                        <ol className="list-decimal pl-6 text-left text-body-s text-foreground-primary">
                             <li>{t('changePhoneModal.step1')}</li>
                             <li>{t('changePhoneModal.step2', { platform })}</li>
                             <li>{t('changePhoneModal.step3')}</li>
@@ -135,7 +135,7 @@ export default function BackupPage() {
                             <p className="mt-1 text-body-s text-foreground-primary">
                                 {t('exportKeysModal.saferIntro')}
                             </p>
-                            <ul className="space-y-1 mt-2 list-disc pl-5 text-body-s text-foreground-primary">
+                            <ul className="space-y-1 mt-2 list-disc pl-6 text-body-s text-foreground-primary">
                                 <li>{t('exportKeysModal.bullets.screenshot')}</li>
                                 <li>{t('exportKeysModal.bullets.textMessage')}</li>
                                 <li>{t('exportKeysModal.bullets.noteApp')}</li>

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1454,7 +1454,7 @@ export default function QRPayPage() {
                         <PointsCard points={pointsData.estimatedPoints} pointsDivRef={pointsDivRef} />
                     )}
 
-                    <div className="space-y-5 w-full">
+                    <div className="space-y-4 w-full">
                         {/* Show Claim Reward button if eligible and not claimed yet */}
                         {rewardClaimable ? (
                             <Button
@@ -1486,7 +1486,7 @@ export default function QRPayPage() {
                             >
                                 {/* progress fill from left to right */}
                                 <div
-                                    className="absolute inset-0 bg-black transition-all duration-100"
+                                    className="absolute inset-0 bg-black transition-all duration-instant"
                                     style={{
                                         width: `${holdProgress}%`,
                                         left: 0,
@@ -1498,7 +1498,7 @@ export default function QRPayPage() {
                                         <>
                                             <span className="relative z-10">{label}</span>
                                             <span
-                                                className="absolute inset-0 z-20 flex items-center justify-center text-white transition-all duration-75"
+                                                className="absolute inset-0 z-20 flex items-center justify-center text-white transition-all duration-instant"
                                                 style={{ clipPath: `inset(0 ${100 - holdProgress}% 0 0)` }}
                                             >
                                                 {label}

--- a/src/app/(mobile-ui)/qr/[code]/page.tsx
+++ b/src/app/(mobile-ui)/qr/[code]/page.tsx
@@ -204,7 +204,7 @@ export default function RedirectQrClaimPage() {
                 <Card className="border-2 border-action-secondary bg-action-secondary/10 p-4">
                     <div className="flex gap-3">
                         <Icon name="info" size={20} className="flex-shrink-0 text-action-secondary" />
-                        <p className="text-body-s font-medium">
+                        <p className="text-body-s">
                             {t.rich('claim.permanentNote', { strong: (chunks) => <strong>{chunks}</strong> })}
                         </p>
                     </div>

--- a/src/app/(mobile-ui)/qr/[code]/success/page.tsx
+++ b/src/app/(mobile-ui)/qr/[code]/success/page.tsx
@@ -64,7 +64,7 @@ export default function RedirectQrSuccessPage() {
                     <div className="flex gap-3">
                         <Icon name="star" size={20} className="flex-shrink-0 text-action-secondary" />
                         <div className="space-y-1">
-                            <p className="text-body-s font-bold">{t('claimSuccess.putItAnywhere')}</p>
+                            <p className="text-label-l">{t('claimSuccess.putItAnywhere')}</p>
                             <p className="text-body-xs text-foreground-secondary">
                                 {t('claimSuccess.stickerDescription')}
                             </p>

--- a/src/app/(mobile-ui)/rewards/invites/page.tsx
+++ b/src/app/(mobile-ui)/rewards/invites/page.tsx
@@ -116,9 +116,7 @@ const InvitesPage = () => {
                     {invites?.summary?.totalLifetimeEarnedUsd !== undefined &&
                     invites.summary.totalLifetimeEarnedUsd > 0 ? (
                         <>
-                            <h2 className="text-center text-body-m font-medium text-foreground-primary">
-                                {t('friendsEarnedYou')}
-                            </h2>
+                            <h2 className="text-center text-body-m text-foreground-primary">{t('friendsEarnedYou')}</h2>
                             <span className="text-heading-m text-foreground-primary">
                                 ${invites.summary.totalLifetimeEarnedUsd.toFixed(2)}
                             </span>
@@ -132,9 +130,7 @@ const InvitesPage = () => {
                         </>
                     ) : (
                         <>
-                            <h2 className="text-center text-body-m font-medium text-foreground-primary">
-                                {t('friendsEarnedYou')}
-                            </h2>
+                            <h2 className="text-center text-body-m text-foreground-primary">{t('friendsEarnedYou')}</h2>
                             <span className="flex items-center gap-2">
                                 <Image src={STAR_STRAIGHT_ICON} alt={t('starAlt')} width={20} height={20} />
                                 <span className="text-heading-m text-foreground-primary">

--- a/src/app/(mobile-ui)/rewards/page.tsx
+++ b/src/app/(mobile-ui)/rewards/page.tsx
@@ -206,7 +206,7 @@ const PointsPage = () => {
                             />
                             <div className="relative h-1 flex-1 overflow-hidden rounded-full bg-background-disabled">
                                 <div
-                                    className="h-full rounded-full bg-gradient-to-r from-action-primary to-action-primary-hover transition-all duration-500"
+                                    className="h-full rounded-full bg-gradient-to-r from-action-primary to-action-primary-hover transition-all duration-slow"
                                     style={{
                                         width: `${
                                             tierInfo?.data.currentTier >= 2
@@ -284,7 +284,7 @@ const PointsPage = () => {
                                         onClick={() => router.push(profileUrl(user.invitedBy!))}
                                         className="inline-flex cursor-pointer items-center gap-1 font-bold"
                                     >
-                                        {user.invitedBy} <Icon name="invite-heart" size={14} />
+                                        {user.invitedBy} <Icon name="invite-heart" size={16} />
                                     </span>{' '}
                                     {t('invitedYou')}{' '}
                                 </>

--- a/src/app/(mobile-ui)/rewards/page.tsx
+++ b/src/app/(mobile-ui)/rewards/page.tsx
@@ -246,11 +246,11 @@ const PointsPage = () => {
                     the explainer is part of that framing, so web and Android skip it */}
                 {isIOSNative() && (
                     <Card className="flex flex-col gap-3 p-6">
-                        <h2 className="text-body-m font-black">{t('howItWorks.title')}</h2>
+                        <h2 className="text-body-m-semibold">{t('howItWorks.title')}</h2>
                         <ol className="flex flex-col gap-2">
                             {(['step1', 'step2', 'step3', 'step4'] as const).map((step, i) => (
                                 <li key={step} className="flex items-start gap-3 text-body-s">
-                                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-black bg-action-secondary text-body-xs font-black">
+                                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-black bg-action-secondary text-label-m">
                                         {i + 1}
                                     </span>
                                     <span>{t(`howItWorks.${step}`)}</span>

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -454,7 +454,7 @@ export default function WithdrawBankPage() {
             />
 
             {view === 'INITIAL' && (
-                <div className="my-auto space-y-4 flex h-full w-full flex-col justify-center pb-5">
+                <div className="my-auto space-y-4 flex h-full w-full flex-col justify-center pb-4">
                     <PeanutActionDetailsCard
                         countryCodeForFlag={countryCodeForFlag()}
                         avatarSize="small"

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -624,7 +624,7 @@ export default function WithdrawCryptoPage() {
     }
 
     return (
-        <div className="mx-auto space-y-4 min-h-[inherit] w-full max-w-md self-center">
+        <div className="mx-auto flex min-h-[inherit] w-full max-w-md flex-col gap-4 self-center">
             {currentView === 'INITIAL' && (
                 <InitialWithdrawView
                     amount={usdAmount}

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -405,7 +405,7 @@ export default function WithdrawPage() {
         const showLimitsCard = !isCryptoWithdraw && (limitsValidation.isBlocking || limitsValidation.isWarning)
 
         return (
-            <div className="space-y-8 flex min-h-[inherit] flex-col justify-start">
+            <div className="flex min-h-[inherit] flex-col justify-start gap-8">
                 <NavHeader
                     title={isFromSendFlow ? tNav('send') : tNav('withdraw')}
                     onPrev={() => {

--- a/src/app/(setup)/setup/finish/page.tsx
+++ b/src/app/(setup)/setup/finish/page.tsx
@@ -28,7 +28,7 @@ function FinishSetupPageContent() {
             description={t('finish.description')}
             showBackButton={false}
             showSkipButton={false}
-            contentClassName="flex flex-col items-center justify-center gap-5"
+            contentClassName="flex flex-col items-center justify-center gap-6"
         >
             <SignTestTransaction />
         </SetupWrapper>

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -315,7 +315,7 @@ function SetupPageContent() {
                 image={PeanutWavingHello.src}
                 title={t('existingSession.title')}
                 description={t('existingSession.description', { username: existingSessionUsername })}
-                contentClassName="flex flex-col items-center justify-center gap-5"
+                contentClassName="flex flex-col items-center justify-center gap-6"
             >
                 <div className="flex w-full flex-col gap-3">
                     <Button shadowSize="4" onClick={handleContinueSession} disabled={isLoggingOut}>

--- a/src/app/kyc/success/page.tsx
+++ b/src/app/kyc/success/page.tsx
@@ -20,7 +20,7 @@ export default function KycSuccessPage() {
         <div className="flex h-screen min-h-full w-full flex-col items-center justify-center gap-4">
             <Image src={HandThumbsUp} alt="Peanut HandThumbsUp" className="size-34" />
             <div className="space-y-2">
-                <p className="text-body-l font-semibold">{t('successTitle')}</p>
+                <p className="text-heading-card">{t('successTitle')}</p>
                 <p className="text-body-s text-foreground-secondary">{t('successCloseWindow')}</p>
             </div>
         </div>

--- a/src/components/0_Bruddle/BaseSelect.tsx
+++ b/src/components/0_Bruddle/BaseSelect.tsx
@@ -112,7 +112,7 @@ const BaseSelect = forwardRef<HTMLButtonElement, BaseSelectProps>(
                                         'relative flex w-full cursor-pointer items-center rounded-sm px-3 py-2 text-label-l outline-none select-none',
                                         'transition-colors',
                                         'hover:bg-gray-200 focus:bg-gray-200',
-                                        'data-[state=checked]:bg-action-primary data-[state=checked]:font-bold data-[state=checked]:text-white'
+                                        'data-[state=checked]:bg-action-primary data-[state=checked]:text-white'
                                     )}
                                 >
                                     <ItemText className="text-label-l">{option.label}</ItemText>

--- a/src/components/0_Bruddle/DataRow.tsx
+++ b/src/components/0_Bruddle/DataRow.tsx
@@ -59,7 +59,7 @@ export const DataRow = ({
             {moreInfoText && (
                 <div className="relative z-20 flex items-center justify-center px-2">
                     <Tooltip content={moreInfoText} position="right">
-                        <Icon name="info" size={12} />
+                        <Icon name="info" size={16} />
                     </Tooltip>
                 </div>
             )}

--- a/src/components/AddMoney/components/ChainChip.tsx
+++ b/src/components/AddMoney/components/ChainChip.tsx
@@ -12,8 +12,8 @@ interface ChainChipProps {
 const ChainChip = ({ chainName, chainSymbol, logo, logoClassName }: ChainChipProps) => {
     return (
         <Card className="flex w-fit flex-row items-center gap-1 rounded-full border-0 bg-transparent p-1 px-2">
-            {chainSymbol && <Image src={chainSymbol} alt={chainName} width={18} height={18} />}
-            {logo && <Icon name={logo} width={18} height={18} className={logoClassName} />}
+            {chainSymbol && <Image src={chainSymbol} alt={chainName} width={16} height={16} />}
+            {logo && <Icon name={logo} width={16} height={16} className={logoClassName} />}
             <p className="text-body-xs text-foreground-primary">{chainName}</p>
         </Card>
     )

--- a/src/components/AddMoney/components/ChainChip.tsx
+++ b/src/components/AddMoney/components/ChainChip.tsx
@@ -11,7 +11,7 @@ interface ChainChipProps {
 
 const ChainChip = ({ chainName, chainSymbol, logo, logoClassName }: ChainChipProps) => {
     return (
-        <Card className="flex w-fit flex-row items-center gap-1 rounded-full border-0 bg-transparent p-1 px-1.5">
+        <Card className="flex w-fit flex-row items-center gap-1 rounded-full border-0 bg-transparent p-1 px-2">
             {chainSymbol && <Image src={chainSymbol} alt={chainName} width={18} height={18} />}
             {logo && <Icon name={logo} width={18} height={18} className={logoClassName} />}
             <p className="text-body-xs text-foreground-primary">{chainName}</p>

--- a/src/components/AddMoney/components/HowToDepositModal.tsx
+++ b/src/components/AddMoney/components/HowToDepositModal.tsx
@@ -23,14 +23,14 @@ const HowToDepositModal = ({ visible, onClose }: HowToDepositModalProps) => {
             onClose={onClose}
             title={t('title')}
             content={
-                <div className="flex w-full flex-col gap-5 text-left">
+                <div className="flex w-full flex-col gap-4 text-left">
                     <div className="flex flex-col overflow-hidden rounded-sm border border-border-default bg-background-default">
                         {steps.map((item, index) => (
                             <div
                                 key={index}
                                 className={`px-4 py-3 ${index !== steps.length - 1 ? 'border-b border-border-default' : ''}`}
                             >
-                                <p className="text-body-s font-bold">{item.step}</p>
+                                <p className="text-label-l">{item.step}</p>
                                 <p className="text-body-s text-foreground-secondary">{item.text}</p>
                             </div>
                         ))}

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -61,7 +61,7 @@ const InputAmountStep = ({
     if (currencyData?.isLoading) {
         // dev keeps the header mounted so back always works during the load
         return (
-            <div className="space-y-8 flex min-h-[inherit] flex-col justify-start">
+            <div className="flex min-h-[inherit] flex-col justify-start gap-8">
                 <NavHeader title={t('title')} onPrev={onBack} />
                 <Loading variant="mascot" />
             </div>
@@ -83,11 +83,11 @@ const InputAmountStep = ({
         : null
 
     return (
-        <div className="space-y-8 flex min-h-[inherit] flex-col justify-start">
+        <div className="flex min-h-[inherit] flex-col justify-start gap-8">
             <NavHeader title={t('title')} onPrev={onBack} />
             <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
                 {maintenanceBanner}
-                <div className="text-body-s font-bold">{t('howMuchToAdd')}</div>
+                <div className="text-label-l">{t('howMuchToAdd')}</div>
 
                 <AmountInput
                     initialAmount={tokenAmount}

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -85,9 +85,7 @@ const CryptoDepositView = ({
                             <p className="text-center text-body-s text-foreground-secondary">
                                 {t('marketMovedDescription')}
                             </p>
-                            <p className="text-center text-body-s font-bold text-foreground-secondary">
-                                {t('marketMovedNote')}
-                            </p>
+                            <p className="text-center text-label-l text-foreground-secondary">{t('marketMovedNote')}</p>
                         </div>
                     </Card>
                     <Button onClick={resetStatus} shadowSize="4" loading={isResetting} disabled={isResetting}>
@@ -155,10 +153,10 @@ const CryptoDepositView = ({
                                 <div className="flex items-center gap-1">
                                     <Tooltip content={tooltipText[network]} position="bottom">
                                         <span className="flex items-center gap-1">
-                                            <span className="text-body-s font-bold">
+                                            <span className="text-label-l">
                                                 {isEvm ? t('universalDepositAddress') : t('depositAddress')}
                                             </span>
-                                            <Icon name="info" size={18} className="text-foreground-secondary" />
+                                            <Icon name="info" size={16} className="text-foreground-secondary" />
                                         </span>
                                     </Tooltip>
                                 </div>
@@ -189,7 +187,7 @@ const CryptoDepositView = ({
                                 }}
                                 className={`border-t border-border-default p-4 ${isEvm ? 'cursor-pointer' : ''}`}
                             >
-                                <p className="mb-2 text-body-s font-bold">{t('supportedNetworks')}</p>
+                                <p className="mb-2 text-label-l">{t('supportedNetworks')}</p>
                                 <div className="flex items-center gap-2">
                                     <div className="flex flex-wrap gap-2">
                                         {isEvm ? (
@@ -228,8 +226,8 @@ const CryptoDepositView = ({
 
                             {/* supported tokens section */}
                             <div className="border-t border-border-default p-4">
-                                <p className="mb-2 text-body-s font-bold">{t('supportedTokens')}</p>
-                                <div className="flex flex-wrap gap-1.5">
+                                <p className="mb-2 text-label-l">{t('supportedTokens')}</p>
+                                <div className="flex flex-wrap gap-2">
                                     {supportedTokens.map((token) => (
                                         <ChainChip
                                             key={token.name}
@@ -252,7 +250,7 @@ const CryptoDepositView = ({
                                 <p className="text-body-s text-foreground-secondary">
                                     {t('minDepositFor', { network: amountLimitsLabel })}
                                 </p>
-                                <p className="text-body-s font-bold">
+                                <p className="text-label-l">
                                     {depositAddressData.minDepositLimitUsd.toLocaleString()} USD
                                 </p>
                             </div>
@@ -260,7 +258,7 @@ const CryptoDepositView = ({
                                 <p className="text-body-s text-foreground-secondary">
                                     {t('maxDepositFor', { network: amountLimitsLabel })}
                                 </p>
-                                <p className="text-body-s font-bold">
+                                <p className="text-label-l">
                                     {depositAddressData.maxDepositLimitUsd.toLocaleString()} USD
                                 </p>
                             </div>
@@ -276,7 +274,7 @@ const CryptoDepositView = ({
                             shadowSize="4"
                             onClick={() => setShowHowToDeposit(true)}
                         >
-                            <Icon name="info" size={16} className="mr-1.5" />
+                            <Icon name="info" size={16} className="mr-1" />
                             {tAddMoney('howToDeposit.title')}
                         </Button>
                     </>

--- a/src/components/AddMoney/views/RhinoDeposit.view.tsx
+++ b/src/components/AddMoney/views/RhinoDeposit.view.tsx
@@ -194,7 +194,7 @@ const RhinoDepositView = ({
                                         </p>
                                     </div>
 
-                                    <p className="text-body-s font-medium text-foreground-secondary">
+                                    <p className="text-body-s text-foreground-secondary">
                                         {depositAddressData.minDepositLimitUsd} USD
                                     </p>
                                 </div>
@@ -207,7 +207,7 @@ const RhinoDepositView = ({
                                         </p>
                                     </div>
 
-                                    <p className="text-body-s font-medium text-foreground-secondary">
+                                    <p className="text-body-s text-foreground-secondary">
                                         {depositAddressData.maxDepositLimitUsd} USD
                                     </p>
                                 </div>

--- a/src/components/AddMoney/views/RhinoDeposit.view.tsx
+++ b/src/components/AddMoney/views/RhinoDeposit.view.tsx
@@ -85,9 +85,7 @@ const RhinoDepositView = ({
                                 {t('marketMovedDescription')}
                             </p>
 
-                            <p className="text-center text-body-s font-bold text-foreground-secondary">
-                                {t('marketMovedNote')}
-                            </p>
+                            <p className="text-center text-label-l text-foreground-secondary">{t('marketMovedNote')}</p>
                         </div>
                     </Card>
                     <Button onClick={resetStatus} shadowSize="4" loading={isResetting} disabled={isResetting}>
@@ -159,7 +157,7 @@ const RhinoDepositView = ({
 
                             <Button
                                 variant="primary-soft"
-                                className="flex h-8 w-2/3 cursor-pointer items-center justify-center gap-1.5 rounded-full px-2.5 md:h-9 md:px-3.5"
+                                className="flex h-8 w-2/3 cursor-pointer items-center justify-center gap-1 rounded-full px-3 md:h-9 md:px-4"
                                 shadowSize="3"
                                 size="small"
                                 onClick={() => copyRef.current?.copy()}
@@ -190,7 +188,7 @@ const RhinoDepositView = ({
                             <div className="flex w-full flex-col gap-1">
                                 <div className="flex w-full items-center justify-between">
                                     <div className="flex items-center gap-2">
-                                        <Icon name="info" size={18} className="text-foreground-secondary" />
+                                        <Icon name="info" size={16} className="text-foreground-secondary" />
                                         <p className="text-body-s text-foreground-secondary">
                                             {t('minDepositForLabel', { network: amountLimitsTitle })}
                                         </p>
@@ -203,7 +201,7 @@ const RhinoDepositView = ({
 
                                 <div className="flex w-full items-center justify-between">
                                     <div className="flex items-center gap-2">
-                                        <Icon name="info" size={18} className="text-foreground-secondary" />
+                                        <Icon name="info" size={16} className="text-foreground-secondary" />
                                         <p className="text-body-s text-foreground-secondary">
                                             {t('maxDepositForLabel', { network: amountLimitsTitle })}
                                         </p>
@@ -217,7 +215,7 @@ const RhinoDepositView = ({
 
                             {chainType === 'EVM' && (
                                 <Card className="space-y-2 p-4">
-                                    <h3 className="text-body-s font-bold text-foreground-primary">
+                                    <h3 className="text-label-l text-foreground-primary">
                                         {t('supportedEvmNetworks')}
                                     </h3>
                                     <div className="flex flex-wrap gap-2">

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -313,7 +313,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                     <span className="text-label-m text-foreground-secondary">{tCommon('or')}</span>
                     <div className="h-px w-full bg-border-subtle"></div>
                 </div>
-                <Button icon="plus" className="mb-5" onClick={() => setShouldShowAllMethods(true)} shadowSize="4">
+                <Button icon="plus" className="mb-4" onClick={() => setShouldShowAllMethods(true)} shadowSize="4">
                     {tAddMoney('selectNewMethod')}
                 </Button>
                 <TokenAndNetworkConfirmationModal

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -93,7 +93,7 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
 
     return (
         <div className={twMerge('space-y-3', className)}>
-            <h2 className="text-body-m font-bold">{t('title')}</h2>
+            <h2 className="text-body-m-semibold">{t('title')}</h2>
             <Card position="single" className="relative flex h-20 items-center justify-center">
                 {/* Badge viewport container */}
                 <div

--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -159,7 +159,7 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
                     </>
                 ) : isFeedback ? (
                     <div className="flex w-full flex-col gap-2 text-left">
-                        <label htmlFor="cancel-feedback" className="text-body-s font-bold">
+                        <label htmlFor="cancel-feedback" className="text-label-l">
                             {t('cancel.feedbackLabel')}
                         </label>
                         <textarea

--- a/src/components/Card/CardCountryConfirmScreen.tsx
+++ b/src/components/Card/CardCountryConfirmScreen.tsx
@@ -77,7 +77,7 @@ const CardCountryConfirmScreen: FC<Props> = ({ candidates, onConfirm, onContactS
                             type="button"
                             onClick={() => setSelected(iso2)}
                             aria-pressed={selected === iso2}
-                            className={`w-full rounded-sm border border-border-default p-4 text-left text-body-s font-semibold ${
+                            className={`w-full rounded-sm border border-border-default p-4 text-left text-label-l ${
                                 selected === iso2 ? 'bg-purple-200' : 'bg-background-default'
                             }`}
                         >

--- a/src/components/Card/CardFace.tsx
+++ b/src/components/Card/CardFace.tsx
@@ -88,7 +88,7 @@ const CardFace: FC<Props> = ({
                 alt=""
                 aria-hidden
                 className={twMerge(
-                    'pointer-events-none absolute right-0 bottom-0 h-[90%] w-auto transition-transform duration-500 select-none',
+                    'pointer-events-none absolute right-0 bottom-0 h-[90%] w-auto transition-transform duration-slow select-none',
                     detailsShown && 'translate-x-full translate-y-full'
                 )}
                 priority

--- a/src/components/Card/CardLimitEditModal.tsx
+++ b/src/components/Card/CardLimitEditModal.tsx
@@ -107,7 +107,7 @@ const CardLimitEditModal: FC<Props> = ({ cardId, frequency, label, initialAmount
             title={t('editTitle')}
             content={
                 <div className="flex w-full flex-col gap-2 text-left">
-                    <label htmlFor="card-limit-input" className="text-body-s font-bold">
+                    <label htmlFor="card-limit-input" className="text-label-l">
                         {label}
                     </label>
                     <div className="flex items-center gap-2 rounded-sm border border-border-default bg-background-default px-3 py-2">

--- a/src/components/Card/CardLimitsScreen.tsx
+++ b/src/components/Card/CardLimitsScreen.tsx
@@ -61,7 +61,7 @@ const CardLimitsScreen: FC<Props> = ({ cardId, onPrev }) => {
                     <div className="flex items-center justify-between rounded-sm border border-border-default bg-background-default px-4 py-3">
                         <div>
                             <div className="text-body-s text-foreground-secondary">{label}</div>
-                            <div className="text-body-m font-bold">
+                            <div className="text-body-m-semibold">
                                 {amount != null ? formatDollars(amount) : t('noLimitSet')}
                             </div>
                         </div>

--- a/src/components/Card/CardRejectionScreen.tsx
+++ b/src/components/Card/CardRejectionScreen.tsx
@@ -183,7 +183,7 @@ const CardRejectionScreen: FC<Props> = ({
         <div className="flex min-h-[inherit] flex-col justify-between gap-6">
             <NavHeader title={t('navTitle')} onPrev={onPrev} />
 
-            <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-6">
                 <ScaledRejectionAsset
                     ref={captureRef}
                     username={safeUsername}
@@ -228,8 +228,8 @@ const CardRejectionScreen: FC<Props> = ({
                     {t('tweetToAppeal')}
                 </Button>
                 {showJoined ? (
-                    <div className="flex h-13 items-center justify-center gap-2 text-center text-body-s font-bold text-foreground-primary">
-                        <Icon name="check-circle" size={18} />
+                    <div className="flex h-13 items-center justify-center gap-2 text-center text-label-l text-foreground-primary">
+                        <Icon name="check-circle" size={16} />
                         {t('onTheList')}
                     </div>
                 ) : (

--- a/src/components/Card/CardUnlockHistoryItem.tsx
+++ b/src/components/Card/CardUnlockHistoryItem.tsx
@@ -54,7 +54,7 @@ const CardUnlockHistoryItem: FC<Props> = ({ entry, position = 'single', classNam
                 aria-label={t('openAssetAria', { title })}
                 leading={
                     <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-200">
-                        <Icon name="credit-card" size={18} />
+                        <Icon name="credit-card" size={20} />
                     </div>
                 }
                 title={title}

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -187,7 +187,7 @@ export const ShareAssetActions: FC<Props> = ({
                 className="w-full"
                 loading={isSharing}
                 disabled={isSharing || isSaving || !ready}
-                icon={<Icon name="share" size={18} />}
+                icon={<Icon name="share" size={20} />}
             >
                 {t('share')}
             </Button>
@@ -197,7 +197,7 @@ export const ShareAssetActions: FC<Props> = ({
                 className="w-full"
                 loading={isSaving}
                 disabled={isSharing || isSaving || !ready}
-                icon={<Icon name="download" size={18} />}
+                icon={<Icon name="download" size={20} />}
             >
                 {t('saveImage')}
             </Button>

--- a/src/components/Claim/Generic/ClaimError.view.tsx
+++ b/src/components/Claim/Generic/ClaimError.view.tsx
@@ -19,7 +19,7 @@ export const ClaimErrorView = ({ title, message, primaryButtonText, onPrimaryCli
     const t = useTranslations('claim')
 
     return (
-        <div className="space-y-4 flex flex-col items-center justify-center rounded-lg text-center">
+        <div className="space-y-4 flex flex-col items-center justify-center text-center">
             <Image src={PeanutCrying.src} unoptimized alt={t('errors.sadPeanutAlt')} width={96} height={96} />
             <div className="space-y-2">
                 <h1 className="text-heading-card text-foreground-primary">{title}</h1>

--- a/src/components/Common/ContactsListSkeleton.tsx
+++ b/src/components/Common/ContactsListSkeleton.tsx
@@ -10,17 +10,17 @@ export const ContactsListSkeleton = ({ count = 10 }: { count?: number }) => {
     const t = useTranslations('global')
     return (
         <div className="space-y-2">
-            <h2 className="text-body-m font-bold">{t('contactsList.title')}</h2>
+            <h2 className="text-body-m-semibold">{t('contactsList.title')}</h2>
             <div className="space-y-0 flex-1 overflow-y-auto">
                 {Array.from({ length: count }).map((_, index) => {
                     const position = getCardPosition(index, count)
                     return (
                         <ListItem
                             key={index}
-                            title={<div className="h-4 w-32 animate-pulse rounded bg-gray-200" />}
+                            title={<div className="h-4 w-32 animate-pulse rounded bg-foreground-primary/10" />}
                             position={position}
                             chevron
-                            leading={<div className="h-8 w-8 animate-pulse rounded-full bg-gray-200" />}
+                            leading={<div className="h-8 w-8 animate-pulse rounded-full bg-foreground-primary/10" />}
                         />
                     )
                 })}

--- a/src/components/Common/CountryList.tsx
+++ b/src/components/Common/CountryList.tsx
@@ -143,7 +143,7 @@ export const CountryList = ({
         <div className="flex h-full w-full flex-1 flex-col justify-start gap-4">
             <div className="space-y-2">
                 <div className="text-body-m-semibold">{inputTitle}</div>
-                {inputDescription && <p className="text-body-xs font-normal">{inputDescription}</p>}
+                {inputDescription && <p className="text-body-xs">{inputDescription}</p>}
                 <SearchInput
                     value={searchTerm}
                     onChange={setSearchTerm}

--- a/src/components/Common/CountryList.tsx
+++ b/src/components/Common/CountryList.tsx
@@ -142,7 +142,7 @@ export const CountryList = ({
     return (
         <div className="flex h-full w-full flex-1 flex-col justify-start gap-4">
             <div className="space-y-2">
-                <div className="text-body-m font-bold">{inputTitle}</div>
+                <div className="text-body-m-semibold">{inputTitle}</div>
                 {inputDescription && <p className="text-body-xs font-normal">{inputDescription}</p>}
                 <SearchInput
                     value={searchTerm}

--- a/src/components/Common/CountryListSkeleton.tsx
+++ b/src/components/Common/CountryListSkeleton.tsx
@@ -13,10 +13,10 @@ export const CountryListSkeleton = () => {
                 return (
                     <ListItem
                         key={index}
-                        title={<div className="h-4 w-24 animate-pulse rounded bg-gray-200" />}
+                        title={<div className="h-4 w-24 animate-pulse rounded bg-foreground-primary/10" />}
                         position={position}
                         chevron
-                        leading={<div className="h-8 w-8 animate-pulse rounded-full bg-gray-200" />}
+                        leading={<div className="h-8 w-8 animate-pulse rounded-full bg-foreground-primary/10" />}
                     />
                 )
             })}

--- a/src/components/Global/ActionModal/index.tsx
+++ b/src/components/Global/ActionModal/index.tsx
@@ -88,8 +88,9 @@ const ActionModal: React.FC<ActionModalProps> = ({
                 <Icon
                     name={icon as IconName}
                     fill="currentColor"
+                    size={24}
                     {...iconProps}
-                    className={twMerge('size-6', defaultIconPropsClassName, iconProps?.className)}
+                    className={twMerge(defaultIconPropsClassName, iconProps?.className)}
                 />
             )
         }

--- a/src/components/Global/AmountInput/index.tsx
+++ b/src/components/Global/AmountInput/index.tsx
@@ -360,7 +360,7 @@ const AmountInput = ({
                 >
                     <IconComponent
                         name={'arrow-exchange'}
-                        className="ml-5 rotate-90 cursor-pointer"
+                        className="ml-4 rotate-90 cursor-pointer"
                         width={32}
                         height={32}
                     />

--- a/src/components/Global/CancelSendLinkDrawer/index.tsx
+++ b/src/components/Global/CancelSendLinkDrawer/index.tsx
@@ -39,13 +39,13 @@ const CancelSendLinkDrawer = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center gap-4 px-5 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center gap-4 px-4 pt-1 pb-6 text-center">
                     <div className="flex size-8 items-center justify-center rounded-full bg-action-primary">
                         <Icon name="link-slash" fill="currentColor" className="size-4 text-black" />
                     </div>
 
                     <DrawerHeader className="w-full gap-2 p-0 text-center sm:text-center">
-                        <DrawerTitle className="text-body-m font-bold text-black">
+                        <DrawerTitle className="text-body-m-semibold text-black">
                             {t('cancelSendLinkModal.title')}
                         </DrawerTitle>
                         <DrawerDescription className="text-body-s text-foreground-secondary">

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -76,7 +76,7 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
 DrawerContent.displayName = 'DrawerContent'
 
 const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={twMerge('grid gap-1.5 p-4 text-center sm:text-left', className)} {...props} />
+    <div className={twMerge('grid gap-1 p-4 text-center sm:text-left', className)} {...props} />
 )
 DrawerHeader.displayName = 'DrawerHeader'
 

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -223,7 +223,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                 }
                             }}
                             type="number"
-                            className="w-full bg-transparent text-body-m font-bold text-foreground-primary outline-none"
+                            className="w-full bg-transparent text-body-m-semibold text-foreground-primary outline-none"
                         />
                     )}
                     <CurrencySelect
@@ -240,7 +240,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                     className="size-4 rounded-full object-cover"
                                 />
                                 {sourceCurrency}{' '}
-                                <Icon name="chevron-down" className="text-foreground-secondary" size={14} />
+                                <Icon name="chevron-down" className="text-foreground-secondary" size={16} />
                             </button>
                         }
                     />
@@ -252,7 +252,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                 className="flex h-8 w-8 items-center justify-center self-center rounded-full hover:bg-background-disabled"
                 aria-label={l.swapCurrencies}
             >
-                <Icon name="arrow-exchange" size={18} className="rotate-90 transition-transform duration-300" />
+                <Icon name="arrow-exchange" size={20} className="rotate-90 transition-transform duration-moderate" />
             </button>
 
             <div className="w-full">
@@ -284,7 +284,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                 }
                             }}
                             type="number"
-                            className="w-full bg-transparent text-body-m font-bold text-foreground-primary outline-none"
+                            className="w-full bg-transparent text-body-m-semibold text-foreground-primary outline-none"
                         />
                     )}
                     <CurrencySelect
@@ -300,7 +300,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
                                     className="size-4 rounded-full object-cover"
                                 />
                                 {destinationCurrency}{' '}
-                                <Icon name="chevron-down" className="text-foreground-secondary" size={14} />
+                                <Icon name="chevron-down" className="text-foreground-secondary" size={16} />
                             </button>
                         }
                     />
@@ -336,16 +336,15 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
             <Button
                 onClick={() => ctaAction(sourceCurrency, destinationCurrency)}
                 icon={ctaIcon}
-                iconSize={13}
                 shadowSize="4"
-                className="w-full text-body-m font-bold"
+                className="w-full"
             >
                 {ctaLabel}
             </Button>
 
             {typeof destinationAmount === 'number' && destinationAmount > 0 && (
                 <div className="flex items-center gap-1">
-                    <Icon name="info" className="text-foreground-secondary" size={14} />
+                    <Icon name="info" className="text-foreground-secondary" size={16} />
                     <p className="text-body-xs text-foreground-secondary">{deliveryTimeText}</p>
                 </div>
             )}

--- a/src/components/Global/FAQs/index.tsx
+++ b/src/components/Global/FAQs/index.tsx
@@ -64,7 +64,7 @@ export function FAQsPanel({ heading, questions, learnMoreLabel = 'Learn more' }:
                         >
                             <summary className="font-roboto-flex-extrabold flex cursor-pointer list-none items-center justify-between gap-4 text-lg font-extraBlack uppercase md:text-xl [&::-webkit-details-marker]:hidden">
                                 <span>{faq.question}</span>
-                                <span className="shrink-0 text-3xl leading-none transition-transform duration-200 group-open:rotate-45">
+                                <span className="shrink-0 text-3xl leading-none transition-transform duration-fast group-open:rotate-45">
                                     +
                                 </span>
                             </summary>

--- a/src/components/Global/GuestVerificationModal/index.tsx
+++ b/src/components/Global/GuestVerificationModal/index.tsx
@@ -55,7 +55,7 @@ export const GuestVerificationModal = ({
                 {
                     text: secondaryCtaLabel,
                     variant: 'transparent',
-                    className: 'w-full h-auto underline font-semibold text-body-s underline-offset-2',
+                    className: 'w-full h-auto underline text-label-l underline-offset-2',
                     onClick: () => {
                         onClose()
                     },

--- a/src/components/Global/HoldToClaimButton.tsx
+++ b/src/components/Global/HoldToClaimButton.tsx
@@ -99,9 +99,9 @@ export const HoldToClaimButton: FC<Props> = ({
         >
             {/* Solid black overlay fills left→right with holdProgress.
                 Matches the QR-claim button exactly: bg-black (not /30),
-                transition-all duration-100. */}
+                transition-all duration-instant. */}
             <div
-                className="absolute inset-0 bg-black transition-all duration-100"
+                className="absolute inset-0 bg-black transition-all duration-instant"
                 style={{ width: `${holdProgress}%`, left: 0 }}
             />
             <span className="relative z-10">{children}</span>

--- a/src/components/Global/IframeWrapper/index.tsx
+++ b/src/components/Global/IframeWrapper/index.tsx
@@ -214,7 +214,7 @@ const IframeWrapper = ({ src, visible, onClose, closeConfirmMessage }: IFrameWra
                         ref={iframeRef}
                         src={src}
                         allow="camera *; microphone *; fullscreen *"
-                        className="h-[85%] w-full rounded-md border-0"
+                        className="h-[85%] w-full rounded-sm border-0"
                         sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-top-navigation-by-user-activation allow-media-devices"
                     />
                     <div className="flex h-[15%] w-full flex-col items-center justify-center gap-2 px-4">

--- a/src/components/Global/Modal/index.tsx
+++ b/src/components/Global/Modal/index.tsx
@@ -50,10 +50,10 @@ const Modal = ({
             >
                 <Transition.Child
                     as={Fragment}
-                    enter="ease-out duration-300"
+                    enter="ease-out duration-moderate"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
-                    leave="ease-in duration-200"
+                    leave="ease-in duration-fast"
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
@@ -72,10 +72,10 @@ const Modal = ({
                 </Transition.Child>
                 <Transition.Child
                     as={Fragment}
-                    enter="ease-out duration-300"
+                    enter="ease-out duration-moderate"
                     enterFrom={`opacity-0 ${!video && 'scale-95'}`}
                     enterTo={`opacity-100 ${!video && 'scale-100'}`}
-                    leave="ease-in duration-200"
+                    leave="ease-in duration-fast"
                     leaveFrom={`opacity-100 ${!video && 'scale-100'}`}
                     leaveTo={`opacity-0 ${!video && 'scale-95'}`}
                 >

--- a/src/components/Global/MoreInfo/index.tsx
+++ b/src/components/Global/MoreInfo/index.tsx
@@ -68,10 +68,10 @@ const MoreInfo = ({ text }: MoreInfoProps) => {
         return createPortal(
             <Transition
                 show={show}
-                enter="transition-opacity duration-150 ease-out"
+                enter="transition-opacity duration-fast ease-out"
                 enterFrom="opacity-0"
                 enterTo="opacity-100"
-                leave="transition-opacity duration-100 ease-out"
+                leave="transition-opacity duration-instant ease-out"
                 leaveFrom="opacity-100"
                 leaveTo="opacity-0"
             >

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -88,7 +88,7 @@ function ScannerControls({ onClose, onToggleCamera }: { onClose: () => void; onT
                 className="mx-auto flex h-8 w-8 items-center justify-center border-white p-0"
                 onClick={onClose}
             >
-                <Icon name="cancel" size={18} fill="white" />
+                <Icon name="cancel" size={20} fill="white" />
             </Button>
             <span className="text-heading-m text-foreground-inverse">{t('qrScanner.scanToPay')}</span>
             <Button
@@ -120,7 +120,7 @@ function PasteActions({
         <>
             <button
                 onClick={onPaste}
-                className="justify mx-auto mt-10 flex items-center gap-1.5 text-center text-white underline underline-offset-2"
+                className="justify mx-auto mt-10 flex items-center gap-1 text-center text-white underline underline-offset-2"
             >
                 <Icon name="paste" fill="white" height={16} width={16} />
                 <span className="text-body-s">{t('qrScanner.clickToPaste')}</span>
@@ -128,18 +128,18 @@ function PasteActions({
             {detectedAddress ? (
                 <button
                     onClick={onUseDetected}
-                    className="mx-auto mt-3 flex items-center gap-1.5 rounded-full border border-white/40 px-3 py-1.5 text-white"
+                    className="mx-auto mt-3 flex items-center gap-1 rounded-full border border-white/40 px-3 py-2 text-white"
                 >
                     <Icon name="wallet" fill="white" height={16} width={16} />
-                    <span className="text-body-s font-semibold">{printableAddress(detectedAddress)}</span>
+                    <span className="text-label-l">{printableAddress(detectedAddress)}</span>
                 </button>
             ) : showPasteChip ? (
                 <button
                     onClick={onUsePasteChip}
-                    className="mx-auto mt-3 flex items-center gap-1.5 rounded-full border border-white/40 px-3 py-1.5 text-white"
+                    className="mx-auto mt-3 flex items-center gap-1 rounded-full border border-white/40 px-3 py-2 text-white"
                 >
                     <Icon name="paste" fill="white" height={16} width={16} />
-                    <span className="text-body-s font-semibold">{t('qrScanner.useCopiedCode')}</span>
+                    <span className="text-label-l">{t('qrScanner.useCopiedCode')}</span>
                 </button>
             ) : null}
         </>

--- a/src/components/Global/QRScanner/index.tsx
+++ b/src/components/Global/QRScanner/index.tsx
@@ -71,7 +71,7 @@ function PaymentMethodBadge({ src, alt, name }: { src: string; alt: string; name
     return (
         <div className="flex max-w-26 items-center gap-1">
             <Image src={src} alt={alt} height={24} priority />
-            <span className="text-left text-body-xs leading-none font-black tracking-wider break-normal text-white uppercase">
+            <span className="text-left text-label-m leading-none tracking-wider break-normal text-white uppercase">
                 {name}
             </span>
         </div>

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -131,9 +131,9 @@ const ShareButton = ({
             shadowSize="4"
         >
             <span className="flex items-center gap-2">
-                {showIcon && iconPosition === 'left' && <Icon name="share" size={18} />}
+                {showIcon && iconPosition === 'left' && <Icon name="share" size={20} />}
                 {children ?? t('shareButton.share')}
-                {showIcon && iconPosition === 'right' && <Icon name="share" size={18} />}
+                {showIcon && iconPosition === 'right' && <Icon name="share" size={20} />}
             </span>
         </Button>
     )

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -409,7 +409,7 @@ const SupportDrawer = () => {
                 the receipt underneath (a fall-through tap on "Cancel deposit"
                 cancelled a user's funded bank deposit). */}
             <div
-                className={`fixed inset-0 z-[999998] bg-black/80 transition-opacity duration-300 ${
+                className={`fixed inset-0 z-[999998] bg-black/80 transition-opacity duration-moderate ${
                     isSupportModalOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
                 }`}
                 onClick={() => setIsSupportModalOpen(false)}
@@ -465,7 +465,7 @@ const SupportDrawer = () => {
                         )}
                         {isCrispFailed && (
                             <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-background px-8 text-center">
-                                <p className="text-body-m font-bold text-foreground-primary">
+                                <p className="text-body-m-semibold text-foreground-primary">
                                     {t('supportDrawer.chatLoadFailed')}
                                 </p>
                                 <p className="text-body-s text-foreground-secondary">

--- a/src/components/Global/TokenSelector/Components/NetworkButton.tsx
+++ b/src/components/Global/TokenSelector/Components/NetworkButton.tsx
@@ -60,9 +60,7 @@ const NetworkButton: React.FC<NetworkButtonProps> = ({
                     <AvatarWithBadge size="extra-small" name={chainName} />
                 )}
             </div>
-            <span className="text-body-s font-medium">
-                {isSearch ? t('tokenSelector.moreNetworksButton') : chainName}
-            </span>
+            <span className="text-body-s">{isSearch ? t('tokenSelector.moreNetworksButton') : chainName}</span>
         </Button>
     )
 }

--- a/src/components/Global/TokenSelector/Components/NetworkButton.tsx
+++ b/src/components/Global/TokenSelector/Components/NetworkButton.tsx
@@ -46,7 +46,7 @@ const NetworkButton: React.FC<NetworkButtonProps> = ({
                 )}
             >
                 {isSearch ? (
-                    <Icon name="cancel" size={12} className="size-4 rotate-45" />
+                    <Icon name="cancel" size={16} className="size-4 rotate-45" />
                 ) : chainIconURI && !chainImageError ? (
                     <Image
                         src={chainIconURI}

--- a/src/components/Global/TokenSelector/Components/NetworkListItem.tsx
+++ b/src/components/Global/TokenSelector/Components/NetworkListItem.tsx
@@ -72,10 +72,10 @@ const NetworkListItem: React.FC<NetworkListItemProps> = ({
                         </div>
                         <div className="flex flex-col">
                             <span
-                                className={`text-body-m ${twMerge(
-                                    'font-semibold text-foreground-primary capitalize',
+                                className={twMerge(
+                                    'text-body-m-semibold text-foreground-primary capitalize',
                                     titleClassName
-                                )}`}
+                                )}
                             >
                                 {name}
                             </span>

--- a/src/components/Global/TokenSelector/Components/TokenListItem.tsx
+++ b/src/components/Global/TokenSelector/Components/TokenListItem.tsx
@@ -115,7 +115,7 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
                                 className={
                                     isPopularToken
                                         ? 'text-body-xs font-medium text-foreground-secondary'
-                                        : 'ml-1 text-body-s font-medium text-foreground-secondary'
+                                        : 'ml-1 text-body-s text-foreground-secondary'
                                 }
                             >
                                 {t.rich('tokenSelector.onChain', {
@@ -128,8 +128,8 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
 
                     {!isPopularToken && !!formattedBalance ? (
                         <div className="flex flex-col items-end">
-                            <div className="text-body-m font-medium text-foreground-primary">{formattedBalance}</div>
-                            <div className="text-body-xs font-normal text-foreground-secondary">
+                            <div className="text-body-m text-foreground-primary">{formattedBalance}</div>
+                            <div className="text-body-xs text-foreground-secondary">
                                 {/* token value in usd */}
                                 {balance.price && balance.price * Number(formattedBalance) > 0
                                     ? `$ ${formatAmount(balance.price * Number(formattedBalance))}`

--- a/src/components/Global/TokenSelector/Components/TokenListItem.tsx
+++ b/src/components/Global/TokenSelector/Components/TokenListItem.tsx
@@ -110,7 +110,7 @@ const TokenListItem: React.FC<TokenListItemProps> = ({
                             )}
                         </div>
                         <div className={twMerge('flex flex-col items-start')}>
-                            <span className="text-body-m font-semibold text-foreground-primary">{balance.symbol}</span>
+                            <span className="text-body-m-semibold text-foreground-primary">{balance.symbol}</span>
                             <span
                                 className={
                                     isPopularToken

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -60,7 +60,7 @@ const Section: React.FC<SectionProps> = ({ title, icon, children, className, tit
     <div className={twMerge('space-y-2', className)}>
         <div className="flex items-center gap-2">
             {icon && <Icon name={icon} size={16} className="text-foreground-secondary" />}
-            <h2 className={twMerge('text-body-m font-bold text-foreground-primary', titleClassName)}>{title}</h2>
+            <h2 className={twMerge('text-body-m-semibold text-foreground-primary', titleClassName)}>{title}</h2>
         </div>
         {children}
     </div>
@@ -446,7 +446,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                             )}
                         </div>
                         <div className="flex flex-col items-start overflow-hidden">
-                            <span className="truncate text-body-m font-semibold text-foreground-primary">
+                            <span className="truncate text-body-m-semibold text-foreground-primary">
                                 {buttonSymbol || t('tokenSelector.selectAToken')}
                                 {buttonChainName && (
                                     <span className="ml-1 text-body-s font-medium text-foreground-secondary">

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -449,7 +449,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                             <span className="truncate text-body-m-semibold text-foreground-primary">
                                 {buttonSymbol || t('tokenSelector.selectAToken')}
                                 {buttonChainName && (
-                                    <span className="ml-1 text-body-s font-medium text-foreground-secondary">
+                                    <span className="ml-1 text-body-s text-foreground-secondary">
                                         {t.rich('tokenSelector.onChain', {
                                             chainName: buttonChainName,
                                             c: (chunks) => <span className="capitalize">{chunks}</span>,
@@ -461,7 +461,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                             {(viewType === 'withdraw' || viewType === 'claim') &&
                                 selectedTokenAddress?.toLowerCase() === PEANUT_WALLET_TOKEN.toLowerCase() &&
                                 selectedChainID === PEANUT_WALLET_CHAIN.id.toString() && (
-                                    <span className="text-body-xs font-normal text-foreground-secondary">
+                                    <span className="text-body-xs text-foreground-secondary">
                                         {t('tokenSelector.noFeesWithToken')}
                                     </span>
                                 )}
@@ -539,7 +539,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                                         />
                                         <div className="flex items-center justify-center gap-2">
                                             <Icon name="info" size={10} className="text-foreground-secondary" />
-                                            <span className="text-body-xs font-normal text-foreground-secondary">
+                                            <span className="text-body-xs text-foreground-secondary">
                                                 {t('tokenSelector.sponsoredHint')}
                                             </span>
                                         </div>

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -270,7 +270,7 @@ const ValidatedInput = ({
                                 dismissSuggestion()
                                 onUpdate({ value: suggestion, isValid: false, isChanging: true })
                             }}
-                            className="flex w-full items-start gap-1.5 rounded-sm border border-border-default bg-background-default px-3 py-2 text-left text-body-xs font-medium text-foreground-primary transition-colors hover:bg-background-disabled"
+                            className="flex w-full items-start gap-1 rounded-sm border border-border-default bg-background-default px-3 py-2 text-left text-body-xs font-medium text-foreground-primary transition-colors hover:bg-background-disabled"
                         >
                             <Icon name="paste" className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                             <span className="break-all">

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -205,7 +205,7 @@ const ValidatedInput = ({
                                 : undefined
                         }
                         className={twMerge(
-                            `notranslate w-full border-0 bg-background-default pr-1 text-body-s font-medium outline-none focus:outline-none focus-visible:outline-none active:bg-background-default`,
+                            `notranslate w-full border-0 bg-background-default pr-1 text-body-s outline-none focus:outline-none focus-visible:outline-none active:bg-background-default`,
                             !!infoText ? 'pl-0' : 'pl-4'
                         )}
                         placeholder={placeholder}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -109,7 +109,7 @@ const GettingStartedChecklist = () => {
 
     return (
         <div>
-            <p className="mb-2 text-body-s font-bold">{t('title')}</p>
+            <p className="mb-2 text-label-l">{t('title')}</p>
             <Card position="single" className="overflow-hidden p-0">
                 {items.map((item) => {
                     const tappable = !item.done && !!item.onTap
@@ -134,10 +134,7 @@ const GettingStartedChecklist = () => {
                             </span>
                             <span className="min-w-0">
                                 <span
-                                    className={twMerge(
-                                        'block text-body-s font-bold',
-                                        item.done && 'text-foreground-secondary'
-                                    )}
+                                    className={twMerge('block text-label-l', item.done && 'text-foreground-secondary')}
                                 >
                                     {item.label}
                                 </span>

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -532,10 +532,10 @@ export const HistorySkeleton = ({ position }: { position: CardPosition }) => {
     return (
         // p-4 matches ListItem row height so content doesn't jump on load
         <Card position={position} className="flex items-center justify-between gap-3 p-4">
-            <div className="h-8 w-8 min-w-8 animate-pulse rounded-full bg-gray-200" />
+            <div className="h-8 w-8 min-w-8 animate-pulse rounded-full bg-foreground-primary/10" />
             <div className="space-y-2 w-full">
-                <div className="h-4.5 w-full animate-pulse rounded-full bg-gray-200" />
-                <div className="h-3 w-1/3 animate-pulse rounded-full bg-gray-200" />
+                <div className="h-4.5 w-full animate-pulse rounded-full bg-foreground-primary/10" />
+                <div className="h-3 w-1/3 animate-pulse rounded-full bg-foreground-primary/10" />
             </div>
         </Card>
     )

--- a/src/components/Home/PendingVerificationTasks.tsx
+++ b/src/components/Home/PendingVerificationTasks.tsx
@@ -176,7 +176,7 @@ export default function PendingVerificationTasks({ dismissible = false }: { dism
                                             <Icon name={isHosted ? 'user-id' : 'badge'} size={20} />
                                         </div>
                                         <div className="w-full">
-                                            <div className="text-body-m font-bold">{copy.title}</div>
+                                            <div className="text-body-m-semibold">{copy.title}</div>
                                             <div className="text-body-s text-foreground-secondary">
                                                 {copy.description}
                                             </div>

--- a/src/components/Home/PerkClaimModal.tsx
+++ b/src/components/Home/PerkClaimModal.tsx
@@ -233,7 +233,7 @@ function SuccessModal({ perk, claimPhase, onClose, onDismiss }: SuccessModalProp
                             </>
                         ) : inviteeName ? (
                             <p className="mt-1 flex items-center justify-center gap-1 text-body-s text-foreground-secondary">
-                                <Icon name="invite-heart" size={14} />
+                                <Icon name="invite-heart" size={16} />
                                 {t.rich('usedPeanut', {
                                     inviteeName,
                                     name: (chunks) => <span className="font-medium">{chunks}</span>,
@@ -345,7 +345,7 @@ function GiftBoxContent({ perk, onHoldComplete, claimPhase }: GiftBoxContentProp
         <div className="flex flex-col items-center">
             {/* Title */}
             <p className="mb-6 text-center text-body-s text-foreground-secondary">
-                <Icon name="invite-heart" size={14} className="mr-1 inline" />
+                <Icon name="invite-heart" size={16} className="mr-1 inline" />
                 {t.rich('usedPeanut', {
                     inviteeName: inviteeName ?? '',
                     name: (chunks) => <span className="font-medium">{chunks}</span>,

--- a/src/components/IdentityVerification/UnlockRegionModal.tsx
+++ b/src/components/IdentityVerification/UnlockRegionModal.tsx
@@ -77,7 +77,7 @@ const UnlockRegionModal = ({
                     <h2 className="text-label-m">{t('whatYoullUnlock')}</h2>
                     <Notification priority="info" className="w-full" items={unlockItems} />
                     <div className="flex items-center gap-2">
-                        <Icon name="info" size={12} className="text-foreground-secondary" />
+                        <Icon name="info" size={16} className="text-foreground-secondary" />
                         <p className="text-body-xs text-foreground-secondary">{tKyc('doesntStoreDocumentsPeriod')}</p>
                     </div>
                 </div>

--- a/src/components/Kyc/AdditionalVerificationView.tsx
+++ b/src/components/Kyc/AdditionalVerificationView.tsx
@@ -59,7 +59,7 @@ export const AdditionalVerificationView = (): React.JSX.Element => {
                 <NavHeader title={t('title')} onPrev={onBack} />
                 <div className="flex flex-col items-center gap-3 text-center" data-testid="hosted-task-done">
                     <IconBubble icon="check-circle" size="l" color="green" />
-                    <p className="text-body-m font-bold">{t('done.title')}</p>
+                    <p className="text-body-m-semibold">{t('done.title')}</p>
                     <p className="text-body-s text-foreground-secondary">{t('done.description')}</p>
                 </div>
                 <Button variant="purple" shadowSize="4" onClick={() => router.replace(IDENTITY_ROUTE)}>

--- a/src/components/Kyc/KycPrepChecklist.tsx
+++ b/src/components/Kyc/KycPrepChecklist.tsx
@@ -42,7 +42,7 @@ const KycPrepChecklist = ({ path }: { path: KycPrepPath }) => {
                     >
                         <Icon name="check-circle" className="mt-0.5 size-4 shrink-0" />
                         <span>
-                            <span className="block text-body-s font-bold">{t(`items.${item}.title`)}</span>
+                            <span className="block text-label-l">{t(`items.${item}.title`)}</span>
                             <span className="block text-body-xs text-foreground-secondary">
                                 {t(`items.${item}.body`)}
                             </span>
@@ -64,7 +64,7 @@ const KycPrepChecklist = ({ path }: { path: KycPrepPath }) => {
             {/* Plain prose, not a card: the framed box read as one more
                 requirement alongside the list above it, when it is only a note. */}
             <div className="flex flex-col gap-0.5">
-                <span className="text-body-xs font-bold tracking-wide uppercase">{t('howLongLabel')}</span>
+                <span className="text-label-m tracking-wide uppercase">{t('howLongLabel')}</span>
                 <span className="text-body-xs text-foreground-secondary">{t(`howLong.${path}`)}</span>
             </div>
             {!isHosted && <p className="text-body-xs text-foreground-secondary">{t('extraDocNote')}</p>}

--- a/src/components/Marketing/mdx/constants.ts
+++ b/src/components/Marketing/mdx/constants.ts
@@ -5,4 +5,4 @@ export const PROSE_WIDTH = 'max-w-[640px]'
  *  Hover: card lifts up-left, shadow grows to compensate (appears stationary).
  *  Active: card presses into shadow. */
 export const CARD_HOVER =
-    'transition-all duration-150 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[6px_6px_0_#000] active:translate-x-[3px] active:translate-y-[4px] active:shadow-none'
+    'transition-all duration-fast hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-[6px_6px_0_#000] active:translate-x-[3px] active:translate-y-[4px] active:shadow-none'

--- a/src/components/Migration/MigrationDownloadModal.tsx
+++ b/src/components/Migration/MigrationDownloadModal.tsx
@@ -75,7 +75,7 @@ export default function MigrationDownloadModal({
     const remindLaterCta = {
         text: t(isUrgent ? 'downloadPrompt.remindLater' : 'downloadPrompt.maybeLater'),
         variant: 'transparent' as const,
-        className: 'underline h-6 text-body-xs font-normal',
+        className: 'underline h-6 text-body-xs',
         onClick: snooze,
     }
 

--- a/src/components/Migration/StoreBadges.tsx
+++ b/src/components/Migration/StoreBadges.tsx
@@ -31,7 +31,7 @@ export default function StoreBadges({
                         icon={s === 'ios' ? 'apple-logo' : 'google-play'}
                         className={
                             isHero
-                                ? 'w-52 bg-white px-6 py-3 text-button-m font-extrabold hover:bg-white/90 md:py-7 md:text-button-l'
+                                ? 'w-52 bg-white px-6 py-3 text-button-m hover:bg-white/90 md:py-7 md:text-button-l'
                                 : 'w-auto px-4'
                         }
                     >

--- a/src/components/Payment/Views/Error.validation.view.tsx
+++ b/src/components/Payment/Views/Error.validation.view.tsx
@@ -43,10 +43,10 @@ function ValidationErrorView({
     }
 
     return (
-        <div className="space-y-4 flex flex-col items-center justify-center rounded-lg text-center">
+        <div className="space-y-4 flex flex-col items-center justify-center text-center">
             <Image src={PeanutSad.src} unoptimized alt={t('validation.sadPeanutAlt')} width={96} height={96} />
             <div className="space-y-2">
-                <h1 className="text-body-l font-semibold">{title}</h1>
+                <h1 className="text-heading-card">{title}</h1>
                 <p className="text-body-s font-normal md:max-w-xs">{message}</p>
             </div>
             {showLearnMore && (

--- a/src/components/Points/InviteePointsBadge.tsx
+++ b/src/components/Points/InviteePointsBadge.tsx
@@ -21,7 +21,7 @@ const InviteePointsBadge = ({ points, inView, lifetimeEarnedUsd }: InviteePoints
         return (
             <div className="flex flex-col items-end">
                 <span className="font-semibold">${lifetimeEarnedUsd.toFixed(2)}</span>
-                <span className="text-body-s font-medium text-foreground-secondary">
+                <span className="text-body-s text-foreground-secondary">
                     +{formatPoints(animated)} {pointsLabel}
                 </span>
             </div>

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -91,7 +91,7 @@ export const BetaUpdatesCard = () => {
         <Card position="single" className="space-y-3 p-4">
             <div className="flex items-center justify-between gap-4">
                 <div>
-                    <h2 className="text-body-s font-bold text-black">{t('heading')}</h2>
+                    <h2 className="text-label-l text-black">{t('heading')}</h2>
                     <p className="text-body-xs text-foreground-secondary">
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -72,7 +72,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 )}
 
                 {/* Name */}
-                <div className="flex items-center gap-1.5">
+                <div className="flex items-center gap-1">
                     <VerifiedUserLabel
                         name={name}
                         username={username}
@@ -96,7 +96,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         onSuccess={() => posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, REFERRAL_PILL_PROPS)}
                         className="h-10 w-fit rounded-full py-3 pr-4 pl-6"
                     >
-                        <div className="text-body-s font-semibold">{profileUrl.replace('https://', '')}</div>
+                        <div className="text-label-l">{profileUrl.replace('https://', '')}</div>
                         <div className="-ml-2">
                             <Icon name="share" size={16} fill="black" />
                         </div>

--- a/src/components/Profile/components/ProfileMenuItem.tsx
+++ b/src/components/Profile/components/ProfileMenuItem.tsx
@@ -63,7 +63,7 @@ const ProfileMenuItem: React.FC<ProfileMenuItemProps> = ({
                 {badge && <StatusBadge status="custom" customText={badge} />}
                 {showTooltip && (
                     <Tooltip content={toolTipText}>
-                        <Icon name="info" size={14} fill="black" />
+                        <Icon name="info" size={16} fill="black" />
                     </Tooltip>
                 )}
             </div>

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -186,7 +186,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                             shadowSize="4"
                             className="flex w-1/2 items-center justify-center gap-2 rounded-full py-3"
                         >
-                            <Icon name="arrow-up-right" size={18} fill="black" />
+                            <Icon name="arrow-up-right" size={20} fill="black" />
                             <span className="font-bold">{tNav('send')}</span>
                         </Button>
 
@@ -202,7 +202,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                             shadowSize="4"
                             className="flex w-1/2 items-center justify-center gap-2 rounded-full py-3"
                         >
-                            <Icon name="arrow-down-left" size={18} fill="black" />
+                            <Icon name="arrow-down-left" size={20} fill="black" />
                             <span className="font-bold">{tNav('request')}</span>
                         </Button>
                     </div>
@@ -268,7 +268,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                     <div>
                         <HomeHistory username={username} />
                         {isSelfProfile && (
-                            <div className="mt-3 mb-1 flex w-full items-center justify-center gap-2 rounded-md bg-background-disabled/25 px-3 py-2">
+                            <div className="mt-3 mb-1 flex w-full items-center justify-center gap-2 rounded-sm bg-background-disabled/25 px-3 py-2">
                                 <Icon name="info" size={16} className="text-foreground-secondary" />
                                 <p className="text-center text-body-s text-foreground-secondary">
                                     {t('activityPrivateNote')}

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -66,7 +66,7 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
                 {POLICY_LINKS.map((doc, index) => (
                     <Card key={doc.href} position={cardPosition(index, POLICY_LINKS.length)}>
                         <DocsLink href={doc.href} className="flex cursor-pointer justify-between py-1">
-                            <span className="text-body-s font-medium text-black">{doc.name}</span>
+                            <span className="text-body-s text-black">{doc.name}</span>
                             <NavigationArrow size={24} className="fill-black" />
                         </DocsLink>
                     </Card>

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -341,7 +341,7 @@ const UnlockPayments = () => {
     const showCardRestrictionNote = !restrictions.banking && restrictions.card
 
     return (
-        <div className="space-y-8 flex min-h-[inherit] flex-col">
+        <div className="flex min-h-[inherit] flex-col gap-8">
             <NavHeader title={t('title')} onPrev={onBack} titleClassName="text-heading-xs md:text-heading-s" />
             <div className="my-auto">
                 <p className="text-body-s">{t('description')}</p>
@@ -357,7 +357,7 @@ const UnlockPayments = () => {
                     {residenceIso2 && (
                         <span
                             className={twMerge(
-                                'ml-auto shrink-0 rounded-full border border-border-default px-2 py-0.5 text-body-xs font-bold uppercase',
+                                'ml-auto shrink-0 rounded-full border border-border-default px-2 py-0.5 text-label-m uppercase',
                                 residence?.verified
                                     ? 'bg-background-badge-success text-foreground-primary'
                                     : 'text-foreground-secondary'
@@ -459,7 +459,7 @@ const UnlockPayments = () => {
 
                 <Link
                     href="/limits"
-                    className="mt-3 flex items-center justify-between rounded-sm border border-border-default bg-background-default px-3 py-2.5 text-body-s dark:border-white dark:bg-foreground-primary"
+                    className="mt-3 flex items-center justify-between rounded-sm border border-border-default bg-background-default px-3 py-2 text-body-s dark:border-white dark:bg-foreground-primary"
                 >
                     <span className="flex items-center gap-2">
                         <Icon name="meter" className="size-4 shrink-0" />
@@ -659,10 +659,10 @@ const UnlockGroupCard = ({
     const t = useTranslations('profile.unlockPayments')
     return (
         <div className="overflow-hidden rounded-sm border border-border-default bg-background-default dark:border-white dark:bg-foreground-primary">
-            <div className="flex items-center gap-2 border-b border-border-default bg-background-badge-helper px-3 py-2 text-body-s font-bold dark:border-white dark:bg-foreground-primary">
+            <div className="flex items-center gap-2 border-b border-border-default bg-background-badge-helper px-3 py-2 text-label-l dark:border-white dark:bg-foreground-primary">
                 <span>{t(`groups.${group.labelKey}`)}</span>
                 {group.isYourRegion && (
-                    <span className="ml-auto rounded-full border border-border-default bg-background-badge-accent px-2 py-0.5 text-label-m font-bold text-foreground-primary uppercase">
+                    <span className="ml-auto rounded-full border border-border-default bg-background-badge-accent px-2 py-0.5 text-label-m text-foreground-primary uppercase">
                         {t('yourRegion')}
                     </span>
                 )}
@@ -679,7 +679,7 @@ const UnlockGroupCard = ({
                         disabled={!tappable}
                         onClick={() => onRowClick(row)}
                         className={twMerge(
-                            'flex w-full items-center gap-2 border-t border-border-default px-3 py-2.5 text-left text-body-s first:border-t-0 dark:border-white',
+                            'flex w-full items-center gap-2 border-t border-border-default px-3 py-2 text-left text-body-s first:border-t-0 dark:border-white',
                             !tappable && 'cursor-default'
                         )}
                     >
@@ -689,7 +689,7 @@ const UnlockGroupCard = ({
                         </span>
                         <span
                             className={twMerge(
-                                'ml-auto shrink-0 rounded-full border border-border-default px-2 py-0.5 text-body-xs font-bold text-foreground-primary uppercase',
+                                'ml-auto shrink-0 rounded-full border border-border-default px-2 py-0.5 text-label-m text-foreground-primary uppercase',
                                 CHIP_CLASSES[row.chip]
                             )}
                         >

--- a/src/components/Request/link/views/Create.request.link.view.tsx
+++ b/src/components/Request/link/views/Create.request.link.view.tsx
@@ -377,7 +377,7 @@ export const CreateRequestLinkView = () => {
     }, [merchantComment, tokenValue, generateLink, recipientAddress])
 
     return (
-        <div className="space-y-8 flex min-h-[inherit] w-full flex-col justify-start">
+        <div className="flex min-h-[inherit] w-full flex-col justify-start gap-8">
             <NavHeader onPrev={onBack} title={tNav('request')} />
             <div className="my-auto flex flex-grow flex-col justify-center gap-4 md:my-0">
                 {/* board order (17831:78719): card, amount, helper note, qr, message, cta */}

--- a/src/components/Send/link/views/Success.link.send.view.tsx
+++ b/src/components/Send/link/views/Success.link.send.view.tsx
@@ -94,7 +94,7 @@ const LinkSendSuccessView = () => {
                         >
                             {!isLoading && (
                                 <div className="flex items-center">
-                                    <Icon name="ban" size={18} />
+                                    <Icon name="ban" size={20} />
                                 </div>
                             )}
                             <span>{cancelLinkText}</span>

--- a/src/components/Send/views/Contacts.view.tsx
+++ b/src/components/Send/views/Contacts.view.tsx
@@ -78,7 +78,7 @@ export default function ContactsView({ onPrev }: { onPrev: () => void }) {
     // handle error state before checking for empty contacts
     if (!!isError) {
         return (
-            <div className="space-y-8 flex min-h-[inherit] flex-col">
+            <div className="flex min-h-[inherit] flex-col gap-8">
                 <NavHeader title={tNav('send')} onPrev={onPrev} />
                 <div className="flex flex-1 items-center justify-center">
                     <EmptyState
@@ -108,7 +108,7 @@ export default function ContactsView({ onPrev }: { onPrev: () => void }) {
     const hasNoSearchResults = isSearching && contacts.length === 0
 
     return (
-        <div className="space-y-8 flex min-h-[inherit] flex-col">
+        <div className="flex min-h-[inherit] flex-col gap-8">
             <NavHeader title={tNav('send')} onPrev={onPrev} />
 
             {hasContacts ? (
@@ -127,7 +127,7 @@ export default function ContactsView({ onPrev }: { onPrev: () => void }) {
                         <ContactsListSkeleton count={5} />
                     ) : contacts.length > 0 ? (
                         <div className="space-y-2">
-                            <h2 className="text-body-m font-bold">{t('contacts.yourContacts')}</h2>
+                            <h2 className="text-body-m-semibold">{t('contacts.yourContacts')}</h2>
                             <div className="space-y-0 flex-1 overflow-y-auto">
                                 {contacts.map((contact, index) => {
                                     const isVerified = contact.isVerified

--- a/src/components/Settings/DeleteAccountButton.tsx
+++ b/src/components/Settings/DeleteAccountButton.tsx
@@ -147,7 +147,7 @@ const DeleteAccountButton: FC = () => {
             <button
                 type="button"
                 onClick={open}
-                className="w-full text-center text-body-s font-semibold text-foreground-error underline underline-offset-2"
+                className="w-full text-center text-label-l text-foreground-error underline underline-offset-2"
             >
                 {t('button')}
             </button>

--- a/src/components/Setup/Setup.consts.tsx
+++ b/src/components/Setup/Setup.consts.tsx
@@ -84,7 +84,7 @@ export const setupSteps: ISetupStep[] = [
         // The heads-up sub-views replace the intro copy; the select view
         // renders the description itself.
         descriptionInView: true,
-        contentClassName: 'flex flex-col items-end pt-8 justify-center gap-5',
+        contentClassName: 'flex flex-col items-end pt-8 justify-center gap-6',
     },
     {
         screenId: 'passkey-permission',

--- a/src/components/Setup/Views/InstallPWA.tsx
+++ b/src/components/Setup/Views/InstallPWA.tsx
@@ -185,7 +185,7 @@ const InstallPWA = ({
                         onClick={() =>
                             posthog.capture(ANALYTICS_EVENTS.PWA_OPEN_APP_CLICKED, { device_type: deviceType })
                         }
-                        className="btn btn-purple btn-shadow-primary-4 flex w-full items-center justify-center gap-2 no-underline transition-all duration-100 active:translate-x-[3px] active:translate-y-[4px] active:shadow-none"
+                        className="btn btn-purple btn-shadow-primary-4 flex w-full items-center justify-center gap-2 no-underline transition-all duration-instant active:translate-x-[3px] active:translate-y-[4px] active:shadow-none"
                     >
                         {t('openPeanutApp')}
                     </a>
@@ -255,7 +255,7 @@ const InstallPWA = ({
                                 title={t('mobileFirstTitle')}
                                 description={t('mobileFirstDescription')}
                                 content={
-                                    <div className="mx-auto rounded-lg">
+                                    <div className="mx-auto">
                                         <QRCodeWrapper
                                             url={`${process.env.NEXT_PUBLIC_BASE_URL || window.location.origin}/setup`}
                                         />

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -68,7 +68,7 @@ const LandingStep = () => {
                         {/* heading only above the desktop QR — a lone store button
                             explains itself */}
                         {deviceType === DeviceType.WEB && (
-                            <p className="text-center text-body-s font-semibold text-foreground-primary">
+                            <p className="text-center text-label-l text-foreground-primary">
                                 {tMigration('banner.title')}
                             </p>
                         )}

--- a/src/components/Setup/Views/Residence.tsx
+++ b/src/components/Setup/Views/Residence.tsx
@@ -118,7 +118,7 @@ const ResidenceStep = () => {
         return (
             <div className="flex h-full w-full flex-col justify-between gap-4">
                 <div className="flex flex-col gap-2">
-                    <h2 className="text-heading-xs font-extrabold">{t('residenceStep.partial.title')}</h2>
+                    <h2 className="text-heading-xs">{t('residenceStep.partial.title')}</h2>
                     <p className="text-body-s text-foreground-secondary">
                         {partialRestriction === 'card'
                             ? t('residenceStep.partial.cardDescription')
@@ -145,7 +145,7 @@ const ResidenceStep = () => {
         return (
             <div className="flex h-full w-full flex-col justify-between gap-4">
                 <div className="flex flex-col gap-2">
-                    <h2 className="text-heading-xs font-extrabold">{t('residenceStep.restricted.title')}</h2>
+                    <h2 className="text-heading-xs">{t('residenceStep.restricted.title')}</h2>
                     <p className="text-body-s text-foreground-secondary">{t('residenceStep.restricted.description')}</p>
                     {view === 'notify' && (
                         <div className="mt-2 flex flex-col gap-2">
@@ -161,7 +161,7 @@ const ResidenceStep = () => {
                         </div>
                     )}
                     {view === 'notify-done' && (
-                        <p className="text-body-s font-bold">{t('residenceStep.restricted.notifyDone')}</p>
+                        <p className="text-label-l">{t('residenceStep.restricted.notifyDone')}</p>
                     )}
                 </div>
                 <div className="flex w-full flex-col gap-2">
@@ -251,7 +251,7 @@ const ResidenceStep = () => {
                                             key={iso2}
                                             className="rounded-sm border border-border-default bg-background-default p-3"
                                         >
-                                            <p className="mb-1 text-body-xs font-bold">
+                                            <p className="mb-1 text-label-m">
                                                 {t('residenceStep.compare.cardTitle', { country: label })}
                                             </p>
                                             <ul className="space-y-0.5 text-body-xs text-foreground-secondary">

--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -235,7 +235,7 @@ const SetupPasskey = () => {
                     >
                         {t('passkey.setItUp')}
                     </Button>
-                    {preflightWarning && <p className="text-body-s font-bold text-orange-400">{preflightWarning}</p>}
+                    {preflightWarning && <p className="text-label-l text-orange-400">{preflightWarning}</p>}
                     {usernameTaken && (
                         <>
                             <Notification priority="error">{t('passkey.usernameTaken')}</Notification>

--- a/src/components/Setup/Views/SignTestTransaction.tsx
+++ b/src/components/Setup/Views/SignTestTransaction.tsx
@@ -253,11 +253,11 @@ const SignTestTransaction = () => {
         return (
             <div className="flex w-full flex-col gap-3 text-left">
                 <div className="rounded-sm border border-border-default bg-background-default p-3">
-                    <p className="text-body-s font-bold">{t('accountReady.worksNowTitle')}</p>
+                    <p className="text-label-l">{t('accountReady.worksNowTitle')}</p>
                     <p className="text-body-s">{t('accountReady.worksNowBody')}</p>
                 </div>
                 <div className="rounded-sm border border-border-default bg-background-default p-3">
-                    <p className="text-body-s font-bold">{t('accountReady.laterTitle')}</p>
+                    <p className="text-label-l">{t('accountReady.laterTitle')}</p>
                     <p className="text-body-s">{t('accountReady.laterBody')}</p>
                 </div>
                 <Button
@@ -291,7 +291,7 @@ const SignTestTransaction = () => {
                     >
                         {getButtonText()}
                     </Button>
-                    {displayError && <p className="text-body-s font-bold text-foreground-error">{displayError}</p>}
+                    {displayError && <p className="text-label-l text-foreground-error">{displayError}</p>}
                 </div>
                 <div>
                     {/* In-app explainer instead of a browser redirect — leaving

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -161,7 +161,7 @@ export const TooltipContent = ({
     const tooltipClasses: HTMLDivElement['className'] = useMemo(
         () =>
             twMerge(
-                'relative z-50 w-max max-w-[230px] rounded-md border border-border-default bg-white px-3 py-2 text-body-s text-black shadow-sm',
+                'relative z-50 w-max max-w-[230px] rounded-sm border border-border-default bg-white px-3 py-2 text-body-s text-black shadow-sm',
                 contentClassName
             ),
         [contentClassName]

--- a/src/components/TransactionDetails/DownloadReceiptPdfLink.tsx
+++ b/src/components/TransactionDetails/DownloadReceiptPdfLink.tsx
@@ -35,7 +35,7 @@ export function DownloadReceiptPdfLink({ entryId, kind }: { entryId: string; kin
                     void openExternalUrl(shareableUrl(pdfPath))
                 }
             }}
-            className="flex w-full items-center justify-center gap-2 text-body-s font-medium text-foreground-secondary underline transition-colors duration-fast hover:text-foreground-primary print:hidden"
+            className="flex w-full items-center justify-center gap-2 text-body-s text-foreground-secondary underline transition-colors duration-fast hover:text-foreground-primary print:hidden"
         >
             <Icon name="download" size={16} className="text-foreground-secondary" />
             {t('actions.downloadPdf')}

--- a/src/components/TransactionDetails/ReceiptActions.tsx
+++ b/src/components/TransactionDetails/ReceiptActions.tsx
@@ -148,7 +148,7 @@ export function ReceiptActions({
                                 className="flex w-full items-center gap-1"
                                 shadowSize="4"
                             >
-                                <div className="flex items-center">{!isLoading && <Icon name="ban" size={18} />}</div>
+                                <div className="flex items-center">{!isLoading && <Icon name="ban" size={20} />}</div>
                                 <span>{t(CANCEL_LINK_KEYS[cancelLinkState])}</span>
                             </Button>
                         )}
@@ -156,7 +156,7 @@ export function ReceiptActions({
             )}
 
             {isPendingSentLink && !shouldShowQrShare && (
-                <div className="flex items-center justify-center gap-1.5 text-center text-label-m text-foreground-secondary">
+                <div className="flex items-center justify-center gap-1 text-center text-label-m text-foreground-secondary">
                     <Icon name="info" size={20} />
                     {t('pendingLinkDeviceNote')}
                 </div>
@@ -188,7 +188,7 @@ export function ReceiptActions({
                         shadowSize="4"
                         className="flex w-full items-center gap-1"
                     >
-                        <Icon name="currency" size={18} />
+                        <Icon name="currency" size={20} />
                         {t('actions.pay')}
                     </Button>
                     <Button

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -212,7 +212,7 @@ function CancelButton({ label, disabled, onClick }: { label?: string; disabled: 
             shadowSize="4"
         >
             <div className="flex items-center">
-                <Icon name="ban" size={18} />
+                <Icon name="ban" size={20} />
             </div>
             <span>{label ?? t('actions.cancelDeposit')}</span>
         </Button>

--- a/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
+++ b/src/components/TransactionDetails/provider-rows/BridgeDepositInstructions.tsx
@@ -60,7 +60,8 @@ export function BridgeDepositInstructions({ transaction }: { transaction: Transa
                     <span>{showBankDetails ? t('bridge.hideBankDetails') : t('bridge.seeBankDetails')}</span>
                     <Icon
                         name="chevron-up"
-                        className={`h-4 w-4 transition-transform ${!showBankDetails ? 'rotate-180' : ''}`}
+                        size={16}
+                        className={`transition-transform ${!showBankDetails ? 'rotate-180' : ''}`}
                     />
                 </button>
             </div>

--- a/src/components/User/PotProgress.tsx
+++ b/src/components/User/PotProgress.tsx
@@ -88,7 +88,7 @@ const PotProgress: React.FC<PotProgressProps> = ({ goal, progress, isClosed }) =
     const renderStatusText = () => {
         if (!isClosed) return null
         return (
-            <div className="flex items-center gap-1 text-body-m font-medium">
+            <div className="flex items-center gap-1 text-body-m">
                 <Image src={COIN_ICON} alt="coin" width={18} height={18} />
                 <p>{getStatusText()}</p>
             </div>
@@ -108,13 +108,10 @@ const PotProgress: React.FC<PotProgressProps> = ({ goal, progress, isClosed }) =
         if (isOverGoal) {
             return (
                 <div className="relative flex w-full items-center pb-2">
-                    <p
-                        className="absolute -translate-x-1/2 text-body-s font-medium"
-                        style={{ left: `${goalPercentage}%` }}
-                    >
+                    <p className="absolute -translate-x-1/2 text-body-s" style={{ left: `${goalPercentage}%` }}>
                         100%
                     </p>
-                    <p className="absolute right-0 text-body-s font-medium">{formatCurrency(progress)}</p>
+                    <p className="absolute right-0 text-body-s">{formatCurrency(progress)}</p>
                 </div>
             )
         }

--- a/src/components/User/UserCard.tsx
+++ b/src/components/User/UserCard.tsx
@@ -61,7 +61,7 @@ const UserCard = ({
         if (type === 'request_pay') title = t('userCard.isRequesting', { name: fullName ?? username })
         if (type === 'request_fulfilment') title = t('userCard.sendingTo', { name: fullName ?? username })
         return (
-            <div className="flex items-center gap-2 text-body-xs font-normal text-foreground-secondary">
+            <div className="flex items-center gap-2 text-body-xs text-foreground-secondary">
                 {icon && <Icon name={icon} size={8} />} {title}
             </div>
         )

--- a/src/components/UserHeader/index.tsx
+++ b/src/components/UserHeader/index.tsx
@@ -23,13 +23,13 @@ export const UserHeader = ({ username }: UserHeaderProps) => {
             <Button
                 variant="primary-soft"
                 className={twMerge(
-                    'flex h-8 w-auto cursor-pointer items-center justify-center gap-1.5 rounded-full px-1 md:h-9'
+                    'flex h-8 w-auto cursor-pointer items-center justify-center gap-1 rounded-full px-1 md:h-9'
                 )}
                 shadowSize="3"
                 size="small"
             >
                 <DotFaceAvatar username={username} className="h-[30px] w-[30px]" />
-                <span className="pr-1.5 text-body-xs font-semibold whitespace-nowrap md:text-body-s">{username}</span>
+                <span className="pr-1 text-body-xs font-semibold whitespace-nowrap md:text-body-s">{username}</span>
             </Button>
         </Link>
     )
@@ -94,7 +94,7 @@ export const VerifiedUserLabel = ({
     const isInviter = user?.invitedBy === username
 
     return (
-        <div className="flex min-w-0 items-center gap-1.5">
+        <div className="flex min-w-0 items-center gap-1">
             {/* The AddressLink lane only wins when the caller passed no worded
                 copy (name === username). A caller that DID word the name — the
                 receipt head's "Added from {ens}" — must not have its title

--- a/src/features/limits/components/CryptoLimitsSection.tsx
+++ b/src/features/limits/components/CryptoLimitsSection.tsx
@@ -17,7 +17,7 @@ export default function CryptoLimitsSection() {
                 <div className="flex items-center gap-2">
                     <span className="text-body-s">{t('noLimits')}</span>
                     <Tooltip content={t('tooltip')} position="top">
-                        <Icon name="info" className="cursor-pointer text-foreground-secondary" size={18} />
+                        <Icon name="info" className="cursor-pointer text-foreground-secondary" size={16} />
                     </Tooltip>
                 </div>
             </Card>

--- a/src/features/limits/components/IncreaseLimitsButton.tsx
+++ b/src/features/limits/components/IncreaseLimitsButton.tsx
@@ -41,7 +41,7 @@ export default function IncreaseLimitsButton() {
 
     if (actionFlow.isComplete) {
         return (
-            <div className="rounded-sm border border-border-default bg-background-badge-success p-4 text-center text-body-s font-medium">
+            <div className="rounded-sm border border-border-default bg-background-badge-success p-4 text-center text-body-s">
                 {t('submitted')}
             </div>
         )

--- a/src/features/limits/components/LimitsWarningCard.tsx
+++ b/src/features/limits/components/LimitsWarningCard.tsx
@@ -82,7 +82,7 @@ export default function LimitsWarningCard({
                         <li key={index}>
                             {item.isLink && item.href ? (
                                 <Link href={item.href} className="underline underline-offset-2">
-                                    {item.icon && <Icon name={item.icon} className="mr-1" size={12} />}
+                                    {item.icon && <Icon name={item.icon} className="mr-1" size={16} />}
                                     <span>{itemText(item)}</span>
                                 </Link>
                             ) : (
@@ -99,7 +99,7 @@ export default function LimitsWarningCard({
                             disabled={isIncreaseLimitsLoading}
                             className="flex items-center gap-1"
                         >
-                            <Icon name="plus-circle" size={12} />
+                            <Icon name="plus-circle" size={16} />
                             <span className="font-semibold underline">
                                 {isIncreaseLimitsLoading ? tCommon('loading') : t('increase.cta')}
                             </span>
@@ -112,7 +112,7 @@ export default function LimitsWarningCard({
                             onClick={() => openSupportWithMessage(LIMITS_COPY.SUPPORT_MESSAGE)}
                             className="flex items-center gap-1"
                         >
-                            <Icon name="plus-circle" size={12} />
+                            <Icon name="plus-circle" size={16} />
                             <span className="font-semibold underline">{t('needHigherLimits')}</span>
                         </button>
                     </>

--- a/src/features/limits/views/MantecaLimitsView.tsx
+++ b/src/features/limits/views/MantecaLimitsView.tsx
@@ -35,7 +35,7 @@ const MantecaLimitsView = () => {
     const [period, setPeriod] = useState<LimitsPeriod>('monthly')
 
     return (
-        <div className="space-y-6 flex min-h-[inherit] flex-col">
+        <div className="flex min-h-[inherit] flex-col gap-6">
             <NavHeader title={t('title')} onPrev={onBack} />
 
             {isLoading && <Loading variant="mascot" coverFullScreen />}

--- a/src/features/payments/flows/contribute-pot/components/ContributorsDrawer.tsx
+++ b/src/features/payments/flows/contribute-pot/components/ContributorsDrawer.tsx
@@ -48,7 +48,7 @@ export function ContributorsDrawer({ contributors }: ContributorsDrawerProps) {
                 <Button
                     icon={<Users />}
                     variant="transparent"
-                    className="relative h-5 w-fit self-start p-0 text-body-xs font-normal underline underline-offset-2 after:absolute after:inset-x-0 after:-inset-y-3.5 active:translate-x-0 active:translate-y-0 active:text-foreground-primary"
+                    className="relative h-5 w-fit self-start p-0 text-body-xs underline underline-offset-2 after:absolute after:inset-x-0 after:-inset-y-3.5 active:translate-x-0 active:translate-y-0 active:text-foreground-primary"
                 >
                     {t('contributors.seeAll')}
                 </Button>


### PR DESCRIPTION
Sweep of composition-level DS drift against `mono/design/design.md`, plus five new ds-lint ratchet metrics so these classes cannot regrow. Token metrics were already green; this PR targets the law-level drift the token ratchet cannot see.

## What changed

**1. Page shells (9 shells, 7 files).** `space-y-*` on the `min-h-[inherit]` outer shell conflicts with `my-auto` centering (design.md outer-shell recipe). Swapped to `gap-*`. withdraw, withdraw/crypto, MantecaLimitsView, UnlockPayments.view, Create.request.link.view, Contacts.view, InputAmountStep.

**2. Motion tokens (25 sites).** Raw `duration-75/100/150/200/300/500` swapped to `duration-instant/fast/moderate/slow`. 100/200/300/500 map to identical values (zero visual change); 75→instant and 150→fast snap to the nearest step.

**3. Type ramp (~55 sites).** Weight classes stacked on type tokens minted styles the ramp does not define. Mapped per the ramp:
- `text-body-s font-bold|font-semibold` → `text-label-l` (same 14/20 box, sanctioned Bold)
- `text-body-m font-bold|font-semibold` → `text-body-m-semibold` (the docs' "no bold step exists" mapping)
- `text-body-xs font-bold` → `text-label-m` (micro-labels/badges)
- `text-body-l font-semibold` → `text-heading-card` (18px titles)
- redundant `font-extrabold` on `text-heading-xs`, `font-bold` on `text-label-m`, `font-extrabold` on `text-button-m` dropped (tokens carry their weight)

**4. Icon steps (~35 sites).** Snapped to the 16/20/24 scale: inline info/hints and icons next to text → 16; icons inside buttons and 40px circles → 20 (matches the button board note that 18 was never on the scale). Trailing 14px icons on Link-pattern rows kept — the LinkButton board sanctions 14 there. Also dropped a stray `iconSize={13}` on the ExchangeRateWidget CTA so the button default (20) applies.

**5. Spacing scale (~30 sites).** Off-scale values snapped to the nearest step by role (design.md anatomy rules): `gap-1.5`→`gap-1` (inline icon↔label), `py-2.5`→`py-2`, `gap-5`→`gap-6`/`gap-4` by section vs container, `px-5`→`px-4` on the drawer container (the documented L/16 inset), `pl-5`→`pl-6` list indents, `pb-5`→`pb-4`, `mb-5`→`mb-4`.

**6. Radii (6 sites).** `rounded-md`→`rounded-sm` on Tooltip/IframeWrapper chrome and the PublicProfile chip; dropped inert `rounded-lg` on three containers with no background/overflow.

**7. Skeleton tint (7 sites).** Legacy `bg-gray-200` pulse placeholders → the ruled interim `bg-foreground-primary/10` (HomeHistory, ContactsListSkeleton, CountryListSkeleton).

**8. ds-lint: five new ratchet metrics.** `fontWeightOnTypeToken`, `offScaleSpacing`, `iconOffScale`, `offScaleRadius`, `rawDuration` added to `scripts/ds-lint-counts.mjs` + baseline regenerated (13 / 181 / 64 / 33 / 9 after the review pass widened them to allowlist inversions — any numeric spacing step off the documented scale, any numeric or arbitrary duration, icons sized via props or classes). Deliberate holds live inside the baseline, not an allowlist: a ruling drives the count down, new drift fails CI.

## Flagged, not changed (per design.md law 6)

| divergence | why left |
|---|---|
| `app/quests/*` inlines `bg-[#FFC900]`, stock `blue-200/600`, `text-[10px]`, raw durations; not in the ds-lint allowlist | needs a ruling: allowlist as growth surface or migrate |
| `Global/Modal` used directly by SumsubKycWrapper, SumsubNativeSdk, QRScannerOverlay | full-screen embed/camera surfaces, not decision modals — adopt as a pattern or migrate to ActionModal |
| `Global/Drawer` `rounded-t-2xl`, `Global/Modal` `rounded-md`, QRScanner viewfinder `rounded-2xl` | radius on DS chrome; the modal-panel radius is already an open conflict — needs the board ruling |
| `Notification` `pl-7` indent | geometry (20px icon + 8px gap), not rhythm-scale drift |
| `BaseInput` `pr-15 md:pr-18` slot reserve | board specs a 40px slot; wider reserve is a figma↔code conflict, not a snap |
| `StatusBadge` `py-1.5`, `StatusPill` `size={14}` | badge board may spec these; verify against board `17802:61533` before changing |
| `SegmentedControl` `py-1.5`, `Checkbox` label `text-body-xs font-bold` | code-only `❓` primitives pending design |
| `PaymentInfoRow` weights + 12px info icon | component pending the receipt-row board decision |
| `UserHeader` username `text-body-xs font-semibold` | no ramp step for 12/600 running text — needs a token or a ruling |
| `CardFace` text styles, PerkClaimModal gift-box art | brand artwork surfaces |
| ≤10px icons in composite mini-badges (TransactionCard, UserCard, PeanutActionDetailsCard, TokenSelector, MantecaDepositShareDetails) | the composite-leading pattern already flagged in the open-conflicts table |
| ~230 `shadowSize="4"` call sites | Button docblock: no-op kept for compatibility — removal is churn, not drift |

## Verification

- `pnpm prettier --check .` clean
- `pnpm typecheck` clean
- 20 affected jest suites pass (adjacent component tests + qr-pay/add-money/withdraw state tests)
- `node scripts/ds-lint-counts.mjs --check` green on all 16 metrics
