### PR TITLE
hotfix: activate the ds-shots PR comment publisher (TASK-22044)

### DIFF
--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -28,20 +28,22 @@
 #   any operational API failure               → red job, comment untouched
 #
 # Supersession is enforced by head-SHA binding, not by cancellation. The
-# concurrency group below serializes publishers for the SAME head only —
-# cancel-in-progress stays false, because one branch can hold two open PRs
-# (dev and main base) whose publishers must both run. Serialization closes
-# the read-then-write race where a no-report run could overwrite the result
-# a sibling same-head run posted between its marker read and its PATCH;
-# once serialized, either order ends correctly, because the marker-head
-# guard makes a no-report run keep any comment already posted for its head.
-# queue: max keeps EVERY same-head publisher (FIFO, up to 100) — the default
-# one-slot queue would let a third run drop a sibling PR's only pending
-# publisher and leave that PR's comment stale.
+# concurrency group below serializes ALL publishers for one head branch.
+# Every writer of a given PR's comment lives in that group: report-path
+# runs come from the PR's own branch, and the stale path only touches PRs
+# of the run's branch. That closes both write races — a no-report run
+# overwriting a sibling same-head result between its marker read and its
+# PATCH, and an older-head publisher stalling past its bind check and
+# overwriting a newer head's comment. Execution order inside the group
+# does not matter: a run that executes after a newer push fails the head
+# binding and no-ops. cancel-in-progress stays false and queue: max keeps
+# every queued publisher — one branch can hold two open PRs (dev and main
+# base) whose publishers must both run, and the default one-slot queue
+# would silently drop one of them.
 #
-# Deploy note: workflow_run only fires once this file exists on the DEFAULT
-# branch (main). It lands on dev first, so the comment starts appearing after
-# the next dev → main release. Until then this file is inert.
+# Deploy note: workflow_run workflows execute the DEFAULT branch's copy of
+# this file. It went live on main via the #2912 hotfix; keep the dev copy
+# byte-identical so every dev → main release merges over it cleanly.
 name: ds-shots comment
 
 on:
@@ -55,7 +57,7 @@ permissions:
     pull-requests: write # the sticky comment
 
 concurrency:
-    group: ds-shots-comment-${{ github.event.workflow_run.head_sha }}
+    group: ds-shots-comment-${{ github.event.workflow_run.head_branch }}
     cancel-in-progress: false
     queue: max
 
@@ -74,8 +76,11 @@ jobs:
         timeout-minutes: 5
         steps:
             # For a workflow_run event github.sha is the default branch head,
-            # so this checks out trusted code — never the PR.
+            # so this checks out trusted code — never the PR. No git commands
+            # run after checkout, so the token is not persisted.
             - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
 
             - uses: actions/setup-node@v4
               with:
@@ -197,11 +202,11 @@ jobs:
                   # from the (untrusted) archive is ever written to disk, so
                   # zip-slip has nothing to work with. A missing member fails
                   # the step loudly.
-                  unzip -p report.zip report.json > report.json
+                  unzip -p report.zip report.json > extracted-report.json
                   if [ -n "$IMG_ID" ]; then
                       export ARTIFACT_URL="https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$IMG_ID"
                   fi
-                  node scripts/ds-shots-publish.mjs report.json > body.md
+                  node scripts/ds-shots-publish.mjs extracted-report.json > body.md
                   echo 'ok=true' >> "$GITHUB_OUTPUT"
 
             # A report that exists but cannot be used must not leave the

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -146,17 +146,18 @@ jobs:
                   # artifact after somebody else's PR posts nothing, and an
                   # out-of-order older run cannot overwrite a newer comment.
                   #
-                  # The PR must also live on the run's own head branch: two
-                  # branches can park on one commit, and only same-branch
-                  # writers share the concurrency group that serializes
-                  # comment updates — a cross-branch writer would bypass it.
+                  # The PR must also live in THIS repo and on the run's own
+                  # head branch: any branch — including a fork's copy with
+                  # the same name — can park on a public commit, and only
+                  # same-repo same-branch writers share the concurrency
+                  # group that serializes comment updates.
                   #
                   # A true 404 (the number points at no PR) is that attack and
                   # stays a no-op. Any other failure — 5xx, rate limit,
                   # network — must fail this job loudly: swallowed, it would
                   # exit green while an older result stands as current.
                   set +e
-                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha + " " + .head.ref' 2>&1)
+                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '(.head.repo.full_name // "gone") + " " + .head.sha + " " + .head.ref' 2>&1)
                   STATUS=$?
                   set -e
                   if [ "$STATUS" -ne 0 ]; then
@@ -169,8 +170,8 @@ jobs:
                       exit 1
                   fi
                   HEAD=$OUT
-                  if [ "$HEAD" != "$RUN_HEAD_SHA $RUN_HEAD_BRANCH" ]; then
-                      echo "PR #$PR head (${HEAD:-<none>}) != run head ($RUN_HEAD_SHA $RUN_HEAD_BRANCH) — mismatched artifact name, stale run, or cross-branch writer. Skipping."
+                  if [ "$HEAD" != "$REPO $RUN_HEAD_SHA $RUN_HEAD_BRANCH" ]; then
+                      echo "PR #$PR head (${HEAD:-<none>}) != run head ($REPO $RUN_HEAD_SHA $RUN_HEAD_BRANCH) — mismatched artifact name, stale run, or cross-repo/branch writer. Skipping."
                       echo 'match=false' >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
@@ -195,7 +196,10 @@ jobs:
                   else
                       # The event omitted the list — routine, ~9 in 10 runs.
                       # Resolve it ourselves: the artifact's PR must be the
-                      # ONLY open PR on this branch+commit. With two sibling
+                      # ONLY open same-repo PR on this branch+commit. Fork
+                      # PRs are excluded, or an outsider could point a
+                      # same-named fork branch at this public commit and
+                      # force a false ambiguity that mutes the publisher. With two sibling
                       # PRs the runs are indistinguishable — code from one
                       # can name the other — so ambiguity posts nothing and
                       # the job summary stays the visible diff for that rare
