### PR TITLE
fix(kyc): drive the restart SDK session from the server-resolved intent (accompanies api-ts#1501)

### DIFF
--- a/src/app/actions/__tests__/sumsub-restart-wire.test.ts
+++ b/src/app/actions/__tests__/sumsub-restart-wire.test.ts
@@ -46,7 +46,13 @@ describe('restartIdentityVerification — request', () => {
         expect(requestBody()).toEqual({})
     })
 
-    it('forwards a supported intent', async () => {
+    // The action still accepts an intent (the residence-change caller on `dev`
+    // passes the NEWLY declared one), but callers with only a stale local intent
+    // must send nothing: `resolveRestartIntent` on the route returns the intent
+    // canonical to the declared residence in every non-null branch and never the
+    // one asked for, so a mismatched request is at best a no-op and at worst a
+    // 400 across the provider axis.
+    it('forwards a supported intent when one is given', async () => {
         respondWith(ok)
 
         await restartIdentityVerification('LATAM')

--- a/src/app/actions/__tests__/sumsub-restart-wire.test.ts
+++ b/src/app/actions/__tests__/sumsub-restart-wire.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Wire-level tests for `restartIdentityVerification`.
+ *
+ * Asserted against the REQUEST and the RESPONSE BODY rather than a mocked
+ * return value, because both defects this covers live in that translation:
+ *
+ *  - the request must carry a JSON body (the backend's schema rejects a POST
+ *    with no `Content-Type`), and must forward only intents the route accepts,
+ *    since a server action is a public endpoint;
+ *  - the response is unvalidated JSON, and its `regionIntent` is stored in the
+ *    ref that `refreshToken` later replays to `initiateSumsubKyc` — so an
+ *    unrecognised value would not merely read as single-level, it would be sent
+ *    back to the API on the next refresh.
+ */
+
+import { restartIdentityVerification } from '@/app/actions/sumsub'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ serverFetch: jest.fn() }))
+
+const mockFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+
+const respondWith = (body: unknown, status = 200) => {
+    mockFetch.mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    } as unknown as Response)
+}
+
+const requestBody = () => JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body)
+
+beforeEach(() => mockFetch.mockReset())
+
+describe('restartIdentityVerification — request', () => {
+    const ok = { token: 'tok', levelName: 'general', applicantId: 'app_1' }
+
+    it('always sends a JSON body, so the route schema does not reject it', async () => {
+        respondWith(ok)
+
+        await restartIdentityVerification()
+
+        const init = mockFetch.mock.calls[0][1] as { method: string; headers: Record<string, string>; body: string }
+        expect(init.method).toBe('POST')
+        expect(init.headers['Content-Type']).toBe('application/json')
+        expect(requestBody()).toEqual({})
+    })
+
+    it('forwards a supported intent', async () => {
+        respondWith(ok)
+
+        await restartIdentityVerification('LATAM')
+
+        expect(requestBody()).toEqual({ regionIntent: 'LATAM' })
+    })
+
+    it('drops an unsupported intent rather than forwarding it', async () => {
+        respondWith(ok)
+
+        await restartIdentityVerification('MARS' as never)
+
+        expect(requestBody()).toEqual({})
+    })
+})
+
+describe('restartIdentityVerification — response', () => {
+    it('preserves a server-resolved intent', async () => {
+        respondWith({ token: 'tok', levelName: 'general', applicantId: 'app_1', regionIntent: 'LATAM' })
+
+        const result = await restartIdentityVerification()
+
+        expect(result.data?.regionIntent).toBe('LATAM')
+        expect(result.data?.levelName).toBe('general')
+    })
+
+    // The caller stores this in the ref `refreshToken` replays to the API, so an
+    // unrecognised value must not survive the boundary. Dropping it lets the
+    // caller's `??` fall back to the intent it already had.
+    it('drops an unrecognised intent so the caller falls back to its own', async () => {
+        respondWith({ token: 'tok', levelName: 'general', applicantId: 'app_1', regionIntent: 'ATLANTIS' })
+
+        const result = await restartIdentityVerification()
+
+        expect(result.data?.regionIntent).toBeUndefined()
+        expect(result.data?.token).toBe('tok')
+    })
+
+    it('a backend that predates the field yields no intent, not a crash', async () => {
+        respondWith({ token: 'tok', levelName: 'general', applicantId: 'app_1' })
+
+        const result = await restartIdentityVerification()
+
+        expect(result.data?.regionIntent).toBeUndefined()
+    })
+
+    it('a refusal is still surfaced as an error', async () => {
+        respondWith({ error: 'restart_failed', userMessage: 'Cannot restart right now' }, 403)
+
+        const result = await restartIdentityVerification()
+
+        expect(result.data).toBeUndefined()
+        expect(result.error).toBeTruthy()
+    })
+})

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -124,6 +124,14 @@ export interface RestartIdentityResponse {
     token: string
     levelName: string
     applicantId: string
+    /**
+     * The intent the SERVER resolved. Drive the SDK session from this, not from
+     * what was asked for: the declared residence can overrule the request, and
+     * `levelName` cannot stand in for it (EU and NA share `bridge-requirements`,
+     * LATAM and ROW share `general`, and only EU and LATAM are multi-level).
+     * Optional so a response from an older backend still parses.
+     */
+    regionIntent?: KYCRegionIntent
 }
 
 /**
@@ -131,13 +139,24 @@ export interface RestartIdentityResponse {
  * "Verify with a different document" CTA on a Manteca rail that's blocked
  * because the user verified with a non-AR/BR document.
  */
