### PR TITLE
fix(kyc): stop selling a bank ID check to residences no bank onboards

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -53,7 +53,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
 import { useLocale, useTranslations } from 'next-intl'
 import { localizedCountryTitle } from '@/utils/country-name.utils'
 
@@ -154,6 +154,7 @@ function BridgeBankOnrampPage() {
     // this page in a "Setting up your account…" wait loop. Unknown country
     // → undefined → falls back to channel-only filter.
     const { gateFor } = useCapabilities()
+    const bankRegionIntent = useBankRegionIntent()
     const bankCountry = useMemo(() => railJurisdictionForBank(selectedCountry?.id), [selectedCountry?.id])
     const gate = useMemo(() => gateFor('deposit', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
     // bridge re-verification ("we're reviewing your details") modal for the
@@ -291,7 +292,7 @@ function BridgeBankOnrampPage() {
             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
         } else {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                 undefined,
                 gate.kind === 'needs-enrollment' || undefined,
                 selectedCountry?.id

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -187,6 +187,12 @@ jest.mock('@/hooks/useTosGuard', () => ({
     useTosGuard: () => mockUseTosGuard(),
 }))
 
+// The page derives its KYC intent from the residence; these cases are about
+// the gate, so keep the residence unrestricted (and out of the redux store).
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => ({ banking: false, card: false }),
+}))
+
 // OnrampFlowContext
 const mockOnrampFlow = {
     error: { showError: false, errorMessage: '' },

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -709,6 +709,17 @@ describe('GROUP 1: Loading & KYC Gate', () => {
         expect(screen.queryByText('Unlock now')).not.toBeInTheDocument()
     })
 
+    // nothing revokes a pool rail when a later reverification is refused on
+    // jurisdiction, so the enabled-pay shortcut must not outrank the refusal
+    test('a jurisdictional rejection closes the pay path even with an enabled QR rail', () => {
+        setCapabilitiesGate('proceed_to_pay')
+        mockIsRegionRestricted = true
+
+        renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
+
+        expect(screen.getByText(/doesn't accept documents issued in your country/i)).toBeInTheDocument()
+    })
+
     test('KYC verification in progress shows ActionModal with continue button', () => {
         setCapabilitiesGate('identity_verification_in_progress')
 

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -102,6 +102,10 @@ jest.mock('@/assets/icons', () => ({
 // @/constants/kyc.consts — used as the real module here). Each gate-state test configures
 // the capability fixture via setCapabilitiesGate() below.
 const mockUseCapabilities = jest.fn()
+let mockIsRegionRestricted = false
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isRegionRestricted: mockIsRegionRestricted }),
+}))
 jest.mock('@/hooks/useCapabilities', () => ({
     useCapabilities: () => mockUseCapabilities(),
 }))
@@ -666,6 +670,7 @@ function applyDefaults() {
 beforeEach(() => {
     jest.clearAllMocks()
     mockSearchParams.clear()
+    mockIsRegionRestricted = false
     applyDefaults()
 })
 
@@ -689,6 +694,19 @@ describe('GROUP 1: Loading & KYC Gate', () => {
         expect(modal).toBeInTheDocument()
         expect(screen.getByText('Unlock QR payments')).toBeInTheDocument()
         expect(screen.getByText('Unlock now')).toBeInTheDocument()
+    })
+
+    // Pool QR pay is residence-agnostic, so the offer is legitimate for almost
+    // every restricted residence — but not when Sumsub refuses the document's
+    // jurisdiction, which no rail can survive and no re-upload can change.
+    test('a jurisdictional rejection ends the flow instead of re-offering verification', () => {
+        setCapabilitiesGate('requires_identity_verification')
+        mockIsRegionRestricted = true
+
+        renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
+
+        expect(screen.getByText(/doesn't accept documents issued in your country/i)).toBeInTheDocument()
+        expect(screen.queryByText('Unlock now')).not.toBeInTheDocument()
     })
 
     test('KYC verification in progress shows ActionModal with continue button', () => {

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -276,16 +276,19 @@ export default function QRPayPage() {
         if (isLoadingCapabilities || (!user && !userFetchSettled)) {
             return { kycGateState: QrKycState.LOADING, qrKycUserMessage: noAction, qrKycActionKey: noAction }
         }
-        if (canDo('pay', { provider: 'manteca' })) {
-            return { kycGateState: QrKycState.PROCEED_TO_PAY, qrKycUserMessage: noAction, qrKycActionKey: noAction }
-        }
-        // Above every rail-derived state: Sumsub rejected the document's
-        // jurisdiction, so no rail can ever enable — not even the pool, which
-        // is otherwise residence-agnostic. Without this the user falls through
-        // to REQUIRES_IDENTITY_VERIFICATION (they own no Manteca rail at all)
-        // and is re-offered the verification that just refused them.
+        // Above the enabled-pay return, not just the rail-derived states below.
+        // A terminal jurisdictional refusal is account-wide, but nothing revokes
+        // a pool rail granted by an earlier approval — so a residence change
+        // that re-verifies into a region rejection leaves an ENABLED rail
+        // behind, and ranking `canDo` first would keep the money path open on
+        // an identity we can no longer verify. Deliberately unlike deriveGate's
+        // ready-wins hoist, which exists to stop a STUCK SIBLING rail from
+        // blocking a working one — a refused identity is not a sibling rail.
         if (isRegionRestricted) {
             return { kycGateState: QrKycState.REGION_RESTRICTED, qrKycUserMessage: noAction, qrKycActionKey: noAction }
+        }
+        if (canDo('pay', { provider: 'manteca' })) {
+            return { kycGateState: QrKycState.PROCEED_TO_PAY, qrKycUserMessage: noAction, qrKycActionKey: noAction }
         }
         // Verdict-first via the shared railVerdict collapse (rail.resolved,
         // BE-derived; legacy fallback for older/cached responses). The

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -1248,7 +1248,8 @@ export default function QRPayPage() {
     // because unverified users should see KYC screen, not error screen
     const needsKycVerification =
         kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION ||
-        kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS
+        kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS ||
+        kycGateState === QrKycState.REGION_RESTRICTED
     const hasProviderRejection =
         kycGateState === QrKycState.PROVIDER_REJECTION_FIXABLE ||
         kycGateState === QrKycState.PROVIDER_REJECTION_BLOCKED ||
@@ -1257,18 +1258,6 @@ export default function QRPayPage() {
     // show loading while KYC state is being determined
     if (isLoadingKycState) {
         return <Loading variant="mascot" />
-    }
-
-    // Ranked above the provider-rejection and unlock screens: re-uploading
-    // cannot change a jurisdictional refusal, so this surface owes the same
-    // one honest ending the drawer and InitiateKycModal give.
-    if (kycGateState === QrKycState.REGION_RESTRICTED) {
-        return (
-            <div className="flex min-h-[inherit] flex-col gap-8">
-                <NavHeader title={tNav('pay')} />
-                <KycRegionRestrictedModal visible onClose={onBack} />
-            </div>
-        )
     }
 
     // provider rejection: user is sumsub-approved but manteca rejected
@@ -1369,6 +1358,10 @@ export default function QRPayPage() {
                     ]}
                     footer={<PeanutDoesntStoreAnyPersonalInformation />}
                 />
+                {/* Re-uploading cannot change a jurisdictional refusal, so this
+                    surface owes the same one honest ending the drawer and
+                    InitiateKycModal give — never the unlock offer above. */}
+                <KycRegionRestrictedModal visible={kycGateState === QrKycState.REGION_RESTRICTED} onClose={onBack} />
                 <ActionModal
                     visible={kycGateState === QrKycState.IDENTITY_VERIFICATION_IN_PROGRESS}
                     onClose={onBack}

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -65,6 +65,8 @@ import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
 import { isPaymentProcessorQR, EQrType, NAME_BY_QR_TYPE, type QrType } from '@/components/Global/DirectSendQR/utils'
 import { QrKycState } from '@/constants/kyc.consts'
+import { useIdentityVerification } from '@/hooks/useIdentityVerification'
+import { KycRegionRestrictedModal } from '@/components/Kyc/modals/KycRegionRestrictedModal'
 import ActionModal from '@/components/Global/ActionModal'
 import InviteFriendsModal from '@/components/Global/InviteFriendsModal'
 import { SoundPlayer } from '@/components/Global/SoundPlayer'
@@ -249,6 +251,7 @@ export default function QRPayPage() {
     //   otherwise → REQUIRES_IDENTITY_VERIFICATION. While loading → LOADING.
     // userMessage ← the rejecting rail's reason.userMessage (was useProviderRejectionStatus).
     const { canDo, railsForProvider, nextActions, isKycApproved, isLoading: isLoadingCapabilities } = useCapabilities()
+    const { isRegionRestricted } = useIdentityVerification()
     const { user, fetchUser } = useAuth()
 
     // On public routes (qr-pay) auth still auto-fetches via React Query, but trigger a one-shot
@@ -275,6 +278,14 @@ export default function QRPayPage() {
         }
         if (canDo('pay', { provider: 'manteca' })) {
             return { kycGateState: QrKycState.PROCEED_TO_PAY, qrKycUserMessage: noAction, qrKycActionKey: noAction }
+        }
+        // Above every rail-derived state: Sumsub rejected the document's
+        // jurisdiction, so no rail can ever enable — not even the pool, which
+        // is otherwise residence-agnostic. Without this the user falls through
+        // to REQUIRES_IDENTITY_VERIFICATION (they own no Manteca rail at all)
+        // and is re-offered the verification that just refused them.
+        if (isRegionRestricted) {
+            return { kycGateState: QrKycState.REGION_RESTRICTED, qrKycUserMessage: noAction, qrKycActionKey: noAction }
         }
         // Verdict-first via the shared railVerdict collapse (rail.resolved,
         // BE-derived; legacy fallback for older/cached responses). The
@@ -337,7 +348,7 @@ export default function QRPayPage() {
             qrKycUserMessage: noAction,
             qrKycActionKey: noAction,
         }
-    }, [isLoadingCapabilities, canDo, railsForProvider, nextActions, user, userFetchSettled])
+    }, [isLoadingCapabilities, canDo, railsForProvider, nextActions, user, userFetchSettled, isRegionRestricted])
 
     const shouldBlockPay = kycGateState !== QrKycState.PROCEED_TO_PAY
 
@@ -1246,6 +1257,18 @@ export default function QRPayPage() {
     // show loading while KYC state is being determined
     if (isLoadingKycState) {
         return <Loading variant="mascot" />
+    }
+
+    // Ranked above the provider-rejection and unlock screens: re-uploading
+    // cannot change a jurisdictional refusal, so this surface owes the same
+    // one honest ending the drawer and InitiateKycModal give.
+    if (kycGateState === QrKycState.REGION_RESTRICTED) {
+        return (
+            <div className="flex min-h-[inherit] flex-col gap-8">
+                <NavHeader title={tNav('pay')} />
+                <KycRegionRestrictedModal visible onClose={onBack} />
+            </div>
+        )
     }
 
     // provider rejection: user is sumsub-approved but manteca rejected

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -45,7 +45,8 @@ import {
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
-import { isBridgeSupportedCountry, getRegionIntent } from '@/utils/regions.utils'
+import { isBridgeSupportedCountry } from '@/utils/regions.utils'
+import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
 import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import posthog from 'posthog-js'
@@ -103,6 +104,7 @@ export default function WithdrawBankPage() {
     // actually withdraws to (PT/DE/… → EU SEPA; US → ACH; etc.) so a stuck
     // PENDING rail in an unrelated jurisdiction can't block this page.
     const { gateFor } = useCapabilities()
+    const bankRegionIntent = useBankRegionIntent()
     const bankCountry = useMemo(() => railJurisdictionForBank(getCountryFromPath(country)?.id), [country])
     const countryFromPath = getCountryFromPath(country)
     const gate = useMemo(() => gateFor('withdraw', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
@@ -604,7 +606,7 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
+                            bankRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             getCountryFromPath(country)?.id

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -34,7 +34,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import ProvideEmailStep from '@/components/Kyc/ProvideEmailStep'
@@ -136,6 +136,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     // them. The prior unscoped `isBankRailUnderReview` check did exactly that
     // and dead-ended ready users behind a "You're all set / Go back" modal.
     const { isKycApproved, gateFor } = useCapabilities()
+    const bankRegionIntent = useBankRegionIntent()
     const isUserKycApproved = isKycApproved
     const bankCountry = useMemo(() => railJurisdictionForBank(currentCountry?.id), [currentCountry?.id])
     const gate = useMemo(() => gateFor('deposit', { channel: 'bank', country: bankCountry }), [gateFor, bankCountry])
@@ -261,7 +262,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
                 undefined,
                 undefined,
                 currentCountry?.id
@@ -376,7 +377,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                            bankRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             currentCountry?.id

--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -28,6 +28,8 @@ import TokenAndNetworkConfirmationModal from '../Global/TokenAndNetworkConfirmat
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useTranslations } from 'next-intl'
+import { Notification } from '@/components/0_Bruddle/Notification'
+import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
 
 interface AddWithdrawRouterViewProps {
     flow: 'add' | 'withdraw'
@@ -82,6 +84,7 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
     const t = useTranslations('withdraw')
     const tAddMoney = useTranslations('addMoney')
     const tCommon = useTranslations('common')
+    const { banking: isBankRestricted } = useResidenceRestrictions()
     const { setSelectedBankAccount, showAllWithdrawMethods, setShowAllWithdrawMethods, setSelectedMethod } =
         useWithdrawFlow()
     const onrampFlowContext = useOnrampFlow()
@@ -355,6 +358,8 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                     }
                 }}
             />
+
+            {isBankRestricted && <Notification priority="helper">{tAddMoney('bankNotAvailableNote')}</Notification>}
 
             <CountryList
                 inputTitle={mainHeading}

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -118,7 +118,11 @@ jest.mock('@/hooks/useGetDeviceType', () => ({
     DeviceType: { IOS: 'IOS', ANDROID: 'ANDROID', WEB: 'WEB' },
     useDeviceType: () => ({ deviceType: 'WEB' }),
 }))
-jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn() }))
+jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn(), useSetupStore: () => ({ residenceCountry: '' }) }))
+// the bank intent hook reads residence restrictions; default to unrestricted
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => ({ banking: false, card: false }),
+}))
 jest.mock('@/redux/slices/bank-form-slice', () => ({ bankFormActions: { clearFormData: () => ({ type: 'noop' }) } }))
 jest.mock('@/app/actions/users', () => ({ addBankAccount: jest.fn() }))
 jest.mock('@/utils/native-routes', () => ({

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -12,7 +12,7 @@
  * the tests exercise the actual context wiring instead of a hand-rolled copy.
  */
 import React, { useEffect } from 'react'
-import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent, cleanup } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
 
 const mockRouterPush = jest.fn()
@@ -58,6 +58,11 @@ jest.mock('@/redux/hooks', () => ({
 
 jest.mock('@/context/OnrampFlowContext', () => ({
     useOnrampFlow: () => ({ setFromBankSelected: jest.fn() }),
+}))
+
+let mockRestrictions = { banking: false, card: false }
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => mockRestrictions,
 }))
 
 jest.mock('@/components/0_Bruddle/Button', () => ({
@@ -162,6 +167,21 @@ function Harness({ user }: { user: MockUser }) {
 describe('AddWithdrawRouterView — withdraw method selection', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockRestrictions = { banking: false, card: false }
+    })
+
+    // Every country on the list dead-ends for these residents; say so once here
+    // rather than after three taps into a flow that cannot finish.
+    test('names the bank restriction above the country list, and only when it applies', () => {
+        render(<Harness user={makeUser()} />)
+        fireEvent.click(screen.getByTestId('select-new-method'))
+        expect(screen.queryByText(/Bank transfers aren't available in your country/i)).not.toBeInTheDocument()
+
+        cleanup()
+        mockRestrictions = { banking: true, card: false }
+        render(<Harness user={makeUser()} />)
+        fireEvent.click(screen.getByTestId('select-new-method'))
+        expect(screen.getByText(/Bank transfers aren't available in your country/i)).toBeInTheDocument()
     })
 
     test('shows saved accounts by default when bank accounts exist', () => {

--- a/src/components/Claim/Link/__tests__/BankFlowManager.residence.test.tsx
+++ b/src/components/Claim/Link/__tests__/BankFlowManager.residence.test.tsx
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+/**
+ * The bank-claim form submits straight into the Sumsub SDK — it never renders
+ * InitiateKycModal on that path, so the residence choke point cannot see it.
+ * A ROW intent still mints a general-level token, which is a verification a
+ * bank-restricted residence can never turn into a rail, so the branch has to
+ * refuse before it calls the SDK.
+ */
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { BankFlowManager } from '../views/BankFlowManager.view'
+
+let mockRestrictions = { banking: false, card: false }
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => mockRestrictions,
+}))
+
+const handleInitiateKyc = jest.fn()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({
+        handleInitiateKyc,
+        handleRestartIdentity: jest.fn(),
+        handleSelfHealResubmit: jest.fn(),
+        isLoading: false,
+        error: null,
+        showWrapper: false,
+    }),
+}))
+
+// the seam: expose the form's onSuccess as a button so the test can submit
+jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({
+    DynamicBankAccountForm: ({ onSuccess }: { onSuccess: (p: unknown, r: unknown) => void }) => (
+        <button data-testid="submit-bank-form" onClick={() => onSuccess({}, {})}>
+            submit
+        </button>
+    ),
+}))
+
+jest.mock('@/context/ClaimBankFlowContext', () => {
+    const actual = jest.requireActual('@/context/ClaimBankFlowContext')
+    return {
+        ...actual,
+        useClaimBankFlow: () => ({
+            flowStep: actual.ClaimBankFlowStep.BankDetailsForm,
+            setFlowStep: jest.fn(),
+            selectedCountry: { id: 'spain', path: 'spain', region: 'europe' },
+            setClaimType: jest.fn(),
+            setBankDetails: jest.fn(),
+            justCompletedKyc: false,
+            setJustCompletedKyc: jest.fn(),
+            setShowVerificationModal: jest.fn(),
+        }),
+    }
+})
+
+jest.mock('@/hooks/useDetermineBankClaimType', () => {
+    const actual = jest.requireActual('@/hooks/useDetermineBankClaimType')
+    return { ...actual, useDetermineBankClaimType: () => ({ claimType: actual.BankClaimType.ReceiverKycNeeded }) }
+})
+
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: null, fetchUser: jest.fn() }) }))
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ gateFor: () => ({ kind: 'needs-identity' }) }),
+}))
+jest.mock('@/hooks/useSavedAccounts', () => ({ __esModule: true, default: () => [] }))
+jest.mock('../../useClaimLink', () => ({ __esModule: true, default: () => ({ claimLink: jest.fn() }) }))
+jest.mock('@/hooks/useFriendlyError', () => ({ useFriendlyError: () => (e: unknown) => String(e) }))
+jest.mock('@/hooks/useTosGuard', () => ({
+    useTosGuard: () => ({ guardWithTos: jest.fn(), showBridgeTos: false, hideTos: jest.fn() }),
+}))
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
+// the SDK host renders a headless-ui Transition that needs a `show` prop it
+// only gets from real flow state; irrelevant to the branch under test
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn() }))
+jest.mock('next/navigation', () => ({
+    useSearchParams: () => new URLSearchParams(),
+    useRouter: () => ({ push: jest.fn() }),
+}))
+
+const claimLinkData = {
+    amount: '1000000',
+    tokenDecimals: 6,
+    tokenSymbol: 'USDC',
+    sender: { userId: 'sender-1' },
+} as never
+
+// the flow reads only these three; the rest of IClaimScreenProps is inert here
+const props = { claimLinkData, onCustom: jest.fn(), setTransactionHash: jest.fn() } as unknown as React.ComponentProps<
+    typeof BankFlowManager
+>
+
+const renderFlow = () =>
+    render(
+        <IntlWrapper>
+            <BankFlowManager {...props} />
+        </IntlWrapper>
+    )
+
+describe('BankFlowManager — bank-restricted residence', () => {
+    beforeEach(() => {
+        handleInitiateKyc.mockClear()
+        mockRestrictions = { banking: false, card: false }
+    })
+
+    it('starts verification when the residence can hold a bank rail', async () => {
+        renderFlow()
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('submit-bank-form'))
+        })
+        expect(handleInitiateKyc).toHaveBeenCalled()
+    })
+
+    it('never opens the SDK for a residence no bank provider onboards', async () => {
+        mockRestrictions = { banking: true, card: false }
+        renderFlow()
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('submit-bank-form'))
+        })
+        expect(handleInitiateKyc).not.toHaveBeenCalled()
+        expect(screen.getByText('Not available in your country')).toBeInTheDocument()
+    })
+})

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -33,6 +33,7 @@ import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
+import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
@@ -88,6 +89,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     // the *claimer's* own capabilities. See utils/capability-gate.ts.
     const { gateFor } = useCapabilities()
     const bankRegionIntent = useBankRegionIntent()