@@ -206,7 +210,7 @@ jobs:
                       # after pagination — page one alone can miss the real
                       # head match.
                       CANDIDATES=$(gh api --paginate "repos/$REPO/commits/$RUN_HEAD_SHA/pulls?per_page=100" \
-                          --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.RUN_HEAD_BRANCH) | .number')
+                          --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.RUN_HEAD_BRANCH and (.head.repo.full_name // "") == env.REPO) | .number')
                       COUNT=$(printf '%s\n' "$CANDIDATES" | grep -c . || true)
                       if [ "$COUNT" -ne 1 ] || ! printf '%s\n' "$CANDIDATES" | grep -qx "$PR"; then
                           echo "Ambiguous or mismatched binding: open PRs on this branch+commit [$CANDIDATES] vs artifact PR #$PR — posting nothing."
@@ -312,7 +316,7 @@ jobs:
                   # endpoint lists PRs containing the commit, and the head
                   # match can sit past page one.
                   CANDIDATES=$(gh api --paginate "repos/$REPO/commits/$RUN_HEAD_SHA/pulls?per_page=100" \
-                      --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.HEAD_BRANCH) | .number')
+                      --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.HEAD_BRANCH and (.head.repo.full_name // "") == env.REPO) | .number')
                   if [ -z "$CANDIDATES" ]; then
                       echo 'No open PR has this branch+commit as its head — superseded or stale run. Nothing to do.'
                       exit 0

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -200,7 +200,12 @@ jobs:
                       # can name the other — so ambiguity posts nothing and
                       # the job summary stays the visible diff for that rare
                       # configuration.
-                      CANDIDATES=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                      # --paginate matters: this endpoint lists every PR whose
+                      # branch CONTAINS the commit (a dev-tip commit sits in
+                      # dozens of rebased branches), and the jq filter runs
+                      # after pagination — page one alone can miss the real
+                      # head match.
+                      CANDIDATES=$(gh api --paginate "repos/$REPO/commits/$RUN_HEAD_SHA/pulls?per_page=100" \
                           --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.RUN_HEAD_BRANCH) | .number')
                       COUNT=$(printf '%s\n' "$CANDIDATES" | grep -c . || true)
                       if [ "$COUNT" -ne 1 ] || ! printf '%s\n' "$CANDIDATES" | grep -qx "$PR"; then
@@ -303,7 +308,10 @@ jobs:
                   set -euo pipefail
                   # env.* inside the jq program, not shell interpolation — a
                   # branch name must never be able to edit the filter.
-                  CANDIDATES=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                  # --paginate for the same reason as in the bind step: the
+                  # endpoint lists PRs containing the commit, and the head
+                  # match can sit past page one.
+                  CANDIDATES=$(gh api --paginate "repos/$REPO/commits/$RUN_HEAD_SHA/pulls?per_page=100" \
                       --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.HEAD_BRANCH) | .number')
                   if [ -z "$CANDIDATES" ]; then
                       echo 'No open PR has this branch+commit as its head — superseded or stale run. Nothing to do.'

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -1,0 +1,327 @@
+# Publishes the ds-shots visual-diff result as one sticky PR comment.
+#
+# Why a separate workflow: the ds-shots job in tests.yml checks out and runs
+# PR code (pnpm install, next build, playwright), so it must hold no write
+# token — a postinstall can plant a GITHUB_PATH or GITHUB_ENV hook that fires
+# in any later step of the same job (see the permissions comment on ds-shots,
+# PR #2819). A workflow_run workflow executes THIS file from the default
+# branch and never checks out PR code, so it can safely hold
+# pull-requests: write.
+#
+# Trust boundary: the artifact was produced by a job that ran PR code, so its
+# contents are attacker-controlled. This workflow extracts exactly one member
+# (report.json) by name — no archive path is ever written to disk — and
+# scripts/ds-shots-publish.mjs validates it strictly before any of it reaches
+# markdown. The PR number is parsed from the artifact name (the PR's build
+# chose it), so it is bound back to the trigger: the numbered PR's head must
+# be the exact commit the run tested, or nothing is posted.
+#
+# Outcome table (report artifact × PR binding × existing comment) — every
+# path must end in one of these cells, so audit changes against the table:
+#   report usable + head matches the named PR → render, post or update
+#   report usable + that PR's head moved      → no-op, the newer run owns it
+#   report usable + named PR is a true 404    → no-op (attacker-chosen name)
+#   report unusable (bad zip / bad schema)    → clear to no-result, fail red
+#   no report + comment is for this head      → keep (a sibling run posted it)
+#   no report + comment is for an older head  → clear to no-result
+#   no report + no comment                    → stay quiet
+#   any operational API failure               → red job, comment untouched
+#
+# Supersession is enforced by head-SHA binding, not by cancellation. The
+# concurrency group below serializes publishers for the SAME head only —
+# cancel-in-progress stays false, because one branch can hold two open PRs
+# (dev and main base) whose publishers must both run. Serialization closes
+# the read-then-write race where a no-report run could overwrite the result
+# a sibling same-head run posted between its marker read and its PATCH;
+# once serialized, either order ends correctly, because the marker-head
+# guard makes a no-report run keep any comment already posted for its head.
+# queue: max keeps EVERY same-head publisher (FIFO, up to 100) — the default
+# one-slot queue would let a third run drop a sibling PR's only pending
+# publisher and leave that PR's comment stale.
+#
+# Deploy note: workflow_run only fires once this file exists on the DEFAULT
+# branch (main). It lands on dev first, so the comment starts appearing after
+# the next dev → main release. Until then this file is inert.
+name: ds-shots comment
+
+on:
+    workflow_run:
+        workflows: [Tests]
+        types: [completed]
+
+permissions:
+    contents: read # checkout of the default branch, for the builder script
+    actions: read # list + download the triggering run's artifacts
+    pull-requests: write # the sticky comment
+
+concurrency:
+    group: ds-shots-comment-${{ github.event.workflow_run.head_sha }}
+    cancel-in-progress: false
+    queue: max
+
+jobs:
+    comment:
+        # Same-repo PRs only. Fork PRs never produce the artifact anyway
+        # (ds-shots-filter skips them), so this is belt and braces. Cancelled
+        # runs are deliberately NOT excluded: a manually cancelled run for the
+        # current head must clear an older sticky result, and a run cancelled
+        # by concurrency after a newer push is already a no-op — its head SHA
+        # no longer matches the PR, so both the bind and the stale path skip.
+        if: >-
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.head_repository.full_name == github.repository
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            # For a workflow_run event github.sha is the default branch head,
+            # so this checks out trusted code — never the PR.
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: Find the report artifact on the triggering run
+              id: art
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+              run: |
+                  set -euo pipefail
+                  ROWS=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
+                      --jq '.artifacts[] | "\(.id)\t\(.name)"')
+                  # Artifacts persist across reruns of the same run id, and
+                  # every attempt of a run tests the SAME head SHA. Take the
+                  # highest attempt's report: "Re-run failed jobs" that skips
+                  # a succeeded ds-shots keeps attempt 1's still-valid result,
+                  # while a full rerun's fresh report wins by attempt number.
+                  # The attempt suffix exists because v4 uploads are immutable
+                  # — a fixed name would collide on rerun.
+                  REPORT=$(printf '%s\n' "$ROWS" | grep -E $'\t''visual-diff-report-[0-9]+-[0-9]+$' | sort -t- -k5,5n | tail -1 || true)
+                  if [ -z "$REPORT" ]; then
+                      echo 'found=false' >> "$GITHUB_OUTPUT"
+                      echo 'No attempt of this run produced a diff report: ds-shots was skipped, failed before the diff, or had no baseline.'
+                      exit 0
+                  fi
+                  REPORT_ID=${REPORT%%$'\t'*}
+                  NAME=${REPORT#*$'\t'}
+                  ATTEMPT_USED=${NAME##*-}
+                  PR=$(printf '%s' "$NAME" | sed -E 's/^visual-diff-report-([0-9]+)-[0-9]+$/\1/')
+                  # The PNG artifact only exists when a screen moved; its id
+                  # becomes the images download link in the comment. Same
+                  # attempt as the report it belongs to.
+                  IMG_ID=$(printf '%s\n' "$ROWS" | grep -E $'\t'"visual-diff-$PR-$ATTEMPT_USED\$" | sed -n '1p' | cut -f1 || true)
+                  {
+                      echo 'found=true'
+                      echo "report_id=$REPORT_ID"
+                      echo "pr=$PR"
+                      echo "img_id=$IMG_ID"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Report artifact $REPORT_ID for PR #$PR (images: ${IMG_ID:-none})"
+
+            - name: Bind the artifact's PR number back to the run
+              if: steps.art.outputs.found == 'true'
+              id: bind
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ steps.art.outputs.pr }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+              run: |
+                  set -euo pipefail
+                  # The artifact name — and so the PR number — was chosen by
+                  # the PR's own build code. Require the numbered PR's head to
+                  # be the exact commit this run tested: a PR naming its
+                  # artifact after somebody else's PR posts nothing, and an
+                  # out-of-order older run cannot overwrite a newer comment.
+                  #
+                  # A true 404 (the number points at no PR) is that attack and
+                  # stays a no-op. Any other failure — 5xx, rate limit,
+                  # network — must fail this job loudly: swallowed, it would
+                  # exit green while an older result stands as current.
+                  set +e
+                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>&1)
+                  STATUS=$?
+                  set -e
+                  if [ "$STATUS" -ne 0 ]; then
+                      if printf '%s' "$OUT" | grep -q 'HTTP 404'; then
+                          echo "PR #$PR does not exist — the artifact name pointed at nothing. Skipping."
+                          echo 'match=false' >> "$GITHUB_OUTPUT"
+                          exit 0
+                      fi
+                      echo "::error::PR-head lookup for #$PR failed: $OUT"
+                      exit 1
+                  fi
+                  HEAD=$OUT
+                  if [ "$HEAD" != "$RUN_HEAD_SHA" ]; then
+                      echo "PR #$PR head ${HEAD:-<none>} != run head $RUN_HEAD_SHA — mismatched artifact name or stale run. Skipping."
+                      echo 'match=false' >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  echo 'match=true' >> "$GITHUB_OUTPUT"
+
+            # The download is a plain API call: a transient failure here is
+            # operational, must go red with the comment untouched, and must
+            # never be misread as a tampered artifact — so it lives OUTSIDE
+            # the continue-on-error step below.
+            - name: Download the report artifact
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  REPORT_ID: ${{ steps.art.outputs.report_id }}
+              run: |
+                  set -euo pipefail
+                  gh api "repos/$REPO/actions/artifacts/$REPORT_ID/zip" > report.zip
+
+            # Extraction and rendering consume attacker-controlled bytes, so
+            # either may refuse them: a broken archive fails unzip, an
+            # out-of-contract report is rejected by the validator.
+            # continue-on-error lets the run reach the fallback and upsert
+            # below — the last step of the job still turns an unusable report
+            # into a red run, so tampering stays loud.
+            - name: Extract and render the report
+              if: steps.bind.outputs.match == 'true'
+              id: render
+              continue-on-error: true
+              env:
+                  REPO: ${{ github.repository }}
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+                  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+                  IMG_ID: ${{ steps.art.outputs.img_id }}
+              run: |
+                  set -euo pipefail
+                  # Extract the one member by exact name, to stdout: no path
+                  # from the (untrusted) archive is ever written to disk, so
+                  # zip-slip has nothing to work with. A missing member fails
+                  # the step loudly.
+                  unzip -p report.zip report.json > report.json
+                  if [ -n "$IMG_ID" ]; then
+                      export ARTIFACT_URL="https://github.com/$REPO/actions/runs/$RUN_ID/artifacts/$IMG_ID"
+                  fi
+                  node scripts/ds-shots-publish.mjs report.json > body.md
+                  echo 'ok=true' >> "$GITHUB_OUTPUT"
+
+            # A report that exists but cannot be used must not leave the
+            # previous head's result standing as current (same stale-success
+            # hazard as a missing report). Overwrite with the trusted generic
+            # body — never with anything taken from the report.
+            - name: Fall back to the no-result body when the report is unusable
+              if: steps.bind.outputs.match == 'true' && steps.render.outputs.ok != 'true'
+              id: fallback
+              env:
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+              run: |
+                  set -euo pipefail
+                  {
+                      echo "<!-- ds-shots-visual-diff head=$RUN_HEAD_SHA -->"
+                      echo
+                      echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
+                      echo
+                      echo "The newest [Tests run]($RUN_URL) uploaded a diff report that could not be used: a broken archive, or a report that failed validation."
+                      echo 'The previous result on this comment no longer reflects the latest run, so it was cleared. This publisher run fails on purpose so someone looks.'
+                      echo
+                      echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
+                  } > body.md
+                  echo 'used=true' >> "$GITHUB_OUTPUT"
+
+            # A run with no report must not leave an older result standing as
+            # if it were current (the stale-success hazard). Which PR a run
+            # belongs to cannot be known exactly — one branch can hold two
+            # open PRs, and any branch can be parked on any commit — so this
+            # never guesses. It checks EVERY open PR whose head is exactly
+            # this run's branch and commit, and clears a comment only when
+            # the head recorded in its marker differs from this run's head:
+            # only then does the comment provably describe an older commit of
+            # that PR. A comment already carrying this head was posted by a
+            # sibling run that had a report, and stays. A PR with no comment
+            # stays quiet, so docs-only PRs get no spam. Every identity input
+            # is a trusted event field or GitHub API response — never
+            # anything the PR's build produced.
+            - name: Clear stale comments when this run has no report
+              if: steps.art.outputs.found != 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+                  RUN_URL: ${{ github.event.workflow_run.html_url }}
+              run: |
+                  set -euo pipefail
+                  # env.* inside the jq program, not shell interpolation — a
+                  # branch name must never be able to edit the filter.
+                  CANDIDATES=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                      --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.HEAD_BRANCH) | .number')
+                  if [ -z "$CANDIDATES" ]; then
+                      echo 'No open PR has this branch+commit as its head — superseded or stale run. Nothing to do.'
+                      exit 0
+                  fi
+                  {
+                      echo "<!-- ds-shots-visual-diff head=$RUN_HEAD_SHA -->"
+                      echo
+                      echo '## 🖼 Visual diff — ⚠️ no result for the latest push'
+                      echo
+                      echo "The newest [Tests run]($RUN_URL) produced no diff report in any attempt: ds-shots was skipped, failed before the diff, or had no cached baseline."
+                      echo 'The previous result on this comment no longer reflects the latest run, so it was cleared.'
+                      echo
+                      echo '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge.</sub>'
+                  } > stale-body.md
+                  for PR in $CANDIDATES; do
+                      ROW=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+                          --jq '.[] | select(.user.login == "github-actions[bot]")
+                                    | select(.body | startswith("<!-- ds-shots-visual-diff"))
+                                    | "\(.id)\t\(try (.body | capture("head=(?<h>[0-9a-f]{40})") | .h) catch "none")"' \
+                          | sed -n '1p')
+                      if [ -z "$ROW" ]; then
+                          echo "PR #$PR has no sticky comment — staying quiet."
+                          continue
+                      fi
+                      CID=${ROW%%$'\t'*}
+                      CHEAD=${ROW##*$'\t'}
+                      if [ "$CHEAD" = "$RUN_HEAD_SHA" ]; then
+                          echo "PR #$PR comment already reflects this head — keeping it."
+                          continue
+                      fi
+                      gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@stale-body.md > /dev/null
+                      echo "Cleared the stale comment on PR #$PR"
+                  done
+
+            - name: Upsert the sticky comment
+              if: steps.bind.outputs.match == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ steps.art.outputs.pr }}
+                  FALLBACK: ${{ steps.fallback.outputs.used }}
+              run: |
+                  set -euo pipefail
+                  # Only a comment this bot authored qualifies — a user who
+                  # pastes the marker into their own comment must not have it
+                  # overwritten. The prefix match covers markers with and
+                  # without the head= field.
+                  # sed, not head: a gh failure must fail the step, not be
+                  # masked into posting a duplicate comment.
+                  CID=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+                      --jq '.[] | select(.user.login == "github-actions[bot]")
+                                | select(.body | startswith("<!-- ds-shots-visual-diff")) | .id' \
+                      | sed -n '1p')
+                  if [ -n "$CID" ]; then
+                      gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@body.md > /dev/null
+                      echo "Updated comment $CID on PR #$PR"
+                  elif [ "$FALLBACK" = 'true' ]; then
+                      # The unusable-report fallback only clears an existing
+                      # result — a PR that never had a comment gets none.
+                      echo "PR #$PR has no sticky comment — staying quiet."
+                  else
+                      gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@body.md > /dev/null
+                      echo "Posted new comment on PR #$PR"
+                  fi
+
+            - name: Fail loud when the report was unusable
+              if: steps.bind.outputs.match == 'true' && steps.render.outputs.ok != 'true'
+              run: |
+                  echo '::error::The report artifact was present but unusable — see "Extract and render the report". The sticky comment was cleared to the no-result state.'
+                  exit 1

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -36,10 +36,12 @@
 # PATCH, and an older-head publisher stalling past its bind check and
 # overwriting a newer head's comment. Execution order inside the group
 # does not matter: a run that executes after a newer push fails the head