-export const restartIdentityVerification = async (): Promise<{
+// The intents the restart route accepts; a server action is a public endpoint,
+// so anything else is dropped here rather than forwarded.
+const RESTART_REGION_INTENTS: ReadonlySet<string> = new Set(['LATAM', 'ROW', 'EU', 'NA'])
+
+export const restartIdentityVerification = async (
+    regionIntent?: KYCRegionIntent
+): Promise<{
     data?: RestartIdentityResponse
     error?: string
     code?: SumsubActionErrorCode
 }> => {
     try {
-        const response = await serverFetch('/users/identity/restart', { method: 'POST' })
+        const intent = regionIntent && RESTART_REGION_INTENTS.has(regionIntent) ? regionIntent : undefined
+        const response = await serverFetch('/users/identity/restart', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(intent ? { regionIntent: intent } : {}),
+        })
         const responseJson = await response.json()
         if (!response.ok) {
             return backendOrFallback(responseJson, 'Failed to restart identity verification', 'restart_failed')

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -161,7 +161,20 @@ export const restartIdentityVerification = async (
         if (!response.ok) {
             return backendOrFallback(responseJson, 'Failed to restart identity verification', 'restart_failed')
         }
-        return { data: responseJson }
+        // Sanitize on the way OUT as well as in. `responseJson` is unvalidated,
+        // and the caller stores `regionIntent` in the ref that `refreshToken`
+        // later replays to `initiateSumsubKyc` — so an unrecognised value would
+        // not merely read as single-level here, it would be sent back to the
+        // API on the next refresh. Dropping it lets the caller's `??` fall back
+        // to the intent it already had.
+        const resolved = responseJson?.regionIntent
+        return {
+            data: {
+                ...responseJson,
+                regionIntent:
+                    typeof resolved === 'string' && RESTART_REGION_INTENTS.has(resolved) ? resolved : undefined,
+            },
+        }
     } catch (e: unknown) {
         return caughtError(e)
     }

--- a/src/constants/capability-reason-labels.consts.ts
+++ b/src/constants/capability-reason-labels.consts.ts
@@ -49,6 +49,10 @@ export const REASON_CODE_KEYS = {
     // restrictions
     manteca_us_nationality: 'reasons.manteca_us_nationality',
     country_not_supported: 'reasons.country_not_supported',
+    // A Manteca first-party rail whose submission found no CUIT/CPF. Reachable
+    // today only in Argentina, i.e. an es-419 audience — without this entry the
+    // one population that can see it gets the backend's English userMessage.
+    tax_id_unresolved: 'reasons.tax_id_unresolved',
     uk_resident_blocked: 'reasons.uk_resident_blocked',
 } as const
 

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -1,7 +1,12 @@
 import { act, waitFor } from '@testing-library/react'
 import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
-import { initiateSumsubKyc, initiateSelfHealResubmission, startKycAction } from '@/app/actions/sumsub'
+import {
+    initiateSumsubKyc,
+    initiateSelfHealResubmission,
+    restartIdentityVerification,
+    startKycAction,
+} from '@/app/actions/sumsub'
 
 // useSumsubKycFlow wires a websocket, redux, the router and three server actions.
 // Stub everything except the one action the cross-region branch reads so the test
@@ -33,6 +38,7 @@ jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
 const mockInitiate = initiateSumsubKyc as jest.MockedFunction<typeof initiateSumsubKyc>
 const mockResubmit = initiateSelfHealResubmission as jest.MockedFunction<typeof initiateSelfHealResubmission>
 const mockStartAction = startKycAction as jest.MockedFunction<typeof startKycAction>
+const mockRestart = restartIdentityVerification as jest.MockedFunction<typeof restartIdentityVerification>
 
 describe('useSumsubKycFlow — cross-region routing', () => {
     beforeEach(() => {
@@ -813,5 +819,75 @@ describe('useSumsubKycFlow — handleFixableRejection routing', () => {
 
         expect(mockResubmit).toHaveBeenLastCalledWith('BRIDGE')
         expect(mockStartAction).toHaveBeenCalledTimes(1)
+    })
+})
+
+/**
+ * The restart CTA drives its SDK session from the intent the SERVER resolved.
+ *
+ * This app sends the restart BODYLESS, so for a residence change the backend
+ * derives the level from the newly declared country and can overrule anything
+ * local. `levelName` cannot stand in for the intent — EU and NA both mint
+ * `bridge-requirements`, LATAM and ROW both mint `general`, and only EU and
+ * LATAM are multi-level — so a hook that fell back to its own ref would open a
+ * LATAM `general` session as single-level and close it after IDENTITY, before
+ * the manteca-requirements questionnaire.
+ */
+describe('useSumsubKycFlow — restart uses the server-resolved intent', () => {
+    beforeEach(() => {
+        mockInitiate.mockReset()
+        mockRestart.mockReset()
+        mockWs.handler = undefined
+    })
+
+    it('a resolved LATAM response opens a MULTI-level session even with no local intent', async () => {
+        mockRestart.mockResolvedValue({
+            data: { token: 'tok_1', levelName: 'general', applicantId: 'app_1', regionIntent: 'LATAM' },
+        })
+
+        const { result } = renderHook(() => useSumsubKycFlow({}))
+        await act(async () => {
+            await result.current.handleRestartIdentity()
+        })
+
+        await waitFor(() => expect(result.current.isMultiLevel).toBe(true))
+    })
+
+    // The override has to work in BOTH directions, or a stale local LATAM would
+    // hold a ROW session open waiting for a questionnaire that never comes.
+    it('a resolved ROW response overrides a local LATAM intent to single-level', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_0', applicantId: 'app_1', status: 'PENDING' },
+        })
+        mockRestart.mockResolvedValue({
+            data: { token: 'tok_1', levelName: 'general', applicantId: 'app_1', regionIntent: 'ROW' },
+        })
+
+        const { result } = renderHook(() => useSumsubKycFlow({ regionIntent: 'LATAM' }))
+        await waitFor(() => expect(mockInitiate).toHaveBeenCalled())
+        await act(async () => {
+            await result.current.handleRestartIdentity()
+        })
+
+        await waitFor(() => expect(result.current.isMultiLevel).toBe(false))
+    })
+
+    // Back-compat: a backend that predates the field must not silently downgrade
+    // a known-LATAM session to single-level.
+    it('a response with no regionIntent falls back to the local intent', async () => {
+        mockInitiate.mockResolvedValue({
+            data: { token: 'tok_0', applicantId: 'app_1', status: 'PENDING' },
+        })
+        mockRestart.mockResolvedValue({
+            data: { token: 'tok_1', levelName: 'general', applicantId: 'app_1' },
+        })
+
+        const { result } = renderHook(() => useSumsubKycFlow({ regionIntent: 'LATAM' }))
+        await waitFor(() => expect(mockInitiate).toHaveBeenCalled())
+        await act(async () => {
+            await result.current.handleRestartIdentity()
+        })
+
+        await waitFor(() => expect(result.current.isMultiLevel).toBe(true))
     })
 })

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -851,10 +851,15 @@ describe('useSumsubKycFlow — restart uses the server-resolved intent', () => {
         })
 
         await waitFor(() => expect(result.current.isMultiLevel).toBe(true))
+        // Bodyless: the route derives the level from the declared residence, and
+        // forwarding a local intent could only no-op or 400.
+        expect(mockRestart).toHaveBeenCalledWith()
     })
 
     // The override has to work in BOTH directions, or a stale local LATAM would
