### PR TITLE
perf(native): prune the press kit from the static export

### DIFF
--- a/scripts/native-build.js
+++ b/scripts/native-build.js
@@ -710,6 +710,9 @@ function pruneExportedAssets() {
     for (const entry of fs.readdirSync(outDir)) {
         if (entry.endsWith('.mov')) targets.push(path.join(outDir, entry))
     }
+    // public/ is copied wholesale, so the press kit rides along (~14 MB of team
+    // photos, brand PDF and EPS) even though /[locale]/press is disabled here.
+    targets.push(path.join(outDir, 'press'))
 
     for (const target of targets) {
         if (fs.existsSync(target)) {


### PR DESCRIPTION
## What

Add `out/press` to the existing `pruneExportedAssets()` pass in `scripts/native-build.js`.

## Why

`public/press` is **13.8 MB across 30 files** — founder photos (3.5 MB + 2.6 MB), `Peanut_Brand_Guidelines.pdf`, `Peanut_Full_Logotype.eps`, added in `928b70763`.

Next copies `public/` into `out/` wholesale, independent of which routes exist. Its only consumer is `/[locale]/press`, and `[locale]` is in this script's disable list:

```js
{ path: '[locale]', type: 'dir' }, // marketing/blog/seo pages
```

So the whole press kit ships inside every native binary **and every OTA bundle**, for a route that 404s in the app. The assets are PNG/PDF/EPS, so they compress badly and land in the OTA zip near full size.

Found while checking whether Capgo's delta-upload pitch applies to us. (It does, but that's a separate change and not being pursued here.)

## How

Three lines, reusing the pass that already drops the PWA `.mov` files and the `/dev` pages. Each target is `existsSync`-guarded, so this is a no-op if `public/press` ever goes away.

## Testing

Confirmed on a real static export — the `native-export` CI job runs `node scripts/native-build.js` in full, and its log shows:

```
🧹 Pruned iosPwaChrome.mov from export
🧹 Pruned iosPwaSafari.mov from export
🧹 Pruned press from export
...
Export ready. File count: 1601
```

Also exercised `pruneExportedAssets()` against a synthetic `out/` tree beforehand (prunes `press` and top-level `.mov`, leaves `home` and `dev/deferred` intact), and `prettier --check` is clean.

## Risk

Low, and web-only assets are untouched — `public/press` still ships on the web build, which is the only place the press page exists.

Deliberately conservative: `badges`, `merchants`, `easter-eggs` and `flags` (~4 MB combined) are also unreferenced from `src/`, but unlike `press` they aren't provably tied to a disabled route, so they're left alone.
