### PR TITLE
fix(receipt): remove issued-on date from PDF receipt footer

### DIFF
--- a/src/app/receipt/[entryId]/pdf/ReceiptPdfDocument.tsx
+++ b/src/app/receipt/[entryId]/pdf/ReceiptPdfDocument.tsx
@@ -153,10 +153,6 @@ export function ReceiptPdfDocument({ model }: { model: ReceiptPdfModel }) {
                         <Text style={styles.footerLabel}>{model.referenceLabel}</Text>
                         <Text style={styles.footerValue}>{breakableIdentifier(model.reference)}</Text>
                     </View>
-                    <View style={styles.footerRow}>
-                        <Text style={styles.footerLabel}>{model.issuedOnLabel}</Text>
-                        <Text style={styles.footerValue}>{model.issuedOn}</Text>
-                    </View>
                     <Text style={styles.site}>{`${model.issuedBy} - https://peanut.me`}</Text>
                 </View>
             </Page>

--- a/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-model.test.ts
+++ b/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-model.test.ts
@@ -72,9 +72,6 @@ describe('buildReceiptPdfModel — completed bank withdraw', () => {
         expect(model.issuedBy).toBe('transaction.officialReceipt.issuedBy')
         expect(model.site).toBe('peanut.me')
         expect(model.reference).toBe(baseTx.id)
-        // settlement timestamp beats creation for the issue date
-        expect(model.issuedOn).toContain('2026')
-        expect(model.issuedOn).toContain('15:22')
         expect(model.fileName).toBe(`peanut-receipt-${baseTx.id}.pdf`)
     })
 

--- a/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-render.test.ts
+++ b/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-render.test.ts
@@ -22,7 +22,7 @@ const model: ReceiptPdfModel = {
         { label: 'Completed', value: 'August 20, 2026 - 15:22 UTC' },
         { label: 'Exchange rate', value: '1 USD = ARS 902.4' },
         { label: 'Fee', value: '0.5' },
-        { label: 'TX ID', value: '0x74a9c1e9c1f5f3ab8a7e2ac5c250aabbccddeeff00112233445566778899aabb' },
+        { label: 'Transaction ID', value: '0x74a9c1e9c1f5f3ab8a7e2ac5c250aabbccddeeff00112233445566778899aabb' },
         { label: 'IBAN', value: 'ES91 **** **** **** **** 1332' },
     ],
     referenceLabel: 'Receipt reference',

--- a/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-render.test.ts
+++ b/src/app/receipt/[entryId]/pdf/__tests__/receipt-pdf-render.test.ts
@@ -27,8 +27,6 @@ const model: ReceiptPdfModel = {
     ],
     referenceLabel: 'Receipt reference',
     reference: 'A3F5C250-1234-4ABC-8DEF-9012AA34BB56',
-    issuedOnLabel: 'Issued on',
-    issuedOn: 'August 20, 2026 - 15:22 UTC',
     fileName: 'peanut-receipt-a3f5c250.pdf',
 }
 

--- a/src/app/receipt/[entryId]/pdf/receipt-pdf-model.ts
+++ b/src/app/receipt/[entryId]/pdf/receipt-pdf-model.ts
@@ -31,8 +31,6 @@ export interface ReceiptPdfModel {
     rows: ReceiptPdfRow[]
     referenceLabel: string
     reference: string
-    issuedOnLabel: string
-    issuedOn: string
     fileName: string
 }
 
@@ -215,9 +213,6 @@ export function buildReceiptPdfModel(
     const numericAmount = Number(transaction.amount)
     const safeAmount = isNaN(numericAmount) ? 0 : Math.abs(numericAmount)
 
-    // Same issue-date preference as the receipt footer: settlement, else creation.
-    const issuedAtSource = transaction.completedAt ?? transaction.claimedAt ?? transaction.createdAt ?? transaction.date
-
     return {
         title: t('transaction.officialReceipt.pdf.title'),
         issuedBy: t('transaction.officialReceipt.issuedBy'),
@@ -228,8 +223,6 @@ export function buildReceiptPdfModel(
         rows,
         referenceLabel: t('transaction.officialReceipt.reference'),
         reference: transaction.id,
-        issuedOnLabel: t('transaction.officialReceipt.issuedOn'),
-        issuedOn: formatDate(issuedAtSource, locale),
         fileName: `peanut-receipt-${safeFileNamePart(transaction.id)}.pdf`,
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2069,7 +2069,7 @@
             "tokenAmount": "Token amount",
             "tokenAndNetwork": "Token and network",
             "tokenOnChain": "{token} on {chain}",
-            "txId": "TX ID",
+            "txId": "Transaction ID",
             "fee": "Fee",
             "transferId": "Transfer ID",
             "pointsEarned": "Points earned",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2069,7 +2069,7 @@
             "tokenAmount": "Monto del token",
             "tokenAndNetwork": "Token y red",
             "tokenOnChain": "{token} en {chain}",
-            "txId": "ID de TX",
+            "txId": "ID de transacción",
             "fee": "Comisión",
             "transferId": "ID de transferencia",
             "pointsEarned": "Puntos ganados",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2069,7 +2069,7 @@
             "tokenAmount": "Valor do token",
             "tokenAndNetwork": "Token e rede",
             "tokenOnChain": "{token} na {chain}",
-            "txId": "ID da TX",
+            "txId": "ID da transação",
             "fee": "Taxa",
             "transferId": "ID da transferência",
             "pointsEarned": "Pontos ganhos",


### PR DESCRIPTION
## Summary
- Removes the "Issued on" label/date row from the bottom of the downloadable PDF receipt footer
- Drops the now-unused `issuedOn`/`issuedOnLabel` fields from `ReceiptPdfModel` and their construction

## Test plan
- [x] `npx jest src/app/receipt/[entryId]/pdf/__tests__/` — 29 tests pass
- [x] `npx tsc --noEmit` clean for the touched files
