### PR TITLE
fix(kyc): localize the tax_id_unresolved rail reason

### DIFF
--- a/src/constants/capability-reason-labels.consts.ts
+++ b/src/constants/capability-reason-labels.consts.ts
@@ -52,6 +52,10 @@ export const REASON_CODE_KEYS = {
     // restrictions
     manteca_us_nationality: 'reasons.manteca_us_nationality',
     country_not_supported: 'reasons.country_not_supported',
+    // A Manteca first-party rail whose submission found no CUIT/CPF. Reachable
+    // today only in Argentina, i.e. an es-419 audience — without this entry the
+    // one population that can see it gets the backend's English userMessage.
+    tax_id_unresolved: 'reasons.tax_id_unresolved',
     uk_resident_blocked: 'reasons.uk_resident_blocked',
 } as const
 

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2988,6 +2988,7 @@
             "card_rejected": "Your card application couldn't be approved. Message support if you think this is a mistake.",
             "manteca_us_nationality": "Payments from this country are not available for US citizens at this time.",
             "country_not_supported": "This rail needs a document from a supported country. You can verify with a different ID.",
+            "tax_id_unresolved": "Local deposits and withdrawals need a local tax ID, and we couldn't read one from your documents. You can verify again with an ID that carries one. QR payments aren't affected.",
             "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime.",
             "identity_region_restricted": "Our verification partner doesn't accept documents issued in your country. Re-uploading won't change the result."
         }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2988,6 +2988,7 @@
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escríbele a soporte si crees que es un error.",
             "manteca_us_nationality": "Los pagos desde este país no están disponibles para ciudadanos de EE. UU. por el momento.",
             "country_not_supported": "Este medio de pago requiere un documento de un país compatible. Puedes verificarte con otro documento.",
+            "tax_id_unresolved": "Los depósitos y retiros locales requieren un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Puedes verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento.",
             "identity_region_restricted": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no cambiará el resultado."
         }

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1322,6 +1322,7 @@
             "duplicate_customer_detected": "Bridge marcó tu cuenta como posible duplicado. Escribile a soporte para verificarla y desbloquearla.",
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escribile a soporte si creés que es un error.",
             "country_not_supported": "Este método necesita un documento de un país compatible. Podés verificarte con otro documento.",
+            "tax_id_unresolved": "Los depósitos y retiros locales necesitan un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Podés verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento.",
             "identity_region_restricted": "Nuestro proveedor de verificación no acepta documentos emitidos en tu país. Volver a subirlos no va a cambiar el resultado."
         }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2988,6 +2988,7 @@
             "card_rejected": "Sua solicitação de cartão não pôde ser aprovada. Fale com o suporte se achar que isso é um engano.",
             "manteca_us_nationality": "Pagamentos deste país não estão disponíveis para cidadãos dos EUA no momento.",
             "country_not_supported": "Este método exige um documento de um país compatível. Você pode verificar com outro documento.",
+            "tax_id_unresolved": "Depósitos e saques locais exigem um número de identificação fiscal, e não conseguimos ler nenhum nos seus documentos. Você pode verificar novamente com um documento que o contenha. Os pagamentos por QR não são afetados.",
             "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para residentes do Reino Unido. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento.",
             "identity_region_restricted": "Nosso parceiro de verificação não aceita documentos emitidos no seu país. Enviar de novo não vai mudar o resultado."
         }


### PR DESCRIPTION
## What

peanut-api-ts#1492 adds a rail reason code the app has never seen:

```
{ code: 'tax_id_unresolved', userMessage: 'Local deposits and withdrawals need a local tax ID…' }
```

Rail reasons resolve through `REASON_CODE_KEYS` (`src/constants/capability-reason-labels.consts.ts`), and an unknown code falls back to the backend's English `userMessage`. That fallback is deliberate, but here it lands on precisely the population that can reach the branch: the resolver only emits this reason for a **first-party** Manteca rail, and Brazil's only geo rail is the QR-pool `PIX_BR` (promoted back to ENABLED, never a block) — so today it is Argentina only. An es-419 audience reads the feature's headline message in English.

Render sites affected: `src/components/Kyc/InitiateKycModal.tsx:88` and `src/components/Profile/views/UnlockPayments.view.tsx:259`.

## Changes

- `tax_id_unresolved: 'reasons.tax_id_unresolved'` in `REASON_CODE_KEYS`.
- Catalogue entries in `en`, `es-419`, `es-AR` (voseo) and `pt-BR`, matching how the sibling Manteca codes (`manteca_us_nationality`, `country_not_supported`) are carried.

`identity` is not in `marketing-namespaces.json`, so no `generate:marketing-messages` run is needed.

## Testing

`pnpm tsc --noEmit`; the 17 i18n suites (222 tests) and the `constants` / `Kyc` / `Profile` suites (539 tests) all pass.

## Merge order

Independent of api-ts#1492 in both directions — the backend copy is already English-safe via the fallback, and this key is inert until the backend ships the code. Either order is fine.
