### PR TITLE
feat(spend): tell the user a second passkey sheet follows on a mixed spend

### DIFF
--- a/src/components/Global/SecurityVerificationOverlay/index.tsx
+++ b/src/components/Global/SecurityVerificationOverlay/index.tsx
@@ -18,7 +18,7 @@ import { useModalsContext } from '@/context/ModalsContext'
  */
 export default function SecurityVerificationOverlay() {
     const t = useTranslations('global')
-    const { isSecurityVerificationOpen } = useModalsContext()
+    const { isSecurityVerificationOpen, securityVerificationVariant } = useModalsContext()
     if (!isSecurityVerificationOpen) return null
     return (
         <div
@@ -27,7 +27,14 @@ export default function SecurityVerificationOverlay() {
             // role="status" live region — nesting two would announce twice.
             className="fixed inset-x-0 top-safe-top bottom-0 z-50 flex items-center justify-center bg-background"
         >
-            <Loading variant="mascot" message={t('securityVerificationOverlay.message')} />
+            <Loading
+                variant="mascot"
+                message={t(
+                    securityVerificationVariant === 'next-passkey'
+                        ? 'securityVerificationOverlay.nextPasskeyMessage'
+                        : 'securityVerificationOverlay.message'
+                )}
+            />
         </div>
     )
 }

--- a/src/context/ModalsContext.tsx
+++ b/src/context/ModalsContext.tsx
@@ -31,8 +31,12 @@ interface ModalsContextType {
     // of the mixed card-withdraw flow so the user has something to look at
     // while the kernel prepares the follow-up UserOp.
     isSecurityVerificationOpen: boolean
-    setIsSecurityVerificationOpen: (isOpen: boolean) => void
+    securityVerificationVariant: SecurityVerificationVariant
+    setIsSecurityVerificationOpen: (isOpen: boolean, variant?: SecurityVerificationVariant) => void
 }
+
+/** 'next-passkey' tells the user a second passkey sheet follows (mixed spend tap #2). */
+export type SecurityVerificationVariant = 'default' | 'next-passkey'
 
 const ModalsContext = createContext<ModalsContextType | undefined>(undefined)
 
@@ -65,7 +69,17 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
     const [isQRScannerOpen, setIsQRScannerOpen] = useState(false)
 
     // Security Verification Overlay
-    const [isSecurityVerificationOpen, setIsSecurityVerificationOpen] = useState(false)
+    const [securityVerification, setSecurityVerification] = useState<{
+        open: boolean
+        variant: SecurityVerificationVariant
+    }>({ open: false, variant: 'default' })
+    const isSecurityVerificationOpen = securityVerification.open
+    const securityVerificationVariant = securityVerification.variant
+    const setIsSecurityVerificationOpen = useCallback(
+        (isOpen: boolean, variant: SecurityVerificationVariant = 'default') =>
+            setSecurityVerification({ open: isOpen, variant }),
+        []
+    )
 
     /*
      * Redact before storing, so every downstream sink is covered at once — the
@@ -106,6 +120,7 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
 
             // Security Verification Overlay
             isSecurityVerificationOpen,
+            securityVerificationVariant,
             setIsSecurityVerificationOpen,
         }),
         [
@@ -118,6 +133,8 @@ export function ModalsProvider({ children }: { children: ReactNode }) {
             openSupportWithMessage,
             isQRScannerOpen,
             isSecurityVerificationOpen,
+            securityVerificationVariant,
+            setIsSecurityVerificationOpen,
         ]
     )
 

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -302,7 +302,15 @@ export const useSignSpendBundle = () => {
                     }),
                 }
 
-                const signedUserOp = await signCallsUserOp([withdrawCall, transferCall], chainIdStr)
+                // Tap #2 follows the admin signature; tell the user so the second
+                // sheet is not dismissed as a duplicate (same beat as useSpendBundle).
+                modals?.setIsSecurityVerificationOpen?.(true, 'next-passkey')
+                let signedUserOp: SignedUserOpData
+                try {
+                    signedUserOp = await signCallsUserOp([withdrawCall, transferCall], chainIdStr)
+                } finally {
+                    modals?.setIsSecurityVerificationOpen?.(false)
+                }
                 return { strategy, signedUserOp, rainPreparationId: prep.preparationId }
             } catch (e) {
                 posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_FAILED, {

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -337,7 +337,7 @@ export const useSpendBundle = () => {
                 // look at and the UI feels intentional rather than frozen.
                 // try/finally guarantees the overlay closes on success AND on
                 // bundler / kernel failure.
-                modals?.setIsSecurityVerificationOpen?.(true)
+                modals?.setIsSecurityVerificationOpen?.(true, 'next-passkey')
                 try {
                     // Backend `/prepare` normalizes the executor salt (bytes32) and signature
                     // to 0x-hex regardless of what Rain returned — trust the wire shape here.

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3257,7 +3257,8 @@
             "doneCta": "Done"
         },
         "securityVerificationOverlay": {
-            "message": "Verifying security…"
+            "message": "Verifying security…",
+            "nextPasskeyMessage": "Verifying security… one more passkey confirmation comes next"
         },
         "iframeWrapper": {
             "troubleTitle": "Need a hand?",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3257,7 +3257,8 @@
             "doneCta": "Listo"
         },
         "securityVerificationOverlay": {
-            "message": "Verificando seguridad…"
+            "message": "Verificando seguridad…",
+            "nextPasskeyMessage": "Verificando seguridad… falta una confirmación más con tu passkey"
         },
         "iframeWrapper": {
             "troubleTitle": "¿Necesitas ayuda?",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3257,7 +3257,8 @@
             "doneCta": "Concluído"
         },
         "securityVerificationOverlay": {
-            "message": "Verificando segurança…"
+            "message": "Verificando segurança…",
+            "nextPasskeyMessage": "Verificando segurança… falta mais uma confirmação com sua passkey"
         },
         "iframeWrapper": {
             "troubleTitle": "Precisa de ajuda?",


### PR DESCRIPTION
## Why

Ceremony telemetry shows the mixed spend's second sheet (the UserOp, ~1.5 s after the Rain admin signature) is the one that gets dismissed: Android `NotAllowedError` and iOS `LOGIN_CANCELED` both cluster at that gap, and the retry then costs four sheets. The overlay between the two taps said only "Verifying security…", which reads as "done". The data cannot tell whether the user or the OS dismisses it; the copy fix covers the first, the one-tap path (#2959) removes the sheet altogether.

## What

- `ModalsContext.setIsSecurityVerificationOpen(open, variant?)` — `'next-passkey'` swaps the overlay copy to "Verifying security… one more passkey confirmation comes next".
- `useSpendBundle` passes it before tap #2.
- `useSignSpendBundle` (QR pay, Manteca withdraw, card lock/cancel, return-excess) showed **no overlay at all** between its two taps; it now shows the same beat, closed in a `finally`.
- Copy in en, es-419, pt-BR; es-AR inherits es-419.

No change to signing or ordering. Stopgap until #2959 lands.

## Verification

- `pnpm typecheck` clean; ModalsContext, useSignSpendBundle, useSendMoney and all i18n suites green; prettier clean.
