### PR TITLE
fix(watchdog): compare the mirror stamp by ancestry, not by string (TASK-22185)

### DIFF
--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -106,28 +106,44 @@ jobs:
                   # often a merge commit that only contains the content change —
                   # someone `git pull`ed without rebasing and pushed the merge. The
                   # published tree is still right, so compare by ancestry, not by
-                  # string: the mirror is current when the stamped commit is the
-                  # expected commit or a descendant of it. A string comparison read
-                  # that as "behind" and alerted every 15 minutes for 8 hours on
-                  # 2026-09-03 (expected 7cf077f, stamped merge 37adb24) on a pipeline
-                  # that was healthy end to end. The compare endpoint is contents:read,
-                  # which MONO_TOKEN has; only the four documented statuses count as an
-                  # answer, so an error body can never read as one.
-                  MIRROR_STATUS=""
+                  # string. A string comparison read that as "behind" and alerted
+                  # every 15 minutes for 8 hours on 2026-09-03 (expected 7cf077f,
+                  # stamped merge 37adb24) on a pipeline that was healthy end to end.
+                  #
+                  # Two questions, both through the compare endpoint (contents:read,
+                  # which MONO_TOKEN has):
+                  #   FRESH   — expected...stamped: is the stamp the expected commit
+                  #             or a descendant of it?
+                  #   ON_MAIN — stamped...main: is the stamp on mono main at all?
+                  #             The mirror has workflow_dispatch and checks out the
+                  #             triggering ref, so a manual run from a branch would
+                  #             publish content main never had. FRESH alone would
+                  #             call that "ahead" and stay green.
+                  # Only the four documented statuses count as an answer; a failed
+                  # call yields "" and lands in the DEGRADED branch below, with the
+                  # raw response in the log.
+                  compare_status() {
+                    local out st
+                    out=$(GH_TOKEN=$MONO_TOKEN gh api "repos/peanutprotocol/mono/compare/$1" --jq '.status' 2>&1)
+                    st=$(printf '%s' "$out" | grep -Eox 'identical|ahead|behind|diverged' || true)
+                    [ -z "$st" ] && echo "::warning::compare $1 gave no status: $(printf '%s' "$out" | head -c 300)" >&2
+                    printf '%s' "$st"
+                  }
+                  FRESH=""
+                  ON_MAIN=""
                   if [ -n "$EXPECTED" ] && [ -n "$MIRRORED" ]; then
-                    MIRROR_STATUS=$(GH_TOKEN=$MONO_TOKEN gh api \
-                        "repos/peanutprotocol/mono/compare/${EXPECTED}...${MIRRORED}" --jq '.status' 2>/dev/null \
-                      | grep -Eox 'identical|ahead|behind|diverged' || true)
+                    FRESH=$(compare_status "${EXPECTED}...${MIRRORED}")
+                    ON_MAIN=$(compare_status "${MIRRORED}...main")
                   fi
 
-                  echo "expected mono@${EXPECTED:0:7} | mirrored @${MIRRORED:-none} (${MIRROR_STATUS:-unknown}) | peanut-content ${TIP:0:7} | live ${LIVE:0:7}"
+                  echo "expected mono@${EXPECTED:0:7} | mirrored @${MIRRORED:-none} (fresh: ${FRESH:-?}, on main: ${ON_MAIN:-?}) | peanut-content ${TIP:0:7} | live ${LIVE:0:7}"
 
                   # Cannot evaluate == broken watchdog, which must NOT look like a
                   # broken pipeline. Label it distinctly so nobody debugs the wrong
                   # thing, but still be loud — a watchdog that can't watch is an
                   # outage of the thing that tells us about outages.
