### PR TITLE
fix: receipt drawer clipped the avatar, profile repeated the username

### DIFF
--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -65,18 +65,25 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                     generated dot-face experiment is reverted. */}
                 <AvatarWithBadge name={name || username} />
 
-                {/* Name */}
-                <div className="flex items-center gap-1">
-                    <VerifiedUserLabel
-                        name={name}
-                        username={username}
-                        isVerified={isVerified}
-                        className="text-heading-s text-foreground-primary"
-                        iconSize={20}
-                        haveSentMoneyToUser={haveSentMoneyToUser}
-                        isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
-                    />
-                </div>
+                {/* Name — dropped entirely when the caller has no name to show.
+                    On the self profile that is the no-full-name case, where the
+                    row used to fall back to the username and just repeat the
+                    handle the share pill already spells out. Callers without a
+                    pill (public profile, profile edit) always pass a name, so
+                    they keep the row. */}
+                {!!name && (
+                    <div className="flex items-center gap-1">
+                        <VerifiedUserLabel
+                            name={name}
+                            username={username}
+                            isVerified={isVerified}
+                            className="text-heading-s text-foreground-primary"
+                            iconSize={20}
+                            haveSentMoneyToUser={haveSentMoneyToUser}
+                            isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
+                        />
+                    </div>
+                )}
                 {/* `isSelfProfile` guards wrong attribution: `showShareButton`
                     defaults to true, so a caller on someone else's profile would
                     share that other handle. */}

--- a/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
+++ b/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
@@ -27,7 +27,7 @@ jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
 jest.mock('@/components/Profile/AvatarWithBadge', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Global/CopyToClipboard', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/UserHeader', () => ({
-    VerifiedUserLabel: ({ name }: { name: string }) => <span>{name}</span>,
+    VerifiedUserLabel: ({ name }: { name: string }) => <span data-testid="profile-name">{name}</span>,
 }))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 
@@ -89,6 +89,21 @@ describe('ProfileHeader share pill', () => {
         expect(shownCalls()).toHaveLength(1)
         rerender(<ProfileHeader name="Satoshi" username="satoshi" showShareButton />)
         expect(shownCalls()).toHaveLength(2)
+    })
+
+    // With no full name the row used to fall back to the username, printing the
+    // handle twice on a page whose pill already reads peanut.example.org/satoshi.
+    it('drops the name row when the caller has no name to show, keeping the pill', () => {
+        renderWithIntl(<ProfileHeader name="" username="satoshi" showShareButton />)
+
+        expect(screen.queryByTestId('profile-name')).not.toBeInTheDocument()
+        expect(sharePill()).toBeInTheDocument()
+    })
+
+    it('keeps the name row when a full name is set', () => {
+        renderWithIntl(<ProfileHeader name="Satoshi Nakamoto" username="satoshi" showShareButton />)
+
+        expect(screen.getByTestId('profile-name')).toHaveTextContent('Satoshi Nakamoto')
     })
 
     it('shares the profile url and captures the click only on a successful share', () => {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -59,8 +59,12 @@ export const Profile = () => {
     }
 
     const username = user?.user.username || 'anonymous'
-    // respect user's showFullName preference: use fullName only if showFullName is true, otherwise use username
-    const displayName = user?.user.showFullName && user?.user.fullName ? user.user.fullName : username
+    // Full name or nothing: the share pill below already spells out
+    // peanut.me/<username>, so falling back to the username here only printed
+    // the handle twice. Empty name → ProfileHeader drops the row entirely.
+    // Still respects the showFullName preference — opting out means there is
+    // no name to show.
+    const displayName = user?.user.showFullName && user?.user.fullName ? user.user.fullName : ''
 
     return (
         <div className="h-full w-full bg-background">

--- a/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
@@ -47,11 +47,16 @@ export const TransactionDetailsDrawer: React.FC<TransactionDetailsDrawerProps> =
                 }
             }}
         >
-            {/* pb only — the drawer chrome owns the space above (handle 8px top / 24px below, per board).
+            {/* The bottom padding sits on the receipt, INSIDE the scroll box, not on the
+                sheet: the footer link's 44px hit area bleeds 14px past its text row, and
+                outside the scroll box that bleed alone made the drawer scrollable by 14px
+                with nothing to scroll — enough for a flick to slide the avatar under the
+                handle band and slice it in half. The drawer chrome owns the space above
+                (handle 8px top / 24px below, per board).
                 No z-index shuffle for the cancel confirmation any more: it is a vaul
                 NestedRoot now, so vaul stacks it above this drawer and scales this one
                 back on its own. */}
-            <DrawerContent accessibleTitle={t('drawerTitle')} className="pb-4">
+            <DrawerContent accessibleTitle={t('drawerTitle')}>
                 <TransactionDetailsReceipt
                     isLoading={isLoading}
                     transaction={transaction}
@@ -62,7 +67,7 @@ export const TransactionDetailsDrawer: React.FC<TransactionDetailsDrawerProps> =
                     isModalOpen={isModalOpen}
                     setIsModalOpen={setIsModalOpen}
                     avatarUrl={avatarUrl}
-                    className="px-4"
+                    className="px-4 pb-4"
                 />
             </DrawerContent>
         </Drawer>


### PR DESCRIPTION
Two small UI fixes on the same branch.

## 1. Receipt drawer scrolled 14px with nothing to scroll

The reported symptom: opening a receipt and touching it left the counterparty avatar sliced in half, with a dead band of sheet background above it.

The sheet is split into a non-scrolling handle band (handle + 24px, per board) and an `overflow-auto` content box below it, so a scrolled content box clips the header against a hard edge. What made it scroll on a receipt that visually fit: the sheet carried its bottom padding on the sheet itself, *outside* the scroll box. The footer link's 44px touch target is an `::after` with `after:-inset-y-3.5` (`LinkButton`), so it bled 14px past the last text row and out of the scroll box — `clientHeight 468 / scrollHeight 482`. Any flick or iOS rubber-band then parked the drawer mid-avatar.

Padding moves onto the receipt, inside the scroll box, where it absorbs the bleed. Sheet height is unchanged — 16px below the content either way.

Measured in the browser at 375x812, before → after:

| | before | after |
|---|---|---|
| `clientHeight / scrollHeight` | 468 / 482 | 484 / 484 |
| max scroll | 14px | 0 |
| sheet height | 521px | 521px |

Residual, called out deliberately: on a genuinely long receipt or a very short viewport the content does overflow and scrolling still runs the header under the handle band. That is ordinary bottom-sheet behaviour now rather than a phantom scroll. Making content run to the sheet's rounded top edge with the handle floating over it is a `DrawerContent` chrome change touching every drawer in the app, so it is not in here.

## 2. Profile: the username row repeated the share pill

`/profile` showed avatar → name → `peanut.me/<username>` pill, where the name row fell back to the username whenever no full name was set — printing the handle twice.

The row now shows the full name or nothing. `ProfileHeader` drops the row on an empty name rather than rendering an empty label, so the two callers without a pill (public profile, profile edit) keep theirs — both already compute a username fallback before passing `name`.

Two judgement calls worth a look in review:

- **The `showFullName` preference still gates it.** Someone with a full name saved but that toggle off now sees no name row rather than their username. That reads as "no name to show" and is what keeps the row from ever duplicating the pill. Dropping the `showFullName &&` would instead always show your own full name on your own profile.
- **Scoped to the self profile.** Hiding the row on the public profile would leave nothing identifying at all, since there is no pill there. That is prevented by the callers' own fallbacks, not by a condition in `ProfileHeader`.

Avatar initials are unaffected — `AvatarWithBadge` already did `name || username`.

## Testing

- `ProfileHeader.test.tsx`: two new cases — row absent but pill still present when there is no name; row present with a name. 21/21 across `ProfileHeader` + `PublicProfile`.
- `tsc --noEmit` clean, prettier clean.
- The drawer fix was reproduced and verified in the browser at 375x812 against a mock receipt, measuring the scroll box before and after.
- Not verified in a browser: the profile screen. It needs a signed-in session and the pill only renders when the auth username matches, so that half is covered structurally by jest, not visually. Worth eyeballing the spacing on device — it is one row removed from a `space-y-2` stack.