-    // hold a ROW session open waiting for a questionnaire that never comes.
+    // hold a ROW session open waiting for a questionnaire that never comes. This
+    // is reachable precisely BECAUSE the request is bodyless: a user with a local
+    // LATAM intent but a ROW declared residence gets ROW back from the server.
     it('a resolved ROW response overrides a local LATAM intent to single-level', async () => {
         mockInitiate.mockResolvedValue({
             data: { token: 'tok_0', applicantId: 'app_1', status: 'PENDING' },

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -550,7 +550,14 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         actionKeyRef.current = null
 
         try {
-            const response = await restartIdentityVerification(regionIntentRef.current)
+            // Bodyless on purpose. `resolveRestartIntent` on the route returns the
+            // intent CANONICAL to the declared residence in every non-null branch
+            // and never the one asked for, so forwarding a local intent can only
+            // be a no-op — or a 400, when it crosses the provider axis. An AR
+            // resident who had tapped a locked non-LATAM region first would send
+            // ROW/EU against a LATAM residence and get an error instead of the
+            // document upload. The server decides; we read its answer below.
+            const response = await restartIdentityVerification()
             if (response.error) {
                 userInitiatedRef.current = false
                 setError(actionErrorMessage(response))
@@ -558,11 +565,6 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
-                // The restart targets a level the backend chose, which need not be
-                // the one this hook last initiated. `refreshToken` replays this ref
-                // to `initiateSumsubKyc`, so leaving it stale would refresh an
-                // expired restart token against the OLD level.
-                levelNameRef.current = response.data.levelName
                 // The restart no longer reopens the applicant's existing level:
                 // the backend targets the level the DECLARED residence needs, and
                 // can overrule the intent we sent. So the multi-level flag comes

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -558,6 +558,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
+                // The restart targets a level the backend chose, which need not be
+                // the one this hook last initiated. `refreshToken` replays this ref
+                // to `initiateSumsubKyc`, so leaving it stale would refresh an
+                // expired restart token against the OLD level.
+                levelNameRef.current = response.data.levelName
                 // The restart no longer reopens the applicant's existing level:
                 // the backend targets the level the DECLARED residence needs, and
                 // can overrule the intent we sent. So the multi-level flag comes

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -550,7 +550,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         actionKeyRef.current = null
 
         try {
-            const response = await restartIdentityVerification()
+            const response = await restartIdentityVerification(regionIntentRef.current)
             if (response.error) {
                 userInitiatedRef.current = false
                 setError(actionErrorMessage(response))
@@ -558,14 +558,20 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             }
             if (response.data?.token) {
                 setAccessToken(response.data.token)
-                // The restart reopens the SAME workflow the original initiate ran
-                // (the token targets the applicant's existing level), so re-derive
-                // the multi-level flag. Left false, a restarted LATAM `general`
-                // session would close on first submit — before the
-                // manteca-requirements questionnaire. Best-effort: the ref is
-                // undefined when this hook instance never initiated, which keeps
-                // today's single-level behavior.
-                setIsMultiLevel(isMultiLevelIntent(regionIntentRef.current))
+                // The restart no longer reopens the applicant's existing level:
+                // the backend targets the level the DECLARED residence needs, and
+                // can overrule the intent we sent. So the multi-level flag comes
+                // from the intent the SERVER resolved, falling back to ours only
+                // for a backend that predates the field. Left false, a restarted
+                // LATAM `general` session closes on first submit — before the
+                // manteca-requirements questionnaire.
+                //
+                // `levelName` cannot substitute: EU and NA both mint
+                // `bridge-requirements`, LATAM and ROW both mint `general`, and
+                // only EU and LATAM are multi-level.
+                const resolvedIntent = response.data.regionIntent ?? regionIntentRef.current
+                regionIntentRef.current = resolvedIntent
+                setIsMultiLevel(isMultiLevelIntent(resolvedIntent))
                 setShowWrapper(true)
             } else {
                 userInitiatedRef.current = false

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2716,7 +2716,7 @@
             "card_rejected": "Your card application couldn't be approved. Message support if you think this is a mistake.",
             "manteca_us_nationality": "Payments from this country are not available for US citizens at this time.",
             "country_not_supported": "This rail needs a document from a supported country. You can verify with a different ID.",
-            "tax_id_unresolved": "Local deposits and withdrawals need a local tax ID, and we couldn't read one from your documents. You can verify again with an ID that carries one. QR payments aren't affected.",
+            "tax_id_unresolved": "We couldn't read the tax ID that local deposits and withdrawals need. You can verify again to provide it. QR payments aren't affected.",
             "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime."
         }
     },

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2716,6 +2716,7 @@
             "card_rejected": "Your card application couldn't be approved. Message support if you think this is a mistake.",
             "manteca_us_nationality": "Payments from this country are not available for US citizens at this time.",
             "country_not_supported": "This rail needs a document from a supported country. You can verify with a different ID.",
+            "tax_id_unresolved": "Local deposits and withdrawals need a local tax ID, and we couldn't read one from your documents. You can verify again with an ID that carries one. QR payments aren't affected.",
             "uk_resident_blocked": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime."
         }
     },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2716,6 +2716,7 @@
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escríbele a soporte si crees que es un error.",
             "manteca_us_nationality": "Los pagos desde este país no están disponibles para ciudadanos de EE. UU. por el momento.",
             "country_not_supported": "Este medio de pago requiere un documento de un país compatible. Puedes verificarte con otro documento.",
+            "tax_id_unresolved": "Los depósitos y retiros locales requieren un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Puedes verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento."
         }
     },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2716,7 +2716,7 @@
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escríbele a soporte si crees que es un error.",
             "manteca_us_nationality": "Los pagos desde este país no están disponibles para ciudadanos de EE. UU. por el momento.",
             "country_not_supported": "Este medio de pago requiere un documento de un país compatible. Puedes verificarte con otro documento.",
-            "tax_id_unresolved": "Los depósitos y retiros locales requieren un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Puedes verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
+            "tax_id_unresolved": "No pudimos leer el número de identificación fiscal que requieren los depósitos y retiros locales. Puedes verificarte de nuevo para proporcionarlo. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento."
         }
     },

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1062,7 +1062,7 @@
             "duplicate_customer_detected": "Bridge marcó tu cuenta como posible duplicado. Escribile a soporte para verificarla y desbloquearla.",
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escribile a soporte si creés que es un error.",
             "country_not_supported": "Este método necesita un documento de un país compatible. Podés verificarte con otro documento.",
