### PR TITLE
copy(home): sell the card by reach, not by the closed beta

### DIFF
--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -203,7 +203,7 @@
             "tapToClaim": "Tap to claim your reward.",
             "card": {
                 "title": "Get your <b>Peanut Card</b>",
-                "description": "Closed beta. <b>Badges skip the line.</b>"
+                "description": "Spend your balance <b>anywhere Visa works</b>."
             },
             "invite": {
                 "title": "Invite friends. Earn rewards",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -203,7 +203,7 @@
             "tapToClaim": "Toca para reclamar tu recompensa.",
             "card": {
                 "title": "Consigue tu <b>Peanut Card</b>",
-                "description": "Beta cerrada. <b>Las insignias saltan la fila.</b>"
+                "description": "Gasta tu saldo <b>donde acepten Visa</b>."
             },
             "invite": {
                 "title": "Invita amigos. Gana recompensas",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -88,7 +88,8 @@
             "usedPeanutTapToClaim": "<name>{inviteeName}</name> usó Peanut. Tocá para reclamar.",
             "tapToClaim": "Tocá para reclamar tu recompensa.",
             "card": {
-                "title": "Conseguí tu <b>Peanut Card</b>"
+                "title": "Conseguí tu <b>Peanut Card</b>",
+                "description": "Gastá tu saldo <b>donde acepten Visa</b>."
             },
             "invite": {
                 "title": "Invitá amigos. Ganá recompensas",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -203,7 +203,7 @@
             "tapToClaim": "Toque para resgatar sua recompensa.",
             "card": {
                 "title": "Peça seu <b>Peanut Card</b>",
-                "description": "Beta fechado. <b>Emblemas furam a fila.</b>"
+                "description": "Gaste seu saldo <b>onde a Visa é aceita</b>."
             },
             "invite": {
                 "title": "Convide amigos. Ganhe recompensas",


### PR DESCRIPTION
The home carousel card slide led with "Closed beta. <b>Badges skip the line.</b>". Product direction (Slava, 2026-09-01): the closed beta stays, but the home screen and onboarding must not name it. The slide now sells what the card does:

> Get your **Peanut Card**
> Spend your balance **anywhere Visa works**.

Translations follow the house Visa phrasing already used elsewhere in each catalog (`donde acepten Visa` / `onde a Visa é aceita`), with a voseo delta in `es-AR` ("Gastá tu saldo…").

Deliberately untouched, per the same direction: the `/card` rejection/waitlist screens, `/shhhhh`, the celebration sublines, badge catalog entries, and the physical-card waiting list — those surfaces may keep naming the beta. The onboarding half of the direction is handled in #2903.

Verified: full i18n message suite green (key parity + duplicate-value drift), prettier run.
