### PR TITLE
fix(ota): stop losing bundles to a background apply the OS freezes

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -101,6 +101,23 @@ describe('shouldIgnoreError — Capgo updater noise', () => {
         expect(shouldIgnoreError(eventWith({ message }))).toBe(false)
     })
 
+    /*
+     * An update that silently un-happens leaves no other trace: Capgo's own logs
+     * only reach Sentry through an eval into a WebView the rollback is about to
+     * tear down, so suppressing these made the whole population read as one
+     * event in 90 days (PEANUT-UI-SVT).
+     */
+    it('keeps a bundle the plugin rolled back for want of notifyAppReady', () => {
+        expect(
+            shouldIgnoreError(
+                eventWith({ message: '[CapgoUpdater] 🔴 notifyAppReady was not called, roll back current bundle: E3J' })
+            )
+        ).toBe(false)
+        expect(shouldIgnoreError(eventWith({ message: '[CapgoUpdater] 🔴 Update to bundle: 1.0.56 Failed!' }))).toBe(
+            false
+        )
+    })
+
     it('keeps a checksum mismatch — the bundle arrived corrupt, not merely late', () => {
         expect(shouldIgnoreError(eventWith({ message: '[CapgoUpdater] 🔴 Checksum mismatch' }))).toBe(false)
     })

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -104,10 +104,19 @@ const IGNORED_ERRORS = {
  * (~95/day on native). The user never sees them: the updater just retries on
  * the next launch. Suppress those, but keep the failures that mean OTA is
  * genuinely broken rather than merely flaky — a bundle that semver-sorts below
- * the installed binary, or one that arrived corrupt.
+ * the installed binary, one that arrived corrupt, or one the plugin rolled back
+ * because notifyAppReady never landed. That last class is the reason this list
+ * is not just the two it started with: an update that silently un-happens
+ * leaves no other trace, and suppressing it made the whole population read as
+ * one event in 90 days (PEANUT-UI-SVT).
  */
 const CAPGO_LOG_PREFIXES = ['[CapgoUpdater]', 'CapgoUpdater :', '[capgo]']
-const CAPGO_ACTIONABLE = ['disable_auto_update_under_native', 'Checksum mismatch']
+const CAPGO_ACTIONABLE = [
+    'disable_auto_update_under_native',
+    'Checksum mismatch',
+    'notifyAppReady was not called',
+    'Update to bundle:',
+]
 
 const isFromCapgo = (searchTexts: string[]): boolean =>
     searchTexts.some((text) => CAPGO_LOG_PREFIXES.some((prefix) => text.includes(prefix)))

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script'
 import '../styles/globals.css'
 import { PEANUT_API_URL, BASE_URL } from '@/constants/general.consts'
 import { CHUNK_ERROR_RECOVERY_SCRIPT } from '@/utils/chunk-error-recovery'
+import { NATIVE_APP_READY_SCRIPT } from '@/utils/native-app-ready'
 import { isProductionDomain } from '@/constants/seo-route-policy'
 import { type Metadata } from 'next'
 
@@ -174,6 +175,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 {/* DNS prefetch for API */}
                 <link rel="dns-prefetch" href={apiHostname} />
                 <link rel="preconnect" href={apiHostname} crossOrigin="anonymous" />
+
+                {/* OTA app-ready: MUST be a raw inline script and MUST come first — a bundle
+                    applied while the app is backgrounded reloads into a process the OS then
+                    freezes, and on resume every overdue chunk-load timer rejects at once, so
+                    anything behind an import() never runs (see src/utils/native-app-ready.ts).
+                    No-op off native: the bridge stub it calls only exists in the WebView. */}
+                <script id="native-app-ready" dangerouslySetInnerHTML={{ __html: NATIVE_APP_READY_SCRIPT }} />
 
                 {/* Chunk-load failure recovery: MUST be a raw inline script — error boundaries
                     are lazy chunks themselves and fail to load in the exact conditions that need

--- a/src/context/OtaUpdateContext.tsx
+++ b/src/context/OtaUpdateContext.tsx
@@ -2,8 +2,11 @@
 
 import type { BundleInfo } from '@capgo/capacitor-updater'
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { isSplashVisible } from '@/hooks/useSplashGate'
 import { isAndroidNativeBridge, isCapacitor } from '@/utils/capacitor'
 import type { OtaApplyOutcome } from '@/utils/capgo-updater'
+import { importWithChunkRetry } from '@/utils/chunk-error-recovery'
+import { markNativeBootComplete } from '@/utils/native-app-ready'
 
 /**
  * `manual-restart` — a reload was issued but the page outlived it (iOS, which
@@ -51,29 +54,41 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         if (!isCapacitor()) return
+        // The app rendered, so the running bundle boots — this is what the
+        // document-start notifyAppReady trades Capgo's rollback net for.
+        markNativeBootComplete()
         let disposed = false
         let cleanup: (() => void) | undefined
 
         // a bundle staged on an earlier launch is still queued in the plugin
-        import('@capgo/capacitor-updater')
+        importWithChunkRetry(() => import('@capgo/capacitor-updater'))
             .then(({ CapacitorUpdater }) => CapacitorUpdater.getNextBundle())
             .then((bundle) => {
                 if (!disposed && bundle) setPendingBundle((current) => current ?? bundle)
             })
             .catch((err) => console.warn('[capgo] next bundle read failed:', err))
 
-        import('@/utils/capgo-updater')
-            .then(({ initCapgoUpdater }) =>
-                initCapgoUpdater({
+        importWithChunkRetry(() => import('@/utils/capgo-updater'))
+            .then(async (updater) => {
+                const remove = await updater.initCapgoUpdater({
                     onUpdateAvailable: (bundle) => setPendingBundle(bundle),
                     onStoreUpdateRequired: () => setStoreUpdateRequired(true),
                 })
-            )
-            .then((fn) => {
                 // Unmounted while init was still resolving: run the cleanup now
                 // or the listeners it registered are never removed.
-                if (disposed) fn()
-                else cleanup = fn
+                if (disposed) {
+                    remove()
+                    return
+                }
+                cleanup = remove
+                // Sequenced after init on purpose: the launch apply writes the
+                // pending-apply marker that init's reportPendingApply consumes,
+                // and racing them would report this launch's marker as a
+                // failure of the previous one. Only while the splash still
+                // hides the reload — see applyStagedBundleOnLaunch.
+                if (!isSplashVisible()) return
+                const staged = await updater.applyStagedBundleOnLaunch()
+                if (!disposed && staged) setPendingBundle((current) => current ?? staged)
             })
             .catch((err) => console.warn('[capgo] ota init failed:', err))
 
@@ -93,7 +108,7 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
 
         let updater: typeof import('@/utils/capgo-updater')
         try {
-            updater = await import('@/utils/capgo-updater')
+            updater = await importWithChunkRetry(() => import('@/utils/capgo-updater'))
         } catch (err) {
             console.warn('[capgo] updater chunk failed to load:', err)
             applyingRef.current = false
@@ -109,7 +124,7 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
             updater.markPendingApply(pendingBundle.id)
             setApplyState('manual-restart')
             try {
-                const { App } = await import('@capacitor/app')
+                const { App } = await importWithChunkRetry(() => import('@capacitor/app'))
                 await App.exitApp()
             } catch (err) {
                 console.warn('[capgo] exitApp failed:', err)
@@ -127,7 +142,7 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
                 // exitApp (or its chunk) failing would otherwise strand the modal in
                 // 'applying': no close button, no enabled CTA, no way out. Fall back
                 // to the instruction iOS already gets.
-                import('@capacitor/app')
+                importWithChunkRetry(() => import('@capacitor/app'))
                     .then(({ App }) => App.exitApp())
                     .catch((err) => {
                         console.warn('[capgo] exitApp failed:', err)

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -22,9 +22,13 @@ const mockUpdater = {
     current: jest.fn().mockResolvedValue({ bundle: { id: 'builtin' } }),
     getNextBundle: jest.fn(),
     getPluginVersion: jest.fn(),
+    getFailedUpdate: jest.fn().mockResolvedValue(null),
 }
 const mockExitApp = jest.fn().mockResolvedValue(undefined)
-const platform = { android: true, capacitor: true }
+// splashVisible false by default: these cases are about a bundle staged while
+// the user is already in the app, where the launch apply deliberately stands
+// down. The behind-the-splash window has its own describe block.
+const platform = { android: true, capacitor: true, splashVisible: false }
 
 jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
 jest.mock('@capacitor/app', () => ({ App: { exitApp: () => mockExitApp() } }))
@@ -33,6 +37,7 @@ jest.mock('@/utils/capacitor', () => ({
     isCapacitor: () => platform.capacitor,
     isAndroidNativeBridge: () => platform.android,
 }))
+jest.mock('@/hooks/useSplashGate', () => ({ isSplashVisible: () => platform.splashVisible }))
 
 import { OtaUpdateProvider, useOtaUpdate } from '../OtaUpdateContext'
 
@@ -49,6 +54,8 @@ beforeEach(() => {
     window.localStorage.clear()
     platform.android = true
     platform.capacitor = true
+    platform.splashVisible = false
+    mockUpdater.getFailedUpdate.mockReset().mockResolvedValue(null)
     mockExitApp.mockClear()
     mockUpdater.set.mockReset().mockReturnValue(new Promise(() => {}))
     mockUpdater.reload.mockClear()
@@ -491,5 +498,87 @@ describe('an apply that never reaches the plugin', () => {
         })
         await waitFor(() => expect(mockUpdater.set).toHaveBeenCalledWith({ id: 'b-2' }))
         expect(result.current.applyState).toBe('applying')
+    })
+})
+
+describe('a bundle staged by an earlier launch, found while the splash is still up', () => {
+    /*
+     * next() is only ever consumed by installNext(), which runs from
+     * appMovedToBackground() — so the reload lands in a process the OS is about
+     * to freeze, and on resume every overdue chunk-load timer rejects at once
+     * (PEANUT-UI-SVT). Applying it here instead reloads an app that is on
+     * screen, running at full speed, and still behind its own splash.
+     */
+    beforeEach(() => {
+        platform.splashVisible = true
+    })
+
+    it('applies it immediately rather than leaving it to the background apply', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+        setup()
+        await waitFor(() => expect(mockUpdater.set).toHaveBeenCalledWith({ id: 'b-2' }))
+        expect(window.localStorage.getItem('capgoPendingApply')).toBe('b-2')
+    })
+
+    it('still surfaces the bundle, so a rejected apply leaves a restart to offer', async () => {
+        mockUpdater.set.mockReset().mockRejectedValue(new Error('no index.html'))
+        mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+        const { result } = setup()
+        await waitFor(() => expect(result.current.pendingBundle).toEqual(STAGED))
+        // The apply never reached the plugin, so the next launch must not report
+        // it as one that did.
+        expect(window.localStorage.getItem('capgoPendingApply')).toBeNull()
+    })
+
+    it('tries a given bundle once, so a set() that never lands cannot reload every launch', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+        setup()
+        await waitFor(() => expect(mockUpdater.set).toHaveBeenCalledTimes(1))
+        mockUpdater.set.mockClear()
+        setup()
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(5_000)
+        })
+        expect(mockUpdater.set).not.toHaveBeenCalled()
+    })
+
+    it('stands down on binaries that would deadlock, leaving the background apply to it', async () => {
+        mockUpdater.getPluginVersion.mockResolvedValue({ version: '8.45.9' })
+        mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+        const { result } = setup()
+        await waitFor(() => expect(result.current.pendingBundle).toEqual(STAGED))
+        expect(mockUpdater.set).not.toHaveBeenCalled()
+        expect(mockExitApp).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when the staged bundle is already the running one', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+        mockUpdater.current.mockResolvedValue({ bundle: { id: STAGED.id } })
+        setup()
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(5_000)
+        })
+        expect(mockUpdater.set).not.toHaveBeenCalled()
+    })
+})
+
+describe('rollbacks the plugin performed while no page could report them', () => {
+    it('reports the plugin-recorded failure at launch, under a prefix Sentry keeps', async () => {
+        mockUpdater.getFailedUpdate.mockResolvedValue({ bundle: { id: 'b-9', version: '1.0.56' } })
+        setup()
+        await waitFor(() =>
+            expect(error).toHaveBeenCalledWith(
+                expect.stringContaining('[capgo-apply] plugin rolled back bundle 1.0.56')
+            )
+        )
+    })
+
+    it('stays quiet on binaries whose plugin has no such record', async () => {
+        mockUpdater.getFailedUpdate.mockRejectedValue(new Error('not implemented'))
+        setup()
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(5_000)
+        })
+        expect(error).not.toHaveBeenCalledWith(expect.stringContaining('[capgo-apply]'))
     })
 })

--- a/src/hooks/useSplashGate.ts
+++ b/src/hooks/useSplashGate.ts
@@ -69,6 +69,15 @@ async function hideSplash() {
     }
 }
 
+/**
+ * Whether the native splash still covers the WebView. The OTA launch apply uses
+ * it as its window: a reload behind the splash is invisible, the same reload a
+ * second later yanks the app out from under someone already using it.
+ */
+export function isSplashVisible(): boolean {
+    return !splashHidden
+}
+
 export function resetSplashGateForTests(): void {
     splashHidden = false
     hardTimeoutArmed = false

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -16,6 +16,7 @@ const mockUpdater = {
     current: jest.fn(),
     reset: jest.fn().mockResolvedValue(undefined),
     getPluginVersion: jest.fn(),
+    getFailedUpdate: jest.fn().mockResolvedValue(null),
 }
 const mockPlatform = { android: true }
 
@@ -36,6 +37,7 @@ beforeEach(() => {
     window.localStorage.clear()
     mockPlatform.android = true
     mockUpdater.getPluginVersion.mockReset()
+    mockUpdater.getFailedUpdate.mockReset().mockResolvedValue(null)
     info = jest.spyOn(console, 'info').mockImplementation(() => {})
     error = jest.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/src/utils/__tests__/chunk-error-recovery.test.ts
+++ b/src/utils/__tests__/chunk-error-recovery.test.ts
@@ -1,4 +1,9 @@
-import { CHUNK_ERROR_RECOVERY_SCRIPT, isChunkLoadError, recoverFromChunkError } from '../chunk-error-recovery'
+import {
+    CHUNK_ERROR_RECOVERY_SCRIPT,
+    importWithChunkRetry,
+    isChunkLoadError,
+    recoverFromChunkError,
+} from '../chunk-error-recovery'
 
 type Listener = (event: { reason?: unknown; error?: unknown; message?: string }) => void
 
@@ -145,5 +150,33 @@ describe('recoverFromChunkError', () => {
         expect(recoverFromChunkError(chunkError())).toBe(true)
         expect(recoverFromChunkError(chunkError())).toBe(false)
         expect(reload).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('importWithChunkRetry', () => {
+    /*
+     * A frozen process resuming fires every overdue timer at once, webpack's
+     * chunkLoadTimeout included, so an import() that was merely in flight
+     * rejects for a local file that is intact (PEANUT-UI-SVT).
+     */
+    it('retries once when the chunk load timed out', async () => {
+        const load = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('Loading chunk 8789 failed.\n(timeout: https://localhost/_next/x.js)'))
+            .mockResolvedValue('module')
+        await expect(importWithChunkRetry(load)).resolves.toBe('module')
+        expect(load).toHaveBeenCalledTimes(2)
+    })
+
+    it('rethrows a non-chunk failure untouched, so it is not a general retry', async () => {
+        const load = jest.fn().mockRejectedValue(new Error('boom'))
+        await expect(importWithChunkRetry(load)).rejects.toThrow('boom')
+        expect(load).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up after the second attempt rather than looping', async () => {
+        const load = jest.fn().mockRejectedValue(new Error('ChunkLoadError'))
+        await expect(importWithChunkRetry(load)).rejects.toThrow('ChunkLoadError')
+        expect(load).toHaveBeenCalledTimes(2)
     })
 })

--- a/src/utils/__tests__/native-app-ready.test.ts
+++ b/src/utils/__tests__/native-app-ready.test.ts
@@ -1,0 +1,100 @@
+import { NATIVE_APP_READY_SCRIPT, markNativeBootComplete } from '../native-app-ready'
+
+/**
+ * The whole point of this script is that it runs with no chunk loaded, so it
+ * is tested the way it ships: the raw string, executed against shadowed
+ * globals, exactly like the chunk-error-recovery script next to it.
+ */
+function bootScript({
+    plugin = true,
+    failures,
+    brokenStorage = false,
+}: { plugin?: boolean; failures?: number; brokenStorage?: boolean } = {}) {
+    const notifyAppReady = jest.fn()
+    const reset = jest.fn()
+    const store = new Map<string, string>()
+    if (failures !== undefined) store.set('peanutNativeBootIncomplete', String(failures))
+
+    const localStorage = brokenStorage
+        ? {
+              getItem: () => {
+                  throw new Error('denied')
+              },
+              setItem: () => {
+                  throw new Error('denied')
+              },
+              removeItem: () => {
+                  throw new Error('denied')
+              },
+          }
+        : {
+              getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+              setItem: (k: string, v: string) => {
+                  store.set(k, v)
+              },
+              removeItem: (k: string) => {
+                  store.delete(k)
+              },
+          }
+
+    const win = {
+        Capacitor: plugin ? { Plugins: { CapacitorUpdater: { notifyAppReady, reset } } } : undefined,
+        localStorage,
+    }
+    new Function('window', 'localStorage', NATIVE_APP_READY_SCRIPT)(win, localStorage)
+    return { notifyAppReady, reset, store }
+}
+
+describe('NATIVE_APP_READY_SCRIPT', () => {
+    it('calls notifyAppReady straight off the bridge stub, with no chunk loaded', () => {
+        const { notifyAppReady } = bootScript()
+        expect(notifyAppReady).toHaveBeenCalled()
+    })
+
+    it('no-ops off native, where the bridge exposes no plugin', () => {
+        const { notifyAppReady, reset } = bootScript({ plugin: false })
+        expect(notifyAppReady).not.toHaveBeenCalled()
+        expect(reset).not.toHaveBeenCalled()
+    })
+
+    it('counts the launch as incomplete until the app clears it', () => {
+        const { store } = bootScript()
+        expect(store.get('peanutNativeBootIncomplete')).toBe('1')
+    })
+
+    /*
+     * Calling notifyAppReady this early gives up Capgo's rollback net, and this
+     * is what replaces it. Capgo could not tell a bundle whose JS is broken from
+     * one the OS froze mid-boot and rolled back on both; a frozen boot resumes
+     * and clears the counter, a broken one never does.
+     */
+    it('falls back to the builtin bundle after three launches that never rendered', () => {
+        const { notifyAppReady, reset, store } = bootScript({ failures: 3 })
+        expect(reset).toHaveBeenCalled()
+        expect(notifyAppReady).not.toHaveBeenCalled()
+        expect(store.has('peanutNativeBootIncomplete')).toBe(false)
+    })
+
+    it('keeps marking ready below the limit, so one slow launch costs nothing', () => {
+        const { notifyAppReady, reset } = bootScript({ failures: 2 })
+        expect(notifyAppReady).toHaveBeenCalled()
+        expect(reset).not.toHaveBeenCalled()
+    })
+
+    it('still marks ready when storage is unavailable', () => {
+        // No storage means the counter never accumulates either, so there is
+        // nothing to protect against — refusing to notify would roll back every
+        // bundle on a private-mode or storage-less WebView.
+        const { notifyAppReady, reset } = bootScript({ brokenStorage: true })
+        expect(notifyAppReady).toHaveBeenCalled()
+        expect(reset).not.toHaveBeenCalled()
+    })
+})
+
+describe('markNativeBootComplete', () => {
+    it('clears the counter, so only consecutive dead launches accumulate', () => {
+        window.localStorage.setItem('peanutNativeBootIncomplete', '2')
+        markNativeBootComplete()
+        expect(window.localStorage.getItem('peanutNativeBootIncomplete')).toBeNull()
+    })
+})

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -27,6 +27,7 @@ export async function initCapgoUpdater(callbacks: OtaUpdateCallbacks = {}): Prom
     // even in demo mode — otherwise capgo auto-rolls back a previously-set bundle.
     await CapacitorUpdater.notifyAppReady()
     await reportPendingApply(CapacitorUpdater)
+    await reportFailedUpdate(CapacitorUpdater)
 
     const listeners: Array<{ remove: () => void }> = []
 
@@ -284,6 +285,81 @@ async function reportPendingApply(updater: Pick<CapacitorUpdaterPlugin, 'current
     const running = current?.bundle?.id ?? 'unknown'
     if (running === expected) console.warn(`[capgo-apply] restart applied bundle ${expected}`)
     else console.error(`[capgo-apply] restart did not apply bundle ${expected}; running ${running}`)
+}
+
+/**
+ * Report a rollback the plugin performed while nothing could hear it.
+ *
+ * Capgo's own logs reach Sentry only through bridge.eval("console.error(…)")
+ * into the WebView (Logger.java), and a background apply destroys the page that
+ * would receive them — the rollback line is emitted ~20 ms before performReset
+ * tears the next one down too. So the whole failure population reported as one
+ * event over 90 days. getFailedUpdate() reads the plugin's own SharedPreferences
+ * record instead, which survives the reload, the rollback and a process kill,
+ * and it self-clears on read. The `[capgo-apply]` prefix is deliberate: the
+ * `[capgo]` / `[CapgoUpdater]` prefixes are dropped as updater noise
+ * (sentry.utils.ts), which is exactly what hid this.
+ */
+async function reportFailedUpdate(updater: Pick<CapacitorUpdaterPlugin, 'getFailedUpdate'>): Promise<void> {
+    let failed
+    try {
+        failed = await updater.getFailedUpdate()
+    } catch (err) {
+        // Binaries older than plugin 7.22 have no such method. This JS ships
+        // over the air onto them, and a missing method is not a failure.
+        console.info('[capgo] failed-update read unavailable:', err instanceof Error ? err.message : String(err))
+        return
+    }
+    if (!failed?.bundle) return
+    console.error(
+        `[capgo-apply] plugin rolled back bundle ${failed.bundle.version} (${failed.bundle.id}); notifyAppReady never landed`
+    )
+}
+
+// One launch-time apply per staged bundle. A set() that never lands must not
+// turn every subsequent launch into a reload.
+const LAUNCH_APPLY_KEY = 'capgoLaunchApplyAttempt'
+
+/**
+ * Apply a bundle staged by an earlier launch now, in the foreground, instead of
+ * leaving it to the plugin's background apply.
+ *
+ * next() is only ever consumed by installNext(), which runs from
+ * appMovedToBackground(): the reload therefore lands in a process the OS is
+ * about to freeze, and the boot has to finish inside a 30 s budget that keeps
+ * burning while nothing is scheduled. Doing it here instead reloads an app that
+ * is on screen and running at full speed. The caller restricts this to the
+ * window where the splash still covers the reload, so adopting an update stays
+ * invisible; outside that window the background apply remains the fallback,
+ * which native-app-ready.ts has made survivable.
+ *
+ * Returns the staged bundle (whether or not it was applied) so the caller can
+ * still offer a manual restart, or null when nothing is staged.
+ */
+export async function applyStagedBundleOnLaunch(): Promise<BundleInfo | null> {
+    const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+    const [next, current] = await Promise.all([
+        CapacitorUpdater.getNextBundle().catch(() => null),
+        CapacitorUpdater.current().catch(() => null),
+    ])
+    if (!next || next.id === current?.bundle?.id) return null
+    // Deadlocking binaries can only quit to apply (see canRestartInPlace), and
+    // quitting an app the user just opened is worse than the background apply.
+    if (readStoredValue(LAUNCH_APPLY_KEY) === next.id || !(await canRestartInPlace())) return next
+
+    writeStoredValue(LAUNCH_APPLY_KEY, next.id)
+    markPendingApply(next.id)
+    try {
+        // Never resolves when it works: the page is torn down mid-call.
+        await CapacitorUpdater.set({ id: next.id })
+    } catch (err) {
+        // The bundle is still staged, so the background apply will retry it.
+        // Drop the marker or the next launch reports a failure for an apply
+        // that never reached the plugin.
+        removeStoredValue(PENDING_APPLY_KEY)
+        console.warn('[capgo] launch apply rejected:', err instanceof Error ? err.message : String(err))
+    }
+    return next
 }
 
 // The normal up-to-date path, not a failure. Plugin 8.45+ rejects getLatest()

--- a/src/utils/chunk-error-recovery.ts
+++ b/src/utils/chunk-error-recovery.ts
@@ -70,6 +70,24 @@ export function recoverFromChunkError(error: unknown): boolean {
     return true
 }
 
+/**
+ * Retry an import() once if it failed to load its chunk.
+ *
+ * A frozen process resuming fires every overdue timer at once, webpack's
+ * chunkLoadTimeout included, so imports that were merely in flight reject with
+ * a timeout ChunkLoadError for local files that are intact. The second attempt
+ * runs with the process scheduled again and succeeds. Non-chunk errors rethrow
+ * untouched — this is not a general retry.
+ */
+export async function importWithChunkRetry<T>(load: () => Promise<T>): Promise<T> {
+    try {
+        return await load()
+    } catch (error) {
+        if (!isChunkLoadError(error)) throw error
+        return load()
+    }
+}
+
 export const CHUNK_ERROR_RECOVERY_SCRIPT = `
 (function () {
     var GUARD_KEY = '${GUARD_KEY}';

--- a/src/utils/native-app-ready.ts
+++ b/src/utils/native-app-ready.ts
@@ -1,0 +1,66 @@
+/**
+ * notifyAppReady(), before any webpack chunk has to load.
+ *
+ * Capgo applies a staged bundle from appMovedToBackground(), so the reload
+ * lands in a process Android is about to freeze. Freezing stops threads but not
+ * the clock: on resume every overdue setTimeout fires at once, including
+ * webpack's 120 s chunkLoadTimeout, and every in-flight import() rejects with a
+ * ChunkLoadError for a local file that was never missing. notifyAppReady used
+ * to sit behind two of those imports plus React hydration, so it was never
+ * called and Capgo rolled the bundle back (PEANUT-UI-SVT: booted at 13:46:04,
+ * resumed 23m46s later, four ChunkLoadErrors and a rollback inside 40 ms).
+ *
+ * Delivered as a raw inline script for the same reason as the chunk-error
+ * recovery next to it in the root layout: it must be in memory before the first
+ * chunk request, not queued behind Next's bootstrap chunk. Capacitor injects
+ * window.Capacitor.Plugins.<Name> stubs at document start on both platforms
+ * (JSExport.java / JSExport.swift), so the plugin is callable with no app JS.
+ *
+ * initCapgoUpdater() still calls notifyAppReady() as well. It is idempotent —
+ * setSuccess plus a semaphoreDown that no-ops with no pending wait — and it is
+ * the fallback for any binary whose bridge does not expose the stub.
+ */
+
+/*
+ * Calling notifyAppReady this early gives up Capgo's rollback net: the bundle
+ * is marked SUCCESS before it has proved it can boot. This counter is the
+ * replacement, and it is the better net — Capgo cannot tell a bundle whose JS
+ * is broken from one the OS froze, and rolled back on both. A frozen boot
+ * eventually finishes and clears the counter; a broken one never does.
+ */
+const BOOT_INCOMPLETE_KEY = 'peanutNativeBootIncomplete'
+const BOOT_INCOMPLETE_LIMIT = 3
+
+/** The app rendered, so whatever bundle is running boots. Clears the counter. */
+export function markNativeBootComplete(): void {
+    try {
+        window.localStorage.removeItem(BOOT_INCOMPLETE_KEY)
+    } catch {
+        // private mode or a storage-less WebView: the counter never accumulates
+        // either, so there is nothing to clear
+    }
+}
+
+export const NATIVE_APP_READY_SCRIPT = `
+(function () {
+    var plugins = window.Capacitor && window.Capacitor.Plugins;
+    var updater = plugins && plugins.CapacitorUpdater;
+    if (!updater || typeof updater.notifyAppReady !== 'function') return;
+
+    var KEY = '${BOOT_INCOMPLETE_KEY}';
+    var LIMIT = ${BOOT_INCOMPLETE_LIMIT};
+    var failures = 0;
+    try { failures = Number(localStorage.getItem(KEY)) || 0; } catch (e) {}
+
+    // Three launches that never rendered: the bundle is the problem, not the
+    // scheduler. Fall back to the builtin one instead of marking this ready.
+    if (failures >= LIMIT && typeof updater.reset === 'function') {
+        try { localStorage.removeItem(KEY); } catch (e) {}
+        try { updater.reset({}); } catch (e) {}
+        return;
+    }
+
+    try { localStorage.setItem(KEY, String(failures + 1)); } catch (e) {}
+    try { updater.notifyAppReady(); } catch (e) {}
+})();
+`


### PR DESCRIPTION
Stacked on #2960 (it owns `canRestartInPlace`). Base it on `dev` once that lands.

## The failure

Capgo consumes a `next()`-staged bundle only from `installNext()`, which runs from `appMovedToBackground()`. The reload therefore lands in a process the OS is about to freeze. Freezing stops threads but not the clock, so on resume every overdue `setTimeout` fires at once — webpack's 120 s `chunkLoadTimeout` included — and every in-flight `import()` rejects with a `ChunkLoadError` for a local file that was never missing. `notifyAppReady` sat behind two of those imports plus React hydration, so it was never called and the plugin rolled the bundle back.

This is **not** the plugin-thread deadlock. `installNext()` has always wrapped `set()`/`_reload()` in `startNewThread`, in 8.45.9 and 8.51.14 alike — I diffed both.

`PEANUT-UI-SVT` is the whole chain in one trace (Honor PLG110, Android 16):

```
13:46:04.029  navigation — new bundle's document begins loading
13:46:04.571  fetch x4 in flight, boot proceeding normally
              ... 23m 46s, zero breadcrumbs ...
14:09:50.784  failed to init app listeners: ChunkLoadError (timeout: ...)
14:09:50.805  [capgo] ota init failed: ChunkLoadError: Loading chunk 8789 failed
14:09:50.823  [CapgoUpdater] notifyAppReady was not called, roll back
```

Chunk 8789 is the `@/utils/capgo-updater` chunk. `PEANUT-UI-SVE` (Samsung SM-A505G, Android 11) is the milder shape: `notifyAppReady` **was** called, 6 ms after the deadline.

## What this changes

- **`notifyAppReady` moves to a raw inline script** in the root layout, calling the bridge stub Capacitor injects at document start (`JSExport.java` / `JSExport.swift`). No chunk, no hydration, no React. `initCapgoUpdater` still calls it too — it is idempotent, and it covers any binary whose bridge does not expose the stub.
- **A boot-incomplete counter replaces Capgo's rollback net**, which the early call gives up. It is the better net: Capgo could not tell a bundle whose JS is broken from one the OS froze and rolled back on both. A frozen boot resumes and clears the counter; a broken one never does. Three consecutive dead launches fall back to builtin.
- **A bundle staged by an earlier launch is applied in the foreground**, while the splash still covers the reload, instead of being left to the background apply. Once per bundle, and only where `canRestartInPlace()`. Outside that window nothing changes — the background apply is now survivable.
- **`import()` retries once on a chunk-load failure.** The second attempt runs with the process scheduled again.

## Why the counts looked like n=1

Capgo's logs reach Sentry only through `bridge.eval("console.error(...)")` into the WebView (`Logger.java:252`), and a background apply destroys the page that would receive them — the rollback line is emitted ~20 ms before `performReset` tears the next one down. Whatever survived, the `[capgo]` / `[CapgoUpdater]` prefix filter dropped. Over 90 days the entire population reported as **one event, one user**; `ChunkLoadError` and `[capgo] ota init failed` reported **zero**.

So: the two rollback strings are now in `CAPGO_ACTIONABLE`, and `getFailedUpdate()` is reported at launch under the `[capgo-apply]` prefix the filter does not match. That record lives in the plugin's SharedPreferences and outlives the reload, the rollback and a process kill — it is the only way to get a real fleet-wide rate.

## Related

`appReadyTimeout` 15 s -> 120 s lives in #2968 (which replaces #2961), since it is binary-only and that PR already touches `capacitor.config.ts`. Android silently floors it at 30 s for a pending bundle, so 15 s was inert there and binding on iOS.

## Testing

- `pnpm tsc --noEmit` clean.
- Full jest suite: 439 suites / 5631 passing.
- New coverage: the inline script executed as it ships (bridge stub, no-op off native, the counter and its builtin fallback, storage-less WebView), the launch apply (applies behind the splash, once per bundle, stands down on deadlocking binaries and when the staged bundle is already running, still surfaces a rejected apply for a manual restart), `importWithChunkRetry`, the `getFailedUpdate` report, and the two new Sentry carve-outs.

Not verified on-device — the inline-script path needs a native build to confirm the bridge stub is reachable that early on both platforms. It fails safe: if the stub is missing the script returns and the existing React path calls `notifyAppReady` exactly as today.