-            "tax_id_unresolved": "Los depósitos y retiros locales necesitan un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Podés verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
+            "tax_id_unresolved": "No pudimos leer el número de identificación fiscal que necesitan los depósitos y retiros locales. Podés verificarte de nuevo para proporcionarlo. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento."
         }
     },

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1062,6 +1062,7 @@
             "duplicate_customer_detected": "Bridge marcó tu cuenta como posible duplicado. Escribile a soporte para verificarla y desbloquearla.",
             "card_rejected": "No se pudo aprobar tu solicitud de tarjeta. Escribile a soporte si creés que es un error.",
             "country_not_supported": "Este método necesita un documento de un país compatible. Podés verificarte con otro documento.",
+            "tax_id_unresolved": "Los depósitos y retiros locales necesitan un número de identificación fiscal, y no pudimos leer ninguno en tus documentos. Podés verificarte de nuevo con un documento que lo incluya. Los pagos con QR no se ven afectados.",
             "uk_resident_blocked": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento."
         }
     },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2716,7 +2716,7 @@
             "card_rejected": "Sua solicitação de cartão não pôde ser aprovada. Fale com o suporte se achar que isso é um engano.",
             "manteca_us_nationality": "Pagamentos deste país não estão disponíveis para cidadãos dos EUA no momento.",
             "country_not_supported": "Este método exige um documento de um país compatível. Você pode verificar com outro documento.",
