### PR TITLE
fix(ota): quit instead of deadlocking the restart on affected Android binaries

### DIFF
--- a/src/context/OtaUpdateContext.tsx
+++ b/src/context/OtaUpdateContext.tsx
@@ -90,6 +90,33 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
         if (!pendingBundle || applyingRef.current || applyState === 'manual-restart') return
         applyingRef.current = true
         setApplyState('applying')
+
+        let updater: typeof import('@/utils/capgo-updater')
+        try {
+            updater = await import('@/utils/capgo-updater')
+        } catch (err) {
+            console.warn('[capgo] updater chunk failed to load:', err)
+            applyingRef.current = false
+            setApplyState('failed')
+            return
+        }
+
+        // Binaries whose plugin deadlocks on an in-place restart (see
+        // canRestartInPlace) can only quit. next() already staged the bundle, so
+        // relaunching applies it — and the state is set BEFORE the exit, so an
+        // exitApp that fails leaves the instruction on screen rather than a spinner.
+        if (!(await updater.canRestartInPlace())) {
+            updater.markPendingApply(pendingBundle.id)
+            setApplyState('manual-restart')
+            try {
+                const { App } = await import('@capacitor/app')
+                await App.exitApp()
+            } catch (err) {
+                console.warn('[capgo] exitApp failed:', err)
+            }
+            return
+        }
+
         const armWatchdog = () => {
             clearTimeout(fallbackTimer.current)
             fallbackTimer.current = setTimeout(() => {
@@ -116,8 +143,7 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
         armWatchdog()
         let outcome: OtaApplyOutcome = 'failed'
         try {
-            const { applyStagedBundle } = await import('@/utils/capgo-updater')
-            outcome = await applyStagedBundle(pendingBundle.id, {
+            outcome = await updater.applyStagedBundle(pendingBundle.id, {
                 onSetRejected: () => clearTimeout(fallbackTimer.current),
                 onRestaged: (bundle) => setPendingBundle(bundle),
             })

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -21,6 +21,7 @@ const mockUpdater = {
     reload: jest.fn().mockResolvedValue(undefined),
     current: jest.fn().mockResolvedValue({ bundle: { id: 'builtin' } }),
     getNextBundle: jest.fn(),
+    getPluginVersion: jest.fn(),
 }
 const mockExitApp = jest.fn().mockResolvedValue(undefined)
 const platform = { android: true, capacitor: true }
@@ -54,6 +55,9 @@ beforeEach(() => {
     mockUpdater.getNextBundle.mockResolvedValue(null)
     mockUpdater.getLatest.mockReset().mockRejectedValue(new Error('no_new_version_available'))
     mockUpdater.current.mockResolvedValue({ bundle: { id: 'builtin' } })
+    // A binary whose plugin restarts in place without deadlocking, so the
+    // existing cases still exercise the set() path.
+    mockUpdater.getPluginVersion.mockReset().mockResolvedValue({ version: '8.51.15' })
     warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
     error = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -106,6 +110,68 @@ it('applyNow records the marker and hands the bundle to set()', async () => {
     })
     expect(mockUpdater.reload).not.toHaveBeenCalled()
     expect(mockExitApp).toHaveBeenCalled()
+})
+
+describe('Android binaries whose plugin deadlocks on an in-place restart', () => {
+    // Capgo < 8.46.0 runs set() inline on Capacitor's single plugin thread and
+    // blocks it waiting for notifyAppReady(), which is queued behind it there —
+    // the page reloads onto a blank screen for 30 s and the bundle is rolled
+    // back. Those binaries must quit instead; next() already staged the bundle.
+    beforeEach(() => {
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.45.9' })
+    })
+
+    it('quits instead of calling set(), keeping the marker on the staged bundle', async () => {
+        const { result } = await withStagedBundle()
+        await act(async () => {
+            await result.current.applyNow()
+        })
+        expect(mockUpdater.set).not.toHaveBeenCalled()
+        expect(mockExitApp).toHaveBeenCalled()
+        expect(window.localStorage.getItem('capgoPendingApply')).toBe('b-2')
+        expect(result.current.applyState).toBe('manual-restart')
+    })
+
+    it('leaves the close-and-reopen instruction up when the exit fails', async () => {
+        mockExitApp.mockRejectedValueOnce(new Error('exitApp unavailable'))
+        const { result } = await withStagedBundle()
+        await act(async () => {
+            await result.current.applyNow()
+        })
+        expect(result.current.applyState).toBe('manual-restart')
+    })
+
+    it('arms no watchdog, so a user who never reopens is not exited twice', async () => {
+        const { result } = await withStagedBundle()
+        await act(async () => {
+            await result.current.applyNow()
+        })
+        mockExitApp.mockClear()
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(3_000)
+        })
+        expect(mockExitApp).not.toHaveBeenCalled()
+    })
+
+    it('treats an unreadable plugin version as deadlocking rather than risking the bundle', async () => {
+        mockUpdater.getPluginVersion.mockRejectedValue(new Error('not implemented'))
+        const { result } = await withStagedBundle()
+        await act(async () => {
+            await result.current.applyNow()
+        })
+        expect(mockUpdater.set).not.toHaveBeenCalled()
+        expect(mockExitApp).toHaveBeenCalled()
+    })
+
+    it('still restarts in place on iOS, where the plugin does not block the caller', async () => {
+        platform.android = false
+        const { result } = await withStagedBundle()
+        act(() => {
+            void result.current.applyNow()
+        })
+        await waitFor(() => expect(mockUpdater.set).toHaveBeenCalledWith({ id: 'b-2' }))
+        expect(mockExitApp).not.toHaveBeenCalled()
+    })
 })
 
 it('re-stages and reloads when set() rejects, then closes the app on Android', async () => {

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -15,12 +15,18 @@ const mockUpdater = {
     getChannel: jest.fn(),
     current: jest.fn(),
     reset: jest.fn().mockResolvedValue(undefined),
+    getPluginVersion: jest.fn(),
 }
+const mockPlatform = { android: true }
 
 jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
 jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+jest.mock('@/utils/capacitor', () => ({
+    ...jest.requireActual('@/utils/capacitor'),
+    isAndroidNativeBridge: () => mockPlatform.android,
+}))
 
-import { initCapgoUpdater } from '../capgo-updater'
+import { canRestartInPlace, initCapgoUpdater } from '../capgo-updater'
 
 let info: jest.SpyInstance
 let error: jest.SpyInstance
@@ -28,6 +34,8 @@ let error: jest.SpyInstance
 beforeEach(() => {
     jest.useFakeTimers()
     window.localStorage.clear()
+    mockPlatform.android = true
+    mockUpdater.getPluginVersion.mockReset()
     info = jest.spyOn(console, 'info').mockImplementation(() => {})
     error = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -368,5 +376,46 @@ describe('beta channel opt-in', () => {
         const { leaveBetaOtaChannel } = await import('../capgo-updater')
         mockUpdater.reset.mockRejectedValueOnce(new Error('reset failed')).mockResolvedValueOnce(undefined)
         await expect(leaveBetaOtaChannel()).resolves.toBeUndefined()
+    })
+})
+
+describe('canRestartInPlace', () => {
+    /*
+     * Capgo < 8.46.0 runs set() inline on Capacitor Android's single plugin
+     * thread and blocks it there waiting for notifyAppReady(), which is queued
+     * behind it — the restart deadlocks on a blank page until Capgo rolls the
+     * bundle back. The check reads the NATIVE plugin version because this JS is
+     * shipped over the air onto binaries built months apart.
+     */
+    it('refuses an in-place restart on the deadlocking Android plugin', async () => {
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.45.9' })
+        await expect(canRestartInPlace()).resolves.toBe(false)
+    })
+
+    it('allows it from the version that moved set() off the plugin thread', async () => {
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.46.0' })
+        await expect(canRestartInPlace()).resolves.toBe(true)
+    })
+
+    it('compares versions numerically, not lexically', async () => {
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.5.0' })
+        await expect(canRestartInPlace()).resolves.toBe(false)
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.51.15' })
+        await expect(canRestartInPlace()).resolves.toBe(true)
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '9.0.0' })
+        await expect(canRestartInPlace()).resolves.toBe(true)
+    })
+
+    it('fails closed on a version it cannot read', async () => {
+        mockUpdater.getPluginVersion.mockRejectedValue(new Error('not implemented'))
+        await expect(canRestartInPlace()).resolves.toBe(false)
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: 'unknown' })
+        await expect(canRestartInPlace()).resolves.toBe(false)
+    })
+
+    it('never asks on iOS, where the plugin does not block the caller', async () => {
+        mockPlatform.android = false
+        await expect(canRestartInPlace()).resolves.toBe(true)
+        expect(mockUpdater.getPluginVersion).not.toHaveBeenCalled()
     })
 })

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -2,6 +2,7 @@
 // only imported when isCapacitor() is true — uses dynamic import in the hook.
 
 import type { BundleInfo, CapacitorUpdaterPlugin } from '@capgo/capacitor-updater'
+import { isAndroidNativeBridge } from '@/utils/capacitor'
 import { isDemoMode } from '@/utils/demo'
 import { readStoredValue, removeStoredValue, writeStoredValue } from '@/utils/safe-storage'
 
@@ -161,6 +162,52 @@ function isNewerBinaryRejection(message: string): boolean {
 // gone, no index.html) re-stages through the normal check and reloads.
 const PENDING_APPLY_KEY = 'capgoPendingApply'
 
+export function markPendingApply(bundleId: string): void {
+    writeStoredValue(PENDING_APPLY_KEY, bundleId)
+}
+
+/*
+ * Capacitor Android runs every plugin call on one shared handler thread
+ * (Bridge.callPluginMethod -> taskHandler.post). Before plugin 8.46.0, set()
+ * ran inline on that thread and blocked there in _reload() for up to 30 s
+ * waiting for notifyAppReady() — a plugin call queued behind it on the SAME
+ * thread, so it could never arrive. The reloaded page therefore sat blank
+ * (every plugin call it made was stuck in that queue too) until Capgo gave up
+ * and rolled the bundle back. 8.46.0 wraps set()/reload() in startNewThread().
+ *
+ * The version is read from the plugin, not from package.json: this JS ships
+ * over the air onto binaries built months apart, and only the native half of
+ * the pair decides whether an in-place restart deadlocks.
+ */
+const THREADED_SET_MIN_PLUGIN_VERSION = [8, 46, 0]
+
+function meetsMinimum(version: string, minimum: number[]): boolean {
+    const parts = version.split('.').map((part) => Number.parseInt(part, 10))
+    if (parts.length < minimum.length || parts.some(Number.isNaN)) return false
+    for (const [index, floor] of minimum.entries()) {
+        if (parts[index] !== floor) return parts[index] > floor
+    }
+    return true
+}
+
+/**
+ * Whether this binary can apply a staged bundle by reloading in place. False
+ * only on the Android binaries whose plugin deadlocks; those have to quit and
+ * relaunch instead, which applies the bundle next() already staged.
+ */
+export async function canRestartInPlace(): Promise<boolean> {
+    if (!isAndroidNativeBridge()) return true
+    try {
+        const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+        const { version } = await CapacitorUpdater.getPluginVersion()
+        return meetsMinimum(version, THREADED_SET_MIN_PLUGIN_VERSION)
+    } catch {
+        // A version we cannot read is treated as the deadlocking one: quitting
+        // costs a relaunch, an in-place restart that hangs costs the bundle.
+        return false
+    }
+}
+
 /**
  * Whether the page was actually handed over to the plugin. `reloading` is the
  * only outcome a restart watchdog may act on: everything else means the app
@@ -173,7 +220,7 @@ export async function applyStagedBundle(
     hooks: { onSetRejected?: () => void; onRestaged?: (bundle: BundleInfo) => void } = {}
 ): Promise<OtaApplyOutcome> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
-    writeStoredValue(PENDING_APPLY_KEY, bundleId)
+    markPendingApply(bundleId)
     const abandon = (reason: string, err: unknown): OtaApplyOutcome => {
         console.warn(`[capgo] ${reason}:`, err instanceof Error ? err.message : String(err ?? ''))
         // The marker is the next launch's evidence that an apply was attempted


### PR DESCRIPTION
## The bug

Tapping **Restart now** on the "Update ready" modal white-screens the app on Android, then rolls the bundle back. Sentry, on a real device an hour before this was written:

```
[capgo-apply] restart did not apply bundle 45oZASTyb6; running builtin
```

— [PEANUT-UI-T0Q](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-T0Q) (SM-S928B, Android 16). That marker is written only by `applyStagedBundle`, so it pins the failure to the button rather than to the plugin's own update path.

## Root cause

Capacitor Android dispatches **every** `@PluginMethod` onto one shared `CapacitorPlugins` HandlerThread (`Bridge.callPluginMethod` → `taskHandler.post`, `Bridge.java:854`).

In `@capgo/capacitor-updater@8.45.9` — the version pinned in `pnpm-lock.yaml` and therefore compiled into every shipped binary — `set()` runs **inline** on that thread and blocks in `_reload()` → `semaphoreWait(phase, resolveAppReadyCheckTimeoutMs())`. For a freshly-set PENDING bundle that timeout is `max(appReadyTimeout, 30_000)` = **30 s**.

`notifyAppReady()` is itself a `@PluginMethod`, so the reloaded page's call is queued *behind* the blocked `set()` on the same thread. It can never arrive.

That explains all three observations:

- **White screen.** The WebView does load the new bundle (the `loadUrl` is posted to the main thread), but every plugin call the booting page makes is stuck in the same queue — `RootRedirect` awaits `hasNativeSession()` → `Preferences.get` and renders `null` until it resolves.
- **Rollback.** At 30 s the wait times out, Capgo marks the bundle failed and reverts to builtin.
- **The watchdog didn't help.** `App.exitApp()` is also a plugin call, also queued behind the blocked `set()`.

Capgo fixed it in **8.46.0** by wrapping `set()`/`reload()` in `startNewThread(...)`. Verified against the published tarballs: 8.45.9 has the inline call, 8.46.0 → 8.51.15 do not.

iOS is unaffected — its `_reload()` returns without waiting on the semaphore.

## Scope: only the manual restart is affected

The plugin's own apply path — `installNext()`, which activates a `next()`-staged bundle when the app is backgrounded — already wraps `set()`/`_reload()` in `startNewThread(...)` even in 8.45.9, so it never contends for the plugin thread. Bundles therefore still land on their own, which is why the fleet has kept moving and why this PR can reach devices over the air at all. Only `set()` invoked *from JS* deadlocks.

Unrelated and still open: [`Update to bundle: 1.0.56 Failed!`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVE) / [`Semaphore timeout: null`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVF) / [`notifyAppReady was not called, roll back`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVT), a week earlier, are that background path timing out — a different failure with its own (unproven) suspect, a throttled background WebView not reaching `notifyAppReady` inside 30 s. Not addressed here.

## The change

`canRestartInPlace()` reads the **native** plugin version (`CapacitorUpdater.getPluginVersion()`) and, on Android below 8.46.0, `applyNow` skips `set()` entirely: it marks the pending-apply marker, shows the existing close-and-reopen copy, and calls `App.exitApp()`. `next()` has already staged the bundle, so the next launch applies it — the user taps the icon instead of watching a blank screen for 30 s and losing the update.

The version comes from the plugin rather than `package.json` on purpose: this JS ships over the air onto binaries built months apart, and only the native half of the pair decides whether the restart deadlocks. So the workaround **retires itself** on the first install that no longer needs it — no follow-up removal, no flag.

An unreadable version fails closed (quit rather than risk the bundle).

## Companion PR

#2961 bumps the plugin to 8.51.14. That half is a native change and cannot reach anyone over the air; this PR is the OTA-shippable half and fixes every Android install already in the field. Once a binary built off #2961 ships, `getPluginVersion()` reports 8.51.14 and this gate retires itself.

## Testing

`src/context/__tests__/OtaUpdateContext.test.tsx` and `src/utils/__tests__/capgo-updater.test.ts` — 66 passing. New coverage: the quit path keeps the marker on the staged bundle and arms no watchdog, a failed exit leaves the instruction on screen, an unreadable plugin version fails closed, iOS and 8.46.0+ still restart in place, and the version compare is numeric (8.5.0 < 8.46.0 < 8.51.15).

Not verifiable in a browser preview — the whole path is behind `isAndroidNativeBridge()` and the Capgo plugin.
