### PR TITLE
fix(qr-pay): fail fast on a refused idempotency key

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/init-error-classifier.test.ts
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/init-error-classifier.test.ts
@@ -61,6 +61,7 @@ describe('isNonRetryableQrInitError', () => {
         QR_INIT_CODE.MISSING_AMOUNT,
         QR_INIT_CODE.EXPIRED,
         QR_INIT_CODE.DECODE,
+        QR_INIT_CODE.KEY_MISMATCH,
     ]
 
     it.each(deterministic)('fails fast on %s, by wire code and by legacy prose', (code) => {

--- a/src/app/(mobile-ui)/qr-pay/init-error-classifier.ts
+++ b/src/app/(mobile-ui)/qr-pay/init-error-classifier.ts
@@ -29,6 +29,7 @@ export const QR_INIT_CODE = {
     DECODE: 'PAYMENT_DESTINATION_DECODING_ERROR',
     PROVIDER_UNAVAILABLE: 'PROVIDER_UNAVAILABLE',
     IN_PROGRESS: 'QR_INIT_IN_PROGRESS',
+    KEY_MISMATCH: 'QR_INIT_KEY_MISMATCH',
 } as const
 
 export type QrInitCode = (typeof QR_INIT_CODE)[keyof typeof QR_INIT_CODE]
@@ -74,6 +75,14 @@ const DETERMINISTIC: Partial<Record<QrInitCode, { amountRetryable: boolean }>> =
     [QR_INIT_CODE.MISSING_AMOUNT]: { amountRetryable: false },
     [QR_INIT_CODE.EXPIRED]: { amountRetryable: false },
     [QR_INIT_CODE.DECODE]: { amountRetryable: false },
+    /*
+     * The backend refuses an idempotency key presented for a different request.
+     * A client bug, not a transport blip: the same key with the same body would
+     * be refused identically, so retrying only burns POSTs and dead-ends on the
+     * generic error. This screen derives keys per (scan, amount), so reaching
+     * it means the derivation broke.
+     */
+    [QR_INIT_CODE.KEY_MISMATCH]: { amountRetryable: false },
 }
 
 /**

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -149,6 +149,9 @@ export default function QRPayPage() {
             [QR_INIT_CODE.DECODE]: qrType === EQrType.PIX ? t('errors.pixDecode') : t('errors.genericDecode'),
             [QR_INIT_CODE.PROVIDER_UNAVAILABLE]: t('errors.providerIssues', { method: qrMethodName }),
             [QR_INIT_CODE.IN_PROGRESS]: t('errors.providerIssues', { method: qrMethodName }),
+            // Never expected from this screen — it derives a key per (scan,
+            // amount). If it happens, it is ours to fix, not the user's.
+            [QR_INIT_CODE.KEY_MISMATCH]: t('errors.initiateUnexpected'),
             offline: t('errors.connectionLost'),
             'auth-missing': t('errors.authError'),
             'provider-issues': t('errors.providerIssues', { method: qrMethodName }),


### PR DESCRIPTION
## Why

Follow-up to #2935, which merged while this last commit was still being reviewed — it missed the merge by minutes and is not in `dev`.

peanutprotocol/peanut-api-ts#1500 adds `QR_INIT_KEY_MISMATCH`: the backend refuses an idempotency key presented for a different request than the one it was issued for. Chip raised the gap on that PR — the code exists in neither the retry gate nor the copy map on this side, so a `409 QR_INIT_KEY_MISMATCH` would be treated as transient: react-query burns three more identical POSTs, each re-running `createQrPaymentLock` against Manteca, and the scan dead-ends on the generic "unexpected error" + Sentry path.

Retrying can never help here. The same key with the same body is refused identically, so the only outcome is three wasted round trips and a worse message.

## What changed

One entry in the deterministic table in `init-error-classifier`, which the single retry gate and the copy map both read — so adding the code makes it fail fast *and* gives it copy, with no second list to keep in sync.

The copy is `errors.initiateUnexpected` on purpose: this screen derives keys per (scan, amount), so reaching this branch means our own derivation broke. That is ours to fix, not something to ask the user to act on.

## Testing

Added to the `isNonRetryableQrInitError` table-driven case, which asserts every deterministic code fails fast by wire code *and* by legacy prose. `pnpm typecheck` clean, prettier clean, 85 tests green across the qr-pay suites.