-# binding and no-ops. cancel-in-progress stays false and queue: max keeps
-# every queued publisher — one branch can hold two open PRs (dev and main
-# base) whose publishers must both run, and the default one-slot queue
-# would silently drop one of them.
+# binding and no-ops. cancel-in-progress stays false and queue: max holds
+# up to 100 pending runs (more than that are cancelled — far beyond real
+# traffic for one branch) — one branch can hold two open PRs (dev and
+# main base) whose publishers must both run, and the default one-slot
+# queue would silently drop one of them. The group is repo-qualified so a
+# fork branch sharing a name never lands in an origin branch's queue.
 #
 # Deploy note: workflow_run workflows execute the DEFAULT branch's copy of
 # this file. It went live on main via the #2912 hotfix; keep the dev copy
@@ -57,7 +59,7 @@ permissions:
     pull-requests: write # the sticky comment
 
 concurrency:
-    group: ds-shots-comment-${{ github.event.workflow_run.head_branch }}
+    group: ds-shots-comment-${{ github.event.workflow_run.head_repository.full_name || 'unknown' }}-${{ github.event.workflow_run.head_branch }}
     cancel-in-progress: false
     queue: max
 
@@ -133,6 +135,7 @@ jobs:
                   REPO: ${{ github.repository }}
                   PR: ${{ steps.art.outputs.pr }}
                   RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+                  RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
               run: |
                   set -euo pipefail
                   # The artifact name — and so the PR number — was chosen by