-            "tax_id_unresolved": "Depósitos e saques locais exigem um número de identificação fiscal, e não conseguimos ler nenhum nos seus documentos. Você pode verificar novamente com um documento que o contenha. Os pagamentos por QR não são afetados.",
+            "tax_id_unresolved": "Não conseguimos ler o número de identificação fiscal que os depósitos e saques locais exigem. Você pode verificar novamente para fornecê-lo. Os pagamentos por QR não são afetados.",
             "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para seus residentes. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento."
         }
     },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2716,6 +2716,7 @@
             "card_rejected": "Sua solicitação de cartão não pôde ser aprovada. Fale com o suporte se achar que isso é um engano.",
             "manteca_us_nationality": "Pagamentos deste país não estão disponíveis para cidadãos dos EUA no momento.",
             "country_not_supported": "Este método exige um documento de um país compatível. Você pode verificar com outro documento.",
+            "tax_id_unresolved": "Depósitos e saques locais exigem um número de identificação fiscal, e não conseguimos ler nenhum nos seus documentos. Você pode verificar novamente com um documento que o contenha. Os pagamentos por QR não são afetados.",
             "uk_resident_blocked": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para seus residentes. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento."
         }
     },


### PR DESCRIPTION
## Why this must accompany peanut-api-ts#1501

