### PR TITLE
fix(i18n): translate the Name Dropper badge in es and pt (TASK-22143)

### DIFF
--- a/src/i18n/app/__tests__/messages.test.ts
+++ b/src/i18n/app/__tests__/messages.test.ts
@@ -132,3 +132,16 @@ describe('ICU message compilation', () => {
         expect(invalid).toEqual([])
     })
 })
+
+// TASK-22143: the ENS badge reached production with no `badges.catalog` entry, so
+// `useBadgeCopy` fell back to the backend's English name and the Spanish and
+// Portuguese Badges screens rendered "Name Dropper" in the middle of translated
+// copy. Key parity alone would not have caught it — the key was absent from every
+// locale, en included — so pin the localized names against English directly.
+describe('ENS badge copy is localized', () => {
+    it.each(APP_LOCALES.filter((locale) => locale !== 'en'))('%s translates the ENS badge', async (locale) => {
+        const messages = await loadMessages(locale)
+        expect(messages.badges.catalog.ENS.name).not.toBe(en.badges.catalog.ENS.name)
+        expect(messages.badges.catalog.ENS.description).not.toBe(en.badges.catalog.ENS.description)
+    })
+})

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2367,6 +2367,10 @@
                 "name": "Founding Pioneer",
                 "description": "You were building Peanut before it had a launch."
             },
+            "ENS": {
+                "name": "Name Dropper",
+                "description": "You paid at a name. Or got paid at yours."
+            },
             "VERIFIED": {
                 "name": "Verified",
                 "description": "ID checked, identity confirmed. You're officially verified."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2367,6 +2367,10 @@
                 "name": "Pionero fundador",
                 "description": "Ya construías Peanut antes de que existiera el lanzamiento."
             },
+            "ENS": {
+                "name": "Nombre propio",
+                "description": "Pagaste a un nombre. O te pagaron al tuyo."
+            },
             "VERIFIED": {
                 "name": "Verificado",
                 "description": "Documento revisado, identidad confirmada. Verificación oficial completa."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2367,6 +2367,10 @@
                 "name": "Pioneiro fundador",
                 "description": "Você já construía Peanut antes de existir lançamento."
             },
+            "ENS": {
+                "name": "Nome próprio",
+                "description": "Você pagou para um nome. Ou recebeu no seu."
+            },
             "VERIFIED": {
                 "name": "Verificado",
                 "description": "Documento conferido, identidade confirmada. Verificação oficial concluída."


### PR DESCRIPTION
## Summary

The ENS badge ("Name Dropper") has no entry in the app message catalog, so `useBadgeCopy` falls back to the backend's English name. On the Spanish and Portuguese Badges screens the badge reads "Name Dropper" in the middle of translated copy.

This adds the badge to the `en`, `es-419` and `pt-BR` catalogs. `es-AR` needs no override: the description is a preterite that reads the same in voseo and tuteo.

| Locale | Name | Description |
|---|---|---|
| en | Name Dropper | You paid at a name. Or got paid at yours. |
| es-419 | Nombre propio | Pagaste a un nombre. O te pagaron al tuyo. |
| pt-BR | Nome próprio | Você pagou para um nome. Ou recebeu no seu. |

## Task

TASK-22143

## Risks / breaking changes

None. Copy-only, one namespace, no code path changes. English is unchanged on screen: the new `en` entry repeats the string the backend already sends.

## QA

1. Open the Badges screen with the locale set to `es-419`, `es-AR` or `pt-BR`.
2. The ENS badge name and its reason line read in that language.
3. `npm test -- --runTestsByPath src/i18n/app/__tests__/messages.test.ts` covers both languages.

## Design notes / accepted trade-offs

Key parity between catalogs could not have caught this, because the key was missing from every catalog including English. The regression check therefore compares each locale's ENS strings against the English ones rather than checking that a key exists.

Thirteen other badge codes in the backend registry have no catalog entry either and render English the same way. Out of scope here, and worth a follow-up task with reviewed copy.

## Screenshots

N/A. Copy in a message catalog. A screenshot would show one badge name, which the table above states exactly.