@@ -141,12 +144,17 @@ jobs:
                   # artifact after somebody else's PR posts nothing, and an
                   # out-of-order older run cannot overwrite a newer comment.
                   #
+                  # The PR must also live on the run's own head branch: two
+                  # branches can park on one commit, and only same-branch
+                  # writers share the concurrency group that serializes
+                  # comment updates — a cross-branch writer would bypass it.
+                  #
                   # A true 404 (the number points at no PR) is that attack and
                   # stays a no-op. Any other failure — 5xx, rate limit,
                   # network — must fail this job loudly: swallowed, it would
                   # exit green while an older result stands as current.
                   set +e
-                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>&1)
+                  OUT=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha + " " + .head.ref' 2>&1)
                   STATUS=$?
                   set -e
                   if [ "$STATUS" -ne 0 ]; then
@@ -159,8 +167,8 @@ jobs:
                       exit 1
                   fi
                   HEAD=$OUT
-                  if [ "$HEAD" != "$RUN_HEAD_SHA" ]; then
-                      echo "PR #$PR head ${HEAD:-<none>} != run head $RUN_HEAD_SHA — mismatched artifact name or stale run. Skipping."
+                  if [ "$HEAD" != "$RUN_HEAD_SHA $RUN_HEAD_BRANCH" ]; then
+                      echo "PR #$PR head (${HEAD:-<none>}) != run head ($RUN_HEAD_SHA $RUN_HEAD_BRANCH) — mismatched artifact name, stale run, or cross-branch writer. Skipping."
                       echo 'match=false' >> "$GITHUB_OUTPUT"
                       exit 0
                   fi

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -136,6 +136,8 @@ jobs:
                   PR: ${{ steps.art.outputs.pr }}
                   RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
                   RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+                  # numbers only, joined — safe to hand to the shell
