### PR TITLE
fix(clipboard): report a failed copy to Sentry once, not twice

### DIFF
--- a/src/utils/__tests__/clipboard.utils.test.ts
+++ b/src/utils/__tests__/clipboard.utils.test.ts
@@ -140,6 +140,8 @@ describe('copyTextToClipboard', () => {
 
         await expect(copyTextToClipboard(LINK)).resolves.toBe(false)
         expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+        // captureConsoleIntegration would turn a console.error here into a second, stackless event
+        expect(consoleErrorSpy).not.toHaveBeenCalled()
         expect((Sentry.captureException as jest.Mock).mock.calls[0][1]).toEqual({
             extra: { failed: { clipboardApi: 'Error: denied', execCommand: 'returned false' } },
         })

--- a/src/utils/clipboard.utils.ts
+++ b/src/utils/clipboard.utils.ts
@@ -69,7 +69,6 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
         textArea.remove()
     }
 
-    console.error('Failed to copy: ', failed)
     Sentry.captureException(new Error('Clipboard copy failed'), { extra: { failed } })
     return false
 }


### PR DESCRIPTION
## Summary

Follow-up to #2911. `copyTextToClipboard` logged the failure map with `console.error` right before `captureException`. `captureConsoleIntegration` is on for the `error` level and promotes a non-Error console argument into its own stackless message event, so every copy that failed every path produced two Sentry issues instead of the one the PR intended, and re-created the stackless-message class #2810 cleaned up.

- Drop the `console.error`; keep the explicit `captureException`, which carries the `extra.failed` context.
- Pin it: the existing failure test now asserts `console.error` was never called, which the old test could not catch because it only counted `captureException`.

## Task

TASK-21690 — https://app.notion.com/p/3c283811757981758696de3bc36cc022

## Risks / breaking changes

None. No behaviour change for the user; one fewer Sentry event per failed copy.

## QA

Unit: `src/utils/__tests__/clipboard.utils.test.ts` (12 passing locally).

Screenshots: N/A — no UI change.