-                  if [ -z "$EXPECTED" ] || [ -z "$MIRRORED" ] || [ -z "$LIVE" ] || [ -z "$TIP" ]; then
-                    echo "::error::WATCHDOG DEGRADED — could not evaluate the pipeline (expected=${EXPECTED:0:7} mirrored=${MIRRORED:-none} live=${LIVE:0:7} tip=${TIP:0:7}). This is a watchdog fault, not necessarily a content fault."
+                  if [ -z "$EXPECTED" ] || [ -z "$MIRRORED" ] || [ -z "$LIVE" ] || [ -z "$TIP" ] || [ -z "$FRESH" ] || [ -z "$ON_MAIN" ]; then
+                    echo "::error::WATCHDOG DEGRADED — could not evaluate the pipeline (expected=${EXPECTED:0:7} mirrored=${MIRRORED:-none} fresh=${FRESH:-?} on_main=${ON_MAIN:-?} live=${LIVE:0:7} tip=${TIP:0:7}). This is a watchdog fault, not necessarily a content fault."
                     DEGRADED=true
                   else
                     DEGRADED=false
@@ -138,8 +154,11 @@ jobs:
                   if [ "$DEGRADED" = true ]; then
                     STALE="**the watchdog itself could not evaluate the pipeline** — check its permissions before assuming content is stuck"
                     MIRROR_BROKEN=true
-                  elif [ "$MIRROR_STATUS" != "identical" ] && [ "$MIRROR_STATUS" != "ahead" ]; then
-                    STALE="the mirror is behind mono (expected \`${EXPECTED:0:7}\`, published \`${MIRRORED:0:7}\`, compare: ${MIRROR_STATUS:-unknown})"
+                  elif [ "$ON_MAIN" != "identical" ] && [ "$ON_MAIN" != "ahead" ]; then
+                    STALE="the mirror published a commit that is not on mono main (published \`${MIRRORED:0:7}\`, compare to main: ${ON_MAIN})"
+                    MIRROR_BROKEN=true
+                  elif [ "$FRESH" != "identical" ] && [ "$FRESH" != "ahead" ]; then
+                    STALE="the mirror is behind mono (expected \`${EXPECTED:0:7}\`, published \`${MIRRORED:0:7}\`, compare: ${FRESH})"
                     MIRROR_BROKEN=true
                   elif [ "$LIVE" != "$TIP" ]; then
                     STALE="production is behind peanut-content (live \`${LIVE:0:7}\`, latest \`${TIP:0:7}\`)"

--- a/.github/workflows/content-pipeline-watchdog.yml
+++ b/.github/workflows/content-pipeline-watchdog.yml
@@ -102,7 +102,25 @@ jobs:
 
                   MIRRORED=$(printf '%s' "$TIP_MSG" | sed -nE 's/.*mono@([0-9a-f]+).*/\1/p')
 
-                  echo "expected mono@${EXPECTED:0:7} | mirrored @${MIRRORED:-none} | peanut-content ${TIP:0:7} | live ${LIVE:0:7}"
+                  # The stamp is whatever mono commit the mirror RAN at, and that is
+                  # often a merge commit that only contains the content change —
+                  # someone `git pull`ed without rebasing and pushed the merge. The
+                  # published tree is still right, so compare by ancestry, not by
+                  # string: the mirror is current when the stamped commit is the
+                  # expected commit or a descendant of it. A string comparison read
+                  # that as "behind" and alerted every 15 minutes for 8 hours on
+                  # 2026-09-03 (expected 7cf077f, stamped merge 37adb24) on a pipeline
+                  # that was healthy end to end. The compare endpoint is contents:read,
+                  # which MONO_TOKEN has; only the four documented statuses count as an
+                  # answer, so an error body can never read as one.
+                  MIRROR_STATUS=""
+                  if [ -n "$EXPECTED" ] && [ -n "$MIRRORED" ]; then
+                    MIRROR_STATUS=$(GH_TOKEN=$MONO_TOKEN gh api \
+                        "repos/peanutprotocol/mono/compare/${EXPECTED}...${MIRRORED}" --jq '.status' 2>/dev/null \
+                      | grep -Eox 'identical|ahead|behind|diverged' || true)
+                  fi
+
+                  echo "expected mono@${EXPECTED:0:7} | mirrored @${MIRRORED:-none} (${MIRROR_STATUS:-unknown}) | peanut-content ${TIP:0:7} | live ${LIVE:0:7}"
 
                   # Cannot evaluate == broken watchdog, which must NOT look like a
                   # broken pipeline. Label it distinctly so nobody debugs the wrong