+                  EVENT_PRS: ${{ join(github.event.workflow_run.pull_requests.*.number, ' ') }}
               run: |
                   set -euo pipefail
                   # The artifact name — and so the PR number — was chosen by
@@ -171,6 +173,25 @@ jobs:
                       echo "PR #$PR head (${HEAD:-<none>}) != run head ($RUN_HEAD_SHA $RUN_HEAD_BRANCH) — mismatched artifact name, stale run, or cross-branch writer. Skipping."
                       echo 'match=false' >> "$GITHUB_OUTPUT"
                       exit 0
+                  fi
+                  # Trusted cross-check when GitHub supplies it: the event's
+                  # pull_requests array names the run's originating PR(s).
+                  # The array is documented-unreliable (often empty), so an
+                  # empty array falls back to the sha+ref binding above
+                  # instead of silencing the publisher. When it is present,
+                  # the artifact's number must be in it — which closes the
+                  # last gap in the binding: a sibling PR on the SAME branch
+                  # and commit (same author, same tree) could otherwise be
+                  # named by the artifact and pass sha+ref.
+                  if [ -n "$EVENT_PRS" ]; then
+                      case " $EVENT_PRS " in
+                          *" $PR "*) ;;
+                          *)
+                              echo "PR #$PR is not among the run's originating PRs ($EVENT_PRS) — mismatched artifact name. Skipping."
+                              echo 'match=false' >> "$GITHUB_OUTPUT"
+                              exit 0
+                              ;;
+                      esac
                   fi
                   echo 'match=true' >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ds-shots-comment.yml
+++ b/.github/workflows/ds-shots-comment.yml
@@ -192,6 +192,22 @@ jobs:
                               exit 0
                               ;;
                       esac
+                  else
+                      # The event omitted the list — routine, ~9 in 10 runs.
+                      # Resolve it ourselves: the artifact's PR must be the
+                      # ONLY open PR on this branch+commit. With two sibling
+                      # PRs the runs are indistinguishable — code from one
+                      # can name the other — so ambiguity posts nothing and
+                      # the job summary stays the visible diff for that rare
+                      # configuration.
+                      CANDIDATES=$(gh api "repos/$REPO/commits/$RUN_HEAD_SHA/pulls" \
+                          --jq '.[] | select(.state == "open" and .head.sha == env.RUN_HEAD_SHA and .head.ref == env.RUN_HEAD_BRANCH) | .number')
+                      COUNT=$(printf '%s\n' "$CANDIDATES" | grep -c . || true)
+                      if [ "$COUNT" -ne 1 ] || ! printf '%s\n' "$CANDIDATES" | grep -qx "$PR"; then
+                          echo "Ambiguous or mismatched binding: open PRs on this branch+commit [$CANDIDATES] vs artifact PR #$PR — posting nothing."
+                          echo 'match=false' >> "$GITHUB_OUTPUT"
+                          exit 0
+                      fi
                   fi
                   echo 'match=true' >> "$GITHUB_OUTPUT"
 

