### PR TITLE
fix(native): OTA beta switch off PostHog, Peanut-only receive, claim settles on CLAIMED

### DIFF
--- a/public/badges/peanut_team.svg
+++ b/public/badges/peanut_team.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Peanut Team">
+    <circle cx="128" cy="128" r="120" fill="#FFC900" stroke="#000000" stroke-width="10" />
+    <path
+        d="M128 44c-19 0-34 14-34 32 0 11 5 18 5 30s-9 17-9 32c0 24 17 42 38 42s38-18 38-42c0-15-9-20-9-32s5-19 5-30c0-18-15-32-34-32z"
+        fill="#FFFFFF"
+        stroke="#000000"
+        stroke-width="9"
+        stroke-linejoin="round"
+    />
+    <path d="M104 118c16 6 32 6 48 0" fill="none" stroke="#000000" stroke-width="9" stroke-linecap="round" />
+    <circle cx="113" cy="92" r="7" fill="#000000" />
+    <circle cx="143" cy="92" r="7" fill="#000000" />
+    <circle cx="113" cy="150" r="7" fill="#000000" />
+    <circle cx="143" cy="150" r="7" fill="#000000" />
+    <circle cx="128" cy="176" r="7" fill="#000000" />
+</svg>

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -8,6 +8,7 @@ import { twMerge } from '@/utils/tw'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '../Global/Icons/Icon'
 import { getBadgeIcon } from './badge.utils'
+import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
 import { useBadgeCopy } from './useBadgeCopy'
 import { BadgeImage } from './BadgeImage'
 
@@ -42,12 +43,20 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
     const [startIdx, setStartIdx] = useState<number>(0)
 
     // sort by earnedAt, newest first
+    //
+    // PEANUT_TEAM never appears. It says "team" and is self-awarded by the
+    // five-tap beta gesture, so rendering it beside earned badges would let any
+    // customer wear Peanut staff colours in a payments app. It is a permission
+    // record, not a collectible — hidden on one's own profile too, since the
+    // beta switch appearing is the feedback that the tap worked.
     const sortedBadges = useMemo(() => {
-        return [...badges].sort((a, b) => {
-            const at = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
-            const bt = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
-            return bt - at
-        })
+        return badges
+            .filter((badge) => badge.code !== PEANUT_TEAM_BADGE)
+            .sort((a, b) => {
+                const at = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
+                const bt = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
+                return bt - at
+            })
     }, [badges])
 
     // calculate how many badges can fit in the viewport

--- a/src/components/Badges/badgeCelebration.utils.ts
+++ b/src/components/Badges/badgeCelebration.utils.ts
@@ -1,3 +1,5 @@
+import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
+
 // Pure helpers for the badge-earn toast (TASK-19791).
 //
 // "Surface it once, while fresh, without interrupting." When a user lands on
@@ -28,9 +30,10 @@ export const FRESHNESS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 // Badges that should NOT trigger the toast:
 //  - WAITLIST_SKIP keeps its bespoke card-flow celebration (BadgeSkipCelebration).
 //  - BETA_TESTER is awarded to every signup — too universal to be worth surfacing.
+//  - PEANUT_TEAM is a permission record for the beta switch, never shown anywhere.
 // Other card-access "skip" badges (OG/Devconnect/Arbiverse) are historical, so
 // the freshness window already keeps them out.
-const EXCLUDED_CODES = new Set<string>(['WAITLIST_SKIP', 'BETA_TESTER'])
+const EXCLUDED_CODES = new Set<string>(['WAITLIST_SKIP', 'BETA_TESTER', PEANUT_TEAM_BADGE])
 
 const STORAGE_PREFIX = 'badge_earn_toast_seen'
 

