### PR TITLE
test: ds-shots verification — DO NOT MERGE (TASK-22044)

### DIFF
--- a/src/components/Settings/LanguageView.tsx
+++ b/src/components/Settings/LanguageView.tsx
@@ -44,7 +44,7 @@ export const LanguageView = () => {
     return (
         <div className="h-full w-full bg-background">
             <NavHeader title={t('title')} onPrev={onBack} />
-            <div className="pt-4">
+            <div className="pt-6">
                 {APP_LOCALES.map((appLocale, index) => (
                     <ListItem
                         key={appLocale}


### PR DESCRIPTION
Throwaway verification PR for the ds-shots changes merged in #2897 and #2907. It nudges the `settings-language` screen 8px so exactly one fixture moves.

**Expected on this PR's Tests run:**
1. ds-shots completes in ~5–7 min (2-width capture, warm Next cache via restore-keys)
2. Capture runs only projects 320 and 430 (~60 shots)
3. Artifacts: `visual-diff-report-<pr#>-1` (small, baseline SHA stamped) and `visual-diff-<pr#>-1` (PNGs)
4. report.json shows `settings-language@320/430` changed, everything else identical, no removed-width noise
5. Running `scripts/ds-shots-publish.mjs` against the report renders the sticky comment the publisher will post once the workflow reaches main (workflow_run fires from the default branch only — the comment itself CANNOT appear on this PR yet, that is the documented deploy gotcha)

**This PR is never merged.** It gets closed after the run is inspected and the branch deleted.

Screenshots: N/A (throwaway test change).
