### PR TITLE
fix(reconsent): bordered document rows + modal-board conformance

### DIFF
--- a/src/components/Global/ReConsentModal/__tests__/index.test.tsx
+++ b/src/components/Global/ReConsentModal/__tests__/index.test.tsx
@@ -33,6 +33,7 @@ jest.mock('@/components/Global/ActionModal', () => ({
     default: (props: {
         visible: boolean
         title?: string
+        description?: React.ReactNode
         content?: React.ReactNode
         checkbox?: { text: string; checked: boolean; onChange: (checked: boolean) => void }
         ctas?: { text: string; disabled?: boolean; onClick: () => void }[]
@@ -42,6 +43,7 @@ jest.mock('@/components/Global/ActionModal', () => ({
         return (
             <div data-testid="modal">
                 <h3>{props.title}</h3>
+                <div>{props.description}</div>
                 <div>{props.content}</div>
                 {checkbox && (
                     <input

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -5,6 +5,10 @@ import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import ActionModal from '../ActionModal'
 import DocsLink from '@/components/Global/DocsLink'
+import { ListItem } from '@/components/0_Bruddle/ListItem'
+import { Notification } from '@/components/0_Bruddle/Notification'
+import { getCardPosition } from '@/components/Global/Card/card.utils'
+import { Icon } from '@/components/Global/Icons/Icon'
 import { legalPolicyForSlug } from '@/constants/legal-policies'
 import { useAuth } from '@/context/authContext'
 import { acceptedLegalDocument, consentApi, type ConsentStatusDocument } from '@/services/consent'
@@ -127,35 +131,40 @@ const ReConsentModal = () => {
         <ActionModal
             visible
             onClose={handlePostpone}
-            icon="info"
+            tone="info"
             title={t('reConsent.title')}
+            description={
+                /* The first sentence answers the question this modal actually raises
+                 * ("is something being taken from me?") before anything else. The
+                 * what-changed line describes the 2026-07-15 tos-v1 rewrite — revisit
+                 * it when a future version bump shows this modal for a different
+                 * change. "No rush" is literal: "Not now" snoozes to the effective
+                 * date (see utils.ts). */
+                <div className="space-y-3">
+                    <p>{t('reConsent.reassurance')}</p>
+                    <p>{t('reConsent.whatChanged')}</p>
+                </div>
+            }
             content={
-                // no text-left: modal body is centered per the modal board
                 <div className="space-y-3 w-full">
-                    {/* The first sentence answers the question this modal actually raises
-                     * ("is something being taken from me?") before anything else. The
-                     * what-changed line describes the 2026-07-15 tos-v1 rewrite — revisit
-                     * it when a future version bump shows this modal for a different
-                     * change. "No rush" is literal: "Not now" snoozes to the effective
-                     * date (see utils.ts). */}
-                    <p className="text-body-s text-foreground-secondary">{t('reConsent.reassurance')}</p>
-                    <p className="text-body-s text-foreground-secondary">{t('reConsent.whatChanged')}</p>
-                    <ul className="space-y-1 text-body-s">
-                        {outdatedDocs.map((doc) => {
+                    {/* one bordered row per updated document, the whole row is the link
+                        (DocsLink handles web/PWA/native targets) */}
+                    <div>
+                        {outdatedDocs.map((doc, index) => {
                             const policy = legalPolicyForSlug(doc.slug)
                             return (
-                                <li key={doc.slug}>
-                                    <DocsLink
-                                        href={policy?.href ?? `/${doc.slug}`}
-                                        className="text-foreground-primary underline"
-                                    >
-                                        {policy ? tPolicies(policy.key) : doc.slug}
-                                    </DocsLink>
-                                </li>
+                                <DocsLink key={doc.slug} href={policy?.href ?? `/${doc.slug}`} className="block">
+                                    <ListItem
+                                        position={getCardPosition(index, outdatedDocs.length)}
+                                        leading={<Icon name="docs" size={24} />}
+                                        title={policy ? tPolicies(policy.key) : doc.slug}
+                                        trailing={<Icon name="external-link" size={20} />}
+                                    />
+                                </DocsLink>
                             )
                         })}
-                    </ul>
-                    {error && <p className="text-body-s text-foreground-error">{error}</p>}
+                    </div>
+                    {error && <Notification priority="error">{error}</Notification>}
                 </div>
             }
             checkbox={{

--- a/src/components/Global/ReConsentModal/index.tsx
+++ b/src/components/Global/ReConsentModal/index.tsx
@@ -3,12 +3,10 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
+import { Fragment } from 'react'
 import ActionModal from '../ActionModal'
 import DocsLink from '@/components/Global/DocsLink'
-import { ListItem } from '@/components/0_Bruddle/ListItem'
 import { Notification } from '@/components/0_Bruddle/Notification'
-import { getCardPosition } from '@/components/Global/Card/card.utils'
-import { Icon } from '@/components/Global/Icons/Icon'
 import { legalPolicyForSlug } from '@/constants/legal-policies'
 import { useAuth } from '@/context/authContext'
 import { acceptedLegalDocument, consentApi, type ConsentStatusDocument } from '@/services/consent'
@@ -147,23 +145,25 @@ const ReConsentModal = () => {
             }
             content={
                 <div className="space-y-3 w-full">
-                    {/* one bordered row per updated document, the whole row is the link
-                        (DocsLink handles web/PWA/native targets) */}
-                    <div>
+                    {/* the updated documents on one centered line, separator-joined
+                        (wraps when it must) — inline-link treatment per the Signup
+                        consent line; DocsLink handles web/PWA/native targets */}
+                    <p className="text-body-s">
                         {outdatedDocs.map((doc, index) => {
                             const policy = legalPolicyForSlug(doc.slug)
                             return (
-                                <DocsLink key={doc.slug} href={policy?.href ?? `/${doc.slug}`} className="block">
-                                    <ListItem
-                                        position={getCardPosition(index, outdatedDocs.length)}
-                                        leading={<Icon name="docs" size={24} />}
-                                        title={policy ? tPolicies(policy.key) : doc.slug}
-                                        trailing={<Icon name="external-link" size={20} />}
-                                    />
-                                </DocsLink>
+                                <Fragment key={doc.slug}>
+                                    {index > 0 && <span className="text-foreground-secondary"> · </span>}
+                                    <DocsLink
+                                        href={policy?.href ?? `/${doc.slug}`}
+                                        className="text-foreground-primary underline underline-offset-2"
+                                    >
+                                        {policy ? tPolicies(policy.key) : doc.slug}
+                                    </DocsLink>
+                                </Fragment>
                             )
                         })}
-                    </div>
+                    </p>
                     {error && <Notification priority="error">{error}</Notification>}
                 </div>
             }

--- a/src/dev/fixtures/registry.ts
+++ b/src/dev/fixtures/registry.ts
@@ -333,6 +333,32 @@ export const FIXTURES: Record<string, Fixture> = {
         },
     },
 
+    reconsent: {
+        route: '/home',
+        about: 'Re-consent modal over home: two updated documents as bordered link rows.',
+        responses: {
+            'GET /users/consent/status': {
+                needsReConsent: true,
+                documents: [
+                    {
+                        slug: 'terms',
+                        currentVersion: '2026-07-15',
+                        acceptedVersion: '2026-01-01',
+                        acceptedAt: '2026-01-01T00:00:00.000Z',
+                        needsAcceptance: true,
+                    },
+                    {
+                        slug: 'privacy',
+                        currentVersion: '2026-07-15',
+                        acceptedVersion: '2026-01-01',
+                        acceptedAt: '2026-01-01T00:00:00.000Z',
+                        needsAcceptance: true,
+                    },
+                ],
+            },
+        },
+    },
+
     // ---------------------------------------------------------------------
     // Error states.
     // ---------------------------------------------------------------------

--- a/src/dev/fixtures/registry.ts
+++ b/src/dev/fixtures/registry.ts
@@ -335,7 +335,7 @@ export const FIXTURES: Record<string, Fixture> = {
 
     reconsent: {
         route: '/home',
-        about: 'Re-consent modal over home: two updated documents as bordered link rows.',
+        about: 'Re-consent modal over home: two updated documents as a centered link line.',
         responses: {
             'GET /users/consent/status': {
                 needsReConsent: true,


### PR DESCRIPTION
## Summary

The re-consent modal ("A small update to our terms") listed its updated documents as bare underlined links — off the list-item board and easy to miss. The updated documents now sit on one centered line, separator-joined (“Terms of Service · Privacy Policy”), using the DS inline-link treatment the Signup consent line uses (`underline underline-offset-2`; LinkButton is for standalone links, its docblock forbids inline embedding). Still `DocsLink`, so web / PWA / Capacitor targets keep working; scales to 1..n documents and wraps for long locales.

While here, a DS audit of this modal against the modal board (design.md) found and fixed three deviations:

- `icon="info"` with the default pink bubble → `tone="info"` (semantic blue info bubble).
- The two body paragraphs sat in the `content` slot, 24px from the title → moved to the `description` slot (board head anatomy: title + description 4px apart). The redundant per-paragraph classes go away — the slot already styles them.
- The accept-failure error was a bare `<p>` in `foreground-error` → `Notification priority="error"` (design.md error table: a flow-level API failure, not a field error).

Checked, no change needed: the top-right close X renders (nothing suppresses it — `hideModalCloseButton` is not set, and dev already carries the ds-ui-nits close-button work); close/backdrop/Escape all still route to `handlePostpone` ("Not now"), per §17.2/§17.3 this modal is a prompt, not a gate; stacked CTAs and centered checkbox are deliberate and untouched.

No copy changes — all i18n strings untouched.

## Task

TASK-22121 follow-up (ds-ui-nits) — ReConsentModal was still on the pre-DS layout.

## Risks / breaking changes

None. One component's content block + its test mock. No backend, no API, no i18n churn.

## QA

- `npm test` — 433 suites green (ReConsentModal suite covers show/accept/postpone/error paths).
- `npm run typecheck` clean.
- Visual: force the modal by seeding a consent-status response with `needsReConsent: true` (sandbox), or see screenshots below.

## Screenshots

375×667, `/home?__fixture=reconsent` (fixture added in this PR, so ds-shots covers this modal per PR from now on).

| Before (dev) | After |
|---|---|
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2948/reconsent-before.png" width="320"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2948/reconsent-after-v2.png" width="320"> |

Assets branch `pr-assets-2948` — delete after merge.

## Design notes / accepted trade-offs

- The links stay `DocsLink` (a real `<a>` — needed for the web new-tab / PWA same-tab / Capacitor in-app-browser targets) with the inline underline treatment; `LinkButton` cannot wrap it (nested anchors) and reimplementing DocsLink's targeting in LinkButton props would duplicate it.
- ds-shots flags `profile` @320 moved 2.83% — dev-baseline drift, not this diff (the diff touches only ReConsentModal + the fixture registry).