@@ -120,8 +138,8 @@ jobs:
                   if [ "$DEGRADED" = true ]; then
                     STALE="**the watchdog itself could not evaluate the pipeline** — check its permissions before assuming content is stuck"
                     MIRROR_BROKEN=true
-                  elif [ "${EXPECTED:0:7}" != "${MIRRORED:0:7}" ]; then
-                    STALE="the mirror is behind mono (expected \`${EXPECTED:0:7}\`, published \`${MIRRORED:0:7}\`)"
+                  elif [ "$MIRROR_STATUS" != "identical" ] && [ "$MIRROR_STATUS" != "ahead" ]; then
+                    STALE="the mirror is behind mono (expected \`${EXPECTED:0:7}\`, published \`${MIRRORED:0:7}\`, compare: ${MIRROR_STATUS:-unknown})"
                     MIRROR_BROKEN=true
                   elif [ "$LIVE" != "$TIP" ]; then
                     STALE="production is behind peanut-content (live \`${LIVE:0:7}\`, latest \`${TIP:0:7}\`)"


### PR DESCRIPTION
## Summary

Since 2026-09-03 ~02:00 UTC the Supervisor has posted "Content is not reaching production — the mirror is behind mono (expected `7cf077f`, published `37adb24`)" to Discord every 15 minutes. Production was serving the right content the whole time.

The mirror stamps peanut-content with the mono commit it ran at. That is a merge commit whenever someone pulls without rebasing and pushes the merge, and a merge commit only *contains* the content change. `37adb24` is a merge whose first parent is `7cf077f`. The watchdog compared the two SHAs by string and read the difference as a stale mirror.

This PR asks the compare API two questions and only alerts when either fails:

- `expected...stamped` is `identical` or `ahead` — the stamp is the expected commit or a descendant (freshness).
- `stamped...main` is `identical` or `ahead` — the stamp is on mono main at all (the mirror has `workflow_dispatch` and checks out the triggering ref, so a manual run from a branch must not read as healthy).

Mono's `split-content-watchdog.yml` already uses the same compare-API check. The endpoint is `contents:read`, which `MONO_READ_TOKEN` has.

## Task

TASK-22185 — https://app.notion.com/p/3d0838117579817ea8f5f0e819685017

## Risks / breaking changes

- Base is `main` because the scheduled watchdog only runs from the default branch. A `dev` merge would not stop the alerts until the next release. Creates main→dev back-merge debt.
- A stale mirror still alerts: `behind` and `diverged` fall through to the existing alert path, with the compare status in the alert text.

## Design notes / accepted trade-offs

- A failed compare call (rate limit, 404, token scope) is a **watchdog** fault, so it lands in the existing DEGRADED branch with the raw API response logged. DEGRADED was already immediate-alert before this PR, so a transient GitHub API failure still fails the run loudly. Unchanged on purpose: a watchdog that cannot watch should not be quiet.
- Two compare calls instead of one. `expected...stamped` alone would call a branch-dispatched mirror run "ahead" and stay green.

## QA

Ran the step's shell body locally with a personal token against the live repos:

| MIRRORED | compare | result |
|---|---|---|
| `37adb24` (live, the false alarm) | `ahead` | "production content is current", exit 0 |
| `26bd181` (older content commit) | `behind` | alert, exit 1 |
| `deadbee` (unknown SHA, API 404) | empty | WATCHDOG DEGRADED, exit 1 |
| `0af3223` (on an unmerged mono branch) | on main: `diverged` | "published a commit that is not on mono main", exit 1 |

Screenshots: N/A (no visible change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mirror freshness monitoring by comparing complete commit histories rather than abbreviated commit identifiers.
  - Added clearer detection for mirrors that are behind or contain commits not present on the main branch.
  - Watchdog status output now reports freshness and main-branch alignment, with warnings when comparison results are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->