### PR TITLE
fix(qr-pay): recover two commits GitHub dropped from #2937

### DIFF
--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -1741,6 +1741,28 @@ describe('GROUP 5: Error States', () => {
     }, 20_000)
 
     /*
+     * A refused idempotency key is our bug, not the user's — but their way out
+     * is a fresh scan (which mints a new key), not a support ticket. The generic
+     * "contact support" copy would strand someone at a till with an action that
+     * cannot help them.
+     */
+    it('a refused idempotency key tells the user to scan again, not to contact support', async () => {
+        mockMantecaApi.initiateQrPayment.mockRejectedValue(
+            Object.assign(new Error('key reused'), { name: 'ApiError', status: 409, code: 'QR_INIT_KEY_MISMATCH' })
+        )
+
+        renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
+
+        const message = await screen.findByText(/scan the QR code again/i)
+        expect(message).toBeInTheDocument()
+        expect(screen.queryByText(/contact support/i)).not.toBeInTheDocument()
+
+        // Deterministic: one POST, not four.
+        await new Promise((resolve) => setTimeout(resolve, 4_000))
+        expect(mockMantecaApi.initiateQrPayment).toHaveBeenCalledTimes(1)
+    }, 20_000)
+
+    /*
      * The other half of the amount-edit rule. A terminal rejection must STAY
      * latched: an unfinished KYC or a merchant refund block is not something a
      * different number fixes, and clearing on any keystroke re-enabled Pay so

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -149,9 +149,14 @@ export default function QRPayPage() {
             [QR_INIT_CODE.DECODE]: qrType === EQrType.PIX ? t('errors.pixDecode') : t('errors.genericDecode'),
             [QR_INIT_CODE.PROVIDER_UNAVAILABLE]: t('errors.providerIssues', { method: qrMethodName }),
             [QR_INIT_CODE.IN_PROGRESS]: t('errors.providerIssues', { method: qrMethodName }),
-            // Never expected from this screen — it derives a key per (scan,
-            // amount). If it happens, it is ours to fix, not the user's.
-            [QR_INIT_CODE.KEY_MISMATCH]: t('errors.initiateUnexpected'),
+            /*
+             * Never expected from this screen — it derives a key per (scan,
+             * amount) — so reaching this is ours to fix, and Sentry still
+             * reports it. But the user's way out is a fresh scan (a new key),
+             * not a support ticket, so the copy says that rather than the
+             * generic "contact support".
+             */
+            [QR_INIT_CODE.KEY_MISMATCH]: t('errors.restartScan'),
             offline: t('errors.connectionLost'),
             'auth-missing': t('errors.authError'),
             'provider-issues': t('errors.providerIssues', { method: qrMethodName }),

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1311,6 +1311,7 @@
             "signFailed": "Could not sign the transaction.",
             "accountStateChanged": "Transaction failed due to account state change. Please try again. If the problem persists, contact support.",
             "sessionExpired": "Payment session expired. Please scan the QR code again.",
+            "restartScan": "We couldn't start this payment. Please scan the QR code again.",
             "merchantNotSupported": "This specific QR code or merchant is not supported. Please try again with a different QR code.",
             "completeFailed": "Could not complete payment. Please scan the QR code again. If problem persists contact support",
             "minMantecaAmount": "Payment amount must be at least ${amount}",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1311,6 +1311,7 @@
             "signFailed": "No se pudo firmar la transacción.",
             "accountStateChanged": "La transacción falló por un cambio de estado de la cuenta. Inténtalo de nuevo. Si el problema persiste, contacta a soporte.",
             "sessionExpired": "La sesión de pago expiró. Escanea el código QR de nuevo.",
+            "restartScan": "No pudimos iniciar este pago. Escanea el código QR de nuevo.",
             "merchantNotSupported": "Este código QR o comercio no es compatible. Inténtalo de nuevo con otro código QR.",
             "completeFailed": "No se pudo completar el pago. Escanea el código QR de nuevo. Si el problema persiste, contacta a soporte",
             "minMantecaAmount": "El monto del pago debe ser de al menos ${amount}",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -709,6 +709,7 @@
             "confirmTransaction": "Confirmá la transacción.",
             "accountStateChanged": "La transacción falló por un cambio de estado de la cuenta. Intentalo de nuevo. Si el problema persiste, contactá a soporte.",
             "sessionExpired": "La sesión de pago expiró. Escaneá el código QR de nuevo.",
+            "restartScan": "No pudimos iniciar este pago. Escaneá el código QR de nuevo.",
             "merchantNotSupported": "Este código QR o comercio no es compatible. Intentalo de nuevo con otro código QR.",
             "completeFailed": "No se pudo completar el pago. Escaneá el código QR de nuevo. Si el problema persiste, contactá a soporte"
         },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1311,6 +1311,7 @@
             "signFailed": "Não foi possível assinar a transação.",
             "accountStateChanged": "A transação falhou por uma mudança no estado da conta. Tente de novo. Se o problema continuar, fale com o suporte.",
             "sessionExpired": "A sessão de pagamento expirou. Escaneie o código QR de novo.",
+            "restartScan": "Não conseguimos iniciar este pagamento. Escaneie o código QR novamente.",
             "merchantNotSupported": "Este código QR ou lojista não é aceito. Tente de novo com outro código QR.",
             "completeFailed": "Não foi possível concluir o pagamento. Escaneie o código QR de novo. Se o problema continuar, fale com o suporte",
             "minMantecaAmount": "O valor do pagamento deve ser de pelo menos ${amount}",