+    const { banking: isBankRestricted } = useResidenceRestrictions()
     const gate = useMemo(() => gateFor('deposit', { channel: 'bank' }), [gateFor])
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const [showKycModal, setShowKycModal] = useState(false)
@@ -311,6 +313,41 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
      * @description Callback for when the DynamicBankAccountForm is successfully submitted.
      * It handles different logic based on the bank claim type (guest, user, kyc needed).
      */
+    // Defined once and rendered by both the form and confirm steps: the direct
+    // claim path refuses inside handleSuccess, and the modal has to exist where
+    // that refusal happens or the submit is a silent no-op.
+    const kycModal = (
+        <InitiateKycModal
+            visible={showKycModal}
+            onClose={() => setShowKycModal(false)}
+            onVerify={async () => {
+                if (gate.kind === 'restart-identity') {
+                    await sumsubFlow.handleRestartIdentity()
+                } else if (gate.kind === 'fixable-rejection') {
+                    await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                } else {
+                    await sumsubFlow.handleInitiateKyc(
+                        bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                        undefined,
+                        gate.kind === 'needs-enrollment' || undefined,
+                        selectedCountry?.id
+                    )
+                }
+                // only close if sdk opened — if it errored, keep modal open to show error
+                if (sumsubFlow.showWrapper) setShowKycModal(false)
+            }}
+            onContactSupport={() => {
+                setShowKycModal(false)
+                setIsSupportModalOpen(true)
+            }}
+            isLoading={sumsubFlow.isLoading}
+            error={sumsubFlow.error}
+            variant={getKycModalVariant(gate.kind)}
+            providerMessage={getGateUserMessage(gate)}
+            reasonCode={getGateReasonCode(gate)}
+        />
+    )
+
     const handleSuccess = async (
         payload: AddBankAccountPayload,
         rawData: IBankAccountDetails
@@ -321,6 +358,14 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // scenario 1: receiver needs KYC
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
+            // This branch opens the SDK without going through InitiateKycModal, so
+            // the residence choke point never sees it. A ROW intent still mints a
+            // general-level token, which is a verification this residence cannot
+            // turn into a bank rail — hand it to the modal for the honest ending.
+            if (isBankRestricted) {
+                setShowKycModal(true)
+                return {}
+            }
             await sumsubFlow.handleInitiateKyc(
                 bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                 undefined,
@@ -576,6 +621,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         initialData={{}}
                         error={error}
                     />
+                    {kycModal}
                     <SumsubKycModals flow={sumsubFlow} />
                 </div>
             )
@@ -608,35 +654,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                             onSkip={hideTos}
                             reasonCode={gate.kind === 'accept-tos' ? gate.reason?.code : undefined}
                         />
-                        <InitiateKycModal
-                            visible={showKycModal}
-                            onClose={() => setShowKycModal(false)}
-                            onVerify={async () => {
-                                if (gate.kind === 'restart-identity') {
-                                    await sumsubFlow.handleRestartIdentity()
-                                } else if (gate.kind === 'fixable-rejection') {
-                                    await sumsubFlow.handleSelfHealResubmit('BRIDGE')
-                                } else {
-                                    await sumsubFlow.handleInitiateKyc(
-                                        bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
-                                        undefined,
-                                        gate.kind === 'needs-enrollment' || undefined,
-                                        selectedCountry?.id
-                                    )
-                                }
-                                // only close if sdk opened — if it errored, keep modal open to show error
-                                if (sumsubFlow.showWrapper) setShowKycModal(false)
-                            }}
-                            onContactSupport={() => {
-                                setShowKycModal(false)
-                                setIsSupportModalOpen(true)
-                            }}
-                            isLoading={sumsubFlow.isLoading}
-                            error={sumsubFlow.error}
-                            variant={getKycModalVariant(gate.kind)}
-                            providerMessage={getGateUserMessage(gate)}
-                            reasonCode={getGateReasonCode(gate)}
-                        />
+                        {kycModal}
                     </>
                 )
             }

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,7 +32,7 @@ import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
@@ -87,6 +87,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     // leverage the sender's KYC and bypass `gate` entirely below), so this reads
     // the *claimer's* own capabilities. See utils/capability-gate.ts.
     const { gateFor } = useCapabilities()
