### PR TITLE
feat(spend): one-tap mixed spend for the sign-only engine, dark behind its own flag

### DIFF
--- a/src/app/(mobile-ui)/dev/session-key-spend/page.tsx
+++ b/src/app/(mobile-ui)/dev/session-key-spend/page.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import {
     SESSION_KEY_SPEND_BUILD_ENABLED,
+    SESSION_KEY_SIGN_FLAG,
     SESSION_KEY_SPEND_FLAG,
     sessionKeySpendDeviceOptIn,
     setSessionKeySpendDeviceOptIn,
@@ -28,6 +29,7 @@ export default function SessionKeySpendPage() {
     const isFlagEnabled = useFeatureFlags()
     const deviceOn = sessionKeySpendDeviceOptIn()
     const flagOn = isFlagEnabled(SESSION_KEY_SPEND_FLAG)
+    const signFlagOn = isFlagEnabled(SESSION_KEY_SIGN_FLAG)
     const effective = SESSION_KEY_SPEND_BUILD_ENABLED && (deviceOn || flagOn)
 
     const toggle = () => {
@@ -49,6 +51,10 @@ export default function SessionKeySpendPage() {
                 <div>
                     <span className="font-bold">PostHog flag ({SESSION_KEY_SPEND_FLAG}) for this user: </span>
                     {flagOn ? '✅ on' : '❌ off'}
+                </div>
+                <div>
+                    <span className="font-bold">PostHog flag ({SESSION_KEY_SIGN_FLAG}) — sign-only engine: </span>
+                    {signFlagOn ? '✅ on' : '❌ off'}
                 </div>
                 <div>
                     <span className="font-bold">Device opt-in: </span>

--- a/src/constants/__tests__/session-key-spend.consts.test.ts
+++ b/src/constants/__tests__/session-key-spend.consts.test.ts
@@ -60,3 +60,25 @@ describe('sessionKeySpendEnabled', () => {
         spy.mockRestore()
     })
 })
+
+describe('sessionKeySignEnabled', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        mockIsFeatureFlagEnabled.mockReset().mockReturnValue(false)
+    })
+
+    it('is off when the build gate is off', () => {
+        const gate = loadGate(undefined)
+        mockIsFeatureFlagEnabled.mockReturnValue(true)
+        expect(gate.sessionKeySignEnabled()).toBe(false)
+    })
+
+    it('follows its own flag, not the broadcasting engine flag or the device opt-in', () => {
+        const gate = loadGate('true')
+        gate.setSessionKeySpendDeviceOptIn(true)
+        mockIsFeatureFlagEnabled.mockImplementation((key: string) => key === 'session_key_spend')
+        expect(gate.sessionKeySignEnabled()).toBe(false)
+        mockIsFeatureFlagEnabled.mockImplementation((key: string) => key === 'session_key_spend_sign')
+        expect(gate.sessionKeySignEnabled()).toBe(true)
+    })
+})

--- a/src/constants/session-key-spend.consts.ts
+++ b/src/constants/session-key-spend.consts.ts
@@ -41,3 +41,16 @@ export function sessionKeySpendEnabled(): boolean {
     if (!SESSION_KEY_SPEND_BUILD_ENABLED) return false
     return sessionKeySpendDeviceOptIn() || isFeatureFlagEnabled(SESSION_KEY_SPEND_FLAG)
 }
+
+export const SESSION_KEY_SIGN_FLAG = 'session_key_spend_sign'
+
+/*
+ * Sign-only engine (QR pay, Manteca withdraw, card lock/cancel): the backend
+ * broadcasts, so a permission that fails on-chain cannot fall back on the
+ * client. Own flag, flipped only after the broadcasting engine has proven
+ * the ERC-1271 ordering on production contracts.
+ */
+export function sessionKeySignEnabled(): boolean {
+    if (!SESSION_KEY_SPEND_BUILD_ENABLED) return false
+    return isFeatureFlagEnabled(SESSION_KEY_SIGN_FLAG)
+}

