### PR TITLE
chore(native): capgo updater 8.51.14, so an in-place OTA restart stops deadlocking

### DIFF
--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -42,7 +42,7 @@ include ':capgo-capacitor-passkey'
 project(':capgo-capacitor-passkey').projectDir = new File('../node_modules/@capgo/capacitor-passkey/android')
 
 include ':capgo-capacitor-updater'
-project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.pnpm/@capgo+capacitor-updater@8.45.9_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater/android')
+project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.pnpm/@capgo+capacitor-updater@8.51.14_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater/android')
 
 include ':onesignal-capacitor-plugin'
 project(':onesignal-capacitor-plugin').projectDir = new File('../node_modules/@onesignal/capacitor-plugin/android')

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -33,7 +33,18 @@ const config: CapacitorConfig = {
             // foreground, which was hammering Capgo's cloud rate limit (429s in
             // Sentry). initCapgoUpdater() does one guarded check per launch instead.
             autoUpdate: false,
-            appReadyTimeout: 15000,
+            /*
+             * The budget for a reloaded bundle to call notifyAppReady() before
+             * the plugin rolls it back. 15 s was not a boot-speed allowance: an
+             * apply from appMovedToBackground() starts the clock while the app
+             * is going away, and the clock keeps running while the OS has the
+             * process frozen, so an SM-A505G on Android 11 missed it by 6 ms
+             * (PEANUT-UI-SVE). Android silently floors this at 30 s for a
+             * pending bundle; iOS applies it as written, which made iOS the
+             * tighter of the two. Binary change — takes effect on the next
+             * store release, not via OTA.
+             */
+            appReadyTimeout: 120000,
             /*
              * Stats OFF. From 8.46.0 the plugin injects a document-start script
              * that forwards every window error, unhandled rejection, CSP

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -34,6 +34,20 @@ const config: CapacitorConfig = {
             // Sentry). initCapgoUpdater() does one guarded check per launch instead.
             autoUpdate: false,
             appReadyTimeout: 15000,
+            /*
+             * Stats OFF. From 8.46.0 the plugin injects a document-start script
+             * that forwards every window error, unhandled rejection, CSP
+             * violation and failed resource to this endpoint — message, stack,
+             * source and location.href — keyed to its persistent device id, and
+             * autoUpdate:false does not gate it. In a wallet those strings carry
+             * claim hashes, API paths and error bodies, and none of it would pass
+             * through the redaction sentry.utils.ts applies to our own events.
+             * An empty url makes sendStats return before it builds a payload
+             * (verified in both native implementations), so nothing leaves the
+             * device. Cost: Capgo's dashboard adoption counters go dark — point
+             * this at a first-party endpoint if we want them back.
+             */
+            statsUrl: '',
             responseTimeout: 30,
             autoDeleteFailed: true,
             autoDeletePrevious: true,

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(name: "CapgoCapacitorCrisp", path: "../../../node_modules/.pnpm/@capgo+capacitor-crisp@8.0.27_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-crisp"),
         .package(name: "CapgoCapacitorNativeBiometric", path: "../../../node_modules/.pnpm/@capgo+capacitor-native-biometric@8.6.0_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-native-biometric"),
         .package(name: "CapgoCapacitorPasskey", path: "../../../node_modules/@capgo/capacitor-passkey"),
-        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.pnpm/@capgo+capacitor-updater@8.45.9_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater"),
+        .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.pnpm/@capgo+capacitor-updater@8.51.14_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater"),
         .package(name: "OnesignalCapacitorPlugin", path: "../../../node_modules/@onesignal/capacitor-plugin"),
         .package(name: "SumsubCordovaIdensicMobileSdkPlugin", path: "../../capacitor-cordova-ios-plugins/sources/SumsubCordovaIdensicMobileSdkPlugin")
     ],

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "@capgo/capacitor-crisp": "^8.0.27",
         "@capgo/capacitor-native-biometric": "8.6.0",
         "@capgo/capacitor-passkey": "^8.2.2",
-        "@capgo/capacitor-updater": "^8.45.9",
+        "@capgo/capacitor-updater": "8.51.14",
         "@headlessui/react": "^2.2.9",
         "@headlessui/tailwindcss": "^0.2.1",
         "@justaname.id/react": "0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@capacitor/core@8.2.0)
       '@capgo/capacitor-updater':
-        specifier: ^8.45.9
-        version: 8.45.9(@capacitor/core@8.2.0)
+        specifier: 8.51.14
+        version: 8.51.14(@capacitor/core@8.2.0)
       '@headlessui/react':
         specifier: ^2.2.9
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -680,8 +680,8 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
-  '@capgo/capacitor-updater@8.45.9':
-    resolution: {integrity: sha512-lAth8jMHXr8tsbq6//XEcKmaybiSqtM4tNny/Tw3AUobKhlScLNYx30/2RSiLAuCWKSOffu8eO8YmkLz8nFmKw==}
+  '@capgo/capacitor-updater@8.51.14':
+    resolution: {integrity: sha512-2x4xEiS9nv3KSviSYKGS94yrZFoi12GYtn5vwv90BsEv7zc2dDh+Imk/F5eWAsSu20sHx5TBq3Hu/8BtWUA9JQ==}
     peerDependencies:
       '@capacitor/core': ^8.0.0
 
@@ -8998,7 +8998,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.2.0
 
-  '@capgo/capacitor-updater@8.45.9(@capacitor/core@8.2.0)':
+  '@capgo/capacitor-updater@8.51.14(@capacitor/core@8.2.0)':
     dependencies:
       '@capacitor/core': 8.2.0
 
@@ -10194,7 +10194,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       lodash: 4.18.1
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10204,7 +10204,7 @@ snapshots:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@10.2.2)
-      semver: 7.7.3
+      semver: 7.8.5
       superstruct: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -10218,7 +10218,7 @@ snapshots:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@10.2.2)
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10232,7 +10232,7 @@ snapshots:
       '@types/debug': 4.1.12
       debug: 4.4.3(supports-color@10.2.2)
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10600,7 +10600,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
-      semver: 7.7.3
+      semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -10612,7 +10612,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
-      semver: 7.7.3
+      semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -10884,7 +10884,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.3
+      semver: 7.8.5
       tar-fs: 3.1.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -16312,7 +16312,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -17927,8 +17927,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.8.5:
-    optional: true
+  semver@7.8.5: {}
 
   serialize-javascript@7.0.5: {}
 


### PR DESCRIPTION
The native half of the OTA restart fix. Companion to #2960, which is the OTA-shippable half — this one only reaches devices through a store release.

## Why

`@capgo/capacitor-updater@8.45.9` makes an in-place OTA restart impossible on Android. Capacitor Android dispatches **every** `@PluginMethod` onto one shared `CapacitorPlugins` HandlerThread (`Bridge.callPluginMethod` → `taskHandler.post`, `Bridge.java:854`). In 8.45.9, `set()` runs inline on that thread and blocks in `_reload()` → `semaphoreWait(phase, resolveAppReadyCheckTimeoutMs())` — `max(appReadyTimeout, 30_000)` = 30 s for a freshly-set PENDING bundle — waiting for `notifyAppReady()`, which is itself a plugin call queued behind it on that same thread. It can never arrive.

So tapping **Restart now** reloaded onto a page whose every plugin call was stuck in the same queue (white screen), the wait timed out, and Capgo marked the bundle failed and reverted to builtin — [PEANUT-UI-T0Q](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-T0Q).

`8.46.0` fixed it by wrapping `set()` and `reload()` in `startNewThread(...)`. Verified against the published tarballs: 8.45.9 calls them inline, 8.46.0 → 8.51.15 do not. iOS was never affected — its `_reload()` returns without waiting on the semaphore.

## Scope: only the manual restart is affected

The plugin's own apply path — `installNext()`, which activates a `next()`-staged bundle when the app is backgrounded — already wraps `set()`/`_reload()` in `startNewThread(...)` even in 8.45.9, so it never contends for the plugin thread. Bundles therefore still land on their own, which is why the fleet has kept moving and why this PR can reach devices over the air at all. Only `set()` invoked *from JS* deadlocks.

Unrelated and still open: [`Update to bundle: 1.0.56 Failed!`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVE) / [`Semaphore timeout: null`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVF) / [`notifyAppReady was not called, roll back`](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-SVT), a week earlier, are that background path timing out — a different failure with its own (unproven) suspect, a throttled background WebView not reaching `notifyAppReady` inside 30 s. Not addressed here.

## Version choice

**8.51.14, pinned exactly.** Not caret-ranged: this is compiled into the binary, and `^8.51.14` resolves to 8.51.15, which was published 2026-08-28 and is still inside the 14-day supply-chain cooldown. 8.51.14 is the newest release that clears it, and matches how the other native plugins are pinned here (`@capacitor/android`, `@capgo/capacitor-native-biometric`).

Checked that every `CapacitorUpdater` config key `capacitor.config.ts` sets still exists in 8.51.14 — `autoUpdate`, `appReadyTimeout`, `responseTimeout`, `autoDeleteFailed`, `autoDeletePrevious`, `publicKey` (the E2E signing key, which would silently reject every bundle if it had moved).

## Self-retiring workaround

#2960 gates on the **native** plugin version via `CapacitorUpdater.getPluginVersion()`, which returns `8.51.14` here. The first binary built off this PR therefore restarts in place again with no further change — no flag to remove, no follow-up PR.

## Capgo stats turned off (Chip finding, addressed)

8.46.0 — the same release that fixed the deadlock — also added `WebViewStatsReporter`, a document-start script that forwards every `window` error, unhandled rejection, CSP violation and failed resource load to Capgo's stats endpoint: **message, stack, source and `location.href`**, keyed to the plugin's persistent device id. `autoUpdate: false` does not gate it.

I checked every published release from 8.46.0 through 8.51.14: **there is no version with the thread fix and without the reporter**, so the bump cannot dodge it by version choice.

In a wallet those strings are not neutral — claim hashes, API paths and error bodies all land in them (Sentry already shows `PATCH .../send-links/claim/0x45f2…` shaped messages), and none of it would pass through the redaction `sentry.utils.ts` applies to our own events.

So `statsUrl: ''` in `capacitor.config.ts`, the documented kill switch. Verified in both native implementations that `sendStats` returns *before* it builds a payload when the url is empty (`CapgoUpdater.java:2820`, `CapgoUpdater.swift:657`/`:3119`), so nothing leaves the device. The injected script still runs and still no-ops.

**Cost:** Capgo's dashboard adoption counters go dark. We already measure applies ourselves via the `capgoPendingApply` marker, and the endpoint was failing often enough to be its own Sentry noise ([PEANUT-UI-R51](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-R51), 187 events). If the counters are wanted, point `statsUrl` at a first-party endpoint instead — say so and I'll do that rather than disabling it.

## Native project files

`android/capacitor.settings.gradle` and `ios/App/CapApp-SPM/Package.swift` embed the resolved pnpm store path, so both move with the version. Regenerated with `cap update android` / `cap update ios` rather than hand-edited; CI regenerates them anyway (`scripts/native-release.sh` runs `cap sync android`, `ios-release.yml` runs `cap sync ios`), so this just keeps a local build working off a fresh checkout.

## Testing

`pnpm typecheck` clean against the new plugin's type definitions. OTA suites green (61 passing across `capgo-updater`, `OtaUpdateContext`, `OtaUpdateModal`).

The real proof is on-device and can only come from a build off this branch: tap **Restart now** on the update modal on Android and confirm the app reloads onto the new bundle instead of white-screening, and that the next launch logs `[capgo-apply] restart applied bundle <id>` rather than `did not apply`.