--- a/src/utils/__tests__/sentry.utils.test.ts
+++ b/src/utils/__tests__/sentry.utils.test.ts
@@ -124,6 +124,30 @@ describe('fetchWithSentry — expected-response suppression', () => {
         expect(Sentry.captureMessage).not.toHaveBeenCalled()
     })
 
+    it('does NOT report qr-payment/init 409 when the retry guard held the key', async () => {
+        // QR_INIT_IN_PROGRESS is the idempotency guard doing its job: a retry met
+        // the in-flight attempt instead of minting a second Manteca price lock.
+        // Paging on it would page us for every rescued scan.
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(409, { error: 'QR_INIT_IN_PROGRESS' }))
+
+        await fetchWithSentry('https://api.peanut.me/manteca/qr-payment/init', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    })
+
+    it('DOES report a refused idempotency key — that one means our derivation broke', async () => {
+        /*
+         * QR_INIT_KEY_MISMATCH is deliberately NOT suppressed. The client derives
+         * a key per (scan, amount), so the backend refusing it can only mean our
+         * own key derivation is wrong — exactly the thing Sentry should show us.
+         */
+        global.fetch = jest.fn().mockResolvedValue(mockResponse(409, { error: 'QR_INIT_KEY_MISMATCH' }))
+
+        await fetchWithSentry('https://api.peanut.me/manteca/qr-payment/init', { method: 'POST', body: '{}' })
+
+        expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+    })
+
     it('DOES report a different qr-payment/init 409 — the status alone must not suppress', async () => {
         global.fetch = jest.fn().mockResolvedValue(mockResponse(409, { error: 'DUPLICATE_PAYMENT_IN_FLIGHT' }))
 

--- a/src/utils/sentry.utils.ts
+++ b/src/utils/sentry.utils.ts
@@ -40,11 +40,21 @@ const SKIP_REPORTING: Array<{ pattern: string | RegExp; statuses: number[]; erro
     // provider can't decode (bad/expired/unsupported) — both are user-input
     // outcomes shown to the user, not server bugs. (BE peanut-api-ts #1041.)
     { pattern: /qr-payment\/init/, statuses: [400, 422] },
-    // 409 on the same route is expected for exactly one outcome: the charge the
-    // cashier rang up on the till timed out (BE peanut-api-ts #1484). Scoped to
-    // that code, so a different conflict on this route — a double-submit, say —
-    // still reaches Sentry instead of being swallowed by the status alone.
-    { pattern: /qr-payment\/init/, statuses: [409], errorCodes: ['PAYMENT_DESTINATION_EXPIRED'] },
+    // 409 on the same route is expected for two outcomes: the charge the cashier
+    // rang up on the till timed out (BE peanut-api-ts #1484), and a retry that
+    // met the in-flight attempt already holding this scan's idempotency key
+    // (peanut-api-ts #1500) — the retry guard doing precisely its job, which
+    // would otherwise page us for every rescued scan.
+    //
+    // QR_INIT_KEY_MISMATCH is deliberately NOT here. The client derives a key
+    // per (scan, amount), so that code can only mean our own derivation broke —
+    // it should reach Sentry. Scoped to codes for the same reason as before: an
+    // unlisted conflict on this route still reports.
+    {
+        pattern: /qr-payment\/init/,
+        statuses: [409],
+        errorCodes: ['PAYMENT_DESTINATION_EXPIRED', 'QR_INIT_IN_PROGRESS'],
+    },
     // Rain card secrets endpoints are intentionally rate-limited (5/min) — a
     // 429 here is an expected outcome surfaced to the user, not a server bug.
     { pattern: /\/rain\/cards\/[^/]+\/details/, statuses: [429] },


### PR DESCRIPTION
## Why

Two commits that were pushed to #2937 never reached it. GitHub's PR object stayed pinned at `92d82ad25660` and merged only that commit, so these two — both green on CI at the time — are not in `dev`. Same failure as #2935, where the head pointer also lagged and the last commit was left behind.

Nothing here is new work; it is the remainder of the QR-init idempotency pair (peanutprotocol/peanut-api-ts#1500).

## What changed

**Sentry: stop paging on the retry guard's own 409.** peanut-api-ts#1500 adds two 409s to `/manteca/qr-payment/init`, and this route's allowlist is code-scoped, so both reported as errors.

`QR_INIT_IN_PROGRESS` is the idempotency guard working as designed — a retry met the in-flight attempt instead of minting a second Manteca price lock. Paging on it means paging on every rescued scan, so it joins the allowlist.

`QR_INIT_KEY_MISMATCH` deliberately does **not**. The client derives a key per (scan, amount), so the backend refusing one can only mean our own derivation broke — exactly what Sentry should surface. Scoping stays per-code for the reason the existing entry gives: an unlisted conflict on this route still reports.

**Copy: a refused key points at a rescan, not support.** The generic `initiateUnexpected` string strands someone at a till with "contact support", which cannot help them — the way out is a fresh scan, which mints a new key. New `restartScan` string in en / es-419 / pt-BR with the es-AR voseo delta. `sessionExpired` was not reused because it states a cause we do not know.

## Testing

Both halves of the Sentry rule pinned (suppressed vs still-reporting), matching the existing pair. Page-level test asserts the rescan copy shows, that "contact support" does not, and that the rejection still stops after one POST rather than four — waiting past the 3s backoff so the assertion can actually fail.

`pnpm typecheck` clean, prettier clean, 113 tests green across the qr-pay and sentry suites.
