### PR TITLE
fix: TASK-21817 history kind vocabulary from generated types + TASK-21815 prepare follow-up

### DIFF
--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -57,8 +57,6 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
     const runCancel = async () => {
         setPhase('canceling')
         setError(null)
-        // Hoisted so the catch can back a signed-but-unused draft out (TASK-21815).
-        let livePreparationId: string | undefined
         try {
             // An unloaded overview reads as zero spending power below, which
             // would skip the withdrawal and get the cancel rejected by the
@@ -87,15 +85,14 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
                     throw new Error(t('errors.unexpectedStrategy'))
                 }
                 verifiedWithdrawal = artifact.rainWithdrawal
-                livePreparationId = artifact.rainWithdrawal.preparationId
             }
+            // No draft back-out on a cancelCard throw: execution-ambiguous —
+            // the probe-verified TTL sweep owns cleanup (TASK-21815 review).
             await rainApi.cancelCard(cardId, { verifiedWithdrawal })
-            livePreparationId = undefined // consumed
             posthog.capture(ANALYTICS_EVENTS.CARD_CANCEL_CONFIRMED)
             setCanceled(true)
             setPhase('feedback')
         } catch (e) {
-            if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
             let message = e instanceof Error ? e.message : t('cancel.failed')
             if (e instanceof InsufficientSpendableError) {
                 message = t('errors.balanceReturnFailed')

--- a/src/components/Card/CancelCardModal.tsx
+++ b/src/components/Card/CancelCardModal.tsx
@@ -57,6 +57,8 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
     const runCancel = async () => {
         setPhase('canceling')
         setError(null)
+        // Hoisted so the catch can back a signed-but-unused draft out (TASK-21815).
+        let livePreparationId: string | undefined
         try {
             // An unloaded overview reads as zero spending power below, which
             // would skip the withdrawal and get the cancel rejected by the
@@ -85,12 +87,15 @@ const CancelCardModal: FC<Props> = ({ cardId, isOpen, onClose }) => {
                     throw new Error(t('errors.unexpectedStrategy'))
                 }
                 verifiedWithdrawal = artifact.rainWithdrawal
+                livePreparationId = artifact.rainWithdrawal.preparationId
             }
             await rainApi.cancelCard(cardId, { verifiedWithdrawal })
+            livePreparationId = undefined // consumed
             posthog.capture(ANALYTICS_EVENTS.CARD_CANCEL_CONFIRMED)
             setCanceled(true)
             setPhase('feedback')
         } catch (e) {
+            if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
             let message = e instanceof Error ? e.message : t('cancel.failed')
             if (e instanceof InsufficientSpendableError) {
                 message = t('errors.balanceReturnFailed')

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -62,6 +62,8 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
     const run = async () => {
         setPhase('loading')
         setError(null)
+        // Hoisted so the catch can back a signed-but-unused draft out (TASK-21815).
+        let livePreparationId: string | undefined
         try {
             if (mode === 'lock') {
                 // An unloaded overview reads as zero spending power below, which
@@ -96,8 +98,10 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
                         throw new Error(t('errors.unexpectedStrategy'))
                     }
                     verifiedWithdrawal = artifact.rainWithdrawal
+                    livePreparationId = artifact.rainWithdrawal.preparationId
                 }
                 await rainApi.lockCard(cardId, verifiedWithdrawal)
+                livePreparationId = undefined // consumed
             } else {
                 await rainApi.activateCard(cardId)
             }
@@ -105,6 +109,7 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
             posthog.capture(mode === 'lock' ? ANALYTICS_EVENTS.CARD_LOCKED : ANALYTICS_EVENTS.CARD_UNLOCKED)
             setPhase('success')
         } catch (e) {
+            if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
             // Friendlier copy for the two known sign-time errors. Any other
             // throw (passkey cancelled, network, backend) keeps its message.
             let message = e instanceof Error ? e.message : t(copyKeys.failed)

--- a/src/components/Card/LockCardModal.tsx
+++ b/src/components/Card/LockCardModal.tsx
@@ -62,8 +62,6 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
     const run = async () => {
         setPhase('loading')
         setError(null)
-        // Hoisted so the catch can back a signed-but-unused draft out (TASK-21815).
-        let livePreparationId: string | undefined
         try {
             if (mode === 'lock') {
                 // An unloaded overview reads as zero spending power below, which
@@ -98,10 +96,11 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
                         throw new Error(t('errors.unexpectedStrategy'))
                     }
                     verifiedWithdrawal = artifact.rainWithdrawal
-                    livePreparationId = artifact.rainWithdrawal.preparationId
                 }
+                // No draft back-out on a lockCard throw: the backend may have
+                // consumed the withdrawal before the error surfaced — cleanup
+                // belongs to the probe-verified TTL sweep (TASK-21815 review).
                 await rainApi.lockCard(cardId, verifiedWithdrawal)
-                livePreparationId = undefined // consumed
             } else {
                 await rainApi.activateCard(cardId)
             }
@@ -109,7 +108,6 @@ const LockCardModal: FC<Props> = ({ cardId, mode, isOpen, onClose }) => {
             posthog.capture(mode === 'lock' ? ANALYTICS_EVENTS.CARD_LOCKED : ANALYTICS_EVENTS.CARD_UNLOCKED)
             setPhase('success')
         } catch (e) {
-            if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
             // Friendlier copy for the two known sign-time errors. Any other
             // throw (passkey cancelled, network, backend) keeps its message.
             let message = e instanceof Error ? e.message : t(copyKeys.failed)

--- a/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
+++ b/src/components/TransactionDetails/__tests__/transaction-predicates.test.ts
@@ -182,6 +182,12 @@ describe('hasReferralNudge', () => {
         CRYPTO_DEPOSIT: { direction: 'add', expected: false },
         REFUND: { direction: 'receive', expected: false },
         PERK_REWARD: { direction: 'receive', expected: false },
+        // TASK-21817: IntentKind now derives from the generated wire
+        // vocabulary — the four ledger kinds get explicit nudge verdicts.
+        P2P_SEND: { direction: 'send', expected: true }, // legacy sends behave like DIRECT_TRANSFER
+        REWARD_PAYOUT: { direction: 'receive', expected: false },
+        INTERNAL_TRANSFER: { direction: 'send', expected: false },
+        CHARGEBACK: { direction: 'send', expected: false },
     }
 
     test.each(Object.entries(NUDGE_BY_KIND).map(([kind, row]) => ({ kind, ...row })))(

--- a/src/components/TransactionDetails/strategies/__tests__/ledger-generic.test.ts
+++ b/src/components/TransactionDetails/strategies/__tests__/ledger-generic.test.ts
@@ -1,0 +1,35 @@
+/**
+ * TASK-21817 — the ledger-bookkeeping strategies' role contracts.
+ * CHARGEBACK direction follows the viewer's ledger entry (the mapper's
+ * userRole), never a fixed sign.
+ */
+import { internalTransfer, chargeback } from '../intent/ledger-generic'
+import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
+
+const entry = (userRole: EHistoryUserRole): HistoryEntry =>
+    ({ uuid: 'x', userRole, extraData: { kind: 'CHARGEBACK' } }) as unknown as HistoryEntry
+
+describe('chargeback — direction follows the viewer entry', () => {
+    it('a viewer on the CREDIT side (RECIPIENT) renders incoming', () => {
+        const out = chargeback(entry(EHistoryUserRole.RECIPIENT))
+        expect(out.direction).toBe('receive')
+        expect(out.transactionCardType).toBe('receive')
+    })
+
+    it.each([EHistoryUserRole.SENDER, EHistoryUserRole.BOTH, EHistoryUserRole.NONE])(
+        'role %s renders outgoing (the common clawback debit)',
+        (role) => {
+            const out = chargeback(entry(role))
+            expect(out.direction).toBe('send')
+            expect(out.transactionCardType).toBe('send')
+        }
+    )
+})
+
+describe('internalTransfer — neutral outgoing bookkeeping shape', () => {
+    it('renders a send-shaped row with a generic name', () => {
+        const out = internalTransfer(entry(EHistoryUserRole.SENDER))
+        expect(out.direction).toBe('send')
+        expect(out.nameForDetails).toBe('Internal transfer')
+    })
+})

--- a/src/components/TransactionDetails/strategies/__tests__/registry.test.ts
+++ b/src/components/TransactionDetails/strategies/__tests__/registry.test.ts
@@ -52,3 +52,17 @@ describe('resolveReceiptKind', () => {
         expect(resolveReceiptKind(undefined, '4')).toBeUndefined()
     })
 })
+
+describe('isIntentKind — own-property guard (TASK-21817 review)', () => {
+    // `in` walks the prototype chain: a crafted receipt URL like
+    // `?kind=toString` would dispatch Object.prototype.toString as a
+    // strategy. Prototype keys must fall through to the fallback.
+    it.each(['toString', 'constructor', 'hasOwnProperty', 'valueOf'])('rejects prototype key %s', (key) => {
+        expect(isIntentKind(key)).toBe(false)
+    })
+
+    it('still accepts real wire kinds', () => {
+        expect(isIntentKind('QR_PAY')).toBe(true)
+        expect(isIntentKind('PERK_REWARD')).toBe(true)
+    })
+})

--- a/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
+++ b/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
@@ -26,7 +26,10 @@ export const internalTransfer: TransactionStrategy = (): TransactionStrategyOutp
  * A chargeback DEBITS the user (the BE's INFLOW_KINDS deliberately excludes
  * CHARGEBACK — funds leave the account when a dispute resolves against it).
  * The kind is enum-reserved with no live writer yet; the shape here keeps a
- * future row honest instead of surprising.
+ * future row honest instead of surprising. A dispute resolving in the
+ * USER's favor is the other lane entirely — it arrives as kind=REFUND and
+ * renders through cardRefund as the credit the card terms promise
+ * (card-terms-international §"Chargebacks resolved in your favor").
  */
 export const chargeback: TransactionStrategy = (): TransactionStrategyOutput => ({
     direction: 'send',

--- a/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
+++ b/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
@@ -5,6 +5,7 @@
 // intentFallback and render as an OUTGOING send with a minus sign — wrong in
 // both direction and tone for anything credit-shaped (TASK-21403's shape).
 
+import { EHistoryUserRole, type HistoryEntry } from '@/hooks/useTransactionHistory'
 import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
 import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
 
@@ -23,19 +24,25 @@ export const internalTransfer: TransactionStrategy = (): TransactionStrategyOutp
 })
 
 /**
- * A chargeback DEBITS the user (the BE's INFLOW_KINDS deliberately excludes
- * CHARGEBACK — funds leave the account when a dispute resolves against it).
- * The kind is enum-reserved with no live writer yet; the shape here keeps a
- * future row honest instead of surprising. A dispute resolving in the
- * USER's favor is the other lane entirely — it arrives as kind=REFUND and
- * renders through cardRefund as the credit the card terms promise
+ * Chargeback direction follows the VIEWER'S ledger entry, not a fixed sign:
+ * the mapper derives userRole from the viewer's PRINCIPAL entry, and the
+ * ledger contract lets a CHARGEBACK debit or credit either side. The common
+ * case is a debit (the BE's INFLOW_KINDS deliberately excludes CHARGEBACK),
+ * so SENDER/BOTH/NONE render outgoing; a viewer whose entry is the CREDIT
+ * side arrives as RECIPIENT and renders incoming. The kind is enum-reserved
+ * with no live writer yet; a dispute resolving in the USER's favor is the
+ * other lane entirely — it arrives as kind=REFUND and renders through
+ * cardRefund as the credit the card terms promise
  * (card-terms-international §"Chargebacks resolved in your favor").
  */
-export const chargeback: TransactionStrategy = (): TransactionStrategyOutput => ({
-    direction: 'send',
-    transactionCardType: 'send',
-    nameForDetails: 'Chargeback',
-    nameKey: TRANSACTION_NAME_KEYS.transaction,
-    isPeerActuallyUser: false,
-    isLinkTx: false,
-})
+export const chargeback: TransactionStrategy = (entry: HistoryEntry): TransactionStrategyOutput => {
+    const incoming = entry.userRole === EHistoryUserRole.RECIPIENT
+    return {
+        direction: incoming ? 'receive' : 'send',
+        transactionCardType: incoming ? 'receive' : 'send',
+        nameForDetails: 'Chargeback',
+        nameKey: TRANSACTION_NAME_KEYS.transaction,
+        isPeerActuallyUser: false,
+        isLinkTx: false,
+    }
+}

--- a/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
+++ b/src/components/TransactionDetails/strategies/intent/ledger-generic.ts
@@ -1,0 +1,38 @@
+// Strategies for the ledger-bookkeeping kinds that reach history rarely (or,
+// for INTERNAL_TRANSFER, only through the detail route — the list hides the
+// kind server-side). They exist so the IntentKind registry stays total over
+// the generated wire vocabulary: an unmapped kind used to fall through to
+// intentFallback and render as an OUTGOING send with a minus sign — wrong in
+// both direction and tone for anything credit-shaped (TASK-21403's shape).
+
+import { type TransactionStrategy, type TransactionStrategyOutput } from '../types'
+import { TRANSACTION_NAME_KEYS } from '@/components/TransactionDetails/transaction-name-keys'
+
+/**
+ * Collateral sweeps, auto-rebalances, admin moves — the user's own money
+ * moving between the user's own ledgers. Neutral outgoing shape, no alert:
+ * the kind is known, just not customer-meaningful.
+ */
+export const internalTransfer: TransactionStrategy = (): TransactionStrategyOutput => ({
+    direction: 'send',
+    transactionCardType: 'send',
+    nameForDetails: 'Internal transfer',
+    nameKey: TRANSACTION_NAME_KEYS.transaction,
+    isPeerActuallyUser: false,
+    isLinkTx: false,
+})
+
+/**
+ * A chargeback DEBITS the user (the BE's INFLOW_KINDS deliberately excludes
+ * CHARGEBACK — funds leave the account when a dispute resolves against it).
+ * The kind is enum-reserved with no live writer yet; the shape here keeps a
+ * future row honest instead of surprising.
+ */
+export const chargeback: TransactionStrategy = (): TransactionStrategyOutput => ({
+    direction: 'send',
+    transactionCardType: 'send',
+    nameForDetails: 'Chargeback',
+    nameKey: TRANSACTION_NAME_KEYS.transaction,
+    isPeerActuallyUser: false,
+    isLinkTx: false,
+})

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -52,9 +52,12 @@ const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
     PERK_REWARD: perkReward,
 }
 
-/** Runtime guard that the kind is one the FE renders. */
+/** Runtime guard that the kind is one the FE renders. Own-property check on
+ *  purpose: `in` walks the prototype chain, so a crafted receipt URL like
+ *  `?kind=toString` would dispatch Object.prototype.toString as a strategy
+ *  instead of falling back (TASK-21817 review). */
 export function isIntentKind(value: unknown): value is IntentKind {
-    return typeof value === 'string' && value in STRATEGIES
+    return typeof value === 'string' && Object.hasOwn(STRATEGIES, value)
 }
 
 // Legacy receipt back-compat. Before the decomplexify migration (commit

--- a/src/components/TransactionDetails/strategies/registry.ts
+++ b/src/components/TransactionDetails/strategies/registry.ts
@@ -15,31 +15,24 @@ import { fiatOnramp } from './intent/fiat-onramp'
 import { perkReward } from './intent/perk-reward'
 import { qrPay, cardSpend } from './intent/card'
 import { refund } from './intent/refund'
+import { internalTransfer, chargeback } from './intent/ledger-generic'
 import { intentFallback } from './fallback'
+import { type paths } from '@/types/api.generated'
 
-// IntentKind enumerates every raw TransactionIntentKind value the FE
-// renders, plus the synthetic 'PERK_REWARD' (sourced from perk_usage rows
-// rather than the transaction_intents table). A drift between this union
-// and the STRATEGIES map below is a TS error — adding a kind without a
-// strategy fails the build.
-export type IntentKind =
-    | 'DIRECT_TRANSFER'
-    | 'SEND_LINK'
-    | 'SEND_LINK_CLAIM'
-    | 'P2P_REQUEST_FULFILL'
-    | 'QR_PAY'
-    | 'CRYPTO_DEPOSIT'
-    | 'CRYPTO_WITHDRAW'
-    | 'ONRAMP'
-    | 'OFFRAMP'
-    | 'CARD_SPEND_AUTH'
-    | 'CARD_SPEND_CLEAR'
-    | 'CARD_AUTH_REVERSAL'
-    | 'REFUND'
-    | 'PERK_REWARD'
+// IntentKind is DERIVED from the generated OpenAPI types (TASK-21817): the
+// BE declares its wire-kind vocabulary — every TransactionIntentKind enum
+// value plus the synthetic 'PERK_REWARD' — on the /history/{entryId} `kind`
+// parameter, and `pnpm gen:api` carries it here. The STRATEGIES map below
+// is Record<IntentKind, …>, so a BE enum addition becomes a COMPILE ERROR
+// on the next type regen instead of a row that silently falls through to
+// the fallback and renders as an outgoing send (TASK-21403's failure
+// shape). No hand-maintained kind list remains.
+export type IntentKind = paths['/history/{entryId}']['get']['parameters']['query']['kind']
 
 const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
     DIRECT_TRANSFER: p2pSendOrRequestFulfill,
+    // Legacy charge-backed sends (pre-2026-04 rows; no new writes).
+    P2P_SEND: p2pSendOrRequestFulfill,
     P2P_REQUEST_FULFILL: p2pSendOrRequestFulfill,
     SEND_LINK: sendLink,
     SEND_LINK_CLAIM: sendLink,
@@ -52,6 +45,10 @@ const STRATEGIES: Record<IntentKind, TransactionStrategy> = {
     CARD_SPEND_CLEAR: cardSpend,
     CARD_AUTH_REVERSAL: cardSpend,
     REFUND: refund,
+    // Reward payouts are credits from Peanut — same face as perk rewards.
+    REWARD_PAYOUT: perkReward,
+    INTERNAL_TRANSFER: internalTransfer,
+    CHARGEBACK: chargeback,
     PERK_REWARD: perkReward,
 }
 

--- a/src/components/TransactionDetails/transaction-predicates.ts
+++ b/src/components/TransactionDetails/transaction-predicates.ts
@@ -116,6 +116,7 @@ const REFERRAL_NUDGE_KINDS: ReadonlySet<string> = new Set([
     'SEND_LINK',
     'SEND_LINK_CLAIM',
     'DIRECT_TRANSFER',
+    'P2P_SEND', // legacy charge-backed sends — same outbound payment as DIRECT_TRANSFER
     'P2P_REQUEST_FULFILL',
     'CRYPTO_WITHDRAW',
     'OFFRAMP',

--- a/src/hooks/__tests__/useZeroDev.boundary.test.tsx
+++ b/src/hooks/__tests__/useZeroDev.boundary.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * TASK-21815 review — the REAL handleSendUserOpEncoded must fire
+ * onBroadcastAttempt at the transport boundary: encode, preparation, and
+ * signature failures leave the marker untouched; a transport rejection
+ * observes it exactly once, fired before the send.
+ */
+import { renderHook } from '@testing-library/react'
+import { useZeroDev } from '../useZeroDev'
+
+const mockDispatch = jest.fn()
+jest.mock('@/redux/hooks', () => ({
+    useAppDispatch: () => mockDispatch,
+    useZerodevStore: () => ({ isSendingUserOp: false }),
+    useSetupStore: () => ({}),
+}))
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: null, fetchUser: jest.fn() }) }))
+const fakeClient: Record<string, jest.Mock | { encodeCalls: jest.Mock; signUserOperation: jest.Mock }> = {} as never
+jest.mock('@/context/kernelClient.context', () => ({
+    useKernelClient: () => ({
+        setWebAuthnKey: jest.fn(),
+        getClientForChain: () => fakeClient,
+        ensureClientForChain: jest.fn(async () => undefined),
+    }),
+}))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('@/services/invites', () => ({ invitesApi: {} }))
+jest.mock('@/services/badge-campaigns', () => ({}))
+
+describe('handleSendUserOpEncoded — real broadcast boundary', () => {
+    function wireClient(overrides: { encode?: jest.Mock; prepare?: jest.Mock; sign?: jest.Mock; send?: jest.Mock }) {
+        const encode = overrides.encode ?? jest.fn(async () => '0xencoded')
+        const prepare = overrides.prepare ?? jest.fn(async () => ({ callData: '0xencoded', callGasLimit: 1n }))
+        const sign = overrides.sign ?? jest.fn(async () => `0x${'e'.repeat(130)}`)
+        const send = overrides.send ?? jest.fn(async () => '0x' + 'f'.repeat(64))
+        fakeClient.account = { encodeCalls: encode, signUserOperation: sign } as never
+        fakeClient.prepareUserOperation = prepare
+        fakeClient.sendUserOperation = send
+        fakeClient.waitForUserOperationReceipt = jest.fn(async () => ({
+            success: true,
+            receipt: { status: 'success' },
+        }))
+        return { encode, prepare, sign, send }
+    }
+
+    const calls = [
+        { to: '0x0000000000000000000000000000000000000001' as `0x${string}`, value: 0n, data: '0x' as `0x${string}` },
+    ]
+
+    it.each([
+        [
+            'encode',
+            () =>
+                wireClient({
+                    encode: jest.fn(async () => {
+                        throw new Error('encode boom')
+                    }),
+                }),
+        ],
+        [
+            'prepare',
+            () =>
+                wireClient({
+                    prepare: jest.fn(async () => {
+                        throw new Error('prepare boom')
+                    }),
+                }),
+        ],
+        [
+            'sign',
+            () =>
+                wireClient({
+                    sign: jest.fn(async () => {
+                        throw new Error('sign boom')
+                    }),
+                }),
+        ],
+    ] as const)('a %s failure never fires the marker', async (_stage, wire) => {
+        wire()
+        const marker = jest.fn()
+        const { result } = renderHook(() => useZeroDev())
+        await expect(
+            result.current.handleSendUserOpEncoded(calls, '42161', { onBroadcastAttempt: marker })
+        ).rejects.toThrow('boom')
+        expect(marker).not.toHaveBeenCalled()
+    })
+
+    it('a transport rejection observes the marker exactly once, fired before the send', async () => {
+        const marker = jest.fn()
+        const send = jest.fn(async () => {
+            expect(marker).toHaveBeenCalledTimes(1)
+            throw new Error('bundler down')
+        })
+        wireClient({ send })
+        const { result } = renderHook(() => useZeroDev())
+        await expect(
+            result.current.handleSendUserOpEncoded(calls, '42161', { onBroadcastAttempt: marker })
+        ).rejects.toThrow('bundler down')
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(marker).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -358,12 +358,19 @@ export const useZeroDev = () => {
             dispatch(zerodevActions.setIsSendingUserOp(true))
 
             let userOpHash: Hash
+            // Encode BEFORE signalling the broadcast boundary — an encoding
+            // failure is provably pre-broadcast and must not read as
+            // execution-ambiguous to the caller. The remaining pre-transport
+            // work inside sendUserOperation (estimation, paymaster, signing)
+            // cannot be split without decomposing the SDK call; the caller's
+            // WebAuthn-rejection carve-out covers the user-visible slice.
+            const encodedCallData = await client.account!.encodeCalls(calls)
             opts?.onBroadcastAttempt?.()
             try {
                 userOpHash = await withCeremonyPurpose('user_op', async () =>
                     client.sendUserOperation({
                         account: client.account,
-                        callData: await client.account!.encodeCalls(calls),
+                        callData: encodedCallData,
                     })
                 )
             } catch (error) {

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -336,7 +336,15 @@ export const useZeroDev = () => {
             // of a reverted userOp so it can verify migration state against
             // on-chain truth (kernelMigration.utils.ts). Payment flows must
             // instead FAIL a reverted op — throwing is the default.
-            opts?: { returnRevertedReceipt?: boolean }
+            opts?: {
+                returnRevertedReceipt?: boolean
+                /** Fired immediately before the UserOp broadcast — the caller's
+                 *  "failures after this are execution-ambiguous" boundary. A
+                 *  WebAuthn ceremony rejection INSIDE the broadcast call still
+                 *  proves pre-broadcast (an unsigned op cannot submit) — see
+                 *  useSpendBundle's ceremony-rejection carve-out. */
+                onBroadcastAttempt?: () => void
+            }
         ): Promise<{ userOpHash: Hash; receipt: TransactionReceipt | null }> => {
             // demo mode: simulated success, no chain.
             if (isDemoMode()) {
@@ -350,6 +358,7 @@ export const useZeroDev = () => {
             dispatch(zerodevActions.setIsSendingUserOp(true))
 
             let userOpHash: Hash
+            opts?.onBroadcastAttempt?.()
             try {
                 userOpHash = await withCeremonyPurpose('user_op', async () =>
                     client.sendUserOperation({

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -355,24 +355,40 @@ export const useZeroDev = () => {
             // Non-Arb chains (recover-funds) aren't pre-built — wait for lazy build.
             await ensureClientForChain(chainId)
             const client = getClientForChain(chainId)
+            // Encode BEFORE the sending-state flag: a rejecting encoder must
+            // not leave isSendingUserOp stuck true (that suppresses
+            // stale-deployment reloads for the rest of the session).
+            const encodedCallData = await client.account!.encodeCalls(calls)
             dispatch(zerodevActions.setIsSendingUserOp(true))
 
             let userOpHash: Hash
-            // Encode BEFORE signalling the broadcast boundary — an encoding
-            // failure is provably pre-broadcast and must not read as
-            // execution-ambiguous to the caller. The remaining pre-transport
-            // work inside sendUserOperation (estimation, paymaster, signing)
-            // cannot be split without decomposing the SDK call; the caller's
-            // WebAuthn-rejection carve-out covers the user-visible slice.
-            const encodedCallData = await client.account!.encodeCalls(calls)
-            opts?.onBroadcastAttempt?.()
             try {
-                userOpHash = await withCeremonyPurpose('user_op', async () =>
-                    client.sendUserOperation({
-                        account: client.account,
+                // Decomposed so onBroadcastAttempt fires at the TRUE transport
+                // boundary: estimation + paymaster (prepareUserOperation) and
+                // the WebAuthn signature both complete first, so any failure
+                // in them is provably pre-broadcast to the caller. The final
+                // sendUserOperation receives the fully-prepared request plus
+                // the signature with `parameters: []`, making it a pure
+                // eth_sendUserOperation transport call (viem skips both the
+                // prepare fill-list and signing when they are supplied).
+                userOpHash = await withCeremonyPurpose('user_op', async () => {
+                    const preparedOp = await client.prepareUserOperation({
+                        account: client.account!,
                         callData: encodedCallData,
                     })
-                )
+                    // Same cast viem's sendUserOperation applies internally
+                    // before calling account.signUserOperation.
+                    const signature = await client.account!.signUserOperation(
+                        preparedOp as Parameters<NonNullable<typeof client.account>['signUserOperation']>[0]
+                    )
+                    opts?.onBroadcastAttempt?.()
+                    return client.sendUserOperation({
+                        ...preparedOp,
+                        account: client.account!,
+                        signature,
+                        parameters: [],
+                    } as never)
+                })
             } catch (error) {
                 console.error('Error sending UserOp:', error)
                 capturePasskeySignFailure(error, 'send-user-op')

--- a/src/hooks/wallet/__tests__/mixedEphemeralSpend.boundary.test.ts
+++ b/src/hooks/wallet/__tests__/mixedEphemeralSpend.boundary.test.ts
@@ -1,0 +1,116 @@
+/**
+ * TASK-21815 review — the REAL tryMixedEphemeralSpend must fire
+ * onBroadcastAttempt at the transport boundary and nowhere earlier: encode,
+ * preparation, and signature failures leave the marker untouched; a
+ * transport rejection observes it exactly once, fired before the send.
+ */
+import { tryMixedEphemeralSpend } from '../mixedEphemeralSpend'
+import { createEphemeralSpendSession } from '@/utils/ephemeralSpendKey'
+
+jest.mock('@/constants/zerodev.consts', () => ({
+    PEANUT_WALLET_TOKEN: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+}))
+jest.mock('@/utils/rainWithdraw.utils', () => ({ buildRainWithdrawTypedData: jest.fn(() => ({})) }))
+jest.mock('@/utils/ephemeralSpendKey', () => ({ createEphemeralSpendSession: jest.fn() }))
+jest.mock('@/utils/userop-rescue.utils', () => ({ rescueUserOpReceipt: jest.fn(async () => null) }))
+
+const mockCreateSession = createEphemeralSpendSession as jest.Mock
+
+const PREP = {
+    preparationId: 'prep-1',
+    coordinatorAddress: '0xc0d5bd6307ec8c8da03e7502a00b8cba24eefc06',
+    collateralProxy: '0x1111111111111111111111111111111111111111',
+    adminAddress: '0xc97fffbf8768ca90cd62fae2e313b084fe13e553',
+    chainId: '42161',
+    tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    amount: '150000000',
+    recipientAddress: '0x4e5b89fd498f333ed7f2a59c5f23d5b5dc41b3de',
+    directTransfer: false,
+    adminSalt: `0x${'a'.repeat(64)}`,
+    adminNonce: '1',
+    executorSignature: `0x${'b'.repeat(130)}`,
+    executorSalt: `0x${'c'.repeat(64)}`,
+    expiresAt: 1234567890,
+}
+
+function makeSession(overrides: { encodeCalls?: jest.Mock; prepare?: jest.Mock; sign?: jest.Mock; send?: jest.Mock }) {
+    const encodeCalls = overrides.encodeCalls ?? jest.fn(async () => '0xencoded')
+    const prepare = overrides.prepare ?? jest.fn(async () => ({ callData: '0xencoded', callGasLimit: 1n }))
+    const sign = overrides.sign ?? jest.fn(async () => `0x${'e'.repeat(130)}`)
+    const send = overrides.send ?? jest.fn(async () => ('0x' + 'f'.repeat(64)) as `0x${string}`)
+    return {
+        account: {
+            address: '0xc97fffbf8768ca90cd62fae2e313b084fe13e553',
+            signTypedData: jest.fn(async () => `0x${'d'.repeat(130)}`),
+            encodeCalls,
+            signUserOperation: sign,
+        },
+        client: {
+            prepareUserOperation: prepare,
+            sendUserOperation: send,
+            waitForUserOperationReceipt: jest.fn(async () => ({ success: true, receipt: { status: 'success' } })),
+        },
+        uninstallCall: { to: '0x0000000000000000000000000000000000000001', value: 0n, data: '0x' },
+        dispose: jest.fn(),
+    }
+}
+
+function args(session: ReturnType<typeof makeSession>, onBroadcastAttempt: jest.Mock) {
+    mockCreateSession.mockResolvedValueOnce(session)
+    return {
+        publicClient: {} as never,
+        chain: { id: 42161 } as never,
+        patchedSudoValidator: {} as never,
+        accountAddress: '0xc97fffbf8768ca90cd62fae2e313b084fe13e553' as `0x${string}`,
+        prep: PREP as never,
+        requiredUsdcAmount: 150_000_000n,
+        subsequentCalls: [],
+        onBroadcastAttempt,
+    }
+}
+
+describe('tryMixedEphemeralSpend — real broadcast boundary', () => {
+    it.each([
+        [
+            'encode',
+            {
+                encodeCalls: jest.fn(async () => {
+                    throw new Error('encode boom')
+                }),
+            },
+        ],
+        [
+            'prepare',
+            {
+                prepare: jest.fn(async () => {
+                    throw new Error('prepare boom')
+                }),
+            },
+        ],
+        [
+            'sign',
+            {
+                sign: jest.fn(async () => {
+                    throw new Error('sign boom')
+                }),
+            },
+        ],
+    ] as const)('a %s failure never fires the marker', async (_stage, overrides) => {
+        const marker = jest.fn()
+        const result = await tryMixedEphemeralSpend(args(makeSession(overrides), marker))
+        expect(result.ok).toBe(false)
+        expect(marker).not.toHaveBeenCalled()
+    })
+
+    it('a transport rejection observes the marker exactly once, fired before the send', async () => {
+        const marker = jest.fn()
+        const send = jest.fn(async () => {
+            expect(marker).toHaveBeenCalledTimes(1)
+            throw new Error('bundler down')
+        })
+        const result = await tryMixedEphemeralSpend(args(makeSession({ send }), marker))
+        expect(result.ok).toBe(false)
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(marker).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
@@ -49,7 +49,7 @@ jest.mock('@/hooks/useRainCardOverview', () => ({
 jest.mock('../useGrantSessionKey', () => ({ useGrantSessionKey: () => ({ grant: jest.fn() }) }))
 jest.mock('../useSignUserOp', () => ({ useSignUserOp: () => ({ signCallsUserOp: jest.fn() }) }))
 jest.mock('@/utils/rainWithdraw.utils', () => ({ buildRainWithdrawTypedData: jest.fn(() => ({})) }))
-jest.mock('@/services/rain', () => ({ rainApi: { prepareWithdrawal: jest.fn() } }))
+jest.mock('@/services/rain', () => ({ rainApi: { prepareWithdrawal: jest.fn(), cancelPreparation: jest.fn() } }))
 // Keep the real InsufficientSpendableError class (instanceof must hold);
 // mock only the two engine entry points.
 jest.mock('../spendPreflight', () => ({
@@ -107,11 +107,12 @@ describe('useSignSpendBundle — forceStrategy: collateral-only', () => {
             })
         })
         expect(mockResolveSpendStrategy).not.toHaveBeenCalled()
+        // The backend chooses the intent kind (TASK-21815) — the wire call
+        // carries no client-declared kind.
         expect(mockPrepareWithdrawal).toHaveBeenCalledWith({
             amount: '15000', // USDC units → Rain cents
             recipientAddress: RECIPIENT,
             directTransfer: true,
-            kind: 'AUTO_REBALANCE',
         })
         expect(artifact).toEqual({
             strategy: 'collateral-only',
@@ -146,5 +147,26 @@ describe('useSignSpendBundle — forceStrategy: collateral-only', () => {
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['rain-card-overview'] })
         expect(mockResolveSpendStrategy).not.toHaveBeenCalled()
         expect(mockPrepareWithdrawal).not.toHaveBeenCalled()
+    })
+
+    it('backs the draft out when the flow dies after a successful prepare (TASK-21815)', async () => {
+        const mockCancelPreparation = rainApi.cancelPreparation as jest.Mock
+        // Prepare succeeds, the admin signature ceremony throws (user
+        // dismissed the passkey prompt) — the hook must fire the best-effort
+        // cancel for the orphaned draft.
+        mockSignTypedData.mockRejectedValueOnce(new Error('ceremony dismissed'))
+        const { result } = renderHook(() => useSignSpendBundle(), { wrapper })
+        await act(async () => {
+            await expect(
+                result.current.signSpend({
+                    requiredUsdcAmount: 150_000_000n,
+                    recipient: RECIPIENT,
+                    rainSpendingPower: 200_000_000n,
+                    kind: 'AUTO_REBALANCE',
+                    forceStrategy: 'collateral-only',
+                })
+            ).rejects.toThrow('ceremony dismissed')
+        })
+        expect(mockCancelPreparation).toHaveBeenCalledWith('prep-1')
     })
 })

--- a/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
@@ -27,11 +27,6 @@ jest.mock('@/constants/zerodev.consts', () => ({
     PEANUT_WALLET_TOKEN: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
     PEANUT_WALLET_TOKEN_DECIMALS: 6,
 }))
-jest.mock('@/constants/rain.consts', () => ({
-    rainCoordinatorAbi: [
-        { type: 'function', name: 'withdrawAsset', inputs: [], outputs: [], stateMutability: 'nonpayable' },
-    ],
-}))
 const mockSignTypedData = jest.fn()
 jest.mock('@/context/kernelClient.context', () => ({
     useKernelClient: () => ({
@@ -39,10 +34,14 @@ jest.mock('@/context/kernelClient.context', () => ({
         rebuildClientForChain: jest.fn(),
     }),
 }))
+const mockAccounts: Array<{ type: string; identifier: string }> = []
 jest.mock('@/context/authContext', () => ({
-    useAuth: () => ({ user: { accounts: [] } }),
+    useAuth: () => ({ user: { accounts: mockAccounts } }),
 }))
-jest.mock('@/hooks/useZeroDev', () => ({ useZeroDev: () => ({ handleSendUserOpEncoded: jest.fn() }) }))
+const mockHandleSendUserOpEncoded = jest.fn()
+jest.mock('@/hooks/useZeroDev', () => ({
+    useZeroDev: () => ({ handleSendUserOpEncoded: mockHandleSendUserOpEncoded }),
+}))
 jest.mock('@/context/ModalsContext', () => ({ useModalsContextOptional: () => undefined }))
 jest.mock('@/hooks/useRainCardOverview', () => ({
     useRainCardOverview: () => ({ overview: { cards: [] } }),
@@ -79,10 +78,10 @@ const PREP = {
     amount: '150000000',
     recipientAddress: RECIPIENT,
     directTransfer: true,
-    adminSalt: '0xsalt',
+    adminSalt: `0x${'a'.repeat(64)}`,
     adminNonce: '1',
-    executorSignature: '0xexecsig',
-    executorSalt: '0xexecsalt',
+    executorSignature: `0x${'b'.repeat(130)}`,
+    executorSalt: `0x${'c'.repeat(64)}`,
     expiresAt: 1234567890,
 }
 
@@ -140,5 +139,40 @@ describe('useSpendBundle — draft back-out boundaries', () => {
             await expect(result.current.spend(spendInput())).rejects.toThrow('gateway timeout')
         })
         expect(mockCancelPreparation).not.toHaveBeenCalled()
+    })
+
+    describe('mixed path — the broadcast boundary sits INSIDE the userop helper', () => {
+        beforeEach(() => {
+            mockAccounts.splice(0, mockAccounts.length, { type: 'peanut-wallet', identifier: ACCOUNT })
+            mockResolveSpendStrategy.mockResolvedValue({ strategy: 'mixed', smartBalance: 50_000_000n })
+            mockPrepareWithdrawal.mockResolvedValue({ ...PREP, directTransfer: false })
+        })
+        afterEach(() => mockAccounts.splice(0, mockAccounts.length))
+
+        it('a dismissed second ceremony (WebAuthn rejection) still cancels — the op was never signed', async () => {
+            mockHandleSendUserOpEncoded.mockImplementationOnce(async (_calls, _chain, opts) => {
+                opts?.onBroadcastAttempt?.()
+                const err = new Error('ceremony dismissed')
+                err.name = 'NotAllowedError'
+                throw err
+            })
+            const { result } = renderHook(() => useSpendBundle(), { wrapper })
+            await act(async () => {
+                await expect(result.current.spend(spendInput())).rejects.toThrow('ceremony dismissed')
+            })
+            expect(mockCancelPreparation).toHaveBeenCalledWith('prep-1')
+        })
+
+        it('a post-broadcast bundler failure is execution-ambiguous — no cancel fires', async () => {
+            mockHandleSendUserOpEncoded.mockImplementationOnce(async (_calls, _chain, opts) => {
+                opts?.onBroadcastAttempt?.()
+                throw new Error('bundler 502')
+            })
+            const { result } = renderHook(() => useSpendBundle(), { wrapper })
+            await act(async () => {
+                await expect(result.current.spend(spendInput())).rejects.toThrow('bundler 502')
+            })
+            expect(mockCancelPreparation).not.toHaveBeenCalled()
+        })
     })
 })

--- a/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * useSpendBundle — draft back-out boundaries (TASK-21815 review).
+ *
+ * Three contracts around /rain/cards/withdraw/prepare/cancel:
+ *  1. charge-backed prep + failure → NO cancel ever (the prep IS the charge;
+ *     cancelling it through the draft door would target the charge intent),
+ *  2. standalone prep + PRE-broadcast failure (admin ceremony dies) → exactly
+ *     one cancel with the preparation id,
+ *  3. standalone prep + POST-broadcast-attempt failure (/submit throws) →
+ *     NO cancel — the failure is execution-ambiguous (money may have moved
+ *     with the response lost); the backend's probe-verified TTL sweep owns
+ *     cleanup.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useSpendBundle } from '../useSpendBundle'
+import { resolveSpendStrategy, runCollateralSpendPreflight } from '../spendPreflight'
+import { rainApi } from '@/services/rain'
+
+const ACCOUNT = '0xc97fffbf8768ca90cd62fae2e313b084fe13e553'
+const RECIPIENT = '0x4e5b89fd498f333ed7f2a59c5f23d5b5dc41b3de'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/constants/zerodev.consts', () => ({
+    PEANUT_WALLET_CHAIN: { id: 42161 },
+    PEANUT_WALLET_TOKEN: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    PEANUT_WALLET_TOKEN_DECIMALS: 6,
+}))
+jest.mock('@/constants/rain.consts', () => ({
+    rainCoordinatorAbi: [
+        { type: 'function', name: 'withdrawAsset', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+    ],
+}))
+const mockSignTypedData = jest.fn()
+jest.mock('@/context/kernelClient.context', () => ({
+    useKernelClient: () => ({
+        getClientForChain: () => ({ account: { address: ACCOUNT, signTypedData: mockSignTypedData } }),
+        rebuildClientForChain: jest.fn(),
+    }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { accounts: [] } }),
+}))
+jest.mock('@/hooks/useZeroDev', () => ({ useZeroDev: () => ({ handleSendUserOpEncoded: jest.fn() }) }))
+jest.mock('@/context/ModalsContext', () => ({ useModalsContextOptional: () => undefined }))
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: () => ({ overview: { cards: [] } }),
+    RAIN_CARD_OVERVIEW_QUERY_KEY: 'rain-card-overview',
+}))
+jest.mock('../useGrantSessionKey', () => ({ useGrantSessionKey: () => ({ grant: jest.fn() }) }))
+jest.mock('@/utils/rainWithdraw.utils', () => ({ buildRainWithdrawTypedData: jest.fn(() => ({})) }))
+jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: {} }))
+jest.mock('@/constants/session-key-spend.consts', () => ({ sessionKeySpendEnabled: () => false }))
+jest.mock('./../mixedEphemeralSpend', () => ({ tryMixedEphemeralSpend: jest.fn() }))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+jest.mock('@/services/rain', () => ({
+    rainApi: { prepareWithdrawal: jest.fn(), cancelPreparation: jest.fn(), submitWithdrawal: jest.fn() },
+}))
+jest.mock('../spendPreflight', () => ({
+    ...jest.requireActual('../spendPreflight'),
+    resolveSpendStrategy: jest.fn(),
+    runCollateralSpendPreflight: jest.fn(),
+}))
+
+const mockResolveSpendStrategy = resolveSpendStrategy as jest.Mock
+const mockPreflight = runCollateralSpendPreflight as jest.Mock
+const mockPrepareWithdrawal = rainApi.prepareWithdrawal as jest.Mock
+const mockSubmitWithdrawal = rainApi.submitWithdrawal as jest.Mock
+const mockCancelPreparation = rainApi.cancelPreparation as jest.Mock
+
+const PREP = {
+    preparationId: 'prep-1',
+    coordinatorAddress: '0xc0d5bd6307ec8c8da03e7502a00b8cba24eefc06',
+    collateralProxy: '0x1111111111111111111111111111111111111111',
+    adminAddress: ACCOUNT,
+    chainId: '42161',
+    tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    amount: '150000000',
+    recipientAddress: RECIPIENT,
+    directTransfer: true,
+    adminSalt: '0xsalt',
+    adminNonce: '1',
+    executorSignature: '0xexecsig',
+    executorSalt: '0xexecsalt',
+    expiresAt: 1234567890,
+}
+
+let queryClient: QueryClient
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    queryClient = new QueryClient()
+    mockPreflight.mockImplementation(async ({ kernelClient }) => kernelClient)
+    mockResolveSpendStrategy.mockResolvedValue({ strategy: 'collateral-only', smartBalance: 0n })
+    mockPrepareWithdrawal.mockResolvedValue(PREP)
+    mockSignTypedData.mockResolvedValue('0xadminsig')
+    mockSubmitWithdrawal.mockResolvedValue({ txHash: '0x' + 'a'.repeat(64) })
+})
+
+function spendInput(overrides: Record<string, unknown> = {}) {
+    return {
+        requiredUsdcAmount: 150_000_000n,
+        recipient: RECIPIENT as `0x${string}`,
+        rainSpendingPower: 200_000_000n,
+        kind: 'CRYPTO_WITHDRAW' as const,
+        ...overrides,
+    }
+}
+
+describe('useSpendBundle — draft back-out boundaries', () => {
+    it('a charge-backed prep is NEVER cancelled, even when signing dies before broadcast', async () => {
+        mockSignTypedData.mockRejectedValueOnce(new Error('ceremony dismissed'))
+        const { result } = renderHook(() => useSpendBundle(), { wrapper })
+        await act(async () => {
+            await expect(result.current.spend(spendInput({ chargeId: 'charge-42' }))).rejects.toThrow(
+                'ceremony dismissed'
+            )
+        })
+        expect(mockCancelPreparation).not.toHaveBeenCalled()
+    })
+
+    it('a standalone prep is cancelled once when the failure precedes any broadcast', async () => {
+        mockSignTypedData.mockRejectedValueOnce(new Error('ceremony dismissed'))
+        const { result } = renderHook(() => useSpendBundle(), { wrapper })
+        await act(async () => {
+            await expect(result.current.spend(spendInput())).rejects.toThrow('ceremony dismissed')
+        })
+        expect(mockCancelPreparation).toHaveBeenCalledTimes(1)
+        expect(mockCancelPreparation).toHaveBeenCalledWith('prep-1')
+    })
+
+    it('a /submit failure is execution-ambiguous — no cancel fires', async () => {
+        mockSubmitWithdrawal.mockRejectedValueOnce(new Error('gateway timeout'))
+        const { result } = renderHook(() => useSpendBundle(), { wrapper })
+        await act(async () => {
+            await expect(result.current.spend(spendInput())).rejects.toThrow('gateway timeout')
+        })
+        expect(mockCancelPreparation).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSpendBundle.test.tsx
@@ -16,6 +16,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { useSpendBundle } from '../useSpendBundle'
 import { resolveSpendStrategy, runCollateralSpendPreflight } from '../spendPreflight'
+import { tryMixedEphemeralSpend } from '../mixedEphemeralSpend'
 import { rainApi } from '@/services/rain'
 
 const ACCOUNT = '0xc97fffbf8768ca90cd62fae2e313b084fe13e553'
@@ -32,6 +33,7 @@ jest.mock('@/context/kernelClient.context', () => ({
     useKernelClient: () => ({
         getClientForChain: () => ({ account: { address: ACCOUNT, signTypedData: mockSignTypedData } }),
         rebuildClientForChain: jest.fn(),
+        getPatchedSudoValidator: jest.fn(async () => ({})),
     }),
 }))
 const mockAccounts: Array<{ type: string; identifier: string }> = []
@@ -50,7 +52,8 @@ jest.mock('@/hooks/useRainCardOverview', () => ({
 jest.mock('../useGrantSessionKey', () => ({ useGrantSessionKey: () => ({ grant: jest.fn() }) }))
 jest.mock('@/utils/rainWithdraw.utils', () => ({ buildRainWithdrawTypedData: jest.fn(() => ({})) }))
 jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: {} }))
-jest.mock('@/constants/session-key-spend.consts', () => ({ sessionKeySpendEnabled: () => false }))
+let mockSessionKeyEnabled = false
+jest.mock('@/constants/session-key-spend.consts', () => ({ sessionKeySpendEnabled: () => mockSessionKeyEnabled }))
 jest.mock('./../mixedEphemeralSpend', () => ({ tryMixedEphemeralSpend: jest.fn() }))
 jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
 jest.mock('@/services/rain', () => ({
@@ -173,6 +176,34 @@ describe('useSpendBundle — draft back-out boundaries', () => {
                 await expect(result.current.spend(spendInput())).rejects.toThrow('bundler 502')
             })
             expect(mockCancelPreparation).not.toHaveBeenCalled()
+        })
+
+        it('a crossed session-key attempt stays ambiguous — a later ceremony rejection must NOT cancel', async () => {
+            // The ephemeral attempt broadcasts (boundary crossed) and falls
+            // through; the passkey fallback reuses the SAME prep and its
+            // ceremony is dismissed. The ceremony carve-out must not override
+            // the earlier ambiguous broadcast (Chip-filed follow-up on r2).
+            mockSessionKeyEnabled = true
+            try {
+                const mockEphemeral = tryMixedEphemeralSpend as jest.Mock
+                mockEphemeral.mockImplementationOnce(async (args) => {
+                    args.onBroadcastAttempt?.()
+                    return { ok: false, reason: 'timeout waiting for receipt' }
+                })
+                mockHandleSendUserOpEncoded.mockImplementationOnce(async (_calls, _chain, opts) => {
+                    opts?.onBroadcastAttempt?.()
+                    const err = new Error('ceremony dismissed')
+                    err.name = 'NotAllowedError'
+                    throw err
+                })
+                const { result } = renderHook(() => useSpendBundle(), { wrapper })
+                await act(async () => {
+                    await expect(result.current.spend(spendInput())).rejects.toThrow('ceremony dismissed')
+                })
+                expect(mockCancelPreparation).not.toHaveBeenCalled()
+            } finally {
+                mockSessionKeyEnabled = false
+            }
         })
     })
 })

--- a/src/hooks/wallet/mixedEphemeralSpend.ts
+++ b/src/hooks/wallet/mixedEphemeralSpend.ts
@@ -121,10 +121,13 @@ export async function tryMixedEphemeralSpend(args: MixedEphemeralSpendArgs): Pro
             session.uninstallCall,
         ]
 
+        // Encode BEFORE the broadcast signal — an encoding failure is
+        // provably pre-broadcast (same rule as useZeroDev's helper).
+        const callData = await session.account.encodeCalls(calls)
         args.onBroadcastAttempt?.()
         const userOpHash = await session.client.sendUserOperation({
             account: session.account,
-            callData: await session.account.encodeCalls(calls),
+            callData,
         })
 
         let receipt: TransactionReceipt | null = null

--- a/src/hooks/wallet/mixedEphemeralSpend.ts
+++ b/src/hooks/wallet/mixedEphemeralSpend.ts
@@ -121,14 +121,26 @@ export async function tryMixedEphemeralSpend(args: MixedEphemeralSpendArgs): Pro
             session.uninstallCall,
         ]
 
-        // Encode BEFORE the broadcast signal — an encoding failure is
-        // provably pre-broadcast (same rule as useZeroDev's helper).
+        // Decomposed prepare → sign → transport (same rule as useZeroDev's
+        // helper): estimation, paymaster work, and the ephemeral-key signature
+        // all complete BEFORE onBroadcastAttempt, so any failure in them is
+        // provably pre-broadcast; the final call is pure transport.
         const callData = await session.account.encodeCalls(calls)
-        args.onBroadcastAttempt?.()
-        const userOpHash = await session.client.sendUserOperation({
+        const preparedOp = await session.client.prepareUserOperation({
             account: session.account,
             callData,
         })
+        // Same cast viem's sendUserOperation applies internally.
+        const signature = await session.account.signUserOperation(
+            preparedOp as Parameters<typeof session.account.signUserOperation>[0]
+        )
+        args.onBroadcastAttempt?.()
+        const userOpHash = await session.client.sendUserOperation({
+            ...preparedOp,
+            account: session.account,
+            signature,
+            parameters: [],
+        } as never)
 
         let receipt: TransactionReceipt | null = null
         try {

--- a/src/hooks/wallet/mixedEphemeralSpend.ts
+++ b/src/hooks/wallet/mixedEphemeralSpend.ts
@@ -35,6 +35,9 @@ export interface MixedEphemeralSpendArgs {
     recipient?: Hex
     requiredUsdcAmount: bigint
     subsequentCalls: { to: Hex; value: bigint; data: Hex }[]
+    /** Fired immediately before the UserOp broadcast — the caller's
+     *  "failures after this are execution-ambiguous" boundary (TASK-21815). */
+    onBroadcastAttempt?: () => void
 }
 
 export type MixedEphemeralSpendResult =
@@ -118,6 +121,7 @@ export async function tryMixedEphemeralSpend(args: MixedEphemeralSpendArgs): Pro
             session.uninstallCall,
         ]
 
+        args.onBroadcastAttempt?.()
         const userOpHash = await session.client.sendUserOperation({
             account: session.account,
             callData: await session.account.encodeCalls(calls),

--- a/src/hooks/wallet/useReturnExcessCollateral.ts
+++ b/src/hooks/wallet/useReturnExcessCollateral.ts
@@ -51,14 +51,11 @@ export const useReturnExcessCollateral = () => {
             if (artifact.strategy !== 'collateral-only') {
                 throw new Error('Unexpected withdrawal strategy')
             }
-            try {
-                await rainApi.submitWithdrawal(artifact.rainWithdrawal)
-            } catch (e) {
-                // Back the signed-but-unsubmitted draft out (best-effort — the
-                // backend refuses while it could still execute; TASK-21815).
-                void rainApi.cancelPreparation(artifact.rainWithdrawal.preparationId)
-                throw e
-            }
+            // No cancel on a submit throw: the failure is execution-ambiguous
+            // (the withdrawal may have executed with the response lost). The
+            // backend's probe-verified TTL sweep owns abandoned-draft cleanup
+            // (TASK-21815 review).
+            await rainApi.submitWithdrawal(artifact.rainWithdrawal)
 
             // Funds moved collateral → smart wallet; refresh both buckets so the
             // unified balance doesn't transiently double-count or crater.

--- a/src/hooks/wallet/useReturnExcessCollateral.ts
+++ b/src/hooks/wallet/useReturnExcessCollateral.ts
@@ -51,7 +51,14 @@ export const useReturnExcessCollateral = () => {
             if (artifact.strategy !== 'collateral-only') {
                 throw new Error('Unexpected withdrawal strategy')
             }
-            await rainApi.submitWithdrawal(artifact.rainWithdrawal)
+            try {
+                await rainApi.submitWithdrawal(artifact.rainWithdrawal)
+            } catch (e) {
+                // Back the signed-but-unsubmitted draft out (best-effort — the
+                // backend refuses while it could still execute; TASK-21815).
+                void rainApi.cancelPreparation(artifact.rainWithdrawal.preparationId)
+                throw e
+            }
 
             // Funds moved collateral → smart wallet; refresh both buckets so the
             // unified balance doesn't transiently double-count or crater.

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -176,6 +176,9 @@ export const useSignSpendBundle = () => {
             // Failure-capture parity with useSpendBundle's catch: without this,
             // a failed migration/grant/signing in the sign-then-broadcast flow
             // emits `attempted` with no terminal event and the funnel lies.
+            // Hoisted so the catch can back the draft out — `prep` itself is
+            // block-scoped inside the try.
+            let livePreparationId: string | undefined
             try {
                 // Shared collateral pre-flights (root-validator migration gate +
                 // session-key grant) — ONE ordered sequence for both spend engines;
@@ -220,12 +223,14 @@ export const useSignSpendBundle = () => {
                 // Only sign the admin EIP-712 — backend submits the withdrawal via
                 // the user's session-key UserOp (1 tap total).
                 if (strategy === 'collateral-only') {
+                    // The backend chooses the intent kind from the destination
+                    // (TASK-21815) — nothing user-declared goes on the wire.
                     const prep = await rainApi.prepareWithdrawal({
                         amount: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                         recipientAddress: recipient,
                         directTransfer: true,
-                        kind,
                     })
+                    livePreparationId = prep.preparationId
 
                     const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
                         activeAccount.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
@@ -263,9 +268,9 @@ export const useSignSpendBundle = () => {
                     // semantics as broadcasting useSpendBundle.spend's mixed path.
                     recipientAddress: adminAddress,
                     directTransfer: false,
-                    kind,
                     totalAmountCents: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                 })
+                livePreparationId = prep.preparationId
 
                 const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
                     activeAccount.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
@@ -305,6 +310,11 @@ export const useSignSpendBundle = () => {
                 const signedUserOp = await signCallsUserOp([withdrawCall, transferCall], chainIdStr)
                 return { strategy, signedUserOp, rainPreparationId: prep.preparationId }
             } catch (e) {
+                // Back the abandoned draft out (cancelled passkey prompt, grant
+                // failure, …). Fire-and-forget: the backend refuses while the
+                // Rain signature could still execute, and the TTL sweep is the
+                // guaranteed cleanup either way (TASK-21815).
+                if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
                 posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_FAILED, {
                     strategy,
                     kind,

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -25,6 +25,7 @@ import { useModalsContextOptional } from '@/context/ModalsContext'
 import { isDemoMode } from '@/utils/demo'
 import { debitDemoBalance } from '@/utils/demo-balance'
 import { resolveSettledTxHash } from '@/utils/settled-tx-hash.utils'
+import { WebAuthnErrorName } from '@/utils/webauthn.utils'
 import {
     resolveSpendStrategy,
     runCollateralSpendPreflight,
@@ -296,10 +297,12 @@ export const useSpendBundle = () => {
                     posthog.capture(ANALYTICS_EVENTS.SESSION_KEY_SPEND_ATTEMPTED, { kind })
                     modals?.setIsSecurityVerificationOpen?.(true)
                     let attempt: Awaited<ReturnType<typeof tryMixedEphemeralSpend>>
-                    broadcastAttempted = true
                     try {
                         const patchedSudoValidator = await getPatchedSudoValidator(peanutPublicClient)
                         attempt = await tryMixedEphemeralSpend({
+                            onBroadcastAttempt: () => {
+                                broadcastAttempted = true
+                            },
                             publicClient: peanutPublicClient,
                             chain: PEANUT_WALLET_CHAIN,
                             patchedSudoValidator,
@@ -393,8 +396,11 @@ export const useSpendBundle = () => {
                         ...(transferCall ? [transferCall] : []),
                         ...subsequentCalls,
                     ]
-                    broadcastAttempted = true
-                    const { userOpHash, receipt } = await handleSendUserOpEncoded(calls, chainIdStr)
+                    const { userOpHash, receipt } = await handleSendUserOpEncoded(calls, chainIdStr, {
+                        onBroadcastAttempt: () => {
+                            broadcastAttempted = true
+                        },
+                    })
 
                     // Stamp the intent so the Rain collateral webhook reconciles to the
                     // right category (P2P_SEND, CRYPTO_WITHDRAW, etc). Non-blocking —
@@ -414,12 +420,20 @@ export const useSpendBundle = () => {
                 }
             } catch (e) {
                 // Back the abandoned draft out ONLY when the failure provably
-                // precedes any broadcast (cancelled passkey prompt, grant
-                // failure). A post-broadcast throw is execution-ambiguous —
-                // money may have moved with the response lost — so those rely
-                // on the backend's probe-verified TTL sweep instead
+                // precedes any broadcast: either the broadcast boundary was
+                // never reached (grant/setup/first-ceremony failure), or the
+                // throw is a WebAuthn ceremony rejection — an unsigned op
+                // cannot have been submitted, so a dismissed tap #2 inside the
+                // broadcast call is still pre-broadcast. Anything else is
+                // execution-ambiguous (money may have moved with the response
+                // lost) and relies on the backend's probe-verified TTL sweep
                 // (TASK-21815 review). Fire-and-forget either way.
-                if (livePreparationId && !broadcastAttempted) void rainApi.cancelPreparation(livePreparationId)
+                const ceremonyRejection = Object.values(WebAuthnErrorName).includes(
+                    (e as Error)?.name as WebAuthnErrorName
+                )
+                if (livePreparationId && (!broadcastAttempted || ceremonyRejection)) {
+                    void rainApi.cancelPreparation(livePreparationId)
+                }
                 const errorKind =
                     e instanceof SessionKeyGrantRequiredError
                         ? `session-key:${e.cause.kind}`

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -168,6 +168,9 @@ export const useSpendBundle = () => {
             onStrategyDecided?.(strategy)
             posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, { strategy, kind })
 
+            // Hoisted so the catch can back an abandoned draft out — `prep`
+            // itself is block-scoped inside the try (TASK-21815).
+            let livePreparationId: string | undefined
             try {
                 // Shared collateral pre-flights (root-validator migration gate +
                 // session-key grant) — ONE ordered sequence for both spend
@@ -190,17 +193,21 @@ export const useSpendBundle = () => {
 
                 // ─── collateral-only ──────────────────────────────────────────────
                 if (strategy === 'collateral-only') {
+                    // The backend chooses the intent kind from the destination
+                    // (TASK-21815) — nothing user-declared goes on the wire.
                     const prep = await rainApi.prepareWithdrawal({
                         amount: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                         recipientAddress: recipient!,
                         directTransfer: true,
-                        kind,
                         // When set, the backend uses the charge as the prep and
                         // completes it directly on confirm; a follow-up
                         // recordPayment re-enters the same trusted-completion
                         // path idempotently (see SpendBundleInput.chargeId).
                         chargeId,
                     })
+                    // A charge-backed prep IS the charge — never back it out
+                    // through the draft-cancel door.
+                    if (!chargeId) livePreparationId = prep.preparationId
 
                     const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
                         activeClient.account!.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
@@ -264,11 +271,11 @@ export const useSpendBundle = () => {
                     // withdraw beneficiary, which equals msg.sender-to-be in the follow-up UserOp.
                     recipientAddress: adminAddress,
                     directTransfer: false,
-                    kind,
                     // History shows the full user-initiated spend, not just the
                     // shortfall Rain signed over.
                     totalAmountCents: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                 })
+                livePreparationId = prep.preparationId
 
                 /*
                  * One-tap variant (dark flag): a per-transaction ephemeral key
@@ -398,6 +405,11 @@ export const useSpendBundle = () => {
                     modals?.setIsSecurityVerificationOpen?.(false)
                 }
             } catch (e) {
+                // Back the abandoned draft out (cancelled passkey prompt,
+                // failed broadcast, …). Fire-and-forget: the backend refuses
+                // while the Rain signature could still execute, and the TTL
+                // sweep is the guaranteed cleanup either way (TASK-21815).
+                if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
                 const errorKind =
                     e instanceof SessionKeyGrantRequiredError
                         ? `session-key:${e.cause.kind}`

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -177,6 +177,12 @@ export const useSpendBundle = () => {
             // owns cleanup.
             let livePreparationId: string | undefined
             let broadcastAttempted = false
+            // Sticky: an attempt that crossed the broadcast boundary and then
+            // failed WITHOUT a ceremony rejection of its own (the session-key
+            // attempt falls through to the passkey path). Once set, NOTHING
+            // may cancel this draft — not even a later ceremony rejection on
+            // the fallback attempt: the earlier broadcast may have landed.
+            let ambiguousBroadcast = false
             try {
                 // Shared collateral pre-flights (root-validator migration gate +
                 // session-key grant) — ONE ordered sequence for both spend
@@ -297,11 +303,13 @@ export const useSpendBundle = () => {
                     posthog.capture(ANALYTICS_EVENTS.SESSION_KEY_SPEND_ATTEMPTED, { kind })
                     modals?.setIsSecurityVerificationOpen?.(true)
                     let attempt: Awaited<ReturnType<typeof tryMixedEphemeralSpend>>
+                    let ephemeralCrossed = false
                     try {
                         const patchedSudoValidator = await getPatchedSudoValidator(peanutPublicClient)
                         attempt = await tryMixedEphemeralSpend({
                             onBroadcastAttempt: () => {
                                 broadcastAttempted = true
+                                ephemeralCrossed = true
                             },
                             publicClient: peanutPublicClient,
                             chain: PEANUT_WALLET_CHAIN,
@@ -315,6 +323,11 @@ export const useSpendBundle = () => {
                     } finally {
                         modals?.setIsSecurityVerificationOpen?.(false)
                     }
+                    // A crossed-but-failed session-key attempt is ambiguous
+                    // forever — the fallback passkey attempt reuses the SAME
+                    // prep (only one can execute on-chain), so the draft must
+                    // never be cancelled after this point.
+                    if (!attempt.ok && ephemeralCrossed) ambiguousBroadcast = true
                     if (attempt.ok) {
                         const mixedTxHash = resolveSettledTxHash(
                             { receipt: attempt.receipt, userOpHash: attempt.userOpHash },
@@ -431,7 +444,7 @@ export const useSpendBundle = () => {
                 const ceremonyRejection = Object.values(WebAuthnErrorName).includes(
                     (e as Error)?.name as WebAuthnErrorName
                 )
-                if (livePreparationId && (!broadcastAttempted || ceremonyRejection)) {
+                if (livePreparationId && !ambiguousBroadcast && (!broadcastAttempted || ceremonyRejection)) {
                     void rainApi.cancelPreparation(livePreparationId)
                 }
                 const errorKind =

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -169,8 +169,13 @@ export const useSpendBundle = () => {
             posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, { strategy, kind })
 
             // Hoisted so the catch can back an abandoned draft out — `prep`
-            // itself is block-scoped inside the try (TASK-21815).
+            // itself is block-scoped inside the try (TASK-21815). Once a
+            // broadcast is ATTEMPTED, a throw is execution-ambiguous (the
+            // response may be lost after money moved) — from that point the
+            // catch must NOT cancel; the backend's TTL sweep (probe-verified)
+            // owns cleanup.
             let livePreparationId: string | undefined
+            let broadcastAttempted = false
             try {
                 // Shared collateral pre-flights (root-validator migration gate +
                 // session-key grant) — ONE ordered sequence for both spend
@@ -213,6 +218,7 @@ export const useSpendBundle = () => {
                         activeClient.account!.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                     )) as Hex
 
+                    broadcastAttempted = true
                     const { txHash } = await rainApi.submitWithdrawal({
                         preparationId: prep.preparationId,
                         amount: prep.amount,
@@ -290,6 +296,7 @@ export const useSpendBundle = () => {
                     posthog.capture(ANALYTICS_EVENTS.SESSION_KEY_SPEND_ATTEMPTED, { kind })
                     modals?.setIsSecurityVerificationOpen?.(true)
                     let attempt: Awaited<ReturnType<typeof tryMixedEphemeralSpend>>
+                    broadcastAttempted = true
                     try {
                         const patchedSudoValidator = await getPatchedSudoValidator(peanutPublicClient)
                         attempt = await tryMixedEphemeralSpend({
@@ -386,6 +393,7 @@ export const useSpendBundle = () => {
                         ...(transferCall ? [transferCall] : []),
                         ...subsequentCalls,
                     ]
+                    broadcastAttempted = true
                     const { userOpHash, receipt } = await handleSendUserOpEncoded(calls, chainIdStr)
 
                     // Stamp the intent so the Rain collateral webhook reconciles to the
@@ -405,11 +413,13 @@ export const useSpendBundle = () => {
                     modals?.setIsSecurityVerificationOpen?.(false)
                 }
             } catch (e) {
-                // Back the abandoned draft out (cancelled passkey prompt,
-                // failed broadcast, …). Fire-and-forget: the backend refuses
-                // while the Rain signature could still execute, and the TTL
-                // sweep is the guaranteed cleanup either way (TASK-21815).
-                if (livePreparationId) void rainApi.cancelPreparation(livePreparationId)
+                // Back the abandoned draft out ONLY when the failure provably
+                // precedes any broadcast (cancelled passkey prompt, grant
+                // failure). A post-broadcast throw is execution-ambiguous —
+                // money may have moved with the response lost — so those rely
+                // on the backend's probe-verified TTL sweep instead
+                // (TASK-21815 review). Fire-and-forget either way.
+                if (livePreparationId && !broadcastAttempted) void rainApi.cancelPreparation(livePreparationId)
                 const errorKind =
                     e instanceof SessionKeyGrantRequiredError
                         ? `session-key:${e.cause.kind}`

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -77,11 +77,12 @@ export interface RainCardOverview {
 }
 
 /**
- * Outbound spend-intent vocabulary. Mirrors the kind values accepted by
- * the backend's withdraw / auto-balancer endpoints — translated to the
- * Prisma `TransactionIntentKind` enum at the API boundary. Named distinctly
- * from the history renderer's `IntentKind` union in strategies/registry.ts
- * (the inbound wire shape) to prevent silent drift between the two.
+ * FE-internal spend-flow vocabulary — analytics events and the collateral
+ * preflight key on it. Since TASK-21815 the backend chooses the intent kind
+ * itself (from the verified destination), so this NEVER goes on the wire;
+ * `/rain/cards/withdraw/prepare` ignores a client-sent kind. Named
+ * distinctly from the history renderer's `IntentKind` union in
+ * strategies/registry.ts (the inbound wire shape).
  */
 export type RainCollateralKind =
     | 'P2P_SEND'
@@ -102,8 +103,6 @@ export interface PrepareRainWithdrawalInput {
     amount: string
     recipientAddress: string
     directTransfer: boolean
-    /** User-semantic kind — drives history categorization for the collateral webhook. */
-    kind: RainCollateralKind
     /** Total user-initiated spend in cents. For mixed strategy this differs from
      *  `amount` (which is only the collateral shortfall). History shows this. */
     totalAmountCents?: string
@@ -562,6 +561,24 @@ export const rainApi = {
             // Non-fatal: intent stays PENDING until expiry, no history
             // categorization until then. Log loudly but don't block the user.
             console.warn('[rainApi.stampWithdrawal] failed:', (e as Error).message)
+        }
+    },
+
+    /**
+     * Best-effort back-out for an unused preparation (TASK-21815). Fire and
+     * forget on flow abandonment — the backend refuses while the Rain
+     * signature could still execute (409) and the 30-min TTL sweep is the
+     * guaranteed cleanup, so every failure mode here is safe to swallow.
+     */
+    cancelPreparation: async (preparationId: string): Promise<void> => {
+        try {
+            await rainRequest<{ ok: boolean }>({
+                method: 'POST',
+                path: '/rain/cards/withdraw/prepare/cancel',
+                body: { preparationId },
+            })
+        } catch (e) {
+            console.warn('[rainApi.cancelPreparation] failed (non-fatal):', (e as Error).message)
         }
     },
 

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -1372,6 +1372,7 @@ export interface paths {
                             admittedTotal: number;
                             eligibilityReason?: string;
                             flowEarlyAccess: boolean;
+                            geoProhibited: boolean;
                             hasCardAccess: boolean;
                             isEligible: boolean;
                             isPublicLaunched: boolean;
@@ -5422,6 +5423,173 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/healthz/bridge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/manteca/{geo}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    geo: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/rain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/rhino": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/sumsub": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/history/{entryId}": {
         parameters: {
             query?: never;
@@ -5432,7 +5600,7 @@ export interface paths {
         get: {
             parameters: {
                 query: {
-                    kind: string;
+                    kind: "ONRAMP" | "OFFRAMP" | "P2P_SEND" | "P2P_REQUEST_FULFILL" | "DIRECT_TRANSFER" | "SEND_LINK" | "SEND_LINK_CLAIM" | "CRYPTO_DEPOSIT" | "CRYPTO_WITHDRAW" | "CARD_SPEND_AUTH" | "CARD_SPEND_CLEAR" | "CARD_AUTH_REVERSAL" | "QR_PAY" | "INTERNAL_TRANSFER" | "REWARD_PAYOUT" | "REFUND" | "CHARGEBACK" | "PERK_REWARD";
                 };
                 header?: never;
                 path: {
@@ -6004,53 +6172,6 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/manteca/initiate-onboarding": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Initiate Manteca onboarding
-         * @description Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    Authorization: string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        exchange?: string;
-                        failureUrl?: string;
-                        returnUrl: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
         delete?: never;
         options?: never;
         head?: never;
@@ -7097,7 +7218,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        actionType: "BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED";
+                        actionType: ("BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED") | "DIRECT_TRANSFER" | "P2P_SEND" | "P2P_REQUEST_FULFILL" | "SEND_LINK" | "QR_PAY" | "ONRAMP" | "OFFRAMP" | "CRYPTO_WITHDRAW" | "CARD_SPEND_AUTH" | "CARD_SPEND_CLEAR";
                         otherUserId?: string;
                         usdAmount?: number;
                     };
@@ -7985,7 +8106,6 @@ export interface paths {
                         amount: string;
                         chargeId?: string;
                         directTransfer: boolean;
-                        kind: "P2P_SEND" | "QR_PAY" | "LINK_CREATE" | "CRYPTO_WITHDRAW" | "FIAT_OFFRAMP" | "FIAT_ONRAMP" | "REQUEST_PAY" | "AUTO_REBALANCE" | "CARD_SPEND" | "DEPOSIT_EXTERNAL" | "OTHER";
                         recipientAddress: string;
                         totalAmountCents?: string;
                     };
@@ -8079,6 +8199,97 @@ export interface paths {
                 };
                 /** @description Default Response */
                 502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/rain/cards/withdraw/prepare/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        preparationId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8209,6 +8420,18 @@ export interface paths {
                     content: {
                         "application/json": {
                             ok: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
                         };
                     };
                 };
@@ -9741,7 +9964,24 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody: {
+                content: {
+                    "multipart/form-data": {
+                        amount?: string | number;
+                        attachment?: unknown;
+                        chainId?: string;
+                        contractVersion?: string;
+                        depositIdx?: string | number;
+                        filename?: string;
+                        mimetype?: string;
+                        preparationId?: string;
+                        pubKey: string;
+                        reference?: string;
+                        tokenAddress?: string;
+                        txHash?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Default Response */
                 200: {
@@ -9838,6 +10078,44 @@ export interface paths {
                 };
                 cookie?: never;
             };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amount: string | number;
+                        chainId: string;
+                        contractVersion: string;
+                        depositIdx: string | number;
+                        tokenAddress: string;
+                        txHash: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/status/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
             requestBody?: never;
             responses: {
                 /** @description Default Response */
@@ -9849,6 +10127,12 @@ export interface paths {
                 };
             };
         };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/sumsub/webhooks": {
@@ -10088,7 +10372,61 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+                /** @description Invalid input — malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code. */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description The declared residence changed too recently. Only the residence keys were refused — every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`. */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "RESIDENCE_CHANGE_COOLDOWN";
+                            error: string;
+                            /** Format: date-time */
+                            retryAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            success: boolean;
+                        };
+                    };
                 };
             };
         };
@@ -10304,7 +10642,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -10341,7 +10679,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -10892,7 +11230,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -10929,7 +11267,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -10960,6 +11298,8 @@ export interface paths {
                             };
                             residence: {
                                 declared: string | null;
+                                declaredSecond: string | null;
+                                kycReported: string | null;
                                 nextChangeAllowedAt: string | null;
                                 verified: string | null;
                             };
@@ -11065,6 +11405,250 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/users/saved-addresses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddresses: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        address: string;
+                        chainId: string;
+                        nickname: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddress: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/saved-addresses/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            deleted: true;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        nickname: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddress: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/users/search": {
@@ -11332,7 +11916,24 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         put?: never;
         post: {
             parameters: {

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -17666,6 +17666,7 @@
                         "name": "limit",
                         "required": false,
                         "schema": {
+                            "maximum": 100,
                             "minimum": 1,
                             "type": "integer"
                         }

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -2450,6 +2450,9 @@
                                         "flowEarlyAccess": {
                                             "type": "boolean"
                                         },
+                                        "geoProhibited": {
+                                            "type": "boolean"
+                                        },
                                         "hasCardAccess": {
                                             "type": "boolean"
                                         },
@@ -2502,6 +2505,7 @@
                                     "required": [
                                         "hasCardAccess",
                                         "isEligible",
+                                        "geoProhibited",
                                         "flowEarlyAccess",
                                         "isPublicLaunched",
                                         "waitlistJoinedAt",
@@ -2730,7 +2734,7 @@
                         "description": "Default Response"
                     }
                 },
-                "summary": "Get the user’s current waitlist state",
+                "summary": "Get the user\u2019s current waitlist state",
                 "tags": [
                     "card"
                 ]
@@ -3331,6 +3335,7 @@
                                     },
                                     "claimParams": {
                                         "items": {},
+                                        "maxItems": 4,
                                         "minItems": 3,
                                         "type": "array"
                                     },
@@ -7281,7 +7286,7 @@
         },
         "/dev/poll": {
             "post": {
-                "description": "Triggers runPollingCycle() on demand — used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
+                "description": "Triggers runPollingCycle() on demand \u2014 used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
                 "responses": {
                     "200": {
                         "content": {
@@ -7946,7 +7951,7 @@
         },
         "/dev/submit-to-providers": {
             "post": {
-                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user → Manteca, US user → Bridge) end-to-end.",
+                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user \u2192 Manteca, US user \u2192 Bridge) end-to-end.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -8184,7 +8189,7 @@
         },
         "/dev/trigger-sumsub-webhook": {
             "post": {
-                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) — same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub → routing chain without real webhook delivery.",
+                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) \u2014 same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub \u2192 routing chain without real webhook delivery.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -9174,6 +9179,61 @@
                 }
             }
         },
+        "/healthz/bridge": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/manteca/{geo}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "geo",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/rain": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/rhino": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/sumsub": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/history/{entryId}": {
             "get": {
                 "parameters": [
@@ -9182,6 +9242,26 @@
                         "name": "kind",
                         "required": true,
                         "schema": {
+                            "enum": [
+                                "ONRAMP",
+                                "OFFRAMP",
+                                "P2P_SEND",
+                                "P2P_REQUEST_FULFILL",
+                                "DIRECT_TRANSFER",
+                                "SEND_LINK",
+                                "SEND_LINK_CLAIM",
+                                "CRYPTO_DEPOSIT",
+                                "CRYPTO_WITHDRAW",
+                                "CARD_SPEND_AUTH",
+                                "CARD_SPEND_CLEAR",
+                                "CARD_AUTH_REVERSAL",
+                                "QR_PAY",
+                                "INTERNAL_TRANSFER",
+                                "REWARD_PAYOUT",
+                                "REFUND",
+                                "CHARGEBACK",
+                                "PERK_REWARD"
+                            ],
                             "type": "string"
                         }
                     },
@@ -10117,7 +10197,7 @@
         },
         "/manteca/deposit/{depositId}/status": {
             "get": {
-                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only — the webhook/poller remain the authoritative completion trigger.",
+                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only \u2014 the webhook/poller remain the authoritative completion trigger.",
                 "parameters": [
                     {
                         "in": "path",
@@ -10142,54 +10222,6 @@
                     }
                 },
                 "summary": "Get deposit order status",
-                "tags": [
-                    "manteca"
-                ]
-            }
-        },
-        "/manteca/initiate-onboarding": {
-            "post": {
-                "description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "Authorization",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "exchange": {
-                                        "type": "string"
-                                    },
-                                    "failureUrl": {
-                                        "type": "string"
-                                    },
-                                    "returnUrl": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "returnUrl"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                },
-                "summary": "Initiate Manteca onboarding",
                 "tags": [
                     "manteca"
                 ]
@@ -12053,38 +12085,102 @@
                                     "actionType": {
                                         "anyOf": [
                                             {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            "BRIDGE_TRANSFER"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "MANTECA_TRANSFER"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "MANTECA_QR_PAYMENT"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "P2P_SEND_LINK"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "P2P_REQUEST_PAYMENT"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "KYC_VERIFIED"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            {
                                                 "enum": [
-                                                    "BRIDGE_TRANSFER"
+                                                    "DIRECT_TRANSFER"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "MANTECA_TRANSFER"
+                                                    "P2P_SEND"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "MANTECA_QR_PAYMENT"
+                                                    "P2P_REQUEST_FULFILL"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_SEND_LINK"
+                                                    "SEND_LINK"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_REQUEST_PAYMENT"
+                                                    "QR_PAY"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "KYC_VERIFIED"
+                                                    "ONRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "OFFRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CRYPTO_WITHDRAW"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CARD_SPEND_AUTH"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CARD_SPEND_CLEAR"
                                                 ],
                                                 "type": "string"
                                             }
@@ -13388,76 +13484,6 @@
                                     "directTransfer": {
                                         "type": "boolean"
                                     },
-                                    "kind": {
-                                        "anyOf": [
-                                            {
-                                                "enum": [
-                                                    "P2P_SEND"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "QR_PAY"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "LINK_CREATE"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CRYPTO_WITHDRAW"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "FIAT_OFFRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "FIAT_ONRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "REQUEST_PAY"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "AUTO_REBALANCE"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CARD_SPEND"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "DEPOSIT_EXTERNAL"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "OTHER"
-                                                ],
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
                                     "recipientAddress": {
                                         "pattern": "^0x[0-9a-fA-F]{40}$",
                                         "type": "string"
@@ -13470,8 +13496,7 @@
                                 "required": [
                                     "amount",
                                     "recipientAddress",
-                                    "directTransfer",
-                                    "kind"
+                                    "directTransfer"
                                 ],
                                 "type": "object"
                             }
@@ -13684,6 +13709,133 @@
                 }
             }
         },
+        "/rain/cards/withdraw/prepare/cancel": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "preparationId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "preparationId"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "ok"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/rain/cards/withdraw/session-approve": {
             "post": {
                 "requestBody": {
@@ -13828,6 +13980,27 @@
                                     },
                                     "required": [
                                         "ok"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
                                     ],
                                     "type": "object"
                                 }
@@ -15923,6 +16096,74 @@
                 }
             },
             "post": {
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "attachment": {},
+                                    "chainId": {
+                                        "type": "string"
+                                    },
+                                    "contractVersion": {
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "filename": {
+                                        "type": "string"
+                                    },
+                                    "mimetype": {
+                                        "type": "string"
+                                    },
+                                    "preparationId": {
+                                        "type": "string"
+                                    },
+                                    "pubKey": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "reference": {
+                                        "type": "string"
+                                    },
+                                    "tokenAddress": {
+                                        "type": "string"
+                                    },
+                                    "txHash": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "pubKey"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16002,6 +16243,75 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "chainId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "contractVersion": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "tokenAddress": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "txHash": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "txHash",
+                                    "chainId",
+                                    "depositIdx",
+                                    "contractVersion",
+                                    "amount",
+                                    "tokenAddress"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/status/summary": {
+            "get": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16242,6 +16552,106 @@
                 },
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": true,
+                                    "properties": {},
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code.",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code."
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`.",
+                                    "properties": {
+                                        "code": {
+                                            "enum": [
+                                                "RESIDENCE_CHANGE_COOLDOWN"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "retryAt": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error",
+                                        "code",
+                                        "retryAt"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }
@@ -16546,6 +16956,12 @@
                                                                             "bridge-hosted"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "rain-hosted"
+                                                                        ],
+                                                                        "type": "string"
                                                                     }
                                                                 ]
                                                             },
@@ -16845,6 +17261,12 @@
                                                                                     {
                                                                                         "enum": [
                                                                                             "bridge-hosted"
+                                                                                        ],
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "enum": [
+                                                                                            "rain-hosted"
                                                                                         ],
                                                                                         "type": "string"
                                                                                     }
@@ -17510,6 +17932,12 @@
                                                                             "bridge-hosted"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "rain-hosted"
+                                                                        ],
+                                                                        "type": "string"
                                                                     }
                                                                 ]
                                                             },
@@ -17811,6 +18239,12 @@
                                                                                             "bridge-hosted"
                                                                                         ],
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "enum": [
+                                                                                            "rain-hosted"
+                                                                                        ],
+                                                                                        "type": "string"
                                                                                     }
                                                                                 ]
                                                                             },
@@ -18033,6 +18467,26 @@
                                                         }
                                                     ]
                                                 },
+                                                "declaredSecond": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "null"
+                                                        }
+                                                    ]
+                                                },
+                                                "kycReported": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "null"
+                                                        }
+                                                    ]
+                                                },
                                                 "nextChangeAllowedAt": {
                                                     "anyOf": [
                                                         {
@@ -18056,7 +18510,9 @@
                                             },
                                             "required": [
                                                 "declared",
+                                                "declaredSecond",
                                                 "verified",
+                                                "kycReported",
                                                 "nextChangeAllowedAt"
                                             ],
                                             "type": "object"
@@ -18122,6 +18578,405 @@
             "post": {
                 "responses": {
                     "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/users/saved-addresses": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddresses": {
+                                            "items": {
+                                                "properties": {
+                                                    "address": {
+                                                        "type": "string"
+                                                    },
+                                                    "chainId": {
+                                                        "type": "string"
+                                                    },
+                                                    "createdAt": {
+                                                        "type": "string"
+                                                    },
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "lastUsedAt": {
+                                                        "type": "string"
+                                                    },
+                                                    "nickname": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "address",
+                                                    "chainId",
+                                                    "nickname",
+                                                    "lastUsedAt",
+                                                    "createdAt"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddresses"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "address": {
+                                        "pattern": "^(0x[a-fA-F0-9]{40}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
+                                        "type": "string"
+                                    },
+                                    "chainId": {
+                                        "maxLength": 32,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "nickname": {
+                                        "maxLength": 15,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "address",
+                                    "chainId",
+                                    "nickname"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddress": {
+                                            "properties": {
+                                                "address": {
+                                                    "type": "string"
+                                                },
+                                                "chainId": {
+                                                    "type": "string"
+                                                },
+                                                "createdAt": {
+                                                    "type": "string"
+                                                },
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "lastUsedAt": {
+                                                    "type": "string"
+                                                },
+                                                "nickname": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "address",
+                                                "chainId",
+                                                "nickname",
+                                                "lastUsedAt",
+                                                "createdAt"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddress"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/users/saved-addresses/{id}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "deleted": {
+                                            "enum": [
+                                                true
+                                            ],
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "deleted"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            },
+            "patch": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "nickname": {
+                                        "maxLength": 15,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "nickname"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddress": {
+                                            "properties": {
+                                                "address": {
+                                                    "type": "string"
+                                                },
+                                                "chainId": {
+                                                    "type": "string"
+                                                },
+                                                "createdAt": {
+                                                    "type": "string"
+                                                },
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "lastUsedAt": {
+                                                    "type": "string"
+                                                },
+                                                "nickname": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "address",
+                                                "chainId",
+                                                "nickname",
+                                                "lastUsedAt",
+                                                "createdAt"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddress"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }
@@ -18305,6 +19160,13 @@
             }
         },
         "/webhooks/onesignal": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            },
             "post": {
                 "responses": {
                     "200": {

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -17666,7 +17666,8 @@
                         "name": "limit",
                         "required": false,
                         "schema": {
-                            "type": "number"
+                            "minimum": 1,
+                            "type": "integer"
                         }
                     },
                     {


### PR DESCRIPTION
## Summary

Paired FE half of peanut-api-ts #1489 (TASK-21817), plus the deferred FE follow-up of api #1488 (TASK-21815). Both concerns live on the same generated-types surface, so they ship as one PR with two sections.

### Section 1 — history wire contract (TASK-21817)

- **`IntentKind` is now DERIVED from generated types** (`paths['/history/{entryId}']['get']['parameters']['query']['kind']`): the BE declares its wire vocabulary — the full `TransactionIntentKind` enum + synthetic `PERK_REWARD` — on the detail route's schema, and `pnpm gen:api` carries it here. The `STRATEGIES` registry is `Record<IntentKind, …>`, so a BE enum addition becomes a **compile error on the next type regen** instead of a row that silently falls through the fallback. No hand-maintained kind list remains (the exhaustiveness also propagated into the referral-nudge test table — by design).
- **Four previously-unmapped kinds get honest strategies.** They used to hit `intentFallback` and render as an *outgoing send with a minus sign*: `P2P_SEND` (legacy sends) → the p2p strategy + joins the referral-nudge set for parity; `REWARD_PAYOUT` → Peanut Rewards credit (BE `INFLOW_KINDS` confirms it's a credit); `INTERNAL_TRANSFER`, `CHARGEBACK` → neutral debits (`INFLOW_KINDS` deliberately excludes CHARGEBACK — it is NOT a credit). The FE-only `OTHER` synthesis survives only in the fallback for kindless legacy rows.
- TASK-21403 context: already Cancelled (fallback existed); what this fixes is the fallback's wrong-direction rendering for real BE kinds.

### Section 2 — TASK-21815 FE follow-up (api #1488)

- `prepareWithdrawal` no longer sends a client-declared `kind` — the backend chooses it from the verified destination. `RainCollateralKind` stays as FE-internal analytics/preflight vocabulary (documented as never-on-the-wire).
- **Abandoned drafts are backed out** via the new `POST /rain/cards/withdraw/prepare/cancel`: both spend-bundle hooks fire a best-effort cancel on their failure unwind (hoisted `livePreparationId`), and `useReturnExcessCollateral` + the Lock/Cancel card modals cancel a signed-but-unconsumed draft. Every cancel is fire-and-forget: the backend refuses while the Rain signature could still execute (409) and the 30-min TTL sweep is the guaranteed cleanup, so no failure mode here can hurt.
- Types regenerated from the paired BE branch: history kind enum, `/prepare/cancel`, prepare-without-kind.
- NOT wired (other lanes own those files): qr-pay page (Kush) and the withdraw flow pages (m2-withdraw-stepper). Their flows still get cleanup via the hooks' unwind + the TTL sweep.

## Task

TASK-21817 (+ TASK-21815 FE follow-up).

## Risks / breaking changes

- **Deploy order: api #1488 → api #1489 → this.** Nothing breaks hard out of order (cancel 404s are swallowed; the kind enum is type-level), but the regenerated snapshot describes the BE branch's contract, so `check:api` self-consistency holds while runtime completeness needs the BE deploys.
- `P2P_SEND` rows (legacy, read-only) now show the invite nudge like other outbound payments — small deliberate behavior extension, called out for review.
- The committed `api.openapi.json` regen also picks up unrelated BE schema drift accumulated since the last snapshot (the snapshot lags dev) — review the `src/types/` diff as "regenerated", not hand-edited.

## QA

- `npm test`: 5067 pass; 1 pre-existing failure (`add-money-states` "10,000 USD" — fails identically with pure origin/dev types, dev-side; not this diff). New test: the sign-spend hook backs the draft out when the ceremony dies after a successful prepare; prepare-call assertions updated (no `kind` on the wire).
- `npm run typecheck`, `pnpm prettier --check .`, `npm run build` all green.
- Screenshots: N/A — no visible change for correctly-rendered kinds; the four remapped kinds have no reachable prod rows to screenshot (REWARD_PAYOUT/CHARGEBACK have no live writer; INTERNAL_TRANSFER is list-hidden; P2P_SEND rows are pre-2026-04 legacy). Strategy outputs are pinned by unit tests instead.



## Design notes / accepted trade-offs (post-review)

- **Six Chip rounds, 9 findings, all fixed** (final verdict: "no blocking findings" at 0f861f27). The load-bearing model: **a draft is cancelled only when its failure provably precedes any broadcast.** Both userop helpers decompose prepare → sign → transport and fire `onBroadcastAttempt` at the pure eth_sendUserOperation line; a WebAuthn rejection is pre-broadcast by definition (unsigned ops cannot submit); a session-key attempt that crossed the boundary marks the draft ambiguous for good, across the passkey fallback. Real-helper boundary suites pin the ordering.
- **Removed, not added:** the returnExcess and Lock/Cancel-card back-outs — every failure there is execution-ambiguous; the backend's probe-verified TTL sweep owns them.
- **Deliberate behavior extensions, called out:** P2P_SEND (legacy rows) joins the referral-nudge set (outbound-payment parity); CHARGEBACK renders by viewer entry role (a user-favorable dispute arrives as REFUND — the credit the card terms promise).
- `isIntentKind` is an own-property guard (`?kind=toString` fell through to Object.prototype before).
