### PR TITLE
fix(native): OTA beta switch off PostHog, Peanut-only receive, claim settles on CLAIMED

### DIFF
--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -43,6 +43,9 @@ export const SuccessClaimLinkView = ({
     // The optimistic claim path lands here before the broadcast is known to
     // have succeeded, so a failure can only arrive through the poll below.
     const [claimFailure, setClaimFailure] = useState<{ code: string | null } | null>(null)
+    // CLAIMED can settle before the on-chain txHash has projected, so success is
+    // its own flag rather than "we have a hash".
+    const [claimConfirmed, setClaimConfirmed] = useState(false)
     const { user: authUser } = useUserStore()
     const { fetchUser } = useAuth()
     const router = useRouter()
@@ -64,8 +67,11 @@ export const SuccessClaimLinkView = ({
     }, [queryClient])
 
     const handleClaimConfirmed = useCallback(
-        (txHash: string) => {
-            setTransactionHash(txHash)
+        (txHash: string | null) => {
+            setClaimConfirmed(true)
+            // The hash may still be projecting when CLAIMED settles; set it once
+            // it is there so any hash-dependent path downstream still gets it.
+            if (txHash) setTransactionHash(txHash)
 
             // Force immediate refetch of balance and transactions,
             // bypassing staleTime; only currently mounted queries.
@@ -93,9 +99,13 @@ export const SuccessClaimLinkView = ({
         captureMessage('Claim confirmation polling gave up without a terminal status', 'warning')
     }, [])
 
+    // Success once the claim is confirmed (CLAIMED status or a projected hash),
+    // matching the point the backend notifies — not "we have observed a hash".
+    const isClaimed = claimConfirmed || !!transactionHash
+
     useClaimSuccessPolling(
         claimLinkData.link,
-        !transactionHash && !claimFailure,
+        !isClaimed && !claimFailure,
         handleClaimConfirmed,
         handleClaimFailed,
         handleClaimUnconfirmed
@@ -167,14 +177,14 @@ export const SuccessClaimLinkView = ({
     useEffect(() => {
         // success feedback belongs to a confirmed claim, not to arriving here —
         // the optimistic path mounts this view before the broadcast is known
-        if (!transactionHash) return
+        if (!isClaimed) return
         triggerHaptic()
-    }, [transactionHash, triggerHaptic])
+    }, [isClaimed, triggerHaptic])
 
-    // The optimistic 202 lands here with no hash and no outcome yet. Rendering
-    // the success card now would claim money that has not moved — and would
-    // keep claiming it for as long as the poll is slow or failing.
-    if (!transactionHash && !claimFailure) {
+    // The optimistic 202 lands here with no outcome yet. Hold the processing
+    // state until the claim is confirmed — rendering success before that would
+    // claim money that has not moved.
+    if (!isClaimed && !claimFailure) {
         return (
             <div className="flex min-h-inherit flex-col justify-between gap-8">
                 <div className="md:hidden">

--- a/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
+++ b/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
@@ -1,10 +1,10 @@
 /**
  * useClaimSuccessPolling — replaces the bare 250ms setInterval that stacked
  * concurrent GETs (89 in one Android session). The contract under test:
- * requests never overlap, CLAIMED without a projected claim keeps polling
- * (the status flips before the claim intent is projected), the cadence backs
- * off after the fast phase, and the ceiling surfaces through onGaveUp instead
- * of stopping silently. Callbacks are one-shot.
+ * requests never overlap, CLAIMED settles as success even without a projected
+ * claim hash (the same point the backend marks the claim done and notifies),
+ * the cadence backs off after the fast phase, and the ceiling surfaces through
+ * onGaveUp instead of stopping silently. Callbacks are one-shot.
  */
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -107,28 +107,22 @@ describe('useClaimSuccessPolling', () => {
         expect(onGaveUp).not.toHaveBeenCalled()
     })
 
-    it('keeps polling through CLAIMED without a projected claim until the hash appears', async () => {
-        // the claim write flips status before the claim intent is projected —
-        // {status: CLAIMED, claim: undefined} must NOT be treated as terminal
-        mockGet
-            .mockResolvedValueOnce({ status: 'CLAIMED', events: [] })
-            .mockResolvedValueOnce({ status: 'CLAIMED', events: [] })
-            .mockResolvedValue({ status: 'CLAIMED', claim: { txHash: '0xdef' }, events: [] })
+    it('settles on CLAIMED without a projected claim, reporting a null hash', async () => {
+        // CLAIMED is the point the backend marks the claim done and notifies, so
+        // the view settles on it whether or not the claim intent's txHash has
+        // projected yet — no waiting the hash out on a screen the user is on.
+        mockGet.mockResolvedValue({ status: 'CLAIMED', events: [] })
         const { onClaimed, onGaveUp } = renderPolling()
 
         await advance(0)
+        await advance(1) // flush the batched observer notify through to the effect
         expect(mockGet).toHaveBeenCalledTimes(1)
-        expect(onClaimed).not.toHaveBeenCalled()
-
-        await advance(2 * CLAIM_POLL_INTERVAL_MS)
-        await advance(1)
-        expect(mockGet).toHaveBeenCalledTimes(3)
         expect(onClaimed).toHaveBeenCalledTimes(1)
-        expect(onClaimed).toHaveBeenCalledWith('0xdef')
+        expect(onClaimed).toHaveBeenCalledWith(null)
 
-        // now terminal — polling stopped
+        // terminal — polling stopped
         await advance(10 * CLAIM_POLL_SLOW_INTERVAL_MS)
-        expect(mockGet).toHaveBeenCalledTimes(3)
+        expect(mockGet).toHaveBeenCalledTimes(1)
         expect(onGaveUp).not.toHaveBeenCalled()
     })
 

--- a/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
+++ b/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
@@ -13,15 +13,19 @@ export const MAX_CLAIM_POLL_ATTEMPTS = 60
 export type ClaimPollFailure = { code: string | null; reason?: string }
 
 /*
- * Terminal means "polling again can't change the answer". A projected claim
- * counts only WITH its txHash: the claim write flips SendLink.status to
- * CLAIMED before the claim intent is projected, so {status: CLAIMED, claim:
- * undefined} is a transient state we must keep polling through — treating it
- * as terminal would stop before the hash ever arrives.
+ * Terminal means "polling again can't change the answer". A CLAIMED status is
+ * the same signal that fires the claim notification — peanut-api-ts marks the
+ * SendLink CLAIMED and runs processPostClaim (which sends the push) once the
+ * claim tx is handled — so the money has moved and we settle on it, whether or
+ * not the claim intent's txHash has projected yet. The hash still counts on its
+ * own for any path that carries it before the status flips.
  */
 const isTerminal = (link: SendLink | undefined): boolean =>
     !!link &&
-    (!!link.claim?.txHash || link.status === ESendLinkStatus.FAILED || link.status === ESendLinkStatus.CANCELLED)
+    (!!link.claim?.txHash ||
+        link.status === ESendLinkStatus.CLAIMED ||
+        link.status === ESendLinkStatus.FAILED ||
+        link.status === ESendLinkStatus.CANCELLED)
 
 const toFailure = (link: SendLink): ClaimPollFailure => ({
     code: link.claimFailureCode ?? null,
@@ -43,7 +47,7 @@ const toFailure = (link: SendLink): ClaimPollFailure => ({
 export function useClaimSuccessPolling(
     link: string,
     enabled: boolean,
-    onClaimed: (txHash: string) => void,
+    onClaimed: (txHash: string | null) => void,
     onFailed: (failure: ClaimPollFailure) => void,
     onGaveUp: () => void
 ): void {
@@ -82,9 +86,12 @@ export function useClaimSuccessPolling(
 
     useEffect(() => {
         if (!data || hasReportedResult.current) return
-        if (data.claim?.txHash) {
+        if (data.claim?.txHash || data.status === ESendLinkStatus.CLAIMED) {
+            // CLAIMED without a projected txHash still settles as success: it is
+            // the point the backend marks the claim done and notifies. Pass the
+            // hash when it is already there, null when it has yet to project.
             hasReportedResult.current = true
-            onClaimedRef.current(data.claim.txHash)
+            onClaimedRef.current(data.claim?.txHash ?? null)
         } else if (data.status === ESendLinkStatus.FAILED || data.status === ESendLinkStatus.CANCELLED) {
             // CANCELLED (sender withdrew mid-claim) has no distinct treatment
             // in the failure UI — it flows through onFailed like FAILED so the

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -52,6 +52,12 @@ import { useTranslations } from 'next-intl'
 
 const SHOW_INVITE_MODAL_FOR_DEVCONNECT = false
 
+// Receive screen is Peanut-only: the alternate claim rails (bank, mercadopago,
+// pix, exchange/wallet) are hidden so the only option is "Receive on Peanut".
+// The rail code below is kept intact behind this flag — flip to true to bring
+// the rails back.
+const SHOW_ALT_RAILS = false
+
 interface ISendLinkActionListProps {
     claimLinkData: ClaimLinkData
     isLoggedIn: boolean
@@ -213,7 +219,7 @@ export default function SendLinkActionList({
     const userHasAppAccess = user?.user?.hasAppAccess ?? false
     const devconnectMethod = DEVCONNECT_CLAIM_METHODS.find((m) => m.id === 'devconnect')!
 
-    if (isGeoLoading) {
+    if (SHOW_ALT_RAILS && isGeoLoading) {
         return (
             <div className="flex w-full items-center justify-center py-8">
                 <Loading />
@@ -272,33 +278,37 @@ export default function SendLinkActionList({
                 </div>
             )}
 
-            <Divider text={tCommon('or')} />
+            {SHOW_ALT_RAILS && (
+                <>
+                    <Divider text={tCommon('or')} />
 
-            <div className="space-y-2">
-                {sortedActionMethods.map((method) => {
-                    let methodRequiresVerification = method.id === 'bank' && requiresVerification
-                    if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
-                        methodRequiresVerification = true
-                    }
+                    <div className="space-y-2">
+                        {sortedActionMethods.map((method) => {
+                            let methodRequiresVerification = method.id === 'bank' && requiresVerification
+                            if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
+                                methodRequiresVerification = true
+                            }
 
-                    return (
-                        <MethodCard
-                            onClick={() => {
-                                if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
-                                    setSelectedMethod(method)
-                                    setShowInviteModal(true)
-                                } else {
-                                    handleMethodClick(method)
-                                }
-                            }}
-                            key={method.id}
-                            method={method}
-                            requiresVerification={methodRequiresVerification}
-                            soon={method.id === 'bank' && isGuestBankClaim}
-                        />
-                    )
-                })}
-            </div>
+                            return (
+                                <MethodCard
+                                    onClick={() => {
+                                        if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
+                                            setSelectedMethod(method)
+                                            setShowInviteModal(true)
+                                        } else {
+                                            handleMethodClick(method)
+                                        }
+                                    }}
+                                    key={method.id}
+                                    method={method}
+                                    requiresVerification={methodRequiresVerification}
+                                    soon={method.id === 'bank' && isGuestBankClaim}
+                                />
+                            )
+                        })}
+                    </div>
+                </>
+            )}
 
             {!isLoggedIn && <SupportCTA />}
 

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
@@ -138,7 +138,11 @@ beforeEach(() => {
     jest.clearAllMocks()
 })
 
-describe('SendLinkActionList — guest claim-to-bank maintenance', () => {
+// Skipped while the receive screen is Peanut-only: the alternate claim rails are
+// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the bank method these
+// cases assert on no longer renders. The gating code is kept — flip the flag and
+// remove .skip to bring these back.
+describe.skip('SendLinkActionList — guest claim-to-bank maintenance', () => {
     test('GuestBankClaim: bank option is greyed + "Soon!" and non-interactive', () => {
         mockClaimType = 'guest-bank-claim'
         renderList()

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
@@ -113,7 +113,11 @@ beforeEach(() => {
     mockSenderCanReceiveBankOfframp = null
 })
 
-describe('guest-verification prompt reason', () => {
+// Skipped while the receive screen is Peanut-only: the alternate claim rails are
+// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the method cards these
+// cases tap no longer render. The gating code is kept — flip the flag and remove
+// .skip to bring these back.
+describe.skip('guest-verification prompt reason', () => {
     test('bank + a definite "sender cannot receive" blames the sender', () => {
         mockSenderCanReceiveBankOfframp = false
         renderList()

--- a/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
+++ b/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
@@ -171,6 +171,20 @@ describe('SUCCESS view — polled claim failure', () => {
         await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
         expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
     })
+
+    test('a CLAIMED status with no projected hash still renders the success card', async () => {
+        // matches the backend's notify point: CLAIMED means the money moved, so
+        // the view must not sit on "processing" waiting the txHash out
+        mockSendLinksApi.get.mockResolvedValue({
+            status: 'CLAIMED',
+            events: [],
+        })
+
+        renderView()
+
+        await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
+        expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
+    })
 })
 
 describe('SUCCESS view — before the poll resolves', () => {

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -4,7 +4,6 @@ import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { useFeatureFlags } from '@/hooks/useFeatureFlag'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
@@ -15,39 +14,32 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * The tap gesture hides the control; the PostHog cohort keeps customers from
- * joining once self-assignment is open on the channel. Neither is a security
- * boundary — `setChannel` talks to Capgo directly — they keep `staging` off the
- * devices of people who did not mean to be there.
+ * The five-tap gesture is the only thing that keeps `staging` off the devices
+ * of people who did not mean to be there — there is no cohort and no server
+ * check. It is not a security boundary: `setChannel` talks to Capgo directly,
+ * and Capgo refuses the join unless the channel allows self-assignment, which
+ * is where the real access control lives.
  *
- * A device already ON the channel keeps the card whatever the cohort says: the
- * off switch is the only way back to the store bundle, and hiding it when
- * someone is offboarded (or the flag fails to load) would strand them on beta
- * code forever.
+ * The card renders on every native build, so the off switch is always
+ * reachable: it is the only way back to the store bundle, and hiding it would
+ * strand a device on beta code.
  */
-export const BETA_OTA_FLAG = 'beta-ota-channel'
 
 /**
  * What the About screen's five-tap reveal can promise: the card only renders
- * on a native build, and outside the cohort only for a device already on beta.
+ * on a native build.
  */
-export function useBetaUpdatesAccess(): { supported: boolean; visible: boolean } {
-    const isEnabled = useFeatureFlags()
-    const { supported, isBeta } = useOtaChannel()
-    const mayJoin = isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })
-    return { supported, visible: supported && (mayJoin || isBeta) }
+export function useBetaUpdatesAccess(): { supported: boolean } {
+    const { supported } = useOtaChannel()
+    return { supported }
 }
 
 export const BetaUpdatesCard = () => {
     const t = useTranslations('profile.about.beta')
     const toast = useToast()
-    const isEnabled = useFeatureFlags()
     const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
 
-    // nonProdBypass: previews and local builds are already non-production by
-    // definition, and QA needs the switch there without a cohort edit.
-    const mayJoin = isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })
-    if (!supported || (!mayJoin && !isBeta)) return null
+    if (!supported) return null
 
     const copyDeviceId = async (deviceId: string) => {
         if (await copyTextToClipboard(deviceId)) toast.info(t('deviceCopied'))
@@ -104,12 +96,7 @@ export const BetaUpdatesCard = () => {
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>
                 </div>
-                <Toggle
-                    checked={isBeta}
-                    disabled={busy || (!mayJoin && !isBeta)}
-                    onChange={onToggle}
-                    aria-label={t('heading')}
-                />
+                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
             </div>
 
             <dl className="space-y-1 text-body-xs text-foreground-secondary">

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,25 +1,19 @@
 /**
- * Two things keep the staging lane off customer devices: the card is native-only
- * and it is gated on an internal PostHog cohort — the five-tap gesture only
- * hides it. Beyond that, every join outcome has to read honestly: a tester told
- * to restart when nothing was downloaded goes looking for a build that isn't
- * there.
+ * The card is native-only, and the five-tap gesture is the only thing that keeps
+ * the staging lane off customer devices. Beyond that, every join outcome has to
+ * read honestly: a tester told to restart when nothing was downloaded goes
+ * looking for a build that isn't there.
  */
 import React from 'react'
 import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
-import { BETA_OTA_FLAG, BetaUpdatesCard } from '../BetaUpdatesCard'
+import { BetaUpdatesCard } from '../BetaUpdatesCard'
 import type { OtaChannelSwitchResult, UseOtaChannel } from '@/hooks/useOtaChannel'
 
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const toast = { success: jest.fn(), error: jest.fn(), info: jest.fn(), warning: jest.fn() }
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
-
-const flags = { enabled: [BETA_OTA_FLAG] as string[] }
-jest.mock('@/hooks/useFeatureFlag', () => ({
-    useFeatureFlags: () => (flag: string) => flags.enabled.includes(flag),
-}))
 
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
@@ -40,7 +34,6 @@ const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mock
 
 beforeEach(() => {
     jest.clearAllMocks()
-    flags.enabled = [BETA_OTA_FLAG]
 })
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
@@ -48,16 +41,9 @@ it('renders nothing off native, where there is no OTA layer at all', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
-it('stays hidden for accounts outside the internal cohort', () => {
-    flags.enabled = []
-    setup()
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
-})
-
-// Offboarding a tester (or a flag that fails to load) must not take the exit
-// with it: the device is already on staging, and nothing else can bring it back.
+// The off switch is the only way back to the store bundle, so it stays reachable
+// on any native build for a device already on staging.
 it('keeps the exit reachable for a device already on the channel', async () => {
-    flags.enabled = []
     setup({
         isBeta: true,
         status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -34,15 +34,14 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
         if (betaRevealed) betaCardRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     }, [betaRevealed])
 
-    // The fifth tap always answers: the card renders nothing on the web and
-    // outside the cohort, and a silent gesture reads as a broken one.
+    // The fifth tap always answers: the card renders nothing on the web, and a
+    // silent gesture reads as a broken one.
     const onVersionTap = () => {
         clearTimeout(tapWindow.current)
         taps.current += 1
         if (taps.current >= TAPS_TO_REVEAL_BETA) {
             taps.current = 0
             if (!betaAccess.supported) toast.info(t('beta.appOnly'))
-            else if (!betaAccess.visible) toast.warning(t('beta.notEnabled'))
             else {
                 setBetaRevealed(true)
                 toast.info(t('beta.revealed'))

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -13,8 +13,8 @@ const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper 
 
 jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
 jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
-const access = { supported: true, visible: true }
-const toast = { info: jest.fn(), warning: jest.fn() }
+const access = { supported: true }
+const toast = { info: jest.fn() }
 
 jest.mock('@/components/Profile/components/BetaUpdatesCard', () => ({
     BetaUpdatesCard: () => <div data-testid="beta-updates-card" />,
@@ -24,9 +24,7 @@ jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 
 beforeEach(() => {
     access.supported = true
-    access.visible = true
     toast.info.mockClear()
-    toast.warning.mockClear()
 })
 
 const tapVersion = (times: number) => {
@@ -55,23 +53,14 @@ describe('AboutView', () => {
         expect(toast.info).toHaveBeenCalledWith('Beta updates switch revealed below.')
     })
 
-    // The card renders nothing on the web and outside the cohort, so without a
-    // toast the fifth tap would look like the gesture is simply broken.
+    // The card renders nothing on the web, so without a toast the fifth tap
+    // would look like the gesture is simply broken.
     it('says the switch is app-only when tapped on the web', () => {
         access.supported = false
-        access.visible = false
         render(<AboutView appVersion="1.2.3" />)
         tapVersion(5)
         expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
         expect(toast.info).toHaveBeenCalledWith('Beta updates are only available in the Peanut app.')
-    })
-
-    it('says beta is not enabled when the device is outside the cohort', () => {
-        access.visible = false
-        render(<AboutView appVersion="1.2.3" />)
-        tapVersion(5)
-        expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
-        expect(toast.warning).toHaveBeenCalledWith("Beta updates aren't enabled for this device.")
     })
 
     it('forgets a partial tap streak once the window lapses', () => {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -558,7 +558,6 @@
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel.",
                 "revealed": "Beta updates switch revealed below.",
-                "notEnabled": "Beta updates aren't enabled for this device.",
                 "appOnly": "Beta updates are only available in the Peanut app."
             }
         }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -558,7 +558,6 @@
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
-                "notEnabled": "Las actualizaciones beta no están habilitadas para este dispositivo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."
             }
         }

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -349,7 +349,6 @@
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
-                "notEnabled": "Las actualizaciones beta no están habilitadas para este dispositivo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."
             }
         }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -558,7 +558,6 @@
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações.",
                 "revealed": "O interruptor de atualizações beta está visível abaixo.",
-                "notEnabled": "As atualizações beta não estão ativadas para este dispositivo.",
                 "appOnly": "As atualizações beta só estão disponíveis no app do Peanut."
             }
         }


### PR DESCRIPTION
## Why

Three fixes found while investigating native "trouble reaching Peanut" reports.

1. **OTA beta switch never appeared.** The five-tap beta switch was gated on a `beta-ota-channel` PostHog flag that was never created, so `isFeatureEnabled` returned false on every prod device — the switch stayed hidden and no device could self-assign to the Capgo `staging` channel.
2. **Receive screen offered non-Peanut rails.** The claim/receive screen showed bank / mercadopago / pix / exchange-wallet options beside the Peanut button.
3. **Claim screen stuck on "Processing".** A user got the "claimed" push notification while the screen kept spinning: the backend marks the SendLink `CLAIMED` and sends the notification before the on-chain `claim.txHash` projects, but the UI only settled once the poll observed that hash.

## What

**1. OTA beta switch without the cohort** (`875d231b`)
- Drop the `beta-ota-channel` flag gate. Five taps now reveals the switch on any native build.
- The off switch stays reachable, so a device on staging can always return to the store bundle.
- Remove the now-dead `notEnabled` toast and its locale strings.

**2. Peanut-only receive screen** (`ae8b6838`)
- Hide the alternate claim rails so the only receive option is Peanut, for logged-in and guest users.
- Rail code is kept intact behind a `SHOW_ALT_RAILS` flag (mirrors the file's `SHOW_INVITE_MODAL_FOR_DEVCONNECT` pattern) — one-line re-enable. Rail-specific tests are `describe.skip`'d, not deleted.
- Guest "Continue with Peanut" button and the devconnect event flow are untouched.

**3. Settle the claim screen on CLAIMED** (`de1aa6f0`)
- Treat `status === CLAIMED` as terminal success — the same point the backend marks the claim done and notifies — with or without the `txHash`.
- The poll reports the hash when present, `null` when it has yet to project; the success view tracks a `claimConfirmed` flag instead of gating on the hash. FAILED/CANCELLED and the give-up fallback are unchanged.

## Tests

- `useClaimSuccessPolling`: updated the CLAIMED-without-hash case to settle instead of poll on; other cadence/failure/ceiling tests unchanged.
- `SuccessClaimLinkView`: added a case for CLAIMED-without-hash rendering the success card.
- `BetaUpdatesCard` / `About.view`: dropped the cohort cases.
- Local gate: prettier clean, changed files typecheck-clean, affected suites pass.

## Notes / risks

- **Money surface.** #2 removes bank/mercadopago/exchange as claim destinations from this screen (kept reversible behind the flag). #3 changes when a claim reads as "success" — verified against `peanut-api-ts`: `SendLink.status` is set to `CLAIMED` and `processPostClaim` (which sends the push) run together, after the claim tx is handled; the failure path writes `FAILED` via `rollbackClaimOnError`.
- The `claimed` push is sent to the **sender**; the claimer's screen now settles on the same `CLAIMED` moment, so both track one signal.
- Follow-up for backend (not in this PR): `processPostClaim` awaits the receipt but does not flip `FAILED` on a revert, so a revert-after-CLAIMED would show success in both the notification and now the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe2ritzXbCgcxnWLLdJyfg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fe2ritzXbCgcxnWLLdJyfg)_