### PR TITLE
fix(passkey): tag step-up ceremonies, bracket every spend, guard card reveal re-entry

### DIFF
--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -49,7 +49,7 @@ const LandingStep = () => {
         if (!isAlreadyReported(error)) {
             Sentry.captureException(error, { extra: { errorCode } })
         }
-        posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode })
+        posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode, native: isCapacitor() })
     }
 
     const onLoginClick = async () => {

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -91,7 +91,7 @@ function LoginButton() {
             if (!isAlreadyReported(error)) {
                 Sentry.captureException(error, { extra: { errorCode } })
             }
-            posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode })
+            posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode, native: isCapacitor() })
         }
     }
 

--- a/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
+++ b/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
@@ -109,7 +109,10 @@ describe('SetupWrapper navigation', () => {
         renderWrapper({ showLoginButton: true })
         fireEvent.click(screen.getByRole('button', { name: 'Log In' }))
         await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('No passkey found'))
-        expect(mockedCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: 'NO_PASSKEY' })
+        expect(mockedCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, {
+            error_code: 'NO_PASSKEY',
+            native: false,
+        })
     })
 
     it('shows the catalog copy for a mapped passkey error code, not the curated English message', async () => {

--- a/src/hooks/__tests__/useCardReveal.test.ts
+++ b/src/hooks/__tests__/useCardReveal.test.ts
@@ -41,6 +41,32 @@ describe('useCardReveal', () => {
         expect(result.current.error).toBeNull()
     })
 
+    it('ignores a second reveal while the first is still in flight', async () => {
+        let resolveDetails!: (v: RainCardDetailsResponse) => void
+        mockedGetCardDetails.mockImplementationOnce(
+            () =>
+                new Promise<RainCardDetailsResponse>((resolve) => {
+                    resolveDetails = resolve
+                })
+        )
+        const { result } = renderHook(() => useCardReveal({ cardId: 'c1', autoMaskMs: 0 }))
+
+        let first!: Promise<void>
+        act(() => {
+            first = result.current.reveal()
+        })
+        await act(async () => {
+            await result.current.reveal()
+        })
+        expect(mockedGetCardDetails).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            resolveDetails(details)
+            await first
+        })
+        expect(result.current.revealed).toEqual(details)
+    })
+
     it('hides revealed details on hide()', async () => {
         mockedGetCardDetails.mockResolvedValueOnce(details)
         const { result } = renderHook(() => useCardReveal({ cardId: 'c1', autoMaskMs: 0 }))

--- a/src/hooks/useCardReveal.ts
+++ b/src/hooks/useCardReveal.ts
@@ -35,6 +35,7 @@ export function useCardReveal({ cardId, autoMaskMs = DEFAULT_AUTO_MASK_MS }: Use
     const [error, setError] = useState<string | null>(null)
     const [isRateLimited, setIsRateLimited] = useState(false)
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const inFlightRef = useRef(false)
 
     const hide = useCallback(() => {
         setRevealed(null)
@@ -47,6 +48,10 @@ export function useCardReveal({ cardId, autoMaskMs = DEFAULT_AUTO_MASK_MS }: Use
     }, [])
 
     const reveal = useCallback(async () => {
+        // A second tap while the step-up sheet is up would open a second ceremony
+        // that fails instantly (overlapped=true in telemetry) and loops.
+        if (inFlightRef.current) return
+        inFlightRef.current = true
         setIsLoading(true)
         setError(null)
         setIsRateLimited(false)
@@ -81,6 +86,7 @@ export function useCardReveal({ cardId, autoMaskMs = DEFAULT_AUTO_MASK_MS }: Use
                 posthog.capture(ANALYTICS_EVENTS.CARD_PAN_FAILED, { error_message: errorMessage.slice(0, 120) })
             }
         } finally {
+            inFlightRef.current = false
             setIsLoading(false)
         }
     }, [cardId, autoMaskMs])

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
-import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
+import { withCeremonyFlow, withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { useQueryClient } from '@tanstack/react-query'
 import type { Address, Hex } from 'viem'
 import { encodeFunctionData, erc20Abi } from 'viem'
@@ -111,7 +111,7 @@ export const useSignSpendBundle = () => {
     const { grant } = useGrantSessionKey()
     const queryClient = useQueryClient()
 
-    const signSpend = useCallback(
+    const signSpendInner = useCallback(
         async (input: SignSpendBundleInput): Promise<SignedSpendArtifact> => {
             const {
                 requiredUsdcAmount,
@@ -325,6 +325,27 @@ export const useSignSpendBundle = () => {
             grant,
             queryClient,
         ]
+    )
+
+    // Brackets every ceremony one spend triggers as a flow (sign_spend:<kind>) so
+    // the prompt count per kind is measurable; link_create nests inside it.
+    const signSpend = useCallback(
+        (input: SignSpendBundleInput) => {
+            let strategy: string | undefined
+            return withCeremonyFlow(
+                `sign_spend:${input.kind}`,
+                () =>
+                    signSpendInner({
+                        ...input,
+                        onStrategyDecided: (decided) => {
+                            strategy = decided
+                            input.onStrategyDecided?.(decided)
+                        },
+                    }),
+                () => ({ strategy })
+            )
+        },
+        [signSpendInner]
     )
 
     return { signSpend }

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback } from 'react'
-import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
+import { withCeremonyFlow, withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import { useQueryClient } from '@tanstack/react-query'
 import type { Address, Hash, Hex, TransactionReceipt } from 'viem'
 import { encodeFunctionData, erc20Abi } from 'viem'
@@ -123,7 +123,7 @@ export const useSpendBundle = () => {
     const modals = useModalsContextOptional()
     const queryClient = useQueryClient()
 
-    const spend = useCallback(
+    const spendInner = useCallback(
         async (input: SpendBundleInput): Promise<SpendBundleResult> => {
             const {
                 requiredUsdcAmount,
@@ -412,6 +412,27 @@ export const useSpendBundle = () => {
             }
         },
         [getClientForChain, rebuildClientForChain, handleSendUserOpEncoded, user, overview, grant, modals, queryClient]
+    )
+
+    // Brackets every ceremony one spend triggers as a flow (spend:<kind>) so
+    // the prompt count per kind is measurable; link_create nests inside it.
+    const spend = useCallback(
+        (input: SpendBundleInput) => {
+            let strategy: string | undefined
+            return withCeremonyFlow(
+                `spend:${input.kind}`,
+                () =>
+                    spendInner({
+                        ...input,
+                        onStrategyDecided: (decided) => {
+                            strategy = decided
+                            input.onStrategyDecided?.(decided)
+                        },
+                    }),
+                () => ({ strategy })
+            )
+        },
+        [spendInner]
     )
 
     return { spend }

--- a/src/services/__tests__/step-up.test.ts
+++ b/src/services/__tests__/step-up.test.ts
@@ -6,8 +6,12 @@ import { clearStepUpToken, getStepUpToken, STEP_UP_HEADER, withStepUpHeader } fr
 import { apiFetch } from '@/utils/api-fetch'
 import { startAuthentication } from '@simplewebauthn/browser'
 import { CeremonyTimeoutError, guardPasskeyCeremony } from '@/utils/passkeyCeremony.utils'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 
 jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn() }))
+jest.mock('@/utils/webauthn-ceremony-telemetry', () => ({
+    withCeremonyPurpose: jest.fn((_purpose: string, fn: () => Promise<unknown>) => fn()),
+}))
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, getNativeRpId: () => 'peanut.me' }))
 // passthrough spy — the suite asserts the ceremony is routed through the guard
 // (shim gate + timeout, TASK-21782) without changing its behavior
@@ -124,5 +128,15 @@ describe('withStepUpHeader', () => {
             'Content-Type': 'application/json',
             [STEP_UP_HEADER]: 'proof-token',
         })
+    })
+})
+
+describe('ceremony telemetry', () => {
+    it('tags the assertion as step_up so it stops showing as unknown', async () => {
+        clearStepUpToken()
+        mockedAuth.mockResolvedValue({ id: 'cred' } as never)
+        happyPath()
+        await getStepUpToken()
+        expect(withCeremonyPurpose).toHaveBeenCalledWith('step_up', expect.any(Function))
     })
 })

--- a/src/services/step-up.ts
+++ b/src/services/step-up.ts
@@ -15,6 +15,7 @@ import { apiFetch } from '@/utils/api-fetch'
 import { getNativeRpId, isCapacitor } from '@/utils/capacitor'
 import { guardPasskeyCeremony, isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
 import { classifyPasskeyError } from '@/utils/webauthn.utils'
+import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 
 export const STEP_UP_HEADER = 'x-step-up-token'
 
@@ -64,7 +65,7 @@ export async function getStepUpToken(): Promise<string> {
     // as StepUpError so callers render the curated copy, not a raw timeout.
     let cred: Awaited<ReturnType<typeof startAuthentication>>
     try {
-        cred = await guardPasskeyCeremony(() => startAuthentication(options))
+        cred = await withCeremonyPurpose('step_up', () => guardPasskeyCeremony(() => startAuthentication(options)))
     } catch (error) {
         if (isCeremonyGuardError(error)) throw new StepUpError(classifyPasskeyError(error).message)
         throw error

--- a/src/utils/webauthn-ceremony-telemetry.ts
+++ b/src/utils/webauthn-ceremony-telemetry.ts
@@ -30,6 +30,7 @@ export type CeremonyPurpose =
     | 'user_op'
     | 'admin_eip712'
     | 'session_key_grant'
+    | 'step_up'
     | 'kernel_migration'
     | 'login'
     | 'registration'


### PR DESCRIPTION
## Why

Six days of ceremony telemetry (#2870) drove the passkey-prompt inventory in `mono/engineering/passkey-prompt-pairs-2026-09-03.md`. It left three blind spots and exposed one loop:

- Step-up assertions (card details, PIN, add bank) carried no purpose and showed as `unknown` — 99 of them.
- Only link creation was bracketed as a flow. QR pay, withdraws, direct send and card actions had to be reconstructed from per-user gaps.
- `signup_login_error` had no `native` flag, so the repeated-login failures could not be split native vs web.
- One device fired 13 step-ups in 27 s on `/card`, each failing in <10 ms with `overlapped=true`: `useCardReveal` had no re-entry guard, so taps while the sheet was up opened a second ceremony that failed instantly.

## What

- `step_up` purpose on the step-up ceremony (`src/services/step-up.ts`).
- Both spend engines bracket every call as `spend:<kind>` / `sign_spend:<kind>` and report the chosen `strategy`; `link_create` nests inside for send links. Done as an outer wrapper around the existing callback, no change to the spend bodies.
- `native: isCapacitor()` on `signup_login_error`.
- Re-entry guard in `useCardReveal.reveal()`.

## Verification

- New tests: step-up purpose tag, reveal re-entry (second call while in flight does not fetch again). SetupWrapper expectation updated for the new property.
- `pnpm typecheck` clean; step-up, useCardReveal, webauthn-ceremony-telemetry, useSignSpendBundle, useSendMoney, Setup suites green; prettier clean.