--- a/scripts/__tests__/ds-shots-publish.test.js
+++ b/scripts/__tests__/ds-shots-publish.test.js
@@ -69,7 +69,6 @@ describe('ds-shots-publish', () => {
         ['newline smuggling', { file: 'a\n## fake@375.png', percent: 1, pixels: 1 }],
         ['overlong name', { file: `${'a'.repeat(200)}@375.png`, percent: 1, pixels: 1 }],
         ['non-string file', { file: 42, percent: 1, pixels: 1 }],
-        ['NaN percent', { file: 'home@375.png', percent: NaN, pixels: 1 }],
         ['percent out of range', { file: 'home@375.png', percent: 101, pixels: 1 }],
         ['string percent', { file: 'home@375.png', percent: '3.2', pixels: 1 }],
         ['injected note', { file: 'home@375.png', percent: 1, pixels: 1, note: '](x) <script>' }],
@@ -93,6 +92,9 @@ describe('ds-shots-publish', () => {
         ['negative unchanged', valid({ unchanged: -1 })],
         ['array report', [1, 2, 3]],
         ['not json at all', 'not json {'],
+        // raw text on purpose: JSON.stringify would turn non-finite numbers
+        // into null, and JSON's own path to Infinity is a 1e999 literal
+        ['infinite percent', JSON.stringify(valid()).replace('3.21', '1e999')],
         ['oversized file', 'x'.repeat(1024 * 1024 + 10)],
     ])('rejects: %s', (_label, report) => {
         const result = run(report)

--- a/scripts/__tests__/ds-shots-publish.test.js
+++ b/scripts/__tests__/ds-shots-publish.test.js
@@ -1,0 +1,120 @@
+const { spawnSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'ds-shots-publish.mjs')
+
+// The script is the trust boundary of the workflow_run comment publisher: its
+// input is an artifact produced by a job that ran PR code. Its contract is
+// stdout + exit code, so drive it the way the workflow does. exit 1 = the
+// report was rejected and nothing gets posted.
+function run(report, env = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-shots-'))
+    const file = path.join(dir, 'report.json')
+    fs.writeFileSync(file, typeof report === 'string' ? report : JSON.stringify(report))
+    return spawnSync(process.execPath, [SCRIPT_PATH, file], { encoding: 'utf-8', env: { ...process.env, ...env } })
+}
+
+const SHA_A = 'a'.repeat(40)
+const valid = (over = {}) => ({
+    changed: [
+        { file: 'home@375.png', percent: 3.21, pixels: 1234 },
+        { file: 'home@320.png', percent: 1.05, pixels: 400 },
+        { file: 'qr-pay@430.png', percent: 100, pixels: 860000, note: '430x900 -> 430x1200' },
+    ],
+    unchanged: 117,
+    added: ['rewards-empty@375.png'],
+    removed: [],
+    baseline: SHA_A,
+    ...over,
+})
+
+describe('ds-shots-publish', () => {
+    it('renders the sticky comment for a normal report', () => {
+        const result = run(valid(), {
+            RUN_URL: 'https://github.com/peanutprotocol/peanut-ui/actions/runs/1',
+            ARTIFACT_URL: 'https://github.com/peanutprotocol/peanut-ui/actions/runs/1/artifacts/2',
+            HEAD_SHA: 'b'.repeat(40),
+        })
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain(`<!-- ds-shots-visual-diff head=${'b'.repeat(40)} -->`)
+        expect(result.stdout).toContain('2 screens moved')
+        expect(result.stdout).toContain('3 of 120 shots changed')
+        expect(result.stdout).toContain('`aaaaaaa` → head `bbbbbbb`')
+        // worst screen first, both widths folded into one row
+        expect(result.stdout).toContain('| 100.00% | `qr-pay` — resized 430x900 -> 430x1200 | 430 |')
+        expect(result.stdout).toContain('| 3.21% | `home` | 320, 375 |')
+        expect(result.stdout).toContain('new screens (1)')
+        expect(result.stdout).toContain('[job summary](https://github.com/peanutprotocol/peanut-ui/actions/runs/1)')
+        expect(result.stdout).toContain('artifacts/2')
+    })
+
+    it('still posts (green) when nothing moved', () => {
+        const result = run(valid({ changed: [], added: [], removed: [], unchanged: 120 }), { HEAD_SHA: '' })
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain('<!-- ds-shots-visual-diff head=unknown -->')
+        expect(result.stdout).toContain('no screen moved')
+        expect(result.stdout).toContain('120 shots, all identical')
+    })
+
+    it.each([
+        ['path traversal', { file: '../../../etc/passwd@375.png', percent: 1, pixels: 1 }],
+        ['absolute path', { file: '/etc/passwd@375.png', percent: 1, pixels: 1 }],
+        ['markdown table breakout', { file: 'a|b@375.png', percent: 1, pixels: 1 }],
+        ['html injection', { file: 'a<img src=x onerror=1>@375.png', percent: 1, pixels: 1 }],
+        ['backtick breakout', { file: 'a`code`@375.png', percent: 1, pixels: 1 }],
+        ['newline smuggling', { file: 'a\n## fake@375.png', percent: 1, pixels: 1 }],
+        ['overlong name', { file: `${'a'.repeat(200)}@375.png`, percent: 1, pixels: 1 }],
+        ['non-string file', { file: 42, percent: 1, pixels: 1 }],
+        ['NaN percent', { file: 'home@375.png', percent: NaN, pixels: 1 }],
+        ['percent out of range', { file: 'home@375.png', percent: 101, pixels: 1 }],
+        ['string percent', { file: 'home@375.png', percent: '3.2', pixels: 1 }],
+        ['injected note', { file: 'home@375.png', percent: 1, pixels: 1, note: '](x) <script>' }],
+    ])('rejects a report with a malicious changed entry: %s', (_label, entry) => {
+        const result = run(valid({ changed: [entry] }))
+
+        expect(result.status).toBe(1)
+        expect(result.stdout).toBe('')
+        expect(result.stderr).toContain('report rejected')
+    })
+
+    it.each([
+        [
+            'oversized changed list',
+            valid({ changed: Array(1001).fill({ file: 'home@375.png', percent: 1, pixels: 1 }) }),
+        ],
+        ['injected added name', valid({ added: ['[click](https://evil.example)@375.png'] })],
+        ['missing baseline', valid({ baseline: undefined })],
+        ['short baseline', valid({ baseline: 'abc123' })],
+        ['injected baseline', valid({ baseline: '`](x)'.padEnd(40, 'a') })],
+        ['negative unchanged', valid({ unchanged: -1 })],
+        ['array report', [1, 2, 3]],
+        ['not json at all', 'not json {'],
+    ])('rejects: %s', (_label, report) => {
+        const result = run(report)
+
+        expect(result.status).toBe(1)
+        expect(result.stdout).toBe('')
+    })
+
+    it('caps the table and stays under the github comment size limit', () => {
+        // 500 screens x 2 widths — a report engineered to bloat the comment
+        const changed = []
+        for (let i = 0; i < 500; i++) {
+            changed.push({ file: `screen-${i}@375.png`, percent: 50, pixels: 1 })
+            changed.push({ file: `screen-${i}@430.png`, percent: 40, pixels: 1 })
+        }
+        const added = Array.from({ length: 200 }, (_, i) => `new-screen-${i}@375.png`)
+        const result = run(valid({ changed, added }))
+
+        expect(result.status).toBe(0)
+        expect(result.stdout).toContain('…and 480 more')
+        expect(result.stdout).toContain('…and 170 more')
+        expect(Buffer.byteLength(result.stdout)).toBeLessThan(65000)
+        // 20 table rows, not 500
+        expect(result.stdout.split('\n').filter((l) => l.startsWith('| 5')).length).toBe(20)
+    })
+})

--- a/scripts/__tests__/ds-shots-publish.test.js
+++ b/scripts/__tests__/ds-shots-publish.test.js
@@ -93,6 +93,7 @@ describe('ds-shots-publish', () => {
         ['negative unchanged', valid({ unchanged: -1 })],
         ['array report', [1, 2, 3]],
         ['not json at all', 'not json {'],
+        ['oversized file', 'x'.repeat(1024 * 1024 + 10)],
     ])('rejects: %s', (_label, report) => {
         const result = run(report)
 

--- a/scripts/ds-shots-publish.mjs
+++ b/scripts/ds-shots-publish.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Renders the ds-shots PR comment from the report.json a Tests run uploaded
+// as the visual-diff-report-<pr> artifact. Runs only in ds-shots-comment.yml,
+// the workflow_run publisher — never inside the job that runs PR code.
+//
+// TRUST BOUNDARY: the report was written by a job that executed the PR's
+// install, build and test code, so every byte of it is attacker-controlled.
+// This script validates the report against a strict schema and refuses the
+// whole file on any violation. The file-name character class has no slash,
+// backslash, pipe, backtick or angle bracket, so no validated string can
+// traverse a path or break out of its markdown cell — nothing here needs
+// escaping. Nothing from the report is ever executed or linked.
+//
+// Deliberately separate from scripts/visual-comment.mjs: that script renders
+// the in-run job summary, trusts its own input, and a PR may edit it. This
+// one always runs from the default branch and trusts nothing.
+//
+// usage:
+//   node scripts/ds-shots-publish.mjs <report.json> > body.md
+//
+// env (set by the publisher workflow, trusted):
+//   RUN_URL       html url of the triggering Tests run, for the summary link
+//   ARTIFACT_URL  download url of the PNG artifact; empty when nothing moved
+//   HEAD_SHA      the commit the run tested, from the workflow_run event
+//
+// exit 0: markdown on stdout. exit 1: the report is out of contract — the
+// publisher goes red and posts nothing, which is the wanted outcome for a
+// tampered report.
+
+import { readFileSync, statSync } from 'node:fs'
+
+// The marker carries the head the comment describes, so a later run with no
+// report can tell a current comment (keep) from a stale one (clear) without
+// guessing which PR a run belongs to. HEAD_SHA is trusted workflow context.
+const RAW_HEAD = process.env.HEAD_SHA ?? ''
+const MARKER = `<!-- ds-shots-visual-diff head=${/^[0-9a-f]{40}$/.test(RAW_HEAD) ? RAW_HEAD : 'unknown'} -->`
+const MAX_BYTES = 1024 * 1024 // a legit report is a few KB
+const MAX_ENTRIES = 1000 // 30 fixtures x 4 widths = 120 legit shots
+const ROW_LIMIT = 20 // table rows, one per screen
+const NAME_LIMIT = 30 // added/removed names listed before "…and N more"
+const BODY_LIMIT = 65000 // github rejects a comment past 65536 bytes
+
+// `<fixture>@<width>.png`, fixture ids from src/dev/fixtures/registry.ts.
+const SHOT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}@\d{3,4}\.png$/
+// visual-diff.mjs writes `640x1136 -> 640x1200` for a resized screen.
+const NOTE = /^\d{1,5}x\d{1,5} -> \d{1,5}x\d{1,5}$/
+const SHA40 = /^[0-9a-f]{40}$/
+
+const fail = (why) => {
+    console.error(`report rejected: ${why}`)
+    process.exit(1)
+}
+
+const [reportPath] = process.argv.slice(2)
+if (!reportPath) fail('no report path given')
+if (statSync(reportPath).size > MAX_BYTES) fail('report too large')
+
+let report
+try {
+    report = JSON.parse(readFileSync(reportPath, 'utf8'))
+} catch {
+    fail('not valid json')
+}
+if (typeof report !== 'object' || report === null || Array.isArray(report)) fail('not an object')
+
+const isShot = (f) => typeof f === 'string' && SHOT.test(f)
+const isCount = (n) => Number.isInteger(n) && n >= 0 && n <= 100_000_000
+
+const { changed, unchanged, added, removed, baseline } = report
+if (!Array.isArray(changed) || changed.length > MAX_ENTRIES) fail('changed is not an array of sane size')
+for (const c of changed) {
+    if (typeof c !== 'object' || c === null) fail('changed entry is not an object')
+    if (!isShot(c.file)) fail(`bad file name ${JSON.stringify(String(c.file).slice(0, 80))}`)
+    if (typeof c.percent !== 'number' || !Number.isFinite(c.percent) || c.percent < 0 || c.percent > 100)
+        fail(`bad percent on ${c.file}`)
+    if (!isCount(c.pixels)) fail(`bad pixels on ${c.file}`)
+    if (c.note !== undefined && !(typeof c.note === 'string' && NOTE.test(c.note))) fail(`bad note on ${c.file}`)
+}
+if (!isCount(unchanged)) fail('bad unchanged count')
+for (const [key, list] of [
+    ['added', added],
+    ['removed', removed],
+]) {
+    if (!Array.isArray(list) || list.length > MAX_ENTRIES || !list.every(isShot)) fail(`bad ${key} list`)
+}
+if (typeof baseline !== 'string' || !SHA40.test(baseline)) fail('bad baseline sha')
+
+// Everything below only sees validated strings and numbers.
+
+const screenOf = (file) => file.replace(/@\d+\.png$/, '')
+const widthOf = (file) => Number(file.match(/@(\d+)\.png$/)[1])
+
+// A screen is shot at four widths; group them and keep the worst width.
+function byScreen(files) {
+    const groups = new Map()
+    for (const c of files) {
+        const name = screenOf(c.file)
+        const g = groups.get(name) ?? { name, worst: c, widths: [] }
+        if (c.percent > g.worst.percent) g.worst = c
+        g.widths.push(widthOf(c.file))
+        groups.set(name, g)
+    }
+    for (const g of groups.values()) g.widths.sort((a, b) => a - b)
+    return [...groups.values()].sort((a, b) => b.worst.percent - a.worst.percent)
+}
+
+const screens = byScreen(changed)
+const short = (sha) => (sha && /^[0-9a-f]{7,40}$/.test(sha) ? `\`${sha.slice(0, 7)}\`` : '`unknown`')
+const provenance = `baseline ${short(baseline)} → head ${short(process.env.HEAD_SHA ?? '')}`
+const totalShots = changed.length + unchanged
+const screenCount = (files) => new Set(files.map(screenOf)).size
+
+const out = [MARKER, '']
+const quiet = changed.length === 0 && added.length === 0 && removed.length === 0
+
+if (quiet) {
+    out.push('## 🖼 Visual diff — no screen moved', '', `${totalShots} shots, all identical. ${provenance}.`)
+} else {
+    const moved =
+        screens.length === 0 ? 'no screen moved' : `${screens.length} screen${screens.length === 1 ? '' : 's'} moved`
+    out.push(`## 🖼 Visual diff — ${moved}`, '')
+    out.push(`${changed.length} of ${totalShots} shots changed · ${unchanged} identical · ${provenance}`, '')
+
+    if (screens.length > 0) {
+        out.push('| worst % | screen | widths |', '| ---: | --- | --- |')
+        for (const g of screens.slice(0, ROW_LIMIT)) {
+            const note = g.worst.note ? ` — resized ${g.worst.note}` : ''
+            out.push(`| ${g.worst.percent.toFixed(2)}% | \`${g.name}\`${note} | ${g.widths.join(', ')} |`)
+        }
+        if (screens.length > ROW_LIMIT) out.push(`| | …and ${screens.length - ROW_LIMIT} more | |`)
+        out.push('')
+    }
+
+    for (const [title, list] of [
+        ['new screens', added],
+        ['gone screens', removed],
+    ]) {
+        if (list.length === 0) continue
+        const names = [...new Set(list.map(screenOf))].sort()
+        out.push(`<details><summary>${title} (${screenCount(list)})</summary>`, '')
+        for (const n of names.slice(0, NAME_LIMIT)) out.push(`- \`${n}\``)
+        if (names.length > NAME_LIMIT) out.push(`- …and ${names.length - NAME_LIMIT} more`)
+        out.push('', '</details>', '')
+    }
+}
+
+const links = []
+if (process.env.RUN_URL) links.push(`[job summary](${process.env.RUN_URL})`)
+if (process.env.ARTIFACT_URL) links.push(`[before/after/diff images — artifact](${process.env.ARTIFACT_URL})`)
+if (links.length > 0) out.push('', links.join(' · '))
+
+out.push(
+    '',
+    '<sub>Fixture screenshots, no backend. Advisory — this check never blocks a merge. ' +
+        'Posted from the default branch by ds-shots-comment.yml; the report it renders is untrusted data.</sub>'
+)
+
+const body = out.join('\n')
+if (Buffer.byteLength(body) > BODY_LIMIT) fail('rendered body too large')
+console.log(body)

--- a/scripts/ds-shots-publish.mjs
+++ b/scripts/ds-shots-publish.mjs
@@ -27,7 +27,7 @@
 // publisher goes red and posts nothing, which is the wanted outcome for a
 // tampered report.
 
-import { readFileSync, statSync } from 'node:fs'
+import { closeSync, openSync, readSync } from 'node:fs'
 
 // The marker carries the head the comment describes, so a later run with no
 // report can tell a current comment (keep) from a stale one (clear) without
@@ -53,11 +53,25 @@ const fail = (why) => {
 
 const [reportPath] = process.argv.slice(2)
 if (!reportPath) fail('no report path given')
-if (statSync(reportPath).size > MAX_BYTES) fail('report too large')
+
+// One bounded read instead of stat-then-read: no size-check race (codeql
+// js/file-system-race) and never more than MAX_BYTES+1 bytes of a hostile
+// file in memory, however large it is on disk.
+let raw
+try {
+    const fd = openSync(reportPath, 'r')
+    const buf = Buffer.alloc(MAX_BYTES + 1)
+    const bytes = readSync(fd, buf, 0, MAX_BYTES + 1, 0)
+    closeSync(fd)
+    if (bytes > MAX_BYTES) fail('report too large')
+    raw = buf.toString('utf8', 0, bytes)
+} catch {
+    fail('cannot read the report file')
+}
 
 let report
 try {
-    report = JSON.parse(readFileSync(reportPath, 'utf8'))
+    report = JSON.parse(raw)
 } catch {
     fail('not valid json')
 }


### PR DESCRIPTION
## Summary

The visual-diff comment publisher merged to dev in #2897 is inert until its workflow file exists on the **default branch** — `workflow_run` workflows only fire from main. This hotfix carries the three publisher files to main **byte-identical to dev** (verified: empty diff), activating the sticky 🖼 Visual diff comment for every PR immediately, dev-based PRs included.

- `.github/workflows/ds-shots-comment.yml` — the workflow_run publisher (runs only default-branch code, `pull-requests: write` + `actions: read` + `contents: read`)
- `scripts/ds-shots-publish.mjs` — strict-validating report→markdown renderer the workflow runs from the main checkout
- `scripts/__tests__/ds-shots-publish.test.js` — its 23-case adversarial suite

**Why this is safe and minimal:** the ds-shots capture job itself is *not* being hotfixed — PRs run it from their own ref (dev already has it) and report artifacts are already uploading (verified live on #2910, where the rendered comment preview was produced from the real artifact). Nothing else from #2897/#2907 does anything on main, so nothing else comes along. The content passed ten Chip review rounds on #2897 with a clean final round; the full security argument is in that PR's body.

**No back-merge debt:** identical bytes already live on dev, so the next dev→main release merges over this cleanly.

**Verification after merge:** the next Tests run that completes on any pixel-touching PR should produce a "ds-shots comment" workflow run and the sticky comment (~expected content proven on #2910). A docs-only PR gets no comment.

**Task:** TASK-22044

Screenshots: N/A (CI only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request comments summarizing visual-diff results.
  * Reports include grouped screenshot changes, added or removed screens, change tables, provenance, workflow links, and the tested commit.
  * Existing results are updated instead of creating duplicates.
* **Bug Fixes**
  * Improved handling of missing, empty, malformed, unsafe, or oversized reports.
  * Prevented comments from exceeding platform size limits.
  * Prevented stale or cross-branch results from replacing the correct visual-diff comments.
  * Ensured queued report updates are processed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->