### PR TITLE
fix(profile): stop claiming a Brazilian bank-transfer rail in Unlock payments

### DIFF
--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -359,10 +359,10 @@
             "rows": {
                 "p2p": "Peanut-to-Peanut payments",
                 "card": "Peanut card",
-                "saBank": "PIX, QR & bank transfers (Brazil & Argentina)",
-                "pixBank": "PIX & bank transfers (Brazil)",
+                "saBank": "PIX (Brazil), QR & bank transfers (Argentina)",
+                "pixBank": "PIX payments & transfers (Brazil)",
                 "pixQr": "PIX QR payments (Brazil)",
-                "brBank": "Bank transfers (Brazil)",
+                "brBank": "PIX transfers (Brazil)",
                 "arQrBank": "QR payments & transfers (Argentina)",
                 "arQr": "QR payments (Argentina)",
                 "arBank": "Bank transfers (Argentina)",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -359,10 +359,10 @@
             "rows": {
                 "p2p": "Pagos de Peanut a Peanut",
                 "card": "Tarjeta Peanut",
-                "saBank": "PIX, QR y transferencias bancarias (Brasil y Argentina)",
-                "pixBank": "PIX y transferencias bancarias (Brasil)",
+                "saBank": "PIX (Brasil), QR y transferencias bancarias (Argentina)",
+                "pixBank": "Pagos y transferencias PIX (Brasil)",
                 "pixQr": "Pagos QR con PIX (Brasil)",
-                "brBank": "Transferencias bancarias (Brasil)",
+                "brBank": "Transferencias PIX (Brasil)",
                 "arQrBank": "Pagos QR y transferencias (Argentina)",
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -188,10 +188,10 @@
             "rows": {
                 "p2p": "Pagos de Peanut a Peanut",
                 "card": "Tarjeta Peanut",
-                "saBank": "PIX, QR y transferencias bancarias (Brasil y Argentina)",
-                "pixBank": "PIX y transferencias bancarias (Brasil)",
+                "saBank": "PIX (Brasil), QR y transferencias bancarias (Argentina)",
+                "pixBank": "Pagos y transferencias PIX (Brasil)",
                 "pixQr": "Pagos QR con PIX (Brasil)",
-                "brBank": "Transferencias bancarias (Brasil)",
+                "brBank": "Transferencias PIX (Brasil)",
                 "arQrBank": "Pagos QR y transferencias (Argentina)",
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -359,10 +359,10 @@
             "rows": {
                 "p2p": "Pagamentos de Peanut para Peanut",
                 "card": "Cartão Peanut",
-                "saBank": "PIX, QR e transferências bancárias (Brasil e Argentina)",
-                "pixBank": "PIX e transferências bancárias (Brasil)",
+                "saBank": "PIX (Brasil), QR e transferências bancárias (Argentina)",
+                "pixBank": "Pagamentos e transferências PIX (Brasil)",
                 "pixQr": "Pagamentos QR com PIX (Brasil)",
-                "brBank": "Transferências bancárias (Brasil)",
+                "brBank": "Transferências PIX (Brasil)",
                 "arQrBank": "Pagamentos QR e transferências (Argentina)",
                 "arQr": "Pagamentos QR (Argentina)",
                 "arBank": "Transferências bancárias (Argentina)",


### PR DESCRIPTION
Brazil has no bank-transfer rail — the active catalog seeds `MANTECA × PIX_BR` only (`peanut-api-ts/scripts/seed-rails.ts`; `BANK_TRANSFER_BR` was never seeded). Chip flagged this claim class on #2903, where the signup residence copy was fixed; this PR fixes the same stale claims on the profile Unlock payments screen.

Three row labels change in `profile.unlockPayments.rows` (all four catalogs, `es-AR` overrides included):

| key | before | after |
|---|---|---|
| `saBank` | PIX, QR & bank transfers (Brazil & Argentina) | PIX (Brazil), QR & bank transfers (Argentina) |
| `pixBank` | PIX & bank transfers (Brazil) | PIX payments & transfers (Brazil) |
| `brBank` | Bank transfers (Brazil) | PIX transfers (Brazil) |

`brBank` wasn't in the original finding but is the same falsehood in the same block: it's the Manteca bank-side row shown to Bridge-verified users who already hold BR QR, and what that unlock actually delivers for Brazil is PIX. Argentina's rows (`arBank`, `arQrBank`, `arQr`) are untouched — AR genuinely has bank transfers and MercadoPago QR.

Where the labels render: `unlock-payments.utils.ts` builds the rows, `UnlockPayments.view.tsx` renders `rows.{labelKey}` and feeds the same label into the Unlock modal title. Nothing keys on the wording; no keys added or removed.

Verified: full i18n messages suite green (key-set parity across catalogs + the duplicate-value drift test — the new English values are unique, so no cross-key translation coupling), prettier run, and no code or test references the old literals.
