### PR TITLE
ci: strip write tokens from PR-code jobs (TASK-21995)

### DIFF
--- a/.github/workflows/supply-chain-check.yml
+++ b/.github/workflows/supply-chain-check.yml
@@ -19,6 +19,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+# Explicit floor — without this the job runs PR lifecycle scripts (pnpm
+# install) with whatever the repo default grants.
+permissions:
+    contents: read
+
 jobs:
     check-min-release-age:
         runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,11 @@ concurrency:
     cancel-in-progress: true
 
 # Default for every job that does not declare its own block. `checks: write`
-# used to live here, inherited by every PR-code job; it now sits only on the
-# one job that publishes check annotations (unit → dorny/test-reporter).
+# used to live here, inherited by every PR-code job — and nothing consumes it:
+# dorny/test-reporter runs with use-actions-summary (its v1 default), which
+# writes the job summary and creates no check run (none exists on dev either).
+# If check-run mode is ever turned back on, grant checks: write in a job that
+# runs no PR code — never in `unit`, which runs PR install/test code first.
 permissions:
     contents: read
 
@@ -194,11 +197,9 @@ jobs:
     unit:
         needs: be-baseline
         runs-on: ubuntu-latest
-        # The only job that publishes check annotations, so the only one that
-        # holds `checks: write` (dorny/test-reporter below).
-        permissions:
-            contents: read
-            checks: write
+        # No checks: write here even though dorny/test-reporter runs below —
+        # in summary mode it needs none, and this job runs PR-authored code
+        # before the reporter, so any token it holds is capturable.
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,11 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+# Default for every job that does not declare its own block. `checks: write`
+# used to live here, inherited by every PR-code job; it now sits only on the
+# one job that publishes check annotations (unit → dorny/test-reporter).
 permissions:
     contents: read
-    # `checks: write` lets dorny/test-reporter publish per-PR check
-    # annotations from the JUnit XML below.
-    checks: write
 
 jobs:
     # Prettier formatting + content-link validation. Fast, no node_modules
@@ -40,6 +40,10 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # The token is only needed to CLONE the submodule; no git op
+                  # after checkout needs it, and pnpm install runs PR-authored
+                  # lifecycle scripts, so don't leave it in .git/config.
+                  persist-credentials: false
 
             - uses: pnpm/action-setup@v4
 
@@ -98,6 +102,8 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # Clone-only token — see the format job.
+                  persist-credentials: false
 
             - uses: pnpm/action-setup@v4
 
@@ -120,6 +126,8 @@ jobs:
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # Clone-only token — see the format job.
+                  persist-credentials: false
 
             - uses: pnpm/action-setup@v4
 
@@ -186,11 +194,18 @@ jobs:
     unit:
         needs: be-baseline
         runs-on: ubuntu-latest
+        # The only job that publishes check annotations, so the only one that
+        # holds `checks: write` (dorny/test-reporter below).
+        permissions:
+            contents: read
+            checks: write
         steps:
             - uses: actions/checkout@v4
               with:
                   submodules: true
                   token: ${{ secrets.SUBMODULE_TOKEN }}
+                  # Clone-only token — see the format job.
+                  persist-credentials: false
 
             - uses: pnpm/action-setup@v4
 
@@ -578,9 +593,10 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
+        # No checkout on purpose: every step below consumes artifacts, and this
+        # job holds a write token — a checkout would let PR-authored config
+        # (e.g. an added nyc.config.js) run with that token in reach.
         steps:
-            - uses: actions/checkout@v4
-
             - uses: actions/setup-node@v4
               with:
                   node-version: '20'


### PR DESCRIPTION
CI workflow hardening — the cheap items of TASK-21995. Principle: a job that checks out PR-authored code and runs its lifecycle scripts must not hold a credential that code can reach.

## The 4 items

1. **`report` job: checkout deleted.** The job holds `pull-requests: write` and ran `npx nyc` with cwd = a bare PR checkout — a PR-added `nyc.config.js` would have executed with the token in reach. Verified every remaining step consumes artifacts only: the two `download-artifact` steps feed `coverage-raw/` and `junit-raw/`, `nyc merge`/`nyc report` read only those plus `coverage-merged/`, the inline `node -e` reads the same, and the github-script comment reads `report-payload.json`. Its `setup-node` has no `cache:` key, so it needs no `package.json` either. Nothing in the job reads a repo file → deletion, not `persist-credentials: false`.
2. **`format`, `eslint`, `typecheck`, `unit`: `persist-credentials: false`** on every checkout that passes `SUBMODULE_TOKEN` (same pattern the `ds-shots` job already used). The token is still used for the submodule clone; it just no longer stays in `.git/config` while `pnpm install` runs PR lifecycle scripts. `ds-lint` and `ds-shots` already had the line; `be-baseline`, `ds-shots-filter`, `human-authors`, and `ci-success` check nothing out.
3. **`checks: write` removed entirely** (revised after Chip round 1). First pass moved it from workflow level to the `unit` job (the dorny/test-reporter host); Chip correctly flagged that `unit` runs PR code before the reporter, so a job-scoped token is still capturable. Second pass deleted the grant: dorny runs in `use-actions-summary` mode (its v1 default), writes the job summary, and creates no check run — no "Unit test report" check-run exists on dev either, so the permission had zero consumers. A comment at the workflow `permissions:` block records where to grant it (an artifact-only job, never `unit`) if check-run mode is ever re-enabled.
4. **`supply-chain-check.yml`: explicit `permissions: contents: read`.** It had no block at all, so it ran `pnpm install` on PR code with the repo default grant. Its `git fetch origin $BASE_REF` step only needs read.

## Risks

- **Could the missing checkout break `report`?** The concrete risk was a step reading a repo file. Checked each one (list above) — none does. The real verification is this PR's own CI: `report` runs here and must stay green.
- `persist-credentials: false` cannot break the submodule clone — checkout uses the token during the clone and only skips *saving* it afterward. No job in the file does a later git op that needs saved credentials.
- ds-shots runs on this PR (tests.yml is in its path filter) — advisory only.

Screenshots: N/A (CI only)

Task: TASK-21995