--- a/src/hooks/wallet/__tests__/mixedEphemeralSign.test.ts
+++ b/src/hooks/wallet/__tests__/mixedEphemeralSign.test.ts
@@ -1,0 +1,105 @@
+import { signMixedEphemeralSpend, SIGN_ONLY_TTL_SECONDS } from '../mixedEphemeralSign'
+import { createEphemeralSpendSession } from '@/utils/ephemeralSpendKey'
+import { signUserOperation } from '@zerodev/sdk/actions'
+
+jest.mock('@/utils/ephemeralSpendKey', () => ({ createEphemeralSpendSession: jest.fn() }))
+jest.mock('@zerodev/sdk/actions', () => ({ signUserOperation: jest.fn() }))
+jest.mock('@/utils/rainWithdraw.utils', () => ({ buildRainWithdrawTypedData: jest.fn(() => ({ typed: true })) }))
+jest.mock('@/constants/zerodev.consts', () => ({
+    PEANUT_WALLET_TOKEN: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    USER_OP_ENTRY_POINT: { address: '0x0000000071727De22E5E9d8BAf0edAc6f37da032' },
+}))
+
+const mockCreateSession = createEphemeralSpendSession as jest.Mock
+const mockSignUserOperation = signUserOperation as jest.Mock
+
+const PREP = {
+    preparationId: 'prep-1',
+    coordinatorAddress: '0xc0d5bd6307ec8c8da03e7502a00b8cba24eefc06',
+    collateralProxy: '0x1111111111111111111111111111111111111111',
+    tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+    amount: '150000000',
+    recipientAddress: '0x2222222222222222222222222222222222222222',
+    directTransfer: false,
+    adminSalt: '0x3333333333333333333333333333333333333333333333333333333333333333',
+    executorSignature: '0x44',
+    executorSalt: '0x5555555555555555555555555555555555555555555555555555555555555555',
+    expiresAt: 1234567890,
+}
+
+function baseArgs() {
+    return {
+        publicClient: {} as never,
+        chain: { id: 42161 } as never,
+        patchedSudoValidator: {} as never,
+        accountAddress: '0x9999999999999999999999999999999999999999' as const,
+        prep: PREP as never,
+        recipient: '0x2222222222222222222222222222222222222222' as const,
+        requiredUsdcAmount: 200_000_000n,
+    }
+}
+
+function fakeSession() {
+    const dispose = jest.fn()
+    const encodeCalls = jest.fn(async (_calls: unknown[]) => '0xcalldata')
+    const session = {
+        account: { signTypedData: jest.fn(async () => '0xephemeraladminsig'), encodeCalls },
+        client: { tag: 'session-client' },
+        uninstallCall: { to: '0x9999999999999999999999999999999999999999', value: 0n, data: '0xuninstall' },
+        dispose,
+    }
+    mockCreateSession.mockResolvedValue(session)
+    return { session, dispose, encodeCalls }
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockSignUserOperation.mockResolvedValue({ sender: '0x99', nonce: 1n, signature: '0xsig' })
+})
+
+describe('signMixedEphemeralSpend', () => {
+    it('signs admin EIP-712 and the UserOp with the ephemeral key, uninstall last, and returns an unbroadcast artifact', async () => {
+        const { session, dispose, encodeCalls } = fakeSession()
+
+        const result = await signMixedEphemeralSpend(baseArgs())
+
+        expect(result).toEqual({
+            ok: true,
+            signedUserOp: {
+                signedUserOp: { sender: '0x99', nonce: 1n, signature: '0xsig' },
+                chainId: '42161',
+                entryPointAddress: '0x0000000071727De22E5E9d8BAf0edAc6f37da032',
+            },
+        })
+        // the permission lives long enough for a backend broadcast
+        expect(mockCreateSession.mock.calls[0][0].ttlSeconds).toBe(SIGN_ONLY_TTL_SECONDS)
+        // silent admin signature from the session key, not a passkey
+        expect(session.account.signTypedData).toHaveBeenCalledWith({ typed: true })
+        // withdraw, transfer, then the self-destruct as the LAST call
+        const calls = encodeCalls.mock.calls[0][0] as Array<{ to: string; data: string }>
+        expect(calls).toHaveLength(3)
+        expect(calls[0].to).toBe(PREP.coordinatorAddress)
+        expect(calls[2]).toBe(session.uninstallCall)
+        // signed through the session client, never sent
+        expect(mockSignUserOperation).toHaveBeenCalledWith(session.client, {
+            account: session.account,
+            callData: '0xcalldata',
+        })
+        expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports a preflight failure as ok:false and still disposes nothing was created', async () => {
+        mockCreateSession.mockRejectedValue(new Error('ephemeral key: validator nonce floored'))
+        const result = await signMixedEphemeralSpend(baseArgs())
+        expect(result).toEqual({ ok: false, reason: 'ephemeral key: validator nonce floored' })
+        expect(mockSignUserOperation).not.toHaveBeenCalled()
+    })
+
+    it('reports a signing failure as ok:false and disposes the key', async () => {
+        const { dispose } = fakeSession()
+        mockSignUserOperation.mockRejectedValue(new Error('bundler estimate failed'))
+        const result = await signMixedEphemeralSpend(baseArgs())
+        expect(result).toEqual({ ok: false, reason: 'bundler estimate failed' })
+        expect(dispose).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
@@ -18,6 +18,8 @@ import posthog from 'posthog-js'
 import { useSignSpendBundle } from '../useSignSpendBundle'
 import { InsufficientSpendableError, resolveSpendStrategy, runCollateralSpendPreflight } from '../spendPreflight'
 import { rainApi } from '@/services/rain'
+import { signMixedEphemeralSpend } from '../mixedEphemeralSign'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 const ACCOUNT = '0xc97fffbf8768ca90cd62fae2e313b084fe13e553'
 const RECIPIENT = '0x4e5b89fd498f333ed7f2a59c5f23d5b5dc41b3de'
@@ -30,7 +32,25 @@ jest.mock('@/constants/zerodev.consts', () => ({
 }))
 jest.mock('@/constants/rain.consts', () => ({
     rainCoordinatorAbi: [
-        { type: 'function', name: 'withdrawAsset', inputs: [], outputs: [], stateMutability: 'nonpayable' },
+        {
+            type: 'function',
+            name: 'withdrawAsset',
+            // the mixed two-tap path encodes the real 10-arg call
+            inputs: [
+                { name: 'proxy', type: 'address' },
+                { name: 'token', type: 'address' },
+                { name: 'amount', type: 'uint256' },
+                { name: 'recipient', type: 'address' },
+                { name: 'expiresAt', type: 'uint256' },
+                { name: 'executorSalt', type: 'bytes32' },
+                { name: 'executorSignature', type: 'bytes' },
+                { name: 'adminSalts', type: 'bytes32[]' },
+                { name: 'adminSignatures', type: 'bytes[]' },
+                { name: 'directTransfer', type: 'bool' },
+            ],
+            outputs: [],
+            stateMutability: 'nonpayable',
+        },
     ],
 }))
 const mockSignTypedData = jest.fn()
@@ -38,8 +58,15 @@ jest.mock('@/context/kernelClient.context', () => ({
     useKernelClient: () => ({
         getClientForChain: () => ({ account: { address: ACCOUNT, signTypedData: mockSignTypedData } }),
         rebuildClientForChain: jest.fn(),
+        getPatchedSudoValidator: jest.fn(async () => ({ validator: 'patched' })),
     }),
 }))
+jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: { tag: 'public' } }))
+const mockSessionKeySignEnabled = jest.fn(() => false)
+jest.mock('@/constants/session-key-spend.consts', () => ({
+    sessionKeySignEnabled: () => mockSessionKeySignEnabled(),
+}))
+jest.mock('../mixedEphemeralSign', () => ({ signMixedEphemeralSpend: jest.fn() }))
 jest.mock('@/hooks/useZeroDev', () => ({ useZeroDev: () => ({ handleSendUserOpEncoded: jest.fn() }) }))
 jest.mock('@/context/ModalsContext', () => ({ useModalsContextOptional: () => undefined }))
 jest.mock('@/hooks/useRainCardOverview', () => ({
@@ -73,10 +100,10 @@ const PREP = {
     amount: '150000000',
     recipientAddress: RECIPIENT,
     directTransfer: true,
-    adminSalt: '0xsalt',
+    adminSalt: '0x3333333333333333333333333333333333333333333333333333333333333333',
     adminNonce: '1',
-    executorSignature: '0xexecsig',
-    executorSalt: '0xexecsalt',
+    executorSignature: '0x44',
+    executorSalt: '0x5555555555555555555555555555555555555555555555555555555555555555',
     expiresAt: 1234567890,
 }
 
@@ -146,5 +173,63 @@ describe('useSignSpendBundle — forceStrategy: collateral-only', () => {
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['rain-card-overview'] })
         expect(mockResolveSpendStrategy).not.toHaveBeenCalled()
         expect(mockPrepareWithdrawal).not.toHaveBeenCalled()
+    })
+})
+
+describe('useSignSpendBundle — mixed, SESSION_KEY_SIGN one-tap path', () => {
+    const mockSignEphemeral = signMixedEphemeralSpend as jest.Mock
+    const SIGNED = { signedUserOp: { sender: ACCOUNT }, chainId: '42161', entryPointAddress: '0xentry' }
+
+    beforeEach(() => {
+        mockResolveSpendStrategy.mockResolvedValue({ strategy: 'mixed', smartBalance: 50_000_000n })
+    })
+
+    async function signMixed() {
+        const { result } = renderHook(() => useSignSpendBundle(), { wrapper })
+        let artifact: Awaited<ReturnType<typeof result.current.signSpend>> | undefined
+        await act(async () => {
+            artifact = await result.current.signSpend({
+                requiredUsdcAmount: 150_000_000n,
+                recipient: RECIPIENT,
+                rainSpendingPower: 200_000_000n,
+                kind: 'QR_PAY',
+            })
+        })
+        return artifact
+    }
+
+    it('flag off: the two-tap passkey path signs the admin EIP-712 itself', async () => {
+        mockSessionKeySignEnabled.mockReturnValue(false)
+        await signMixed()
+        expect(mockSignEphemeral).not.toHaveBeenCalled()
+        expect(mockSignTypedData).toHaveBeenCalledTimes(1)
+    })
+
+    it('flag on: returns the ephemeral-signed artifact for the same prep, no passkey admin signature', async () => {
+        mockSessionKeySignEnabled.mockReturnValue(true)
+        mockSignEphemeral.mockResolvedValue({ ok: true, signedUserOp: SIGNED })
+        const artifact = await signMixed()
+        expect(artifact).toEqual({ strategy: 'mixed', signedUserOp: SIGNED, rainPreparationId: 'prep-1' })
+        expect(mockSignEphemeral).toHaveBeenCalledWith(
+            expect.objectContaining({ prep: PREP, recipient: RECIPIENT, requiredUsdcAmount: 150_000_000n })
+        )
+        expect(mockSignTypedData).not.toHaveBeenCalled()
+        expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_KEY_SPEND_ATTEMPTED, {
+            kind: 'QR_PAY',
+            flow: 'sign-only',
+        })
+    })
+
+    it('flag on, ephemeral signing fails: falls back to the two-tap path with the SAME prep and reports why', async () => {
+        mockSessionKeySignEnabled.mockReturnValue(true)
+        mockSignEphemeral.mockResolvedValue({ ok: false, reason: 'ephemeral key: session setup failed' })
+        await signMixed()
+        expect(mockPrepareWithdrawal).toHaveBeenCalledTimes(1)
+        expect(mockSignTypedData).toHaveBeenCalledTimes(1)
+        expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_KEY_SPEND_FALLBACK, {
+            kind: 'QR_PAY',
+            flow: 'sign-only',
+            reason: 'ephemeral key: session setup failed',
+        })
     })
 })

--- a/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
+++ b/src/hooks/wallet/__tests__/useSignSpendBundle.test.tsx
@@ -54,11 +54,12 @@ jest.mock('@/constants/rain.consts', () => ({
     ],
 }))
 const mockSignTypedData = jest.fn()
+const mockGetPatchedSudoValidator = jest.fn(async () => ({ validator: 'patched' }))
 jest.mock('@/context/kernelClient.context', () => ({
     useKernelClient: () => ({
         getClientForChain: () => ({ account: { address: ACCOUNT, signTypedData: mockSignTypedData } }),
         rebuildClientForChain: jest.fn(),
-        getPatchedSudoValidator: jest.fn(async () => ({ validator: 'patched' })),
+        getPatchedSudoValidator: () => mockGetPatchedSudoValidator(),
     }),
 }))
 jest.mock('@/app/actions/clients', () => ({ peanutPublicClient: { tag: 'public' } }))
@@ -182,6 +183,7 @@ describe('useSignSpendBundle — mixed, SESSION_KEY_SIGN one-tap path', () => {
 
     beforeEach(() => {
         mockResolveSpendStrategy.mockResolvedValue({ strategy: 'mixed', smartBalance: 50_000_000n })
+        mockGetPatchedSudoValidator.mockResolvedValue({ validator: 'patched' })
     })
 
     async function signMixed() {
@@ -230,6 +232,20 @@ describe('useSignSpendBundle — mixed, SESSION_KEY_SIGN one-tap path', () => {
             kind: 'QR_PAY',
             flow: 'sign-only',
             reason: 'ephemeral key: session setup failed',
+        })
+    })
+
+    it('flag on, sudo validator cannot be resolved: falls back to the two-tap path with the SAME prep', async () => {
+        mockSessionKeySignEnabled.mockReturnValue(true)
+        mockGetPatchedSudoValidator.mockRejectedValue(new Error('Cannot resolve sudo validator: not authenticated'))
+        await signMixed()
+        expect(mockSignEphemeral).not.toHaveBeenCalled()
+        expect(mockPrepareWithdrawal).toHaveBeenCalledTimes(1)
+        expect(mockSignTypedData).toHaveBeenCalledTimes(1)
+        expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SESSION_KEY_SPEND_FALLBACK, {
+            kind: 'QR_PAY',
+            flow: 'sign-only',
+            reason: 'Cannot resolve sudo validator: not authenticated',
         })
     })
 })