+    const bankRegionIntent = useBankRegionIntent()
     const gate = useMemo(() => gateFor('deposit', { channel: 'bank' }), [gateFor])
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const [showKycModal, setShowKycModal] = useState(false)
@@ -321,7 +322,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                 undefined,
                 undefined,
                 selectedCountry?.id
@@ -617,7 +618,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                     await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                                 } else {
                                     await sumsubFlow.handleInitiateKyc(
-                                        getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                                        bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
                                         undefined,
                                         gate.kind === 'needs-enrollment' || undefined,
                                         selectedCountry?.id

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -89,15 +89,21 @@ const GettingStartedChecklist = () => {
                 id: 'add-money',
                 // The row opens /add-money, which offers bank transfer AND
                 // crypto — naming one rail promised a route the chooser doesn't
-                // take you straight to.
+                // take you straight to. A residence no bank provider onboards
+                // drops the bank half rather than selling an ID check that
+                // cannot deliver it (same ruling as the signup residence step).
                 label: t('addMoney'),
-                sub: isVerified ? t('addMoneyRoutes') : t('addMoneyRoutesKyc'),
+                sub: restrictions.banking
+                    ? t('addMoneyRoutesNoBank')
+                    : isVerified
+                      ? t('addMoneyRoutes')
+                      : t('addMoneyRoutesKyc'),
                 done: isFunded,
                 onTap: tap('add-money', () => router.push('/add-money')),
             },
             thirdItem,
         ]
-    }, [cardAvailable, hasActiveCard, hasSentPayment, isFunded, isVerified, milestone, router, t])
+    }, [cardAvailable, hasActiveCard, hasSentPayment, isFunded, isVerified, milestone, restrictions.banking, router, t])
 
     const allDone = items.every((item) => item.done)
 

