### PR TITLE
feat(auth): a login primes the step-up proof so the card does not ask again

### DIFF
--- a/src/config/peanut.config.tsx
+++ b/src/config/peanut.config.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react'
 import 'react-tooltip/dist/react-tooltip.css'
 import { isCapacitor, getNativeRpId } from '@/utils/capacitor'
 import { authReady } from '@/utils/auth-token'
-import { installNativeAuthCapture } from '@/utils/native-auth-capture'
+import { installPasskeyVerifyCapture } from '@/utils/native-auth-capture'
 import { scheduleTransportCanary } from '@/utils/native-canary'
 import { installCeremonyTelemetry } from '@/utils/webauthn-ceremony-telemetry'
 import { markPasskeyShimFailed } from '@/utils/passkeyCeremony.utils'
@@ -34,9 +34,11 @@ export function PeanutProvider({ children }: { children: React.ReactNode }) {
         // in the response body, the fetch wrapper below captures it into native
         // Preferences, and every api request sends it as Authorization
         // (see src/utils/auth-token.ts).
+        // Every platform: the verify body carries the login-minted step-up proof
+        // and, on failure, the server's reason (ZeroDev discards both).
+        installPasskeyVerifyCapture()
         if (isCapacitor()) {
             void authReady() // start Preferences hydration before any API call needs it
-            installNativeAuthCapture()
             scheduleTransportCanary()
             const installPasskeyShim = async () => {
                 const { CapacitorPasskey } = await import('@capgo/capacitor-passkey')

--- a/src/services/__tests__/step-up.test.ts
+++ b/src/services/__tests__/step-up.test.ts
@@ -2,7 +2,7 @@
  * The cache is the risky part: too eager and one Face ID prompt unlocks
  * sensitive routes indefinitely, too shy and a withdrawal prompts twice.
  */
-import { clearStepUpToken, getStepUpToken, STEP_UP_HEADER, withStepUpHeader } from '../step-up'
+import { clearStepUpToken, getStepUpToken, primeStepUpToken, STEP_UP_HEADER, withStepUpHeader } from '../step-up'
 import { apiFetch } from '@/utils/api-fetch'
 import { startAuthentication } from '@simplewebauthn/browser'
 import { CeremonyTimeoutError, guardPasskeyCeremony } from '@/utils/passkeyCeremony.utils'
@@ -124,5 +124,26 @@ describe('withStepUpHeader', () => {
             'Content-Type': 'application/json',
             [STEP_UP_HEADER]: 'proof-token',
         })
+    })
+})
+
+describe('primeStepUpToken', () => {
+    it('serves a login-minted proof without a second ceremony until it expires', async () => {
+        clearStepUpToken()
+        mockedFetch.mockReset()
+        mockedAuth.mockReset()
+        primeStepUpToken('from-login', 300)
+        await expect(getStepUpToken()).resolves.toBe('from-login')
+        expect(mockedAuth).not.toHaveBeenCalled()
+        expect(mockedFetch).not.toHaveBeenCalled()
+    })
+
+    it('ignores a primed proof inside the expiry margin', async () => {
+        clearStepUpToken()
+        mockedAuth.mockResolvedValue({ id: 'cred' } as never)
+        primeStepUpToken('almost-dead', 10)
+        happyPath('fresh')
+        await expect(getStepUpToken()).resolves.toBe('fresh')
+        expect(mockedAuth).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/services/step-up-cache.ts
+++ b/src/services/step-up-cache.ts
@@ -1,0 +1,18 @@
+/** Retire the token early so a request never leaves with one about to expire. */
+const EXPIRY_MARGIN_MS = 30_000
+
+let cached: { token: string; expiresAt: number } | null = null
+
+export function getCachedStepUpToken(): string | null {
+    if (cached && cached.expiresAt - EXPIRY_MARGIN_MS > Date.now()) return cached.token
+    cached = null
+    return null
+}
+
+export function setCachedStepUpToken(token: string, expiresIn: number): void {
+    cached = { token, expiresAt: Date.now() + expiresIn * 1000 }
+}
+
+export function clearCachedStepUpToken(): void {
+    cached = null
+}

--- a/src/services/step-up.ts
+++ b/src/services/step-up.ts
@@ -7,7 +7,9 @@
  * exchanges it for a short-lived proof token.
  *
  * The token is cached for its lifetime so a multi-step flow (approve → prepare)
- * costs one Face ID prompt, not one per request.
+ * costs one Face ID prompt, not one per request. A login mints one too
+ * (primeStepUpToken via the verify-capture fetch wrapper), so opening the
+ * card right after logging in costs no extra sheet.
  */
 
 import { startAuthentication } from '@simplewebauthn/browser'
@@ -15,13 +17,9 @@ import { apiFetch } from '@/utils/api-fetch'
 import { getNativeRpId, isCapacitor } from '@/utils/capacitor'
 import { guardPasskeyCeremony, isCeremonyGuardError } from '@/utils/passkeyCeremony.utils'
 import { classifyPasskeyError } from '@/utils/webauthn.utils'
+import { clearCachedStepUpToken, getCachedStepUpToken, setCachedStepUpToken } from './step-up-cache'
 
 export const STEP_UP_HEADER = 'x-step-up-token'
-
-/** Retire the token early so a request never leaves with one about to expire. */
-const EXPIRY_MARGIN_MS = 30_000
-
-let cached: { token: string; expiresAt: number } | null = null
 
 export class StepUpError extends Error {
     constructor(message: string) {
@@ -36,12 +34,20 @@ function currentRpId(): string {
 
 /** Drops the cached proof. Call on logout, or after a 401 from a gated route. */
 export function clearStepUpToken(): void {
-    cached = null
+    clearCachedStepUpToken()
+}
+
+/**
+ * Seeds the cache from a token minted alongside a login: a login assertion
+ * seconds old is as fresh as a step-up one, so the card does not ask again.
+ */
+export function primeStepUpToken(token: string, expiresIn: number): void {
+    setCachedStepUpToken(token, expiresIn)
 }
 
 export async function getStepUpToken(): Promise<string> {
-    if (cached && cached.expiresAt - EXPIRY_MARGIN_MS > Date.now()) return cached.token
-    cached = null
+    const primed = getCachedStepUpToken()
+    if (primed) return primed
 
     const rpID = currentRpId()
 
@@ -79,7 +85,7 @@ export async function getStepUpToken(): Promise<string> {
     }
 
     const { token, expiresIn } = (await verifyResponse.json()) as { token: string; expiresIn: number }
-    cached = { token, expiresAt: Date.now() + expiresIn * 1000 }
+    setCachedStepUpToken(token, expiresIn)
     return token
 }
 

--- a/src/utils/__tests__/native-auth-capture.test.ts
+++ b/src/utils/__tests__/native-auth-capture.test.ts
@@ -1,0 +1,57 @@
+import { installPasskeyVerifyCapture } from '../native-auth-capture'
+import { stashCeremonyStepUpToken, stashCeremonyVerifyToken } from '@/utils/passkeyCeremony.utils'
+import { isCapacitor } from '@/utils/capacitor'
+
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
+jest.mock('@/utils/sentry-lazy', () => ({ withScope: jest.fn(), captureMessage: jest.fn() }))
+jest.mock('@/utils/passkeyCeremony.utils', () => ({
+    currentCeremonyId: () => 7,
+    stashCeremonyVerifyToken: jest.fn(),
+    stashCeremonyStepUpToken: jest.fn(),
+}))
+
+const mockIsCapacitor = isCapacitor as jest.Mock
+
+// jsdom has no Response; the wrapper only touches ok/clone/json/text.
+function jsonResponse(body: unknown): Response {
+    const response = {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+        clone: () => response,
+    }
+    return response as unknown as Response
+}
+
+describe('installPasskeyVerifyCapture', () => {
+    const verifyBody = { verification: { verified: true }, token: 'jwt', stepUpToken: 'proof', stepUpExpiresIn: 300 }
+
+    beforeAll(() => {
+        window.fetch = jest.fn(async () => jsonResponse(verifyBody))
+        installPasskeyVerifyCapture()
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsCapacitor.mockReturnValue(false)
+    })
+
+    it('web: stashes the login-minted step-up proof but leaves the session token to the cookie', async () => {
+        await window.fetch('/passkeys/login/verify', { method: 'POST' })
+        expect(stashCeremonyStepUpToken).toHaveBeenCalledWith('proof', 300, 7)
+        expect(stashCeremonyVerifyToken).not.toHaveBeenCalled()
+    })
+
+    it('native: stashes both', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        await window.fetch('https://api.peanut.me/passkeys/login/verify', { method: 'POST' })
+        expect(stashCeremonyVerifyToken).toHaveBeenCalledWith('jwt', 7)
+        expect(stashCeremonyStepUpToken).toHaveBeenCalledWith('proof', 300, 7)
+    })
+
+    it('ignores non-passkey requests', async () => {
+        await window.fetch('/users/me')
+        expect(stashCeremonyStepUpToken).not.toHaveBeenCalled()
+    })
+})

--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -10,9 +10,11 @@ import {
     isPasskeyShimInstalled,
     markPasskeyShimFailed,
     raceCeremonyTimeout,
+    stashCeremonyStepUpToken,
     stashCeremonyVerifyToken,
     waitForPasskeyShim,
 } from '../passkeyCeremony.utils'
+import { clearCachedStepUpToken, getCachedStepUpToken } from '@/services/step-up-cache'
 import { isCapacitor } from '@/utils/capacitor'
 import { setAuthToken } from '@/utils/auth-token'
 
@@ -240,6 +242,37 @@ describe('guardPasskeyCeremony', () => {
         // a token landing with no ceremony active is refused outright
         stashCeremonyVerifyToken('jwt-late', null)
         expect(mockSetAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('primes the step-up cache from a login-minted proof only when the ceremony resolves', async () => {
+        clearCachedStepUpToken()
+        let resolveCeremony!: (v: string) => void
+        const pending = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveCeremony = resolve
+                })
+        )
+        await Promise.resolve()
+        stashCeremonyStepUpToken('step-up-abc', 300, currentCeremonyId())
+        expect(getCachedStepUpToken()).toBeNull()
+        resolveCeremony('key')
+        await pending
+        expect(getCachedStepUpToken()).toBe('step-up-abc')
+        clearCachedStepUpToken()
+    })
+
+    it('discards a stashed step-up proof when the ceremony fails', async () => {
+        clearCachedStepUpToken()
+        const pending = guardPasskeyCeremony(async () => {
+            stashCeremonyStepUpToken('step-up-stale', 300, currentCeremonyId())
+            throw new Error('cancelled')
+        })
+        await expect(pending).rejects.toThrow('cancelled')
+        expect(getCachedStepUpToken()).toBeNull()
+        // and one landing with no ceremony active is refused outright
+        stashCeremonyStepUpToken('step-up-late', 300, null)
+        expect(getCachedStepUpToken()).toBeNull()
     })
 
     it('refuses a token whose request was issued outside the active window', async () => {

--- a/src/utils/native-auth-capture.ts
+++ b/src/utils/native-auth-capture.ts
@@ -1,13 +1,13 @@
-// Captures the session JWT from passkey verify responses on native.
-// The ZeroDev SDK performs the /passkeys/{login,register}/verify fetch
-// internally and discards the response body, so the token the API ships for
-// cookie-less clients would otherwise be lost. Wrapping window.fetch here
-// works with CapacitorHttp both on (bridge-patched fetch) and off (plain
-// WebView fetch), so the same JS runs on old and new binaries.
+// Captures what the ZeroDev SDK throws away from /passkeys/{login,register}/verify:
+// it performs the fetch internally and discards the response body. On native
+// the body carries the session JWT for cookie-less clients; on every platform
+// it carries the step-up proof a login mints (so the card does not ask for a
+// second sheet) and, for non-2xx, the server's reason. Wrapping window.fetch
+// works with CapacitorHttp both on (bridge-patched fetch) and off.
 
 import * as Sentry from '@/utils/sentry-lazy'
 import { isCapacitor } from './capacitor'
-import { currentCeremonyId, stashCeremonyVerifyToken } from './passkeyCeremony.utils'
+import { currentCeremonyId, stashCeremonyStepUpToken, stashCeremonyVerifyToken } from './passkeyCeremony.utils'
 
 // ZeroDev swallows the status/body of these fetches, so a rejected ceremony
 // reaches Sentry only as an opaque "Login not verified" (PEANUT-UI-R0X) with
@@ -48,8 +48,8 @@ export function getUnderlyingFetch(): typeof fetch | null {
     return underlyingFetch
 }
 
-export function installNativeAuthCapture(): void {
-    if (!isCapacitor() || installed || typeof window === 'undefined') return
+export function installPasskeyVerifyCapture(): void {
+    if (installed || typeof window === 'undefined') return
     installed = true
 
     underlyingFetch = window.fetch
@@ -89,8 +89,11 @@ export function installNativeAuthCapture(): void {
             // half-authenticated session (TASK-21782).
             if (response.ok && isVerify) {
                 const body = await response.clone().json()
-                if (body && typeof body.token === 'string' && body.token) {
+                if (isCapacitor() && body && typeof body.token === 'string' && body.token) {
                     stashCeremonyVerifyToken(body.token, issuingCeremonyId)
+                }
+                if (body && typeof body.stepUpToken === 'string' && typeof body.stepUpExpiresIn === 'number') {
+                    stashCeremonyStepUpToken(body.stepUpToken, body.stepUpExpiresIn, issuingCeremonyId)
                 }
             }
         } catch {

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@/utils/sentry-lazy'
 import { isCapacitor } from '@/utils/capacitor'
 import { setAuthToken } from '@/utils/auth-token'
+import { setCachedStepUpToken } from '@/services/step-up-cache'
 
 /**
  * Guards for the passkey ceremony (TASK-21782).
@@ -127,6 +128,11 @@ export const waitForPasskeyShim = async (timeoutMs: number = SHIM_WAIT_TIMEOUT_M
 let ceremonySeq = 0
 let activeCeremonyId: number | null = null
 let stashedVerifyToken: string | null = null
+type StashedStepUp = { token: string; expiresIn: number }
+let stashedStepUp: StashedStepUp | null = null
+// Read through a function: TS narrows the module `let` to null across the
+// await below and cannot see the fetch wrapper assigning it meanwhile.
+const takeStashedStepUp = (): StashedStepUp | null => stashedStepUp
 export const currentCeremonyId = (): number | null => activeCeremonyId
 export const isCeremonyStillActive = (id: number | null): boolean => id !== null && id === activeCeremonyId
 
@@ -138,6 +144,11 @@ export const isCeremonyStillActive = (id: number | null): boolean => id !== null
  */
 export const stashCeremonyVerifyToken = (token: string, issuingCeremonyId: number | null): void => {
     if (isCeremonyStillActive(issuingCeremonyId)) stashedVerifyToken = token
+}
+
+/** Same window rule as the session token: the step-up proof a login mints is committed only with its ceremony. */
+export const stashCeremonyStepUpToken = (token: string, expiresIn: number, issuingCeremonyId: number | null): void => {
+    if (isCeremonyStillActive(issuingCeremonyId)) stashedStepUp = { token, expiresIn }
 }
 
 /**
@@ -177,15 +188,19 @@ export const guardPasskeyCeremony = async <T>(startCeremony: () => Promise<T>): 
     const ceremonyId = ++ceremonySeq
     activeCeremonyId = ceremonyId
     stashedVerifyToken = null
+    stashedStepUp = null
     try {
         const result = await raceCeremonyTimeout(
             startCeremony(),
             native ? CEREMONY_TIMEOUT_MS : WEB_CEREMONY_TIMEOUT_MS
         )
         if (stashedVerifyToken !== null) setAuthToken(stashedVerifyToken)
+        const stepUp = takeStashedStepUp()
+        if (stepUp !== null) setCachedStepUpToken(stepUp.token, stepUp.expiresIn)
         return result
     } finally {
         if (activeCeremonyId === ceremonyId) activeCeremonyId = null
         stashedVerifyToken = null
+        stashedStepUp = null
     }
 }


### PR DESCRIPTION
## Why

Telemetry: log in, open the card, a second passkey sheet 7 s later. A login assertion seconds old is as fresh as a step-up one. The API now mints a step-up proof alongside the session token on `/passkeys/login/verify` (peanut-api-ts `feat/login-mints-step-up-token`).

## What

- The ZeroDev SDK discards the verify body, so the fetch wrapper that already recovers the session JWT on native (`native-auth-capture.ts`, now `installPasskeyVerifyCapture`) runs on **every** platform. It stashes `stepUpToken` / `stepUpExpiresIn` under the same ceremony-window rule as the session token; `guardPasskeyCeremony` commits it to the step-up cache only when the ceremony resolves, and discards it on failure or timeout.
- On web the session token still comes from the cookie; only the proof is taken from the body.
- Side effect worth having: non-2xx verify responses are now reported to Sentry on web too (`passkey_http_failure`, with status and body). That is the missing signal behind the "Login not verified" retries (16 users in six days) — the client only ever saw an opaque TypeError.
- The cache moved to `step-up-cache.ts` so the ceremony guard can seed it without a `step-up.ts` ↔ `passkeyCeremony.utils` import cycle. `getStepUpToken` behaviour is unchanged.

Safe against old servers: without the fields nothing is stashed and the card prompts as today.

## Verification

- New tests: step-up proof committed only on resolve, discarded on failure and outside the window; `primeStepUpToken` serves without a ceremony and respects the expiry margin; capture wrapper on web vs native.
- `pnpm typecheck` clean; step-up, passkeyCeremony, native-auth-capture, native-canary, useZeroDev suites green; prettier clean.