--- a/src/components/Claim/Link/Onchain/Success.view.tsx
+++ b/src/components/Claim/Link/Onchain/Success.view.tsx
@@ -43,6 +43,9 @@ export const SuccessClaimLinkView = ({
     // The optimistic claim path lands here before the broadcast is known to
     // have succeeded, so a failure can only arrive through the poll below.
     const [claimFailure, setClaimFailure] = useState<{ code: string | null } | null>(null)
+    // CLAIMED can settle before the on-chain txHash has projected, so success is
+    // its own flag rather than "we have a hash".
+    const [claimConfirmed, setClaimConfirmed] = useState(false)
     const { user: authUser } = useUserStore()
     const { fetchUser } = useAuth()
     const router = useRouter()
@@ -64,8 +67,11 @@ export const SuccessClaimLinkView = ({
     }, [queryClient])
 
     const handleClaimConfirmed = useCallback(
-        (txHash: string) => {
-            setTransactionHash(txHash)
+        (txHash: string | null) => {
+            setClaimConfirmed(true)
+            // The hash may still be projecting when CLAIMED settles; set it once
+            // it is there so any hash-dependent path downstream still gets it.
+            if (txHash) setTransactionHash(txHash)
 
             // Force immediate refetch of balance and transactions,
             // bypassing staleTime; only currently mounted queries.
@@ -93,9 +99,13 @@ export const SuccessClaimLinkView = ({
         captureMessage('Claim confirmation polling gave up without a terminal status', 'warning')
     }, [])
 
+    // Success once the claim is confirmed (CLAIMED status or a projected hash),
+    // matching the point the backend notifies — not "we have observed a hash".
+    const isClaimed = claimConfirmed || !!transactionHash
+
     useClaimSuccessPolling(
         claimLinkData.link,
-        !transactionHash && !claimFailure,
+        !isClaimed && !claimFailure,
         handleClaimConfirmed,
         handleClaimFailed,
         handleClaimUnconfirmed
@@ -167,14 +177,14 @@ export const SuccessClaimLinkView = ({
     useEffect(() => {
         // success feedback belongs to a confirmed claim, not to arriving here —
         // the optimistic path mounts this view before the broadcast is known
-        if (!transactionHash) return
+        if (!isClaimed) return
         triggerHaptic()
-    }, [transactionHash, triggerHaptic])
+    }, [isClaimed, triggerHaptic])
 
-    // The optimistic 202 lands here with no hash and no outcome yet. Rendering
-    // the success card now would claim money that has not moved — and would
-    // keep claiming it for as long as the poll is slow or failing.
-    if (!transactionHash && !claimFailure) {
+    // The optimistic 202 lands here with no outcome yet. Hold the processing
+    // state until the claim is confirmed — rendering success before that would
+    // claim money that has not moved.
+    if (!isClaimed && !claimFailure) {
         return (
             <div className="flex min-h-inherit flex-col justify-between gap-8">
                 <div className="md:hidden">

--- a/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
+++ b/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
@@ -1,10 +1,10 @@
 /**
  * useClaimSuccessPolling — replaces the bare 250ms setInterval that stacked
  * concurrent GETs (89 in one Android session). The contract under test:
- * requests never overlap, CLAIMED without a projected claim keeps polling
- * (the status flips before the claim intent is projected), the cadence backs
- * off after the fast phase, and the ceiling surfaces through onGaveUp instead
- * of stopping silently. Callbacks are one-shot.
+ * requests never overlap, CLAIMED settles as success even without a projected
+ * claim hash (the same point the backend marks the claim done and notifies),
+ * the cadence backs off after the fast phase, and the ceiling surfaces through
+ * onGaveUp instead of stopping silently. Callbacks are one-shot.
  */
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -107,28 +107,22 @@ describe('useClaimSuccessPolling', () => {
         expect(onGaveUp).not.toHaveBeenCalled()
     })
 
-    it('keeps polling through CLAIMED without a projected claim until the hash appears', async () => {
-        // the claim write flips status before the claim intent is projected —
-        // {status: CLAIMED, claim: undefined} must NOT be treated as terminal
-        mockGet
-            .mockResolvedValueOnce({ status: 'CLAIMED', events: [] })
-            .mockResolvedValueOnce({ status: 'CLAIMED', events: [] })
-            .mockResolvedValue({ status: 'CLAIMED', claim: { txHash: '0xdef' }, events: [] })
+    it('settles on CLAIMED without a projected claim, reporting a null hash', async () => {
+        // CLAIMED is the point the backend marks the claim done and notifies, so
+        // the view settles on it whether or not the claim intent's txHash has
+        // projected yet — no waiting the hash out on a screen the user is on.
+        mockGet.mockResolvedValue({ status: 'CLAIMED', events: [] })
         const { onClaimed, onGaveUp } = renderPolling()
 
         await advance(0)
+        await advance(1) // flush the batched observer notify through to the effect
         expect(mockGet).toHaveBeenCalledTimes(1)
-        expect(onClaimed).not.toHaveBeenCalled()
-
-        await advance(2 * CLAIM_POLL_INTERVAL_MS)
-        await advance(1)
-        expect(mockGet).toHaveBeenCalledTimes(3)
         expect(onClaimed).toHaveBeenCalledTimes(1)
-        expect(onClaimed).toHaveBeenCalledWith('0xdef')
+        expect(onClaimed).toHaveBeenCalledWith(null)
 
-        // now terminal — polling stopped
+        // terminal — polling stopped
         await advance(10 * CLAIM_POLL_SLOW_INTERVAL_MS)
-        expect(mockGet).toHaveBeenCalledTimes(3)
+        expect(mockGet).toHaveBeenCalledTimes(1)
         expect(onGaveUp).not.toHaveBeenCalled()
     })
 

--- a/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
+++ b/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
@@ -13,15 +13,19 @@ export const MAX_CLAIM_POLL_ATTEMPTS = 60
 export type ClaimPollFailure = { code: string | null; reason?: string }
 
 /*
- * Terminal means "polling again can't change the answer". A projected claim
- * counts only WITH its txHash: the claim write flips SendLink.status to
- * CLAIMED before the claim intent is projected, so {status: CLAIMED, claim:
- * undefined} is a transient state we must keep polling through — treating it
- * as terminal would stop before the hash ever arrives.
+ * Terminal means "polling again can't change the answer". A CLAIMED status is
+ * the same signal that fires the claim notification — peanut-api-ts marks the
+ * SendLink CLAIMED and runs processPostClaim (which sends the push) once the
+ * claim tx is handled — so the money has moved and we settle on it, whether or
+ * not the claim intent's txHash has projected yet. The hash still counts on its
+ * own for any path that carries it before the status flips.
  */
 const isTerminal = (link: SendLink | undefined): boolean =>
     !!link &&
-    (!!link.claim?.txHash || link.status === ESendLinkStatus.FAILED || link.status === ESendLinkStatus.CANCELLED)
+    (!!link.claim?.txHash ||
+        link.status === ESendLinkStatus.CLAIMED ||
+        link.status === ESendLinkStatus.FAILED ||
+        link.status === ESendLinkStatus.CANCELLED)
 
 const toFailure = (link: SendLink): ClaimPollFailure => ({
     code: link.claimFailureCode ?? null,
@@ -43,7 +47,7 @@ const toFailure = (link: SendLink): ClaimPollFailure => ({
 export function useClaimSuccessPolling(
     link: string,
     enabled: boolean,
-    onClaimed: (txHash: string) => void,
+    onClaimed: (txHash: string | null) => void,
     onFailed: (failure: ClaimPollFailure) => void,
     onGaveUp: () => void
 ): void {
@@ -82,9 +86,12 @@ export function useClaimSuccessPolling(
 
     useEffect(() => {
         if (!data || hasReportedResult.current) return
-        if (data.claim?.txHash) {
+        if (data.claim?.txHash || data.status === ESendLinkStatus.CLAIMED) {
+            // CLAIMED without a projected txHash still settles as success: it is
+            // the point the backend marks the claim done and notifies. Pass the
+            // hash when it is already there, null when it has yet to project.
             hasReportedResult.current = true
-            onClaimedRef.current(data.claim.txHash)
+            onClaimedRef.current(data.claim?.txHash ?? null)
         } else if (data.status === ESendLinkStatus.FAILED || data.status === ESendLinkStatus.CANCELLED) {
             // CANCELLED (sender withdrew mid-claim) has no distinct treatment
             // in the failure UI — it flows through onFailed like FAILED so the

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -9,6 +9,10 @@
  * - mercadopago/pix (regional, requires verification)
  * - external wallet (claim to any address)
  *
+ * the alternate rails are for recipients we cannot identify as Peanut users.
+ * once a session or a passkey from an earlier registration says otherwise, the
+ * screen collapses to the Peanut option alone
+ *
  * handles invite link logic - shows invite modal before allowing
  * non-peanut claim methods
  *
@@ -49,14 +53,9 @@ import { CLAIM_RAIL_MINIMUMS, validateMinimumAmount } from '@/constants/payment.
 import { useAppDispatch } from '@/redux/hooks'
 import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 import { useTranslations } from 'next-intl'
+import { useKnownPeanutDevice } from '@/hooks/useKnownPeanutDevice'
 
 const SHOW_INVITE_MODAL_FOR_DEVCONNECT = false
-
-// Receive screen is Peanut-only: the alternate claim rails (bank, mercadopago,
-// pix, exchange/wallet) are hidden so the only option is "Receive on Peanut".
-// The rail code below is kept intact behind this flag — flip to true to bring
-// the rails back.
-const SHOW_ALT_RAILS = false
 
 interface ISendLinkActionListProps {
     claimLinkData: ClaimLinkData
@@ -98,6 +97,7 @@ export default function SendLinkActionList({
     const [selectedMethod, setSelectedMethod] = useState<PaymentMethod | null>(null)
     const [showInviteModal, setShowInviteModal] = useState(false)
     const { user } = useAuth()
+    const knownDevice = useKnownPeanutDevice()
     const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({ trackImpressionWhenGuest: !isLoggedIn })
     const {
         setSelectedTokenAddress,
@@ -219,13 +219,18 @@ export default function SendLinkActionList({
     const userHasAppAccess = user?.user?.hasAppAccess ?? false
     const devconnectMethod = DEVCONNECT_CLAIM_METHODS.find((m) => m.id === 'devconnect')!
 
-    if (SHOW_ALT_RAILS && isGeoLoading) {
-        return (
-            <div className="flex w-full items-center justify-center py-8">
-                <Loading />
-            </div>
-        )
-    }
+    /*
+     * The alternate rails (bank, mercadopago, pix, exchange/wallet) are what a
+     * recipient without a Peanut account claims to — the published Send Links
+     * flow, so they stay. They only make sense for a recipient we cannot place:
+     * a live session, or passkey credentials from an earlier registration on
+     * this device, means the account already exists and Peanut is the answer.
+     *
+     * `knownDevice` is null until the storage read lands after mount. Treat that
+     * tick as identified: appending the rails a frame late is invisible, while
+     * showing them to a returning user and then pulling them away is not.
+     */
+    const showAltRails = !isLoggedIn && knownDevice === false
 
     return (
         <div className="space-y-2">
@@ -278,35 +283,41 @@ export default function SendLinkActionList({
                 </div>
             )}
 
-            {SHOW_ALT_RAILS && (
+            {showAltRails && (
                 <>
                     <Divider text={tCommon('or')} />
 
-                    <div className="space-y-2">
-                        {sortedActionMethods.map((method) => {
-                            let methodRequiresVerification = method.id === 'bank' && requiresVerification
-                            if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
-                                methodRequiresVerification = true
-                            }
+                    {isGeoLoading ? (
+                        <div className="flex w-full items-center justify-center py-8">
+                            <Loading />
+                        </div>
+                    ) : (
+                        <div className="space-y-2">
+                            {sortedActionMethods.map((method) => {
+                                let methodRequiresVerification = method.id === 'bank' && requiresVerification
+                                if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
+                                    methodRequiresVerification = true
+                                }
 
-                            return (
-                                <MethodCard
-                                    onClick={() => {
-                                        if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
-                                            setSelectedMethod(method)
-                                            setShowInviteModal(true)
-                                        } else {
-                                            handleMethodClick(method)
-                                        }
-                                    }}
-                                    key={method.id}
-                                    method={method}
-                                    requiresVerification={methodRequiresVerification}
-                                    soon={method.id === 'bank' && isGuestBankClaim}
-                                />
-                            )
-                        })}
-                    </div>
+                                return (
+                                    <MethodCard
+                                        onClick={() => {
+                                            if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
+                                                setSelectedMethod(method)
+                                                setShowInviteModal(true)
+                                            } else {
+                                                handleMethodClick(method)
+                                            }
+                                        }}
+                                        key={method.id}
+                                        method={method}
+                                        requiresVerification={methodRequiresVerification}
+                                        soon={method.id === 'bank' && isGuestBankClaim}
+                                    />
+                                )
+                            })}
+                        </div>
+                    )}
                 </>
             )}
 

--- a/src/components/Claim/Link/SendLinkActionList.tsx
+++ b/src/components/Claim/Link/SendLinkActionList.tsx
@@ -52,6 +52,12 @@ import { useTranslations } from 'next-intl'
 
 const SHOW_INVITE_MODAL_FOR_DEVCONNECT = false
 
+// Receive screen is Peanut-only: the alternate claim rails (bank, mercadopago,
+// pix, exchange/wallet) are hidden so the only option is "Receive on Peanut".
+// The rail code below is kept intact behind this flag — flip to true to bring
+// the rails back.
+const SHOW_ALT_RAILS = false
+
 interface ISendLinkActionListProps {
     claimLinkData: ClaimLinkData
     isLoggedIn: boolean
@@ -213,7 +219,7 @@ export default function SendLinkActionList({
     const userHasAppAccess = user?.user?.hasAppAccess ?? false
     const devconnectMethod = DEVCONNECT_CLAIM_METHODS.find((m) => m.id === 'devconnect')!
 
-    if (isGeoLoading) {
+    if (SHOW_ALT_RAILS && isGeoLoading) {
         return (
             <div className="flex w-full items-center justify-center py-8">
                 <Loading />
@@ -272,33 +278,37 @@ export default function SendLinkActionList({
                 </div>
             )}
 
-            <Divider text={tCommon('or')} />
+            {SHOW_ALT_RAILS && (
+                <>
+                    <Divider text={tCommon('or')} />
 
-            <div className="space-y-2">
-                {sortedActionMethods.map((method) => {
-                    let methodRequiresVerification = method.id === 'bank' && requiresVerification
-                    if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
-                        methodRequiresVerification = true
-                    }
+                    <div className="space-y-2">
+                        {sortedActionMethods.map((method) => {
+                            let methodRequiresVerification = method.id === 'bank' && requiresVerification
+                            if (!isMantecaPayEnabled && ['mercadopago', 'pix'].includes(method.id)) {
+                                methodRequiresVerification = true
+                            }
 
-                    return (
-                        <MethodCard
-                            onClick={() => {
-                                if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
-                                    setSelectedMethod(method)
-                                    setShowInviteModal(true)
-                                } else {
-                                    handleMethodClick(method)
-                                }
-                            }}
-                            key={method.id}
-                            method={method}
-                            requiresVerification={methodRequiresVerification}
-                            soon={method.id === 'bank' && isGuestBankClaim}
-                        />
-                    )
-                })}
-            </div>
+                            return (
+                                <MethodCard
+                                    onClick={() => {
+                                        if (isInviteLink && !userHasAppAccess && method.id !== 'devconnect') {
+                                            setSelectedMethod(method)
+                                            setShowInviteModal(true)
+                                        } else {
+                                            handleMethodClick(method)
+                                        }
+                                    }}
+                                    key={method.id}
+                                    method={method}
+                                    requiresVerification={methodRequiresVerification}
+                                    soon={method.id === 'bank' && isGuestBankClaim}
+                                />
+                            )
+                        })}
+                    </div>
+                </>
+            )}
 
             {!isLoggedIn && <SupportCTA />}
 

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
@@ -1,10 +1,15 @@
 /**
- * SendLinkActionList — guest claim-to-bank maintenance gating
+ * SendLinkActionList — who sees the alternate claim rails, and how the bank
+ * option behaves once they do.
  *
- * The GUEST claim-to-bank off-ramp is under maintenance (BE 503s
- * POST /bridge/offramp/create-for-guest). The bank method must render greyed +
- * "Soon!" and be non-interactive when the claim resolves to GuestBankClaim,
- * while the authenticated self off-ramp (UserBankClaim) stays fully clickable.
+ * The rails exist for a recipient with no Peanut account; a device we can
+ * identify as a Peanut user's (live session or an earlier registration) gets
+ * the Peanut option alone.
+ *
+ * On the rails themselves, the GUEST claim-to-bank off-ramp is under
+ * maintenance (BE 503s POST /bridge/offramp/create-for-guest): the bank method
+ * must render greyed + "Soon!" and be non-interactive when the claim resolves
+ * to GuestBankClaim, while UserBankClaim stays fully clickable.
  */
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -117,6 +122,12 @@ jest.mock('@/hooks/useGeoFilteredPaymentOptions', () => ({
     useGeoFilteredPaymentOptions: () => ({ filteredMethods: [bankMethod, walletMethod], isLoading: false }),
 }))
 
+// Device recognition — null while the storage reads are in flight.
+let mockKnownDevice: boolean | null = false
+jest.mock('@/hooks/useKnownPeanutDevice', () => ({
+    useKnownPeanutDevice: () => mockKnownDevice,
+}))
+
 // ---------- import component under test AFTER mocks ----------
 import SendLinkActionList from '../SendLinkActionList'
 
@@ -126,23 +137,51 @@ const claimLinkData = {
     sender: { userId: 'sender-123', username: 'alice' },
 } as any
 
-function renderList() {
+function renderList({ isLoggedIn = false }: { isLoggedIn?: boolean } = {}) {
     return render(
         <IntlWrapper>
-            <SendLinkActionList claimLinkData={claimLinkData} isLoggedIn isInviteLink={false} />
+            <SendLinkActionList claimLinkData={claimLinkData} isLoggedIn={isLoggedIn} isInviteLink={false} />
         </IntlWrapper>
     )
 }
 
 beforeEach(() => {
     jest.clearAllMocks()
+    mockClaimType = 'user-bank-claim'
+    mockKnownDevice = false
 })
 
-// Skipped while the receive screen is Peanut-only: the alternate claim rails are
-// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the bank method these
-// cases assert on no longer renders. The gating code is kept — flip the flag and
-// remove .skip to bring these back.
-describe.skip('SendLinkActionList — guest claim-to-bank maintenance', () => {
+describe('SendLinkActionList — who gets the alternate rails', () => {
+    test('an unrecognised recipient keeps every rail, so a bank claim needs no account', () => {
+        renderList()
+
+        expect(screen.getByText('Bank')).toBeInTheDocument()
+        expect(screen.getByText('Exchange or Wallet')).toBeInTheDocument()
+    })
+
+    test('a logged-in recipient gets Peanut only', () => {
+        renderList({ isLoggedIn: true })
+
+        expect(screen.queryByText('Bank')).not.toBeInTheDocument()
+        expect(screen.queryByText('Exchange or Wallet')).not.toBeInTheDocument()
+    })
+
+    test('a logged-out device holding credentials gets Peanut only', () => {
+        mockKnownDevice = true
+        renderList()
+
+        expect(screen.queryByText('Bank')).not.toBeInTheDocument()
+    })
+
+    test('nothing is offered before recognition resolves, so no rail is shown then withdrawn', () => {
+        mockKnownDevice = null
+        renderList()
+
+        expect(screen.queryByText('Bank')).not.toBeInTheDocument()
+    })
+})
+
+describe('SendLinkActionList — guest claim-to-bank maintenance', () => {
     test('GuestBankClaim: bank option is greyed + "Soon!" and non-interactive', () => {
         mockClaimType = 'guest-bank-claim'
         renderList()
@@ -155,7 +194,7 @@ describe.skip('SendLinkActionList — guest claim-to-bank maintenance', () => {
         expect(mockSetFlowStep).not.toHaveBeenCalled()
     })
 
-    test('UserBankClaim: authenticated self off-ramp stays interactive (no "Soon!")', () => {
+    test('UserBankClaim: the non-guest off-ramp stays interactive (no "Soon!")', () => {
         mockClaimType = 'user-bank-claim'
         renderList()
 

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.test.tsx
@@ -138,7 +138,11 @@ beforeEach(() => {
     jest.clearAllMocks()
 })
 
-describe('SendLinkActionList — guest claim-to-bank maintenance', () => {
+// Skipped while the receive screen is Peanut-only: the alternate claim rails are
+// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the bank method these
+// cases assert on no longer renders. The gating code is kept — flip the flag and
+// remove .skip to bring these back.
+describe.skip('SendLinkActionList — guest claim-to-bank maintenance', () => {
     test('GuestBankClaim: bank option is greyed + "Soon!" and non-interactive', () => {
         mockClaimType = 'guest-bank-claim'
         renderList()

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
@@ -87,6 +87,9 @@ jest.mock('@/context/tokenSelector.context', () => ({
 
 const bankMethod = { id: 'bank', title: 'Bank', description: 'EUR, USD & more', icons: [], soon: false }
 const mercadoPagoMethod = { id: 'mercadopago', title: 'Mercado Pago', description: 'ARS', icons: [], soon: false }
+// An unrecognised recipient — the only case where the rails render at all.
+jest.mock('@/hooks/useKnownPeanutDevice', () => ({ useKnownPeanutDevice: () => false }))
+
 jest.mock('@/hooks/useGeoFilteredPaymentOptions', () => ({
     useGeoFilteredPaymentOptions: () => ({ filteredMethods: [bankMethod, mercadoPagoMethod], isLoading: false }),
 }))
@@ -113,11 +116,7 @@ beforeEach(() => {
     mockSenderCanReceiveBankOfframp = null
 })
 
-// Skipped while the receive screen is Peanut-only: the alternate claim rails are
-// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the method cards these
-// cases tap no longer render. The gating code is kept — flip the flag and remove
-// .skip to bring these back.
-describe.skip('guest-verification prompt reason', () => {
+describe('guest-verification prompt reason', () => {
     test('bank + a definite "sender cannot receive" blames the sender', () => {
         mockSenderCanReceiveBankOfframp = false
         renderList()

--- a/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
+++ b/src/components/Claim/Link/__tests__/SendLinkActionList.verificationReason.test.tsx
@@ -113,7 +113,11 @@ beforeEach(() => {
     mockSenderCanReceiveBankOfframp = null
 })
 
-describe('guest-verification prompt reason', () => {
+// Skipped while the receive screen is Peanut-only: the alternate claim rails are
+// hidden behind SHOW_ALT_RAILS in SendLinkActionList, so the method cards these
+// cases tap no longer render. The gating code is kept — flip the flag and remove
+// .skip to bring these back.
+describe.skip('guest-verification prompt reason', () => {
     test('bank + a definite "sender cannot receive" blames the sender', () => {
         mockSenderCanReceiveBankOfframp = false
         renderList()

--- a/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
+++ b/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
@@ -171,6 +171,20 @@ describe('SUCCESS view — polled claim failure', () => {
         await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
         expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
     })
+
+    test('a CLAIMED status with no projected hash still renders the success card', async () => {
+        // matches the backend's notify point: CLAIMED means the money moved, so
+        // the view must not sit on "processing" waiting the txHash out
+        mockSendLinksApi.get.mockResolvedValue({
+            status: 'CLAIMED',
+            events: [],
+        })
+
+        renderView()
+
+        await waitFor(() => expect(screen.getByTestId('success-card')).toBeInTheDocument())
+        expect(screen.queryByText(/network is busy/i)).not.toBeInTheDocument()
+    })
 })
 
 describe('SUCCESS view — before the poll resolves', () => {

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -40,6 +40,7 @@ import { formatUnits } from 'viem'
 import { useAppHaptic } from '@/hooks/useAppHaptic'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { Icon } from '../Global/Icons/Icon'
+import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
 
 /** Kinds that affect the user's wallet balance. Hoisted to module scope to avoid re-allocation. */
 const BALANCE_AFFECTING_KINDS: ReadonlySet<IntentKind> = new Set<IntentKind>([
@@ -201,8 +202,11 @@ const HomeHistory = ({
 
                 // inject badge entries using user's badges (newest first) and earnedAt chronology
                 // filter out beta tester badge — it creates confusing first impressions for new users
+                // filter out PEANUT_TEAM — a permission record for the beta switch, never displayed
                 if (isViewingOwnHistory) {
-                    const badges = (user?.user?.badges ?? []).filter((b) => b.code !== 'BETA_TESTER')
+                    const badges = (user?.user?.badges ?? []).filter(
+                        (b) => b.code !== 'BETA_TESTER' && b.code !== PEANUT_TEAM_BADGE
+                    )
                     badges.forEach((b) => {
                         if (!b.earnedAt) return
                         entries.push({

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -4,8 +4,9 @@ import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { useFeatureFlags } from '@/hooks/useFeatureFlag'
+import { useAuth } from '@/context/authContext'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
+import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
 import { useTranslations } from 'next-intl'
@@ -15,22 +16,19 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * Joining is gated on the `beta-ota-channel` cohort. The tap gesture only
- * controls discoverability, and Capgo's self-assignment setting is global —
- * it cannot tell an internal tester from a customer — so without the cohort
- * the two together let anyone who finds the gesture onto the `dev` firehose
- * whenever self-assignment is open.
+ * Joining requires the PEANUT_TEAM badge, which the About screen awards on the
+ * fifth tap. The badge is a record of who opted in and a handle to revoke it,
+ * NOT an access boundary — anyone who performs the gesture can award it to
+ * themselves. Capgo's channel self-assignment setting is the real boundary.
  *
- * The cohort gates the JOIN, never the card. An earlier version gated the
- * whole reveal, so the flag going missing hid the switch from everyone and
- * looked exactly like being outside the cohort — invisible for months. A
- * blocked device now says so on screen and names the fix.
+ * The badge gates the JOIN, never the card. An earlier version gated the whole
+ * reveal on a PostHog cohort, so the flag never being created hid the switch
+ * from everyone and looked exactly like exclusion — invisible for months.
  *
  * The card therefore renders on every native build, and the off switch stays
- * live whatever the cohort says: it is the only way back to the store bundle,
- * and a device offboarded mid-beta would otherwise be stranded on beta code.
+ * live whether or not the badge is held: it is the only way back to the store
+ * bundle, and revoking someone mid-beta must not strand them on beta code.
  */
-export const BETA_OTA_FLAG = 'beta-ota-channel'
 
 /**
  * What the About screen's five-tap reveal can promise: the card only renders
@@ -41,11 +39,10 @@ export function useBetaUpdatesAccess(): { supported: boolean } {
     return { supported }
 }
 
-/** Outside the cohort, only a device already on beta may work the switch — off. */
+/** Without the badge, only a device already on beta may work the switch — off. */
 function useCanJoinBeta(): boolean {
-    // nonProdBypass: staging and preview builds are internal by construction,
-    // so the cohort only has to exist for the production store binary.
-    return useFeatureFlags()(BETA_OTA_FLAG, { nonProdBypass: true })
+    const { user } = useAuth()
+    return !!user?.user.badges?.some((badge) => badge.code === PEANUT_TEAM_BADGE)
 }
 
 export const BetaUpdatesCard = () => {

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -4,7 +4,6 @@ import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { useFeatureFlags } from '@/hooks/useFeatureFlag'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
@@ -15,39 +14,32 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * The tap gesture hides the control; the PostHog cohort keeps customers from
- * joining once self-assignment is open on the channel. Neither is a security
- * boundary — `setChannel` talks to Capgo directly — they keep `staging` off the
- * devices of people who did not mean to be there.
+ * The five-tap gesture is the only thing that keeps `staging` off the devices
+ * of people who did not mean to be there — there is no cohort and no server
+ * check. It is not a security boundary: `setChannel` talks to Capgo directly,
+ * and Capgo refuses the join unless the channel allows self-assignment, which
+ * is where the real access control lives.
  *
- * A device already ON the channel keeps the card whatever the cohort says: the
- * off switch is the only way back to the store bundle, and hiding it when
- * someone is offboarded (or the flag fails to load) would strand them on beta
- * code forever.
+ * The card renders on every native build, so the off switch is always
+ * reachable: it is the only way back to the store bundle, and hiding it would
+ * strand a device on beta code.
  */
-export const BETA_OTA_FLAG = 'beta-ota-channel'
 
 /**
  * What the About screen's five-tap reveal can promise: the card only renders
- * on a native build, and outside the cohort only for a device already on beta.
+ * on a native build.
  */
-export function useBetaUpdatesAccess(): { supported: boolean; visible: boolean } {
-    const isEnabled = useFeatureFlags()
-    const { supported, isBeta } = useOtaChannel()
-    const mayJoin = isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })
-    return { supported, visible: supported && (mayJoin || isBeta) }
+export function useBetaUpdatesAccess(): { supported: boolean } {
+    const { supported } = useOtaChannel()
+    return { supported }
 }
 
 export const BetaUpdatesCard = () => {
     const t = useTranslations('profile.about.beta')
     const toast = useToast()
-    const isEnabled = useFeatureFlags()
     const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
 
-    // nonProdBypass: previews and local builds are already non-production by
-    // definition, and QA needs the switch there without a cohort edit.
-    const mayJoin = isEnabled(BETA_OTA_FLAG, { nonProdBypass: true })
-    if (!supported || (!mayJoin && !isBeta)) return null
+    if (!supported) return null
 
     const copyDeviceId = async (deviceId: string) => {
         if (await copyTextToClipboard(deviceId)) toast.info(t('deviceCopied'))
@@ -104,12 +96,7 @@ export const BetaUpdatesCard = () => {
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>
                 </div>
-                <Toggle
-                    checked={isBeta}
-                    disabled={busy || (!mayJoin && !isBeta)}
-                    onChange={onToggle}
-                    aria-label={t('heading')}
-                />
+                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
             </div>
 
             <dl className="space-y-1 text-body-xs text-foreground-secondary">

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -4,6 +4,7 @@ import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { useToast } from '@/components/0_Bruddle/Toast'
+import { useFeatureFlags } from '@/hooks/useFeatureFlag'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
@@ -14,16 +15,22 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * The five-tap gesture is the only thing that keeps `staging` off the devices
- * of people who did not mean to be there — there is no cohort and no server
- * check. It is not a security boundary: `setChannel` talks to Capgo directly,
- * and Capgo refuses the join unless the channel allows self-assignment, which
- * is where the real access control lives.
+ * Joining is gated on the `beta-ota-channel` cohort. The tap gesture only
+ * controls discoverability, and Capgo's self-assignment setting is global —
+ * it cannot tell an internal tester from a customer — so without the cohort
+ * the two together let anyone who finds the gesture onto the `dev` firehose
+ * whenever self-assignment is open.
  *
- * The card renders on every native build, so the off switch is always
- * reachable: it is the only way back to the store bundle, and hiding it would
- * strand a device on beta code.
+ * The cohort gates the JOIN, never the card. An earlier version gated the
+ * whole reveal, so the flag going missing hid the switch from everyone and
+ * looked exactly like being outside the cohort — invisible for months. A
+ * blocked device now says so on screen and names the fix.
+ *
+ * The card therefore renders on every native build, and the off switch stays
+ * live whatever the cohort says: it is the only way back to the store bundle,
+ * and a device offboarded mid-beta would otherwise be stranded on beta code.
  */
+export const BETA_OTA_FLAG = 'beta-ota-channel'
 
 /**
  * What the About screen's five-tap reveal can promise: the card only renders
@@ -34,12 +41,22 @@ export function useBetaUpdatesAccess(): { supported: boolean } {
     return { supported }
 }
 
+/** Outside the cohort, only a device already on beta may work the switch — off. */
+function useCanJoinBeta(): boolean {
+    // nonProdBypass: staging and preview builds are internal by construction,
+    // so the cohort only has to exist for the production store binary.
+    return useFeatureFlags()(BETA_OTA_FLAG, { nonProdBypass: true })
+}
+
 export const BetaUpdatesCard = () => {
     const t = useTranslations('profile.about.beta')
     const toast = useToast()
     const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
+    const canJoin = useCanJoinBeta()
 
     if (!supported) return null
+
+    const blockedFromJoining = !canJoin && !isBeta
 
     const copyDeviceId = async (deviceId: string) => {
         if (await copyTextToClipboard(deviceId)) toast.info(t('deviceCopied'))
@@ -96,8 +113,15 @@ export const BetaUpdatesCard = () => {
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>
                 </div>
-                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
+                <Toggle
+                    checked={isBeta}
+                    disabled={busy || blockedFromJoining}
+                    onChange={onToggle}
+                    aria-label={t('heading')}
+                />
             </div>
+
+            {blockedFromJoining && <p className="text-body-xs text-foreground-secondary">{t('notEligible')}</p>}
 
             <dl className="space-y-1 text-body-xs text-foreground-secondary">
                 <div className="flex justify-between gap-4">

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,8 +1,10 @@
 /**
- * The card is native-only, and the five-tap gesture is the only thing that keeps
- * the staging lane off customer devices. Beyond that, every join outcome has to
- * read honestly: a tester told to restart when nothing was downloaded goes
- * looking for a build that isn't there.
+ * The card is native-only. The tap gesture controls discoverability; the
+ * `beta-ota-channel` cohort is what decides who may JOIN. It must never decide
+ * who may leave, and it must never hide the card — a blocked device has to be
+ * able to read why. Beyond that, every join outcome has to read honestly: a
+ * tester told to restart when nothing was downloaded goes looking for a build
+ * that isn't there.
  */
 import React from 'react'
 import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
@@ -17,6 +19,9 @@ jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
+
+let inCohort = true
+jest.mock('@/hooks/useFeatureFlag', () => ({ useFeatureFlags: () => () => inCohort }))
 
 const setup = (overrides: Partial<UseOtaChannel> = {}) => {
     channel.current = {
@@ -34,11 +39,47 @@ const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mock
 
 beforeEach(() => {
     jest.clearAllMocks()
+    inCohort = true
 })
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
     setup({ supported: false })
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+})
+
+describe('cohort gating', () => {
+    it('will not let an account outside the cohort join', () => {
+        inCohort = false
+        setup()
+        expect(screen.getByRole('switch')).toBeDisabled()
+    })
+
+    // The cohort going missing must never look like silence: that is how the
+    // previous gate hid the switch from its own testers for months.
+    it('tells a blocked account why, and what to ask for', () => {
+        inCohort = false
+        setup()
+        expect(screen.getByText(/internal testers/i)).toBeInTheDocument()
+    })
+
+    // Offboarding someone mid-beta must not strand them on beta code.
+    it('still lets a device already on beta leave once it is out of the cohort', async () => {
+        inCohort = false
+        setup({
+            isBeta: true,
+            status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
+        })
+        const toggle = screen.getByRole('switch')
+        expect(toggle).toBeEnabled()
+        fireEvent.click(toggle)
+        await waitFor(() => expect(channel.current.setBeta).toHaveBeenCalledWith(false))
+    })
+
+    it('says nothing about eligibility to an account that can join', () => {
+        setup()
+        expect(screen.queryByText(/internal testers/i)).not.toBeInTheDocument()
+        expect(screen.getByRole('switch')).toBeEnabled()
+    })
 })
 
 // The off switch is the only way back to the store bundle, so it stays reachable

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,10 +1,10 @@
 /**
  * The card is native-only. The tap gesture controls discoverability; the
- * `beta-ota-channel` cohort is what decides who may JOIN. It must never decide
- * who may leave, and it must never hide the card — a blocked device has to be
- * able to read why. Beyond that, every join outcome has to read honestly: a
- * tester told to restart when nothing was downloaded goes looking for a build
- * that isn't there.
+ * PEANUT_TEAM badge is what decides who may JOIN. It must never decide who may
+ * leave, and it must never hide the card — a blocked device has to be able to
+ * read why. Beyond that, every join outcome has to read honestly: a tester told
+ * to restart when nothing was downloaded goes looking for a build that isn't
+ * there.
  */
 import React from 'react'
 import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
@@ -20,8 +20,8 @@ jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
 
-let inCohort = true
-jest.mock('@/hooks/useFeatureFlag', () => ({ useFeatureFlags: () => () => inCohort }))
+let badges: { code: string }[] = [{ code: 'PEANUT_TEAM' }]
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: { user: { badges } } }) }))
 
 const setup = (overrides: Partial<UseOtaChannel> = {}) => {
     channel.current = {
@@ -39,7 +39,7 @@ const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mock
 
 beforeEach(() => {
     jest.clearAllMocks()
-    inCohort = true
+    badges = [{ code: 'PEANUT_TEAM' }]
 })
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
@@ -47,24 +47,24 @@ it('renders nothing off native, where there is no OTA layer at all', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
-describe('cohort gating', () => {
-    it('will not let an account outside the cohort join', () => {
-        inCohort = false
+describe('badge gating', () => {
+    it('will not let an account without the badge join', () => {
+        badges = []
         setup()
         expect(screen.getByRole('switch')).toBeDisabled()
     })
 
-    // The cohort going missing must never look like silence: that is how the
-    // previous gate hid the switch from its own testers for months.
+    // A missing badge must never look like silence: that is how the previous
+    // PostHog gate hid the switch from its own testers for months.
     it('tells a blocked account why, and what to ask for', () => {
-        inCohort = false
+        badges = []
         setup()
-        expect(screen.getByText(/internal testers/i)).toBeInTheDocument()
+        expect(screen.getByText(/not enabled for this account/i)).toBeInTheDocument()
     })
 
-    // Offboarding someone mid-beta must not strand them on beta code.
-    it('still lets a device already on beta leave once it is out of the cohort', async () => {
-        inCohort = false
+    // Revoking the badge mid-beta must not strand a device on beta code.
+    it('still lets a device already on beta leave once the badge is revoked', async () => {
+        badges = []
         setup({
             isBeta: true,
             status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
@@ -75,9 +75,9 @@ describe('cohort gating', () => {
         await waitFor(() => expect(channel.current.setBeta).toHaveBeenCalledWith(false))
     })
 
-    it('says nothing about eligibility to an account that can join', () => {
+    it('says nothing about eligibility to an account holding the badge', () => {
         setup()
-        expect(screen.queryByText(/internal testers/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/not enabled for this account/i)).not.toBeInTheDocument()
         expect(screen.getByRole('switch')).toBeEnabled()
     })
 })

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,25 +1,19 @@
 /**
- * Two things keep the staging lane off customer devices: the card is native-only
- * and it is gated on an internal PostHog cohort — the five-tap gesture only
- * hides it. Beyond that, every join outcome has to read honestly: a tester told
- * to restart when nothing was downloaded goes looking for a build that isn't
- * there.
+ * The card is native-only, and the five-tap gesture is the only thing that keeps
+ * the staging lane off customer devices. Beyond that, every join outcome has to
+ * read honestly: a tester told to restart when nothing was downloaded goes
+ * looking for a build that isn't there.
  */
 import React from 'react'
 import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
-import { BETA_OTA_FLAG, BetaUpdatesCard } from '../BetaUpdatesCard'
+import { BetaUpdatesCard } from '../BetaUpdatesCard'
 import type { OtaChannelSwitchResult, UseOtaChannel } from '@/hooks/useOtaChannel'
 
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
 const toast = { success: jest.fn(), error: jest.fn(), info: jest.fn(), warning: jest.fn() }
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
-
-const flags = { enabled: [BETA_OTA_FLAG] as string[] }
-jest.mock('@/hooks/useFeatureFlag', () => ({
-    useFeatureFlags: () => (flag: string) => flags.enabled.includes(flag),
-}))
 
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
@@ -40,7 +34,6 @@ const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mock
 
 beforeEach(() => {
     jest.clearAllMocks()
-    flags.enabled = [BETA_OTA_FLAG]
 })
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
@@ -48,16 +41,9 @@ it('renders nothing off native, where there is no OTA layer at all', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
-it('stays hidden for accounts outside the internal cohort', () => {
-    flags.enabled = []
-    setup()
-    expect(screen.queryByRole('switch')).not.toBeInTheDocument()
-})
-
-// Offboarding a tester (or a flag that fails to load) must not take the exit
-// with it: the device is already on staging, and nothing else can bring it back.
+// The off switch is the only way back to the store bundle, so it stays reachable
+// on any native build for a device already on staging.
 it('keeps the exit reachable for a device already on the channel', async () => {
-    flags.enabled = []
     setup({
         isBeta: true,
         status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -34,15 +34,14 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
         if (betaRevealed) betaCardRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     }, [betaRevealed])
 
-    // The fifth tap always answers: the card renders nothing on the web and
-    // outside the cohort, and a silent gesture reads as a broken one.
+    // The fifth tap always answers: the card renders nothing on the web, and a
+    // silent gesture reads as a broken one.
     const onVersionTap = () => {
         clearTimeout(tapWindow.current)
         taps.current += 1
         if (taps.current >= TAPS_TO_REVEAL_BETA) {
             taps.current = 0
             if (!betaAccess.supported) toast.info(t('beta.appOnly'))
-            else if (!betaAccess.visible) toast.warning(t('beta.notEnabled'))
             else {
                 setBetaRevealed(true)
                 toast.info(t('beta.revealed'))

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -7,6 +7,8 @@ import NavigationArrow from '@/components/Global/NavigationArrow'
 import { BetaUpdatesCard, useBetaUpdatesAccess } from '@/components/Profile/components/BetaUpdatesCard'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { LEGAL_POLICIES } from '@/constants/legal-policies'
+import { useAuth } from '@/context/authContext'
+import { claimPeanutTeamBadge } from '@/services/peanut-team-badge'
 import { useAppVersion } from '@/hooks/useAppVersion'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useTranslations } from 'next-intl'
@@ -29,10 +31,28 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
     const toast = useToast()
     const betaAccess = useBetaUpdatesAccess()
     const betaCardRef = useRef<HTMLDivElement>(null)
+    const { fetchUser } = useAuth()
 
     useEffect(() => {
         if (betaRevealed) betaCardRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     }, [betaRevealed])
+
+    /**
+     * The tap is what earns PEANUT_TEAM, and the badge is what the switch reads
+     * as permission to join. Claim and refetch BEFORE revealing: the card asks
+     * the user object for the badge, so revealing first would show a disabled
+     * toggle and an "ask for access" line for a round trip, on the very gesture
+     * that just granted it.
+     *
+     * The toast fires first so the gesture is acknowledged immediately, and a
+     * failed claim still reveals the card — the off switch has to stay
+     * reachable for a device already on beta, whatever the network did.
+     */
+    const revealBetaCard = async () => {
+        toast.info(t('beta.revealed'))
+        if (await claimPeanutTeamBadge()) await fetchUser()
+        setBetaRevealed(true)
+    }
 
     // The fifth tap always answers: the card renders nothing on the web, and a
     // silent gesture reads as a broken one.
@@ -42,10 +62,7 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
         if (taps.current >= TAPS_TO_REVEAL_BETA) {
             taps.current = 0
             if (!betaAccess.supported) toast.info(t('beta.appOnly'))
-            else {
-                setBetaRevealed(true)
-                toast.info(t('beta.revealed'))
-            }
+            else void revealBetaCard()
             return
         }
         tapWindow.current = setTimeout(() => {

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -4,7 +4,7 @@
  * OTA channels mean nothing on the web.
  */
 import React from 'react'
-import { fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import { fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
 import en from '@/i18n/app/messages/en.json'
 import { AboutView } from '../About.view'
@@ -22,9 +22,17 @@ jest.mock('@/components/Profile/components/BetaUpdatesCard', () => ({
 }))
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 
+const fetchUser = jest.fn()
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ fetchUser }) }))
+
+const claimPeanutTeamBadge = jest.fn<Promise<boolean>, []>()
+jest.mock('@/services/peanut-team-badge', () => ({ claimPeanutTeamBadge: () => claimPeanutTeamBadge() }))
+
 beforeEach(() => {
     access.supported = true
     toast.info.mockClear()
+    fetchUser.mockClear()
+    claimPeanutTeamBadge.mockReset().mockResolvedValue(true)
 })
 
 const tapVersion = (times: number) => {
@@ -44,23 +52,47 @@ describe('AboutView', () => {
         )
     })
 
-    it('keeps the beta switch hidden until the fifth tap', () => {
+    it('keeps the beta switch hidden until the fifth tap', async () => {
         render(<AboutView appVersion="1.2.3" />)
         tapVersion(4)
         expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
         tapVersion(1)
-        expect(screen.getByTestId('beta-updates-card')).toBeInTheDocument()
         expect(toast.info).toHaveBeenCalledWith('Beta updates switch revealed below.')
+        expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
+    })
+
+    // The card reads the badge off the user object, so revealing before the
+    // claim lands would show a disabled toggle and an "ask for access" line on
+    // the very gesture that just granted it.
+    it('earns the team badge and refetches the user before revealing the card', async () => {
+        render(<AboutView appVersion="1.2.3" />)
+        tapVersion(5)
+
+        await waitFor(() => expect(claimPeanutTeamBadge).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(fetchUser).toHaveBeenCalledTimes(1))
+        expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
+    })
+
+    // Offline, the switch still has to appear: a device already on beta needs
+    // the off switch, and that must not depend on the claim succeeding.
+    it('still reveals the card when the badge claim fails', async () => {
+        claimPeanutTeamBadge.mockResolvedValue(false)
+        render(<AboutView appVersion="1.2.3" />)
+        tapVersion(5)
+
+        expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
+        expect(fetchUser).not.toHaveBeenCalled()
     })
 
     // The card renders nothing on the web, so without a toast the fifth tap
     // would look like the gesture is simply broken.
-    it('says the switch is app-only when tapped on the web', () => {
+    it('says the switch is app-only when tapped on the web, and earns nothing', () => {
         access.supported = false
         render(<AboutView appVersion="1.2.3" />)
         tapVersion(5)
         expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
         expect(toast.info).toHaveBeenCalledWith('Beta updates are only available in the Peanut app.')
+        expect(claimPeanutTeamBadge).not.toHaveBeenCalled()
     })
 
     it('forgets a partial tap streak once the window lapses', () => {

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -13,8 +13,8 @@ const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper 
 
 jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
 jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
-const access = { supported: true, visible: true }
-const toast = { info: jest.fn(), warning: jest.fn() }
+const access = { supported: true }
+const toast = { info: jest.fn() }
 
 jest.mock('@/components/Profile/components/BetaUpdatesCard', () => ({
     BetaUpdatesCard: () => <div data-testid="beta-updates-card" />,
@@ -24,9 +24,7 @@ jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 
 beforeEach(() => {
     access.supported = true
-    access.visible = true
     toast.info.mockClear()
-    toast.warning.mockClear()
 })
 
 const tapVersion = (times: number) => {
@@ -55,23 +53,14 @@ describe('AboutView', () => {
         expect(toast.info).toHaveBeenCalledWith('Beta updates switch revealed below.')
     })
 
-    // The card renders nothing on the web and outside the cohort, so without a
-    // toast the fifth tap would look like the gesture is simply broken.
+    // The card renders nothing on the web, so without a toast the fifth tap
+    // would look like the gesture is simply broken.
     it('says the switch is app-only when tapped on the web', () => {
         access.supported = false
-        access.visible = false
         render(<AboutView appVersion="1.2.3" />)
         tapVersion(5)
         expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
         expect(toast.info).toHaveBeenCalledWith('Beta updates are only available in the Peanut app.')
-    })
-
-    it('says beta is not enabled when the device is outside the cohort', () => {
-        access.visible = false
-        render(<AboutView appVersion="1.2.3" />)
-        tapVersion(5)
-        expect(screen.queryByTestId('beta-updates-card')).not.toBeInTheDocument()
-        expect(toast.warning).toHaveBeenCalledWith("Beta updates aren't enabled for this device.")
     })
 
     it('forgets a partial tap streak once the window lapses', () => {

--- a/src/constants/badges.consts.ts
+++ b/src/constants/badges.consts.ts
@@ -1,0 +1,12 @@
+/**
+ * The badge that records a device's owner as having found the five-tap beta
+ * switch on the About screen. The OTA card reads it back as permission to join
+ * the `staging` channel — a record of who opted in and a handle to revoke it,
+ * NOT an access boundary: anyone who performs the gesture awards it to
+ * themselves. Capgo's channel self-assignment setting is the real boundary.
+ *
+ * It is never rendered. It says "team" and is handed out on a gesture, so
+ * showing it beside earned badges would let any customer wear Peanut staff
+ * colours in a payments app.
+ */
+export const PEANUT_TEAM_BADGE = 'PEANUT_TEAM'

--- a/src/hooks/__tests__/useKnownPeanutDevice.test.ts
+++ b/src/hooks/__tests__/useKnownPeanutDevice.test.ts
@@ -1,0 +1,69 @@
+/**
+ * useKnownPeanutDevice — "this device already belongs to a Peanut user"
+ *
+ * Two independent sources: the web passkey markers (cookie or a `webAuthnKey`
+ * inside any `<userId>:user-preferences` entry) and a stored native session.
+ * Either one is enough; the answer is null until both have been consulted.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+
+let mockHasNativeSession = false
+jest.mock('@/utils/auth-token', () => ({
+    hasNativeSession: () => Promise.resolve(mockHasNativeSession),
+}))
+
+import { useKnownPeanutDevice } from '../useKnownPeanutDevice'
+
+function clearCookies() {
+    document.cookie.split(';').forEach((entry) => {
+        const name = entry.trim().split('=')[0]
+        if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+    })
+}
+
+beforeEach(() => {
+    mockHasNativeSession = false
+    localStorage.clear()
+    clearCookies()
+})
+
+test('starts null, then resolves — the reads cannot run during SSR or hydration', async () => {
+    const { result } = renderHook(() => useKnownPeanutDevice())
+
+    expect(result.current).toBeNull()
+    await waitFor(() => expect(result.current).toBe(false))
+})
+
+test('the passkey cookie marks the device known', async () => {
+    document.cookie = 'web-authn-key=some-key'
+
+    const { result } = renderHook(() => useKnownPeanutDevice())
+
+    await waitFor(() => expect(result.current).toBe(true))
+})
+
+test('a webAuthnKey in stored user preferences marks the device known', async () => {
+    localStorage.setItem('user-1:user-preferences', JSON.stringify({ webAuthnKey: { authenticatorId: 'a' } }))
+
+    const { result } = renderHook(() => useKnownPeanutDevice())
+
+    await waitFor(() => expect(result.current).toBe(true))
+})
+
+test('user preferences without a webAuthnKey are not evidence of registration', async () => {
+    // logout strips the key but leaves the entry behind
+    localStorage.setItem('user-1:user-preferences', JSON.stringify({ balanceHidden: true }))
+
+    const { result } = renderHook(() => useKnownPeanutDevice())
+
+    await waitFor(() => expect(result.current).toBe(false))
+})
+
+test('a stored native session marks the device known without any web marker', async () => {
+    // the WebView case: the passkey cookie is cross-origin-empty there
+    mockHasNativeSession = true
+
+    const { result } = renderHook(() => useKnownPeanutDevice())
+
+    await waitFor(() => expect(result.current).toBe(true))
+})

--- a/src/hooks/useKnownPeanutDevice.ts
+++ b/src/hooks/useKnownPeanutDevice.ts
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { hasKnownDeviceCredentials } from '@/components/Setup/setup-entry'
+import { hasNativeSession } from '@/utils/auth-token'
+
+/**
+ * Whether this device already belongs to a Peanut user, with no live session
+ * required: passkey credentials from an earlier registration (the web markers)
+ * or a stored native session (the only branch that is reliable in the WebView,
+ * where the passkey cookie is cross-origin-empty).
+ *
+ * `null` until the reads land — they touch document/localStorage and Capacitor
+ * Preferences, so none of them can run during SSR or the hydration render.
+ *
+ * An explicit logout clears both signals, by design: that device goes back to
+ * being anonymous until someone registers or logs in on it again.
+ */
+export function useKnownPeanutDevice(): boolean | null {
+    const [knownDevice, setKnownDevice] = useState<boolean | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+
+        const resolve = async () => {
+            const known = hasKnownDeviceCredentials() || (await hasNativeSession())
+            if (!cancelled) setKnownDevice(known)
+        }
+        void resolve()
+
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    return knownDevice
+}

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -556,7 +556,7 @@
                 "leftOverride": "This device was put on beta from the Capgo dashboard, so the app cannot take it off. Ask an admin to remove the device's channel override.",
                 "leftUnconfirmed": "Could not reach Capgo to confirm the switch, so this device is still on the beta build. Try again when you are back online.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
-                "notEligible": "Beta updates are limited to internal testers. Ask an admin to add this account to the beta cohort.",
+                "notEligible": "Beta updates are not enabled for this account yet. Tap the version number five times again to retry.",
                 "failed": "Could not change the update channel.",
                 "revealed": "Beta updates switch revealed below.",
                 "appOnly": "Beta updates are only available in the Peanut app."

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -558,7 +558,6 @@
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
                 "failed": "Could not change the update channel.",
                 "revealed": "Beta updates switch revealed below.",
-                "notEnabled": "Beta updates aren't enabled for this device.",
                 "appOnly": "Beta updates are only available in the Peanut app."
             }
         }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -556,6 +556,7 @@
                 "leftOverride": "This device was put on beta from the Capgo dashboard, so the app cannot take it off. Ask an admin to remove the device's channel override.",
                 "leftUnconfirmed": "Could not reach Capgo to confirm the switch, so this device is still on the beta build. Try again when you are back online.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
+                "notEligible": "Beta updates are limited to internal testers. Ask an admin to add this account to the beta cohort.",
                 "failed": "Could not change the update channel.",
                 "revealed": "Beta updates switch revealed below.",
                 "appOnly": "Beta updates are only available in the Peanut app."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -556,6 +556,7 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
+                "notEligible": "Las actualizaciones beta son solo para testers internos. Pedile a un administrador que agregue esta cuenta al grupo de beta.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -556,7 +556,7 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
-                "notEligible": "Las actualizaciones beta son solo para testers internos. Pedile a un administrador que agregue esta cuenta al grupo de beta.",
+                "notEligible": "Las actualizaciones beta todavía no están habilitadas para esta cuenta. Toca cinco veces el número de versión para reintentar.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -558,7 +558,6 @@
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
-                "notEnabled": "Las actualizaciones beta no están habilitadas para este dispositivo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."
             }
         }

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -347,7 +347,7 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
-                "notEligible": "Las actualizaciones beta son solo para testers internos. Pedile a un administrador que agregue esta cuenta al grupo de beta.",
+                "notEligible": "Las actualizaciones beta todavía no están habilitadas para esta cuenta. Tocá cinco veces el número de versión para reintentar.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -349,7 +349,6 @@
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
-                "notEnabled": "Las actualizaciones beta no están habilitadas para este dispositivo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."
             }
         }

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -347,6 +347,7 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
+                "notEligible": "Las actualizaciones beta son solo para testers internos. Pedile a un administrador que agregue esta cuenta al grupo de beta.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -556,7 +556,7 @@
                 "leftOverride": "Este aparelho foi colocado em beta pelo painel do Capgo, então o app não consegue tirá-lo. Peça a um administrador para remover a atribuição de canal do aparelho.",
                 "leftUnconfirmed": "Não foi possível falar com o Capgo para confirmar a mudança, então este aparelho continua na versão beta. Tente de novo quando estiver online.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
-                "notEligible": "As atualizações beta são apenas para testadores internos. Peça a um administrador para adicionar esta conta ao grupo de beta.",
+                "notEligible": "As atualizações beta ainda não estão habilitadas para esta conta. Toque cinco vezes no número da versão para tentar de novo.",
                 "failed": "Não foi possível alterar o canal de atualizações.",
                 "revealed": "O interruptor de atualizações beta está visível abaixo.",
                 "appOnly": "As atualizações beta só estão disponíveis no app do Peanut."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -556,6 +556,7 @@
                 "leftOverride": "Este aparelho foi colocado em beta pelo painel do Capgo, então o app não consegue tirá-lo. Peça a um administrador para remover a atribuição de canal do aparelho.",
                 "leftUnconfirmed": "Não foi possível falar com o Capgo para confirmar a mudança, então este aparelho continua na versão beta. Tente de novo quando estiver online.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
+                "notEligible": "As atualizações beta são apenas para testadores internos. Peça a um administrador para adicionar esta conta ao grupo de beta.",
                 "failed": "Não foi possível alterar o canal de atualizações.",
                 "revealed": "O interruptor de atualizações beta está visível abaixo.",
                 "appOnly": "As atualizações beta só estão disponíveis no app do Peanut."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -558,7 +558,6 @@
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
                 "failed": "Não foi possível alterar o canal de atualizações.",
                 "revealed": "O interruptor de atualizações beta está visível abaixo.",
-                "notEnabled": "As atualizações beta não estão ativadas para este dispositivo.",
                 "appOnly": "As atualizações beta só estão disponíveis no app do Peanut."
             }
         }

--- a/src/services/peanut-team-badge.ts
+++ b/src/services/peanut-team-badge.ts
@@ -1,0 +1,16 @@
+import { serverFetch } from '@/utils/api-fetch'
+
+/**
+ * Records the tap. Idempotent server-side, and deliberately quiet: a failure
+ * here costs the tester nothing they can act on, and the switch reveals itself
+ * either way — the join is what needs the badge, and that is checked against
+ * the freshly refetched user.
+ */
+export async function claimPeanutTeamBadge(): Promise<boolean> {
+    try {
+        const response = await serverFetch('/badge/team', { method: 'POST', body: JSON.stringify({}) })
+        return response.ok
+    } catch {
+        return false
+    }
+}

--- a/src/types/badge-assets.json
+++ b/src/types/badge-assets.json
@@ -39,6 +39,7 @@
         "OFFRAMP_USER": "/badges/offramp_user.png",
         "OG_2025_10_12": "/badges/og_v1.svg",
         "PEANUT_SHAPER": "/badges/peanut_shaper.png",
+        "PEANUT_TEAM": "/badges/peanut_team.svg",
         "PRODUCT_HUNT": "/badges/product_hunt.svg",
         "PSYOPS_DIVISION": "/badges/psyops_division.svg",
         "SECOND_INVITE": "/badges/second_invite.svg",


### PR DESCRIPTION
## Why

Three fixes found while investigating native "trouble reaching Peanut" reports.

1. **OTA beta switch never appeared, and the gate it hid behind was the wrong shape.** The five-tap switch was gated on a `beta-ota-channel` PostHog flag that was never created, so `isFeatureEnabled` returned false on every prod device — the switch stayed hidden and no device could self-assign to the Capgo `staging` channel. Gating the whole reveal is what made a missing flag invisible; eligibility belongs on the join.
2. **Receive screen offered non-Peanut rails to people who already have Peanut.** The claim/receive screen showed bank / mercadopago / pix / exchange-wallet options beside the Peanut button, including to recipients whose device we can already identify as a Peanut user's.
3. **Claim screen stuck on "Processing".** A user got the "claimed" push notification while the screen kept spinning: the backend marks the SendLink `CLAIMED` and sends the notification before the on-chain `claim.txHash` projects, but the UI only settled once the poll observed that hash.

## What

**1. OTA beta switch: the gesture earns a badge, and the badge gates the join** (`6a1e1488` → `a3a3f3294` → `11ef89b57`)
- The old gate hid the whole switch behind a `beta-ota-channel` PostHog flag that was never created, so `isFeatureEnabled` returned false on every prod device: invisible to its own testers, and indistinguishable from exclusion.
- The fifth tap now claims `PEANUT_TEAM` and refetches the user before revealing the card; the card reads that badge as permission to join. No dashboard step to forget — the record is created by the act of tapping.
- The badge gates **joining** only. The card renders on any native build, and the off switch stays live whether or not the badge is held, so revoking someone mid-beta cannot strand them on beta code.
- A failed claim still reveals the card, with copy telling the tester to tap again.
- **The badge is a record and a revoke handle, not an access boundary** — anyone who performs the gesture awards it to themselves; Capgo's channel self-assignment setting remains the real one. It buys a list of who opted in and a way to take it back.
- Never rendered: excluded from the profile badge row, the home feed, and the celebration toast. It says "team" and is handed out on a gesture, so showing it would let any customer wear Peanut staff colours in a payments app.
- **Depends on [peanut-api-ts#1518](https://github.com/peanutprotocol/peanut-api-ts/pull/1518)** (`POST /badge/team`), which must deploy first. (TASK-22248)

**2. Peanut-only receive screen for recognised users** (`d0943dd2`, revised in `f687f9c01`)
- The alternate rails now render only for a recipient we cannot identify as a Peanut user. Recognition = a live session, passkey credentials from an earlier registration (`hasKnownDeviceCredentials`), or a stored native session (`hasNativeSession` — the only branch that fires in the WebView, where the passkey cookie is cross-origin-empty).
- A recipient **without** a Peanut account keeps every rail, so the published "claim to SEPA/ACH without a Peanut account" flow is unchanged and no product-source update is needed.
- Recognition resolves in the new `useKnownPeanutDevice` hook after mount (both reads touch storage — neither can run during SSR or hydration). The unresolved tick counts as recognised and the geo spinner moved inside the rail block, so the Peanut button paints once and nothing is offered then withdrawn.
- Guest "Continue with Peanut" button and the devconnect event flow are untouched.

**3. Settle the claim screen on CLAIMED** (`927c18cd`)
- Treat `status === CLAIMED` as terminal success — the same point the backend marks the claim done and notifies — with or without the `txHash`.
- The poll reports the hash when present, `null` when it has yet to project; the success view tracks a `claimConfirmed` flag instead of gating on the hash. FAILED/CANCELLED and the give-up fallback are unchanged.

## Tests

- `useClaimSuccessPolling`: updated the CLAIMED-without-hash case to settle instead of poll on; other cadence/failure/ceiling tests unchanged.
- `SuccessClaimLinkView`: added a case for CLAIMED-without-hash rendering the success card.
- `useKnownPeanutDevice`: new suite — null before the reads land, each credential source in isolation, and a stripped `webAuthnKey` (post-logout) reading as unknown.
- `SendLinkActionList`: new `who gets the alternate rails` block (unrecognised keeps every rail, logged-in and known-device get Peanut only, nothing shown while recognition is unresolved). The rail tests skipped in `d0943dd2` are un-skipped and green.
- `BetaUpdatesCard`: four badge-gating cases — an account without the badge cannot join, is told why, a device already on beta can still leave after the badge is revoked, and a badge-holding account sees no eligibility copy.
- `About.view`: the tap earns the badge and refetches before revealing; a failed claim still reveals the card; a web tap earns nothing.
- Local gate: prettier clean, changed files typecheck-clean, affected suites pass.

## Notes / risks

- **Money surface.** #2 removes bank/mercadopago/exchange as claim destinations *for recognised Peanut users only* — a logged-in recipient claims into Peanut and withdraws from the app. Recipients with no account are unaffected. An explicit logout clears both credential signals, so that device falls back to the full rail list; passive session expiry does not. #3 changes when a claim reads as "success" — verified against `peanut-api-ts`: `SendLink.status` is set to `CLAIMED` and `processPostClaim` (which sends the push) run together, after the claim tx is handled; the failure path writes `FAILED` via `rollbackClaimOnError`.
- The `claimed` push is sent to the **sender**; the claimer's screen now settles on the same `CLAIMED` moment, so both track one signal.
- Follow-up for backend (not in this PR): `processPostClaim` awaits the receipt but does not flip `FAILED` on a revert, so a revert-after-CLAIMED would show success in both the notification and now the UI.