--- a/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
@@ -81,6 +81,16 @@ describe('GettingStartedChecklist', () => {
         expect(screen.getAllByText(/one-time ID check/).length).toBe(1) // only the first render's copy
     })
 
+    it('drops the bank half for a residence no bank provider onboards', () => {
+        // the ID check would unlock nothing there, so it must not be the price
+        // named on the row (same ruling as the signup residence step)
+        mockRestrictions = { banking: true, card: false }
+        render()
+        expect(screen.getByText('Crypto from any wallet or exchange')).toBeInTheDocument()
+        expect(screen.queryByText(/one-time ID check/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Bank transfer/)).not.toBeInTheDocument()
+    })
+
     it('marks add money done once funded', () => {
         mockUser = { user: { activationMilestone: 'funded' }, residence: { declared: 'BR', verified: 'BR' } }
         render()

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -18,6 +18,14 @@ import { KycRegionRestrictedModal } from '@/components/Kyc/modals/KycRegionRestr
 import { useRegionRestrictedCta } from '@/components/Kyc/KycRegionRestrictedContent'
 import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
 
+type InitiateKycVariant =
+    | 'default'
+    | 'provider_rejection'
+    | 'blocked'
+    | 'restart_identity'
+    | 'cross_region'
+    | 'region-unavailable'
+
 interface InitiateKycModalProps {
     visible: boolean
     onClose: () => void
@@ -27,7 +35,7 @@ interface InitiateKycModalProps {
     /** error message from a failed verify/resubmit attempt */
     error?: string | null
     /** when set, shows context-specific messaging instead of the generic "unlock" copy */
-    variant?: 'default' | 'provider_rejection' | 'blocked' | 'restart_identity' | 'cross_region' | 'region-unavailable'
+    variant?: InitiateKycVariant
     providerMessage?: string
     /** Stable `CapabilityReason.code` behind `providerMessage` — known codes
      *  render localized identity.reasons.* copy; unknown fall back to prose. */
@@ -104,11 +112,16 @@ export const InitiateKycModal = ({
     const reasonKey = reasonCodeKey(reasonCode)
     const resolvedProviderMessage = reasonKey ? tIdentity(reasonKey) : providerMessage
     const isRegionUnavailable = variant === 'region-unavailable'
-    const isBankUnavailable = isBankRestricted && !isRegionUnavailable
-    const isProviderRejection = !isBankUnavailable && variant === 'provider_rejection'
-    const isBlocked = !isBankUnavailable && variant === 'blocked'
-    const isRestartIdentity = !isBankUnavailable && variant === 'restart_identity'
-    const isCrossRegion = !isBankUnavailable && variant === 'cross_region'
+    // Resolved once so every branch below reads one variant rather than each
+    // re-checking the residence — the caller's variant is what the rail gate
+    // could see, this is what the user's residence makes of it.
+    const resolvedVariant: InitiateKycVariant | 'bank-unavailable' =
+        isBankRestricted && !isRegionUnavailable ? 'bank-unavailable' : variant
+    const isBankUnavailable = resolvedVariant === 'bank-unavailable'
+    const isProviderRejection = resolvedVariant === 'provider_rejection'
+    const isBlocked = resolvedVariant === 'blocked'
+    const isRestartIdentity = resolvedVariant === 'restart_identity'
+    const isCrossRegion = resolvedVariant === 'cross_region'
     const router = useRouter()
     const regionRestrictedCta = useRegionRestrictedCta(onClose)
 
@@ -245,7 +258,7 @@ export const InitiateKycModal = ({
     // the cross-region unlock) carry the prep checklist, so no path reaches the
     // vendor without it. Every other variant is an error/action state where the
     // list would be noise.
-    const showPrepChecklist = (variant === 'default' || variant === 'cross_region') && !error && !isBankUnavailable
+    const showPrepChecklist = (resolvedVariant === 'default' || resolvedVariant === 'cross_region') && !error
     // The checklist is left-aligned, so the paragraph introducing it is too:
     // centered prose stacked on a left-aligned list reads as two columns.
     const description = showPrepChecklist ? (

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -15,6 +15,8 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { IconBubble } from '@/components/0_Bruddle/IconBubble'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { KycRegionRestrictedModal } from '@/components/Kyc/modals/KycRegionRestrictedModal'
+import { useRegionRestrictedCta } from '@/components/Kyc/KycRegionRestrictedContent'
+import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
 
 interface InitiateKycModalProps {
     visible: boolean
@@ -55,6 +57,9 @@ interface InitiateKycModalProps {
 // blocked            → "We couldn't unlock this — contact support"
 // restart_identity   → "Verify with a different document" (self-fix for country mismatch)
 // cross_region       → "Unlock {region}"
+// Three states are decided HERE and outrank whatever variant the caller asked
+// for: the verification outage, a region-restricted rejection, and a residence
+// no bank provider onboards.
 export const InitiateKycModal = ({
     visible,
     onClose,
@@ -85,18 +90,32 @@ export const InitiateKycModal = ({
     // site to miss.
     const { isRegionRestricted } = useIdentityVerification()
     const isKycDegraded = useKycDegraded()
+    // Every gate that opens this modal unlocks a BANK rail (the two bank pages,
+    // the shared country list, both Manteca flow managers, the Manteca
+    // withdraw), so a residence no bank provider onboards has nothing behind
+    // the offer. The gates cannot see this themselves: pre-KYC there is no rail
+    // to carry `uk_resident_blocked` and no rejection to set `isRegionRestricted`,
+    // so a restricted resident reads as plain `needs-identity` and would be sold
+    // an ID check that unlocks nothing. Ranked BELOW the region screen (a
+    // document-jurisdiction block is the more specific ending) and below the
+    // outage, and it yields to `region-unavailable`, whose UK copy is more
+    // specific than this country-neutral one.
+    const { banking: isBankRestricted } = useResidenceRestrictions()
     const reasonKey = reasonCodeKey(reasonCode)
     const resolvedProviderMessage = reasonKey ? tIdentity(reasonKey) : providerMessage
-    const isProviderRejection = variant === 'provider_rejection'
-    const isBlocked = variant === 'blocked'
-    const isRestartIdentity = variant === 'restart_identity'
-    const isCrossRegion = variant === 'cross_region'
     const isRegionUnavailable = variant === 'region-unavailable'
+    const isBankUnavailable = isBankRestricted && !isRegionUnavailable
+    const isProviderRejection = !isBankUnavailable && variant === 'provider_rejection'
+    const isBlocked = !isBankUnavailable && variant === 'blocked'
+    const isRestartIdentity = !isBankUnavailable && variant === 'restart_identity'
+    const isCrossRegion = !isBankUnavailable && variant === 'cross_region'
     const router = useRouter()
+    const regionRestrictedCta = useRegionRestrictedCta(onClose)
 
     const getTitle = () => {
         if (error) return tCommon('somethingWentWrong')
         if (isRegionUnavailable) return t('initiate.titleRegionUnavailable')
+        if (isBankUnavailable) return t('initiate.titleBankUnavailable')
         if (isBlocked) return t('initiate.titleBlocked')
         if (isRestartIdentity) return t('initiate.titleRestartIdentity')
         if (isProviderRejection) return t('initiate.titleProviderRejection')
@@ -110,6 +129,7 @@ export const InitiateKycModal = ({
     const getDescription = () => {
         if (error) return t('initiate.descriptionError', { error })
         if (isRegionUnavailable) return t('initiate.descriptionRegionUnavailable')
+        if (isBankUnavailable) return t('initiate.descriptionBankUnavailable')
         if (isBlocked) return resolvedProviderMessage || t('initiate.descriptionBlocked')
         if (isRestartIdentity) return resolvedProviderMessage || t('initiate.descriptionRestartIdentity')
         if (isProviderRejection) return resolvedProviderMessage || t('initiate.descriptionProviderRejection')
@@ -122,6 +142,12 @@ export const InitiateKycModal = ({
     }
 
     const getCta = (): { text: string; onClick: () => void; icon?: IconName } => {
+        // No retry and no contact-support: nobody can lift a residence block, so
+        // the only useful CTA is the part of the app that still works. Same three
+        // rules as KycRegionRestrictedContent, whose CTA this reuses.
+        if (isBankUnavailable) {
+            return { text: regionRestrictedCta.label, onClick: regionRestrictedCta.onClick }
+        }
         if (error || isBlocked) {
             return {
                 text: tCommon('contactSupport'),
@@ -219,7 +245,7 @@ export const InitiateKycModal = ({
     // the cross-region unlock) carry the prep checklist, so no path reaches the
     // vendor without it. Every other variant is an error/action state where the
     // list would be noise.
-    const showPrepChecklist = (variant === 'default' || variant === 'cross_region') && !error
+    const showPrepChecklist = (variant === 'default' || variant === 'cross_region') && !error && !isBankUnavailable
     // The checklist is left-aligned, so the paragraph introducing it is too:
     // centered prose stacked on a left-aligned list reads as two columns.
     const description = showPrepChecklist ? (
@@ -233,10 +259,15 @@ export const InitiateKycModal = ({
     // Red for anything the user has to recover from (a rejection, a block, an
     // unavailable region), blue for the plain "start verification" offer — never
     // green, which the app reserves for a finished state.
-    const isErrorState = !!error || isBlocked || isRestartIdentity || isProviderRejection || isRegionUnavailable
+    const isErrorState =
+        !!error || isBlocked || isRestartIdentity || isProviderRejection || isRegionUnavailable || isBankUnavailable
     const iconName = (isErrorState ? 'alert' : 'badge') as IconName
     const footer =
-        isProviderRejection || isBlocked || isRestartIdentity || isRegionUnavailable ? undefined : (
+        isProviderRejection ||
+        isBlocked ||
+        isRestartIdentity ||
+        isRegionUnavailable ||
+        isBankUnavailable ? undefined : (
             <PeanutDoesntStoreAnyPersonalInformation className="w-full justify-center" />
         )
 

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -293,7 +293,7 @@ export const InitiateKycModal = ({
          * where it can wrap; NavHeader truncates at the width between its two
          * side buttons.
          */
-        const titleIsGeneric = variant === 'default' && !error
+        const titleIsGeneric = resolvedVariant === 'default' && !error
         const headerTitle = navTitle ?? getTitle()
         return (
             <div className="flex flex-col gap-6">

--- a/src/components/Kyc/__tests__/InitiateKycModal.residence.test.tsx
+++ b/src/components/Kyc/__tests__/InitiateKycModal.residence.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * The residence choke point. Every gate that opens this modal unlocks a bank
+ * rail, and pre-KYC none of them can tell that the user's residence rules bank
+ * rails out — there is no rail to carry `uk_resident_blocked` and no rejection
+ * to set `isRegionRestricted`. Without the check here they all offer an ID
+ * check that unlocks nothing.
+ */
+/** @jest-environment jsdom */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { InitiateKycModal } from '../InitiateKycModal'
+
+let mockRestrictions = { banking: false, card: false }
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => mockRestrictions,
+}))
+
+let mockIsRegionRestricted = false
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isRegionRestricted: mockIsRegionRestricted }),
+}))
+
+jest.mock('@/hooks/useKycDegraded', () => ({ useKycDegraded: () => false }))
+
+const mockPush = jest.fn()
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
+
+const onVerify = jest.fn()
+
+const renderModal = (props: Partial<React.ComponentProps<typeof InitiateKycModal>> = {}) =>
+    render(
+        <IntlWrapper>
+            <InitiateKycModal visible onClose={jest.fn()} onVerify={onVerify} {...props} />
+        </IntlWrapper>
+    )
+
+describe('InitiateKycModal — residence check', () => {
+    beforeEach(() => {
+        mockRestrictions = { banking: false, card: false }
+        mockIsRegionRestricted = false
+        onVerify.mockClear()
+        mockPush.mockClear()
+    })
+
+    it('offers the unlock when banking is available', () => {
+        renderModal()
+        expect(screen.getByText('Unlock now')).toBeInTheDocument()
+    })
+
+    it('replaces the unlock offer when the residence rules out bank rails', () => {
+        mockRestrictions = { banking: true, card: false }
+        renderModal()
+        expect(screen.getByText('Not available in your country')).toBeInTheDocument()
+        expect(screen.queryByText('Unlock now')).not.toBeInTheDocument()
+    })
+
+    it('leaves no path into the SDK for a restricted residence', () => {
+        mockRestrictions = { banking: true, card: true }
+        renderModal()
+        screen.getByRole('button', { name: 'Send or request money' }).click()
+        expect(onVerify).not.toHaveBeenCalled()
+        expect(mockPush).toHaveBeenCalledWith('/send')
+    })
+
+    it('outranks a gate variant that would have said contact support', () => {
+        mockRestrictions = { banking: true, card: false }
+        renderModal({ variant: 'blocked' })
+        expect(screen.getByText('Not available in your country')).toBeInTheDocument()
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+    })
+
+    it('yields to the UK screen, whose copy is more specific', () => {
+        mockRestrictions = { banking: true, card: true }
+        renderModal({ variant: 'region-unavailable' })
+        expect(screen.getByText('Not available for UK residents')).toBeInTheDocument()
+    })
+
+    it('yields to the document-jurisdiction screen', () => {
+        mockRestrictions = { banking: true, card: true }
+        mockIsRegionRestricted = true
+        renderModal()
+        expect(screen.getByText("We can't verify IDs from your country")).toBeInTheDocument()
+    })
+})

--- a/src/components/Kyc/__tests__/InitiateKycModal.residence.test.tsx
+++ b/src/components/Kyc/__tests__/InitiateKycModal.residence.test.tsx
@@ -76,6 +76,14 @@ describe('InitiateKycModal — residence check', () => {
         expect(screen.getByText('Not available for UK residents')).toBeInTheDocument()
     })
 
+    // page presentation drops the visible heading for the generic unlock offer;
+    // the unavailable ending is not generic and must keep its own title
+    it('shows the unavailable title in page presentation, not the generic nav title', () => {
+        mockRestrictions = { banking: true, card: false }
+        renderModal({ presentation: 'page', navTitle: 'Unlock payments' })
+        expect(screen.getByRole('heading', { name: 'Not available in your country' })).toBeInTheDocument()
+    })
+
     it('yields to the document-jurisdiction screen', () => {
         mockRestrictions = { banking: true, card: true }
         mockIsRegionRestricted = true

--- a/src/components/Kyc/states/__tests__/KycRegionRestricted.test.tsx
+++ b/src/components/Kyc/states/__tests__/KycRegionRestricted.test.tsx
@@ -11,6 +11,11 @@ jest.mock('@/hooks/useIdentityVerification', () => ({
 }))
 let mockKycDegraded = false
 jest.mock('@/hooks/useKycDegraded', () => ({ useKycDegraded: () => mockKycDegraded }))
+// InitiateKycModal also checks the residence; unrestricted keeps these
+// cases about the outage and region-rejection short-circuits alone.
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => ({ banking: false, card: false }),
+}))
 
 const push = jest.fn()
 jest.mock('next/navigation', () => ({

--- a/src/constants/kyc.consts.ts
+++ b/src/constants/kyc.consts.ts
@@ -41,6 +41,11 @@ export enum QrKycState {
      * a different ID.
      */
     PROVIDER_RESTART_IDENTITY = 'provider_restart_identity',
+    /**
+     * Sumsub rejected the document's jurisdiction. Terminal for every rail,
+     * pool included, so the surface must stop offering verification.
+     */
+    REGION_RESTRICTED = 'region_restricted',
 }
 
 // sets of status values by category — single source of truth

--- a/src/constants/residence.consts.ts
+++ b/src/constants/residence.consts.ts
@@ -25,10 +25,15 @@ export const RESTRICTED_RESIDENCE_ISO2 = new Set(['CN', 'IR', 'RU', 'BY', 'GB', 
 export const CARD_RESTRICTED_RESIDENCE_ISO2 = new Set(['IN', 'TR', 'UA', 'VE', 'VN', 'IL', 'IQ', 'NP', 'NI'])
 
 /**
- * Banking-only restriction: Bridge does not onboard residents of these
- * countries. The card and everything else still work.
+ * Banking-only restriction: Bridge onboards these residents but no rail is
+ * ever `Yes`, so the account is unusable. The card and everything else still
+ * work.
+ *
+ * GW is in Bridge's table and absent from Bridge's prose note on the same
+ * page; this list mirrored the prose and lost it. The table is the authority
+ * (product/providers/fiat/eligibility.md).
  */
-export const BANKING_RESTRICTED_RESIDENCE_ISO2 = new Set(['DZ', 'BI', 'JP', 'TN'])
+export const BANKING_RESTRICTED_RESIDENCE_ISO2 = new Set(['DZ', 'BI', 'GW', 'JP', 'TN'])
 
 /**
  * countryData is the add-money DESTINATION list and deliberately omits

--- a/src/hooks/__tests__/useBankRegionIntent.test.tsx
+++ b/src/hooks/__tests__/useBankRegionIntent.test.tsx
@@ -52,6 +52,7 @@ describe('useBankRegionIntent', () => {
         ['GB', 'the UK rule'],
         ['RU', 'a sanctioned residence'],
         ['JP', 'a Bridge banking exclusion'],
+        ['GW', 'a Bridge banking exclusion its prose note omits'],
     ])('forces ROW for %s (%s), whatever the destination', (iso2) => {
         mockUser = { residence: { declared: iso2 } }
         expect(intentFor('europe')).toBe('ROW')

--- a/src/hooks/__tests__/useBankRegionIntent.test.tsx
+++ b/src/hooks/__tests__/useBankRegionIntent.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react'
+import { useBankRegionIntent } from '@/hooks/useBankRegionIntent'
+
+let mockUser: {
+    residenceRestrictions?: { banking: boolean; card: boolean }
+    residence?: { declared?: string | null; declaredSecond?: string | null }
+    user?: { userId: string }
+} | null = null
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: mockUser }),
+}))
+
+let mockSetupState: { residenceCountry: string }
+jest.mock('@/redux/hooks', () => ({
+    useSetupStore: () => mockSetupState,
+}))
+
+// Hermetic: the real sets hook fetches the server tier lists on first mount.
+jest.mock('@/hooks/useResidenceRestrictionSets', () => {
+    const actual = jest.requireActual('@/hooks/useResidenceRestrictionSets')
+    return {
+        ...actual,
+        useResidenceRestrictionSets: () => actual.LOCAL_RESIDENCE_RESTRICTION_SETS,
+    }
+})
+
+const intentFor = (regionPath: string) => renderHook(() => useBankRegionIntent()).result.current(regionPath)
+
+describe('useBankRegionIntent', () => {
+    beforeEach(() => {
+        mockUser = null
+        mockSetupState = { residenceCountry: '' }
+    })
+
+    it('leaves the destination in charge when no residence is known', () => {
+        expect(intentFor('europe')).toBe('EU')
+        expect(intentFor('north-america')).toBe('NA')
+        expect(intentFor('latam')).toBe('LATAM')
+        expect(intentFor('rest-of-the-world')).toBe('ROW')
+    })
+
+    it('keeps the destination intent for a residence banks do onboard', () => {
+        mockUser = { residence: { declared: 'BR' } }
+        // a Brazilian resident really does need the Bridge level for a SEPA
+        // destination — the residence must not narrow it to LATAM
+        expect(intentFor('europe')).toBe('EU')
+        expect(intentFor('latam')).toBe('LATAM')
+    })
+
+    it.each([
+        ['GB', 'the UK rule'],
+        ['RU', 'a sanctioned residence'],
+        ['JP', 'a Bridge banking exclusion'],
+    ])('forces ROW for %s (%s), whatever the destination', (iso2) => {
+        mockUser = { residence: { declared: iso2 } }
+        expect(intentFor('europe')).toBe('ROW')
+        expect(intentFor('north-america')).toBe('ROW')
+        expect(intentFor('latam')).toBe('ROW')
+    })
+
+    it('ignores a card-only restriction — bank rails still work there', () => {
+        mockUser = { residence: { declared: 'IN' } }
+        expect(intentFor('europe')).toBe('EU')
+    })
+
+    it('keeps the destination intent when a second residence is unrestricted', () => {
+        // dual resident: the bank level is still winnable under BR, so the
+        // offer stands (mirrors the intersection in useResidenceRestrictions)
+        mockUser = { residence: { declared: 'GB', declaredSecond: 'BR' } }
+        expect(intentFor('europe')).toBe('EU')
+    })
+
+    it('honours the server answer over the local declaration', () => {
+        mockUser = { residenceRestrictions: { banking: true, card: false }, residence: { declared: 'BR' } }
+        expect(intentFor('europe')).toBe('ROW')
+    })
+})

--- a/src/hooks/__tests__/useResidenceRestrictions.test.tsx
+++ b/src/hooks/__tests__/useResidenceRestrictions.test.tsx
@@ -33,6 +33,8 @@ describe('deriveResidenceRestrictions', () => {
         ['KP', { banking: true, card: true }],
         ['IN', { banking: false, card: true }],
         ['JP', { banking: true, card: false }],
+        // in Bridge's table, absent from its prose note — the table wins
+        ['GW', { banking: true, card: false }],
         ['BR', { banking: false, card: false }],
         ['', { banking: false, card: false }],
     ])('%s → %j', (iso2, expected) => {

--- a/src/hooks/useBankRegionIntent.ts
+++ b/src/hooks/useBankRegionIntent.ts
@@ -1,0 +1,31 @@
+import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
+import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
+import { getRegionIntent } from '@/utils/regions.utils'
+import { useCallback } from 'react'
+
+/**
+ * The region intent a BANK flow should verify under.
+ *
+ * The destination country stays the input — it is what decides which
+ * provider's rails the verification opens, and a Brazilian resident really
+ * does need the Bridge level to withdraw to a Spanish IBAN. The one exception
+ * is a residence no bank provider onboards (the sanctioned set, the UK rule,
+ * Bridge's banking exclusions): every bank level can only end on a terminal
+ * rejection there, so those get the provider-less level whatever destination
+ * was picked. Same ruling as `regionIntentForResidence` makes for the
+ * residence-change path, applied to the six bank entry points.
+ *
+ * Read off `banking` rather than the residence code so it inherits the
+ * server's answer (`user.residenceRestrictions`, derived from the KYC-reported
+ * residence when there is one) and the dual-resident intersection: a user who
+ * can verify under a second, unrestricted residence keeps the destination
+ * intent, because a bank level is still winnable for them.
+ */
+export const useBankRegionIntent = (): ((regionPath: string) => KYCRegionIntent) => {
+    const { banking: isBankRestricted } = useResidenceRestrictions()
+
+    return useCallback(
+        (regionPath: string) => (isBankRestricted ? 'ROW' : getRegionIntent(regionPath)),
+        [isBankRestricted]
+    )
+}

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -140,6 +140,7 @@
             "firstPaymentNote": "Send a few dollars to a Peanut user, ENS name or wallet address. It lands in seconds.",
             "addMoneyRoutes": "Bank transfer or crypto",
             "addMoneyRoutesKyc": "Bank transfer or crypto · bank needs a one-time ID check",
+            "addMoneyRoutesNoBank": "Crypto from any wallet or exchange",
             "getCardNote": "Your dollars, in pink, wherever Visa is accepted."
         },
         "autoBalance": {
@@ -2566,6 +2567,8 @@
             "descriptionCrossRegion": "Your identity is already verified. To turn on payments in {region}, we just need to confirm a few more details — about a minute.",
             "descriptionCrossRegionGeneric": "Your identity is already verified. To turn on payments here, we just need to confirm a few more details — about a minute.",
             "descriptionRegionUnavailable": "Due to UK regulations, bank transfers aren't available for UK residents. Your funds are safe — you can withdraw them as crypto anytime.",
+            "titleBankUnavailable": "Not available in your country",
+            "descriptionBankUnavailable": "Bank transfers aren't available in your country, so an ID check wouldn't unlock them. Your funds are safe, and you can still send and receive money with other people.",
             "descriptionDefault": "Confirm your ID to unlock payments. Takes about a minute.",
             "ctaUploadDocument": "Upload document",
             "ctaUnlockNow": "Unlock now",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1802,7 +1802,8 @@
             "bankAccountSettingUp": "Your bank account is still being set up. Please try again in a moment."
         },
         "pixMaintenanceBadge": "Maintenance",
-        "addCryptoTitle": "Add crypto"
+        "addCryptoTitle": "Add crypto",
+        "bankNotAvailableNote": "Bank transfers aren't available in your country. You can still add and withdraw crypto."
     },
     "withdraw": {
         "amountToWithdraw": "Amount to withdraw",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1802,7 +1802,8 @@
             "bankAccountSettingUp": "Tu cuenta bancaria aún se está configurando. Inténtalo de nuevo en un momento."
         },
         "pixMaintenanceBadge": "Mantenimiento",
-        "addCryptoTitle": "Agregar cripto"
+        "addCryptoTitle": "Agregar cripto",
+        "bankNotAvailableNote": "Las transferencias bancarias no están disponibles en tu país. Todavía puedes ingresar y retirar cripto."
     },
     "withdraw": {
         "amountToWithdraw": "Monto a retirar",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -140,6 +140,7 @@
             "firstPaymentNote": "Envía unos dólares a un usuario de Peanut, un nombre ENS o una dirección de wallet. Llegan en segundos.",
             "addMoneyRoutes": "Transferencia bancaria o cripto",
             "addMoneyRoutesKyc": "Transferencia bancaria o cripto · el banco requiere una verificación de identidad por única vez",
+            "addMoneyRoutesNoBank": "Cripto desde cualquier wallet o exchange",
             "getCardNote": "Tus dólares, en rosa, donde sea que acepten Visa."
         },
         "autoBalance": {
@@ -2566,6 +2567,8 @@
             "descriptionCrossRegion": "Tu identidad ya está verificada. Para activar los pagos en {region}, solo necesitamos confirmar algunos datos más — alrededor de un minuto.",
             "descriptionCrossRegionGeneric": "Tu identidad ya está verificada. Para activar los pagos aquí, solo necesitamos confirmar algunos datos más — alrededor de un minuto.",
             "descriptionRegionUnavailable": "Debido a las regulaciones del Reino Unido, las transferencias bancarias no están disponibles para sus residentes. Tus fondos están seguros: puedes retirarlos como cripto en cualquier momento.",
+            "titleBankUnavailable": "No disponible en tu país",
+            "descriptionBankUnavailable": "Las transferencias bancarias no están disponibles en tu país, así que verificar tu identidad no las desbloquearía. Tus fondos están seguros y puedes seguir enviando y recibiendo dinero con otras personas.",
             "descriptionDefault": "Confirma tu identidad para desbloquear los pagos. Toma alrededor de un minuto.",
             "ctaUploadDocument": "Subir documento",
             "ctaUnlockNow": "Desbloquear ahora",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1062,6 +1062,7 @@
             "descriptionRestartIdentity": "Este método necesita un documento de un país compatible. Podés verificarte con otro documento.",
             "descriptionProviderRejection": "Subí una foto más nítida de tu documento para continuar.",
             "descriptionRegionUnavailable": "Por regulaciones del Reino Unido, las transferencias bancarias no están disponibles para residentes del Reino Unido. Tus fondos están seguros: podés retirarlos como cripto en cualquier momento.",
+            "descriptionBankUnavailable": "Las transferencias bancarias no están disponibles en tu país, así que verificar tu identidad no las desbloquearía. Tus fondos están seguros y podés seguir enviando y recibiendo dinero con otras personas.",
             "descriptionDefault": "Confirmá tu identidad para desbloquear los pagos. Toma alrededor de un minuto."
         },
         "regionRestricted": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -897,7 +897,8 @@
             "onrampDetails": "No pudimos obtener los datos para agregar dinero. Intentalo de nuevo.",
             "bankAccountFailed": "No se pudo procesar la cuenta bancaria. Intentalo de nuevo o contactá a soporte.",
             "bankAccountSettingUp": "Tu cuenta bancaria aún se está configurando. Intentalo de nuevo en un momento."
-        }
+        },
+        "bankNotAvailableNote": "Las transferencias bancarias no están disponibles en tu país. Todavía podés ingresar y retirar cripto."
     },
     "withdraw": {
         "howWouldYouLikeToWithdraw": "¿Cómo querés retirar?",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1802,7 +1802,8 @@
             "bankAccountSettingUp": "Sua conta bancária ainda está sendo configurada. Tente de novo em instantes."
         },
         "pixMaintenanceBadge": "Manutenção",
-        "addCryptoTitle": "Adicionar cripto"
+        "addCryptoTitle": "Adicionar cripto",
+        "bankNotAvailableNote": "Transferências bancárias não estão disponíveis no seu país. Você ainda pode adicionar e sacar cripto."
     },
     "withdraw": {
         "amountToWithdraw": "Valor a sacar",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -140,6 +140,7 @@
             "firstPaymentNote": "Envie alguns dólares para um usuário Peanut, um nome ENS ou um endereço de carteira. Chega em segundos.",
             "addMoneyRoutes": "Transferência bancária ou cripto",
             "addMoneyRoutesKyc": "Transferência bancária ou cripto · o banco exige uma verificação de identidade única",
+            "addMoneyRoutesNoBank": "Cripto de qualquer carteira ou corretora",
             "getCardNote": "Seus dólares, em rosa, onde a Visa for aceita."
         },
         "autoBalance": {
@@ -2566,6 +2567,8 @@
             "descriptionCrossRegion": "Sua identidade já está verificada. Para ativar os pagamentos em {region}, só precisamos confirmar mais alguns dados — cerca de um minuto.",
             "descriptionCrossRegionGeneric": "Sua identidade já está verificada. Para ativar os pagamentos aqui, só precisamos confirmar mais alguns dados — cerca de um minuto.",
             "descriptionRegionUnavailable": "Devido às regulamentações do Reino Unido, transferências bancárias não estão disponíveis para residentes do Reino Unido. Seu dinheiro está seguro — você pode sacá-lo como cripto a qualquer momento.",
+            "titleBankUnavailable": "Indisponível no seu país",
+            "descriptionBankUnavailable": "Transferências bancárias não estão disponíveis no seu país, então verificar seu documento não vai desbloqueá-las. Seu dinheiro está seguro e você ainda pode enviar e receber dinheiro de outras pessoas.",
             "descriptionDefault": "Confirme seu documento para desbloquear os pagamentos. Leva cerca de um minuto.",
             "ctaUploadDocument": "Enviar documento",
             "ctaUnlockNow": "Desbloquear agora",


### PR DESCRIPTION
## The bug

The six bank KYC entry points derived the Sumsub region intent from the **destination country**, never from the user's residence:

| call site | line |
|---|---|
| `AddWithdrawCountriesList.tsx` | 264, 379 |
| `add-money/[country]/bank/page.tsx` | 294 |
| `withdraw/[country]/bank/page.tsx` | 607 |
| `BankFlowManager.view.tsx` | 324, 620 |

So a UK, Japanese or sanctioned resident tapping **Withdraw → Spain → SEPA** was routed to `bridge-requirements` — a Bridge level that, for their residence, can only end on a terminal rejection. They uploaded a document and did liveness before anything told them.

The residence-aware helper already existed and was already correct (`regionIntentForResidence`, routing `RESTRICTED_RESIDENCE_ISO2` and `BANKING_RESTRICTED_RESIDENCE_ISO2` to `ROW`) — it just had no call site on this path.

## Why the existing guards never fired

Both read **post-hoc** signals:

- `isRegionRestricted` is `status === 'failed' && reason.code === 'identity_region_restricted'` — it needs a Sumsub rejection to have already happened, so the `InitiateKycModal` choke point could not help a user who had not yet been rejected.
- The capability model's UK block reads `sumsubGeo` (peanut-api-ts `kyc/capabilities/load.ts`), which is null until KYC approves.

Pre-KYC a restricted resident therefore has no rail to carry `uk_resident_blocked` and no rejection to flag, reads as plain `needs-identity`, and gets offered "Unlock now". Meanwhile `user.residenceRestrictions` — the server's own answer, derived from the KYC-reported residence or the one declared at signup — was sitting right there unused.

## The change

**1. `useBankRegionIntent`** — the destination stays in charge, because it is what decides which provider's rails the verification opens; a Brazilian resident really does need the Bridge level to withdraw to a Spanish IBAN. It forces `ROW` only when every residence we know rules bank rails out.

It reads `useResidenceRestrictions().banking` rather than the country code, which buys three things for free: the server's answer wins over the local declaration, the KYC-reported residence wins over the declared one, and the dual-resident intersection applies — someone who declared GB **and** BR keeps the destination intent, because a bank level is still winnable for them.

**2. `InitiateKycModal`** — the same decision made once, next to the outage and region-restricted short-circuits, so a future call site cannot miss it. All eight render sites are bank/Manteca money-movement gates, so no escape hatch is needed. Ordering: outage > region-restricted (a document-jurisdiction block is the more specific ending) > `region-unavailable` (the UK copy is more specific than the new country-neutral pair) > this.

New copy in all four catalogs, country-neutral for the same reason `restricted-regions.ts` gives — one string covers every restricted residence, and compliance changing the list needs no re-translation. CTA reuses `useRegionRestrictedCta`: no retry, no contact-support (nobody can lift a residence block), just the part of the app that still works.

**3. Get-started checklist** — decided **yes, drop it**. The row's subtitle read *"Bank transfer or crypto · bank needs a one-time ID check"* for everyone, naming the ID check as the price of a rail these residences cannot have. It now reads *"Crypto from any wallet or exchange"*. This follows the ruling the signup residence step already makes for its congrats copy: where no rail exists, the ID-check clause is dropped entirely rather than promising a rail verification cannot deliver.

## The two surfaces the guard above does not reach

**`qr-pay`** renders its own CTAs rather than `InitiateKycModal`, so the choke point never covered it — and it derives every state from *rail* status, never reading the identity verdict. A user Sumsub refused on jurisdiction owns no Manteca rail at all, so the candidate list is empty, they fall through to `REQUIRES_IDENTITY_VERIFICATION`, and are offered the verification that just turned them down. Indefinitely.

It now short-circuits on `isRegionRestricted` above every rail-derived state, rendering the same ending the drawer and `InitiateKycModal` already give.

Keyed on the post-hoc Sumsub signal and **deliberately not on residence**. The QR pool is residence-agnostic by design (`rails.consts.ts`: *"any Sumsub-approved user can pay QR codes via the corporate pool account, regardless of residence"*), and the resolver's UK block only touches `provider === 'bridge'` — so Japanese, Algerian, Burundian, Tunisian and UK residents all legitimately hold QR pay. Gating this on `banking` would have removed a capability those users really have. Only a jurisdictional document refusal makes the offer dishonest here, and that list stays in Sumsub where `restricted-regions.ts` insists it belongs.

**The add-money / withdraw country list** keeps every entry — the residence sets are advisory offer-shaping, and hiding the list would leave a near-empty screen — but names the restriction once above it, instead of letting the user discover it three taps into a flow that cannot finish. Mirrors the note Unlock payments already carries.

## Still not in scope — worth a separate task

- **`BANKING_RESTRICTED_RESIDENCE` (DZ/BI/JP/TN) has no backend enforcement at all.** No capability block analogous to the UK one, and `POST /users/identity` never consults residence — it mints `verificationLevelForIntent(regionIntent)` verbatim. The residence-aware `canonicalIntentForResidence` exists in `kyc/residence-intent.ts` but is only wired into `restart-identity.ts`. These residents complete `bridge-requirements` and land on a raw Bridge provider rejection → "contact support", a ticket nobody can resolve. This PR closes the client half; the server still accepts whatever intent an older build sends it.

## Verification

- `tsc --noEmit` clean; `eslint` clean on all touched files (remaining warnings are pre-existing `fetchUser` / `useCallback` dep warnings on untouched code, confirmed by stashing); `prettier --check` clean; `ds-lint --check` at baseline on every ratchet.
- New tests: `useBankRegionIntent.test.tsx` (8 cases — destination precedence, the three restricted tiers, card-only pass-through, dual-residence softening, server-over-local), `InitiateKycModal.residence.test.tsx` (6 — including that no path reaches the SDK, and both yield-to orderings), plus one case each for the qr-pay ending and the list notice.
- Full unit suite: **435 suites / 5585 tests green**. Four existing suites needed a `useResidenceRestrictions` stub now that the shared modal, the bank pages and the router view read it.