--- a/src/hooks/wallet/mixedEphemeralSign.ts
+++ b/src/hooks/wallet/mixedEphemeralSign.ts
@@ -1,0 +1,101 @@
+import type { Chain, Hex, PublicClient } from 'viem'
+import { encodeFunctionData, erc20Abi } from 'viem'
+import type { KernelValidator } from '@zerodev/sdk/types'
+import { signUserOperation } from '@zerodev/sdk/actions'
+import { PEANUT_WALLET_TOKEN, USER_OP_ENTRY_POINT } from '@/constants/zerodev.consts'
+import { buildRainWithdrawTypedData } from '@/utils/rainWithdraw.utils'
+import type { PrepareRainWithdrawalResponse } from '@/services/rain'
+import { createEphemeralSpendSession, type EphemeralCall } from '@/utils/ephemeralSpendKey'
+import { buildWithdrawCall } from './mixedEphemeralSpend'
+import type { SignedUserOpData } from './useSignUserOp'
+
+/*
+ * Sign-only twin of tryMixedEphemeralSpend (SESSION_KEY_SIGN flag) for the
+ * engine whose UserOp the BACKEND broadcasts (QR pay, Manteca withdraw, card
+ * lock/cancel). Same one tap: the enable signature inside
+ * createEphemeralSpendSession; the Rain admin EIP-712 and the UserOp are then
+ * signed silently by the in-memory key and handed back unbroadcast.
+ *
+ * What differs from the broadcasting twin: nothing is sent from here, so a
+ * signing failure falls back to the two-tap path with nothing at stake — but
+ * a permission that turns out not to validate on-chain surfaces later, as
+ * the backend's broadcast reverting, with no client-side retry. That is why
+ * this path sits behind its own flag, flipped only after the broadcasting
+ * engine has proven the ERC-1271 ordering on production contracts.
+ *
+ * The permission outlives the broadcasting default because the backend
+ * may hold the op briefly before eth_sendUserOperation; the op's nonce
+ * still makes it single-use, and the batch still ends in the self-uninstall.
+ */
+export const SIGN_ONLY_TTL_SECONDS = 10 * 60
+
+export interface MixedEphemeralSignArgs {
+    publicClient: PublicClient
+    chain: Chain
+    /** From useKernelClient().getPatchedSudoValidator (v0.0.3 PATCHED). */
+    patchedSudoValidator: KernelValidator
+    /** The user's kernel account address (= Rain admin). */
+    accountAddress: Hex
+    prep: PrepareRainWithdrawalResponse
+    recipient: Hex
+    requiredUsdcAmount: bigint
+}
+
+export type MixedEphemeralSignResult = { ok: true; signedUserOp: SignedUserOpData } | { ok: false; reason: string }
+
+export async function signMixedEphemeralSpend(args: MixedEphemeralSignArgs): Promise<MixedEphemeralSignResult> {
+    const { publicClient, chain, patchedSudoValidator, accountAddress, prep, recipient, requiredUsdcAmount } = args
+
+    let dispose: (() => void) | undefined
+    try {
+        const transferCall: EphemeralCall = {
+            to: PEANUT_WALLET_TOKEN as Hex,
+            value: 0n,
+            data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: 'transfer',
+                args: [recipient, requiredUsdcAmount],
+            }),
+        }
+
+        // Placeholder admin signature: scoping reads targets, selectors and the
+        // static leading args only, all final here.
+        const session = await createEphemeralSpendSession({
+            publicClient,
+            chain,
+            patchedSudoValidator,
+            ttlSeconds: SIGN_ONLY_TTL_SECONDS,
+            scope: {
+                accountAddress,
+                calls: [buildWithdrawCall(prep, '0x'), transferCall],
+                withdrawAmountCap: BigInt(prep.amount),
+                collateralProxy: prep.collateralProxy as Hex,
+                coordinatorAddress: prep.coordinatorAddress as Hex,
+            },
+        })
+        dispose = session.dispose
+
+        const adminSignature = (await session.account.signTypedData(buildRainWithdrawTypedData(prep, chain.id))) as Hex
+
+        // uninstallCall last: the permission destroys itself at the end of the
+        // same UserOp, whoever broadcasts it.
+        const calls = [buildWithdrawCall(prep, adminSignature), transferCall, session.uninstallCall]
+        const signedUserOp = await signUserOperation(session.client, {
+            account: session.account,
+            callData: await session.account.encodeCalls(calls),
+        })
+
+        return {
+            ok: true,
+            signedUserOp: {
+                signedUserOp,
+                chainId: chain.id.toString(),
+                entryPointAddress: USER_OP_ENTRY_POINT.address,
+            },
+        }
+    } catch (e) {
+        return { ok: false, reason: e instanceof Error ? e.message : String(e) }
+    } finally {
+        dispose?.()
+    }
+}

