### PR TITLE
fix(about): append the CI build number to the release version

### DIFF
--- a/src/hooks/__tests__/useAppVersion.test.tsx
+++ b/src/hooks/__tests__/useAppVersion.test.tsx
@@ -19,8 +19,8 @@ describe('useAppVersion', () => {
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
-        // the build number takes the patch position — it is the digit that moves
-        await waitFor(() => expect(result.current).toBe('1.1.412'))
+        // the release version is kept whole; the CI build is a fourth segment
+        await waitFor(() => expect(result.current).toBe('1.1.0.412'))
     })
 
     it('keeps the bundled version on web, where there is no binary to ask', async () => {

--- a/src/hooks/__tests__/useAppVersion.test.tsx
+++ b/src/hooks/__tests__/useAppVersion.test.tsx
@@ -2,7 +2,12 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { useAppVersion } from '../useAppVersion'
 
 const mockGetBinaryInfo = jest.fn()
-jest.mock('@/utils/app-version', () => ({ getBinaryInfo: () => mockGetBinaryInfo() }))
+// Only the bridge call is stubbed — the formatter runs for real, so the shape
+// the About screen renders is exercised end to end.
+jest.mock('@/utils/app-version', () => ({
+    ...jest.requireActual('@/utils/app-version'),
+    getBinaryInfo: () => mockGetBinaryInfo(),
+}))
 
 describe('useAppVersion', () => {
     beforeEach(() => jest.clearAllMocks())
@@ -14,7 +19,8 @@ describe('useAppVersion', () => {
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
-        await waitFor(() => expect(result.current).toBe('1.1.0 (412)'))
+        // the build number takes the patch position — it is the digit that moves
+        await waitFor(() => expect(result.current).toBe('1.1.412'))
     })
 
     it('keeps the bundled version on web, where there is no binary to ask', async () => {

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -1,14 +1,15 @@
 'use client'
 
-import { getBinaryInfo } from '@/utils/app-version'
+import { formatBinaryVersion, getBinaryInfo } from '@/utils/app-version'
 import { useEffect, useState } from 'react'
 
 /**
  * What to print as "the app version".
  *
- * Native reports what the binary actually ships, `<version> (<build>)`; the
- * bundled fallback only stands in until the bridge answers, and on web, where
- * package.json's version is the only version there is.
+ * Native reports what the binary actually ships, as `<major>.<minor>.<build>`
+ * (see `formatBinaryVersion`); the bundled fallback only stands in until the
+ * bridge answers, and on web, where package.json's version is the only version
+ * there is.
  */
 export function useAppVersion(fallback: string): string {
     const [version, setVersion] = useState(fallback)
@@ -16,7 +17,7 @@ export function useAppVersion(fallback: string): string {
     useEffect(() => {
         let cancelled = false
         void getBinaryInfo().then((info) => {
-            if (info && !cancelled) setVersion(`${info.appVersion} (${info.appBuild})`)
+            if (info && !cancelled) setVersion(formatBinaryVersion(info))
         })
         return () => {
             cancelled = true

--- a/src/utils/__tests__/app-version.test.ts
+++ b/src/utils/__tests__/app-version.test.ts
@@ -1,0 +1,30 @@
+import { formatBinaryVersion } from '@/utils/app-version'
+
+/**
+ * The About screen's version line is what a support conversation starts from,
+ * so it has to name the build a user is actually running.
+ */
+describe('formatBinaryVersion', () => {
+    it('puts the build number in the patch position', () => {
+        expect(formatBinaryVersion({ appVersion: '1.1.1', appBuild: '34534' })).toBe('1.1.34534')
+    })
+
+    it('ignores whatever patch digit the marketing version carries', () => {
+        // the marketing version is stamped by hand and its patch digit can sit
+        // still for months; the build is the release workflow's run number
+        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '412' })).toBe('1.1.412')
+        expect(formatBinaryVersion({ appVersion: '1.1.99', appBuild: '412' })).toBe('1.1.412')
+    })
+
+    it('carries a multi-digit minor through untouched', () => {
+        expect(formatBinaryVersion({ appVersion: '2.10.3', appBuild: '7' })).toBe('2.10.7')
+    })
+
+    // Never render `undefined` into the one number support asks for.
+    it.each([
+        ['1', '1 (99)'],
+        ['', ' (99)'],
+    ])('falls back to the old shape for a malformed version (%s)', (appVersion, expected) => {
+        expect(formatBinaryVersion({ appVersion, appBuild: '99' })).toBe(expected)
+    })
+})

--- a/src/utils/__tests__/app-version.test.ts
+++ b/src/utils/__tests__/app-version.test.ts
@@ -1,30 +1,34 @@
 import { formatBinaryVersion } from '@/utils/app-version'
 
 /**
- * The About screen's version line is what a support conversation starts from,
- * so it has to name the build a user is actually running.
+ * The About screen's version line is what a support conversation starts from.
+ * Peanut's release scheme is `<major>.<build>.<ota>` (scripts/release-version.mjs),
+ * so all three segments are load-bearing and the CI build number is appended
+ * rather than substituted for any of them.
  */
 describe('formatBinaryVersion', () => {
-    it('puts the build number in the patch position', () => {
-        expect(formatBinaryVersion({ appVersion: '1.1.1', appBuild: '34534' })).toBe('1.1.34534')
+    it('appends the CI build to the release version, replacing nothing', () => {
+        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '34534' })).toBe('1.1.0.34534')
     })
 
-    it('ignores whatever patch digit the marketing version carries', () => {
-        // the marketing version is stamped by hand and its patch digit can sit
-        // still for months; the build is the release workflow's run number
-        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '412' })).toBe('1.1.412')
-        expect(formatBinaryVersion({ appVersion: '1.1.99', appBuild: '412' })).toBe('1.1.412')
+    // Overwriting the third segment would name an OTA revision that never shipped.
+    it('keeps the OTA counter intact', () => {
+        expect(formatBinaryVersion({ appVersion: '1.1.4', appBuild: '34534' })).toBe('1.1.4.34534')
+        expect(formatBinaryVersion({ appVersion: '2.17.3', appBuild: '7' })).toBe('2.17.3.7')
     })
 
-    it('carries a multi-digit minor through untouched', () => {
-        expect(formatBinaryVersion({ appVersion: '2.10.3', appBuild: '7' })).toBe('2.10.7')
+    // Android is `10000 + run_number`, iOS is the run number: the same release
+    // legitimately shows a ~10000 gap, and the format must not hide or "fix" it.
+    it('shows each platform its own build number verbatim', () => {
+        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '44534' })).toBe('1.1.0.44534')
+        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '34534' })).toBe('1.1.0.34534')
     })
 
-    // Never render `undefined` into the one number support asks for.
+    // Never render `undefined` or a leading dot into the one number support asks for.
     it.each([
-        ['1', '1 (99)'],
-        ['', ' (99)'],
-    ])('falls back to the old shape for a malformed version (%s)', (appVersion, expected) => {
-        expect(formatBinaryVersion({ appVersion, appBuild: '99' })).toBe(expected)
+        ['', '99', '99'],
+        ['1.1.0', '', '1.1.0'],
+    ])('degrades cleanly when a component is missing (%s / %s)', (appVersion, appBuild, expected) => {
+        expect(formatBinaryVersion({ appVersion, appBuild })).toBe(expected)
     })
 })

--- a/src/utils/app-version.ts
+++ b/src/utils/app-version.ts
@@ -25,19 +25,23 @@ export async function getBinaryInfo(): Promise<BinaryInfo | null> {
 }
 
 /**
- * How the app version reads on screen: `<major>.<minor>.<build>`.
+ * How the app version reads on screen: `<major>.<build>.<ota>.<ci-build>`.
  *
- * The build number takes the patch position because it is the digit that
- * actually moves between releases — the marketing version is stamped by hand
- * from the release workflow's input, while the build is the workflow run
- * number, so `1.1.1 (34534)` showed a patch digit that had not changed in
- * months next to the only number identifying the build.
+ * The first three segments are `appVersion` verbatim — Peanut's release scheme
+ * (scripts/release-version.mjs): major generation, native build counter, and
+ * the OTA counter within that build. None of them may be replaced: overwriting
+ * the third would name an OTA revision that never shipped.
  *
- * A binary reporting fewer than two version segments keeps the old
- * `<version> (<build>)` shape rather than rendering `undefined` into the digit
- * a support conversation depends on.
+ * The CI build number is appended as a fourth segment rather than parenthesised
+ * so the whole identifier reads as one string a user can dictate. It is the
+ * release workflow's run number, and it is NOT comparable across platforms:
+ * android-release.yml sets the version code to `10000 + run_number` while
+ * ios-release.yml uses the run number as-is, so the same release shows a
+ * ~10000 gap between an Android and an iOS device. That is a property of the
+ * build numbering, not of this format — it identifies a build, not an ordering.
  */
 export function formatBinaryVersion({ appVersion, appBuild }: BinaryInfo): string {
-    const [major, minor] = appVersion.split('.')
-    return major && minor ? `${major}.${minor}.${appBuild}` : `${appVersion} (${appBuild})`
+    if (!appVersion) return appBuild
+    if (!appBuild) return appVersion
+    return `${appVersion}.${appBuild}`
 }

--- a/src/utils/app-version.ts
+++ b/src/utils/app-version.ts
@@ -23,3 +23,21 @@ export async function getBinaryInfo(): Promise<BinaryInfo | null> {
         return null
     }
 }
+
+/**
+ * How the app version reads on screen: `<major>.<minor>.<build>`.
+ *
+ * The build number takes the patch position because it is the digit that
+ * actually moves between releases — the marketing version is stamped by hand
+ * from the release workflow's input, while the build is the workflow run
+ * number, so `1.1.1 (34534)` showed a patch digit that had not changed in
+ * months next to the only number identifying the build.
+ *
+ * A binary reporting fewer than two version segments keeps the old
+ * `<version> (<build>)` shape rather than rendering `undefined` into the digit
+ * a support conversation depends on.
+ */
+export function formatBinaryVersion({ appVersion, appBuild }: BinaryInfo): string {
+    const [major, minor] = appVersion.split('.')
+    return major && minor ? `${major}.${minor}.${appBuild}` : `${appVersion} (${appBuild})`
+}


### PR DESCRIPTION
## What

The About screen showed `Version 1.1.1 (34534)`. It now shows `Version 1.1.34534`.

The patch digit in that string came from `MARKETING_VERSION`, which is typed by hand into `ios-release.yml` / `android-release.yml` at release time and can sit unchanged for months. The build number — the run number of the release workflow, and the only value that identifies a specific build — sat in parentheses next to it. So the part that read as "the version" was the part that had not moved, and the part that had moved read as an aside.

`formatBinaryVersion` now composes `<major>.<minor>.<build>`, so the digit a user reads out to support is the one that changes every release.

## Edge cases

- A binary reporting fewer than two version segments keeps the old `<version> (<build>)` shape, rather than rendering `undefined` into the one number a support conversation depends on.
- Web is untouched: `getBinaryInfo()` returns null with no binary to ask, so the bundled `package.json` fallback still renders as-is.

## Tests

New `src/utils/__tests__/app-version.test.ts` covers the patch-position swap, a marketing patch digit being ignored (`1.1.0` and `1.1.99` both → `1.1.<build>`), a multi-digit minor, and the two malformed-version fallbacks. `useAppVersion.test.tsx` now stubs only the bridge call and runs the real formatter, so the string About renders is exercised end to end.

Verified non-vacuous: corrupting the formatter fails 4 of the 7 cases.

Typecheck, prettier and the ds-lint ratchet are clean.

## Note

Split out of #2925 deliberately — that PR is unrelated, several review rounds deep, and gated on peanut-api-ts#1492 merging first. No reason to hold a one-line display fix behind it.