**This app already calls `POST /users/identity/restart`** — `src/app/actions/sumsub.ts` has shipped that caller for a while, and the endpoint has simply been returning 404. #1501 brings the route to `main`, which **activates** that path. Landing the backend without this turns a dead endpoint into a broken flow, which is worse than the 404.

The restart no longer reopens the applicant's existing level. The backend targets the level the **declared residence** needs and can overrule the intent we send, so the multi-level flag has to come from the intent the SERVER resolved. `levelName` cannot stand in for it: EU and NA both mint `bridge-requirements`, LATAM and ROW both mint `general`, and only EU and LATAM are multi-level.

Concrete failure without this: a PT→BR restart is sent **bodyless** (which is how this app sends it), the server resolves LATAM and returns a `general` token, `regionIntentRef.current` is `undefined`, `isMultiLevel` stays false — and the SDK closes after IDENTITY, **before the `manteca-requirements` questionnaire**, stranding the user mid-verification.

## Changes

- `RestartIdentityResponse` gains optional `regionIntent`; the action forwards a validated intent and reads the resolved one back.
- `handleRestartIdentity` derives `isMultiLevel` from `response.data.regionIntent`, falling back to the local ref only for a backend that predates the field — so this is safe to merge before or after #1501.
- `tax_id_unresolved` reason key + `en` / `es-419` / `es-AR` / `pt-BR` entries. Rail reasons resolve through `REASON_CODE_KEYS` and an unknown code falls back to the backend's English `userMessage`; that fallback is deliberate, but this branch is reachable today only in Argentina, so the one population that can see it would read it untranslated.

Ports peanut-ui#2925 and #2934, both already merged to `dev`.

## Deliberately NOT ported

- The `overrideIntent` parameter on `handleRestartIdentity`, which belongs to the residence-change modal flow on `dev`. Not needed here: without it the request is bodyless and the server derives the level from the declared residence, which is exactly the designed behaviour.
- `firstPaymentAt`. `main` has no consumer for it (`git grep` returns nothing), so the new backend field is simply ignored.

## Testing

Against `main`: `tsc --noEmit` clean; `useSumsubKycFlow`, i18n and constants suites — 332 passing across 25 suites; `Kyc` / `Profile` / `actions` suites — 115 passing across 14; `prettier --check` clean on every touched file.

`identity` is not a marketing namespace, so no `generate:marketing-messages` run is needed.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Identity verification restarts now use the selected region and reflect the region resolved by the verification service.
  - Added a clear tax ID verification reason for users whose documents do not contain a readable local tax ID.
  - QR payments remain available when this verification issue occurs.

- **Localization**
  - Added English, Latin American Spanish, Argentine Spanish, and Brazilian Portuguese translations for the new verification message.

- **Bug Fixes**
  - Restarted verification sessions now open at the correct verification level for the resolved region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