--- a/src/hooks/wallet/mixedEphemeralSpend.ts
+++ b/src/hooks/wallet/mixedEphemeralSpend.ts
@@ -41,7 +41,7 @@ export type MixedEphemeralSpendResult =
     | { ok: true; userOpHash: Hash; receipt: TransactionReceipt | null }
     | { ok: false; reason: string }
 
-function buildWithdrawCall(prep: PrepareRainWithdrawalResponse, adminSignature: Hex): EphemeralCall {
+export function buildWithdrawCall(prep: PrepareRainWithdrawalResponse, adminSignature: Hex): EphemeralCall {
     return {
         to: prep.coordinatorAddress as Hex,
         value: 0n,

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -280,6 +280,8 @@ export const useSignSpendBundle = () => {
                     modals?.setIsSecurityVerificationOpen?.(true)
                     let attempt: MixedEphemeralSignResult
                     try {
+                        // Resolving the sudo validator is outside the helper's own
+                        // catch: a rejection here must still take the passkey path.
                         const patchedSudoValidator = await getPatchedSudoValidator(peanutPublicClient)
                         attempt = await signMixedEphemeralSpend({
                             publicClient: peanutPublicClient,
@@ -290,6 +292,8 @@ export const useSignSpendBundle = () => {
                             recipient: recipient as Hex,
                             requiredUsdcAmount,
                         })
+                    } catch (e) {
+                        attempt = { ok: false, reason: e instanceof Error ? e.message : String(e) }
                     } finally {
                         modals?.setIsSecurityVerificationOpen?.(false)
                     }

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -8,6 +8,9 @@ import { encodeFunctionData, erc20Abi } from 'viem'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useKernelClient } from '@/context/kernelClient.context'
+import { peanutPublicClient } from '@/app/actions/clients'
+import { sessionKeySignEnabled } from '@/constants/session-key-spend.consts'
+import { signMixedEphemeralSpend, type MixedEphemeralSignResult } from './mixedEphemeralSign'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import { rainCoordinatorAbi } from '@/constants/rain.consts'
 import { buildRainWithdrawTypedData } from '@/utils/rainWithdraw.utils'
@@ -103,7 +106,7 @@ export interface SignSpendBundleInput {
  */
 
 export const useSignSpendBundle = () => {
-    const { getClientForChain, rebuildClientForChain } = useKernelClient()
+    const { getClientForChain, rebuildClientForChain, getPatchedSudoValidator } = useKernelClient()
     const { handleSendUserOpEncoded } = useZeroDev()
     const modals = useModalsContextOptional()
     const { signCallsUserOp } = useSignUserOp()
@@ -267,6 +270,39 @@ export const useSignSpendBundle = () => {
                     totalAmountCents: usdcUnitsToRainCents(requiredUsdcAmount).toString(),
                 })
 
+                /*
+                 * SESSION_KEY_SIGN: one tap instead of two — see mixedEphemeralSign.ts.
+                 * Falls through to the two-tap path on any failure; nothing has
+                 * been broadcast, so the same prep is reused with nothing at stake.
+                 */
+                if (sessionKeySignEnabled()) {
+                    posthog.capture(ANALYTICS_EVENTS.SESSION_KEY_SPEND_ATTEMPTED, { kind, flow: 'sign-only' })
+                    modals?.setIsSecurityVerificationOpen?.(true)
+                    let attempt: MixedEphemeralSignResult
+                    try {
+                        const patchedSudoValidator = await getPatchedSudoValidator(peanutPublicClient)
+                        attempt = await signMixedEphemeralSpend({
+                            publicClient: peanutPublicClient,
+                            chain: PEANUT_WALLET_CHAIN,
+                            patchedSudoValidator,
+                            accountAddress: activeAccount.address as Hex,
+                            prep,
+                            recipient: recipient as Hex,
+                            requiredUsdcAmount,
+                        })
+                    } finally {
+                        modals?.setIsSecurityVerificationOpen?.(false)
+                    }
+                    if (attempt.ok) {
+                        return { strategy, signedUserOp: attempt.signedUserOp, rainPreparationId: prep.preparationId }
+                    }
+                    posthog.capture(ANALYTICS_EVENTS.SESSION_KEY_SPEND_FALLBACK, {
+                        kind,
+                        flow: 'sign-only',
+                        reason: attempt.reason.slice(0, 200),
+                    })
+                }
+
                 const adminSignature = (await withCeremonyPurpose('admin_eip712', () =>
                     activeAccount.signTypedData(buildRainWithdrawTypedData(prep, chainIdNum))
                 )) as Hex
@@ -318,6 +354,7 @@ export const useSignSpendBundle = () => {
         [
             getClientForChain,
             rebuildClientForChain,
+            getPatchedSudoValidator,
             handleSendUserOpEncoded,
             modals,
             signCallsUserOp,

--- a/src/utils/ephemeralSpendKey.ts
+++ b/src/utils/ephemeralSpendKey.ts
@@ -194,8 +194,11 @@ export async function createEphemeralSpendSession(args: {
     scope: EphemeralSpendScope
     /** From useKernelClient().getPatchedSudoValidator — NEVER the plugin-manager internal. */
     patchedSudoValidator: KernelValidator
+    /** Permission lifetime. Sign-only flows hand the op to the backend to
+     *  broadcast and need more than the broadcasting default. */
+    ttlSeconds?: number
 }): Promise<EphemeralSpendSession> {
-    const { publicClient, chain, scope, patchedSudoValidator } = args
+    const { publicClient, chain, scope, patchedSudoValidator, ttlSeconds = TTL_SECONDS } = args
     assertZeroDevRpcUrls(BUNDLER_URL, PAYMASTER_URL)
 
     try {
@@ -225,7 +228,7 @@ export async function createEphemeralSpendSession(args: {
         })
         // FOR_ALL_VALIDATION on purpose: expiry must kill the 1271 path too,
         // or a leaked key could authorize withdrawals long after the flow.
-        const timestampPolicy = await toTimestampPolicy({ validAfter: 0, validUntil: now + TTL_SECONDS })
+        const timestampPolicy = await toTimestampPolicy({ validAfter: 0, validUntil: now + ttlSeconds })
         const rateLimitPolicy = await toRateLimitPolicy({
             policyFlag: PolicyFlags.NOT_FOR_VALIDATE_SIG,
             count: 1,


### PR DESCRIPTION
> **Stacked on #2959** (`feat/session-key-spend-build-gate`) — it needs the PostHog-flag gate from there. Retarget to `dev` once #2959 merges. Stacked PRs get no automatic tests/format/chip run; `tests.yml` is triggered by hand on this branch.

## Why

QR pay, Manteca withdraw and the card lock/cancel modals sign a mixed spend through `useSignSpendBundle` and hand the UserOp to the backend to broadcast. That engine still costs two passkey sheets (Rain admin EIP-712, then the UserOp). #2959 covers only the broadcasting engine (`useSpendBundle`). Item 3 of `mono/engineering/passkey-prompt-pairs-2026-09-03.md`.

## What

- `signMixedEphemeralSpend` (`src/hooks/wallet/mixedEphemeralSign.ts`): sign-only twin of `tryMixedEphemeralSpend`. Same single enable-signature tap inside `createEphemeralSpendSession`; the ephemeral key then signs the Rain admin EIP-712 and the UserOp silently, self-uninstall as the last call, and returns the unbroadcast op in the existing `SignedUserOpData` shape. `signUserOperation` from the ZeroDev SDK, exactly what `useSignUserOp` uses.
- `useSignSpendBundle` mixed path tries it first when `sessionKeySignEnabled()`; on any failure it falls through to the two-tap path with the **same** prep (nothing was broadcast, nothing at stake) and reports `session_key_spend_fallback` with `flow: 'sign-only'`.
- **Own flag `session_key_spend_sign`** (build gate shared with #2959). Why not reuse `session_key_spend`: here a permission that does not validate on-chain surfaces later, as the backend's broadcast reverting, with no client-side retry. So this flag stays off until #2959 has proven the ERC-1271 ordering on production contracts, then it is one click.
- `createEphemeralSpendSession` takes an optional `ttlSeconds`; this path uses 10 min (default stays 180 s). The backend broadcasts after Manteca settles inside the same request, with a receipt re-poll on timeout, so 3 min was tight. The op stays single-use through its nonce and the batch still ends in the self-uninstall.
- `/dev/session-key-spend` shows the second flag.
- `buildWithdrawCall` exported from `mixedEphemeralSpend.ts` (shared with the twin).

## Rollout

1. #2959 merges, flag `session_key_spend` proves one real mixed send on prod (one sheet, no fallback).
2. Then create `session_key_spend_sign`, internal cohort; one real QR pay on a mixed balance; expect one sheet and `session_key_spend_attempted{flow:'sign-only'}` with no fallback and a successful backend broadcast.
3. Widen.

## Verification

- New tests: `mixedEphemeralSign` (artifact shape, TTL, silent admin sig, uninstall last, signed through the session client and never sent, dispose on every exit; preflight and signing failures as `ok:false`), `sessionKeySignEnabled` gate matrix, and three `useSignSpendBundle` cases (flag off unchanged, flag on returns the ephemeral artifact with no passkey admin signature, fallback reuses the same prep and reports the reason).
- `pnpm typecheck` clean; ephemeralSpendKey, useGrantSessionKey, session-key-spend.consts, useSignSpendBundle suites green; prettier clean.
