### PR TITLE
fix(about): show the OTA bundle version the app is actually running

### DIFF
--- a/src/hooks/__tests__/useAppVersion.test.tsx
+++ b/src/hooks/__tests__/useAppVersion.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { useAppVersion } from '../useAppVersion'
 
-const mockGetBinaryInfo = jest.fn()
+const mockGetRunningVersion = jest.fn()
 // Only the bridge call is stubbed — the formatter runs for real, so the shape
 // the About screen renders is exercised end to end.
 jest.mock('@/utils/app-version', () => ({
     ...jest.requireActual('@/utils/app-version'),
-    getBinaryInfo: () => mockGetBinaryInfo(),
+    getRunningVersion: () => mockGetRunningVersion(),
 }))
 
 describe('useAppVersion', () => {
@@ -15,7 +15,7 @@ describe('useAppVersion', () => {
     it('reports what the binary ships, not what package.json says', async () => {
         // package.json no longer tracks releases — the release workflow stamps
         // MARKETING_VERSION, which is how a 1.1.0 build reported 1.0.53.
-        mockGetBinaryInfo.mockResolvedValue({ appVersion: '1.1.0', appBuild: '412' })
+        mockGetRunningVersion.mockResolvedValue({ appVersion: '1.1.0', appBuild: '412', otaVersion: null })
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
@@ -23,12 +23,22 @@ describe('useAppVersion', () => {
         await waitFor(() => expect(result.current).toBe('1.1.0.412'))
     })
 
-    it('keeps the bundled version on web, where there is no binary to ask', async () => {
-        mockGetBinaryInfo.mockResolvedValue(null)
+    // The binary never moves past the `.0` it shipped with, so an OTA'd install
+    // that still reported it would name code the user stopped running.
+    it('reports the OTA bundle once one is applied', async () => {
+        mockGetRunningVersion.mockResolvedValue({ appVersion: '1.1.0', appBuild: '10048', otaVersion: '1.1.2' })
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
-        await waitFor(() => expect(mockGetBinaryInfo).toHaveBeenCalled())
+        await waitFor(() => expect(result.current).toBe('1.1.2.10048'))
+    })
+
+    it('keeps the bundled version on web, where there is no binary to ask', async () => {
+        mockGetRunningVersion.mockResolvedValue(null)
+
+        const { result } = renderHook(() => useAppVersion('1.0.53'))
+
+        await waitFor(() => expect(mockGetRunningVersion).toHaveBeenCalled())
         expect(result.current).toBe('1.0.53')
     })
 })

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -1,23 +1,24 @@
 'use client'
 
-import { formatBinaryVersion, getBinaryInfo } from '@/utils/app-version'
+import { formatRunningVersion, getRunningVersion } from '@/utils/app-version'
 import { useEffect, useState } from 'react'
 
 /**
  * What to print as "the app version".
  *
- * Native reports what the binary actually ships, as `<major>.<minor>.<build>`
- * (see `formatBinaryVersion`); the bundled fallback only stands in until the
- * bridge answers, and on web, where package.json's version is the only version
- * there is.
+ * Native reports the release version of the code actually running — the OTA
+ * bundle when one is applied, otherwise the binary — plus the binary's build
+ * number (see `formatRunningVersion`). The bundled fallback only stands in
+ * until the bridge answers, and on web, where package.json's version is the
+ * only version there is.
  */
 export function useAppVersion(fallback: string): string {
     const [version, setVersion] = useState(fallback)
 
     useEffect(() => {
         let cancelled = false
-        void getBinaryInfo().then((info) => {
-            if (info && !cancelled) setVersion(formatBinaryVersion(info))
+        void getRunningVersion().then((info) => {
+            if (info && !cancelled) setVersion(formatRunningVersion(info))
         })
         return () => {
             cancelled = true

--- a/src/utils/__tests__/app-version.test.ts
+++ b/src/utils/__tests__/app-version.test.ts
@@ -1,4 +1,10 @@
-import { formatBinaryVersion } from '@/utils/app-version'
+import { formatBinaryVersion, formatRunningVersion, getRunningVersion } from '@/utils/app-version'
+
+const mockGetInfo = jest.fn()
+const mockCurrent = jest.fn()
+jest.mock('@capacitor/app', () => ({ App: { getInfo: () => mockGetInfo() } }))
+jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: { current: () => mockCurrent() } }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => true }))
 
 /**
  * The About screen's version line is what a support conversation starts from.
@@ -11,7 +17,6 @@ describe('formatBinaryVersion', () => {
         expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '34534' })).toBe('1.1.0.34534')
     })
 
-    // Overwriting the third segment would name an OTA revision that never shipped.
     it('keeps the OTA counter intact', () => {
         expect(formatBinaryVersion({ appVersion: '1.1.4', appBuild: '34534' })).toBe('1.1.4.34534')
         expect(formatBinaryVersion({ appVersion: '2.17.3', appBuild: '7' })).toBe('2.17.3.7')
@@ -30,5 +35,54 @@ describe('formatBinaryVersion', () => {
         ['1.1.0', '', '1.1.0'],
     ])('degrades cleanly when a component is missing (%s / %s)', (appVersion, appBuild, expected) => {
         expect(formatBinaryVersion({ appVersion, appBuild })).toBe(expected)
+    })
+})
+
+describe('formatRunningVersion', () => {
+    // The binary is frozen at the `.0` it shipped with; the OTA counter only
+    // moves in the bundle, so the bundle is what names the running revision.
+    it('names the OTA bundle when one is applied, keeping the binary build', () => {
+        expect(formatRunningVersion({ appVersion: '1.1.0', appBuild: '10048', otaVersion: '1.1.2' })).toBe(
+            '1.1.2.10048'
+        )
+    })
+
+    it('falls back to the binary on the builtin bundle', () => {
+        expect(formatRunningVersion({ appVersion: '1.1.0', appBuild: '10048', otaVersion: null })).toBe('1.1.0.10048')
+    })
+})
+
+describe('getRunningVersion', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetInfo.mockResolvedValue({ version: '1.1.0', build: '10048' })
+    })
+
+    it('reads the running bundle version off the updater', async () => {
+        mockCurrent.mockResolvedValue({ bundle: { id: 'abc', version: '1.1.2' } })
+
+        await expect(getRunningVersion()).resolves.toEqual({
+            appVersion: '1.1.0',
+            appBuild: '10048',
+            otaVersion: '1.1.2',
+        })
+    })
+
+    // Capgo echoes the native version for builtin on some plugin versions and
+    // the literal "builtin" on others; neither beats App.getInfo().
+    it.each([
+        ['builtin', '1.1.0'],
+        ['abc', 'builtin'],
+    ])('ignores the builtin bundle (id %s / version %s)', async (id, version) => {
+        mockCurrent.mockResolvedValue({ bundle: { id, version } })
+
+        await expect(getRunningVersion()).resolves.toMatchObject({ otaVersion: null })
+    })
+
+    // An install with no OTA layer still has to report its binary.
+    it('keeps the binary when the updater cannot answer', async () => {
+        mockCurrent.mockRejectedValue(new Error('plugin not implemented'))
+
+        await expect(getRunningVersion()).resolves.toMatchObject({ appVersion: '1.1.0', otaVersion: null })
     })
 })

--- a/src/utils/app-version.ts
+++ b/src/utils/app-version.ts
@@ -5,6 +5,11 @@ export interface BinaryInfo {
     appBuild: string
 }
 
+export interface RunningVersionInfo extends BinaryInfo {
+    /** Capgo bundle actually executing, or null when it is the JS baked into the binary */
+    otaVersion: string | null
+}
+
 /**
  * The version the native shell actually ships, read off the binary.
  *
@@ -24,13 +29,44 @@ export async function getBinaryInfo(): Promise<BinaryInfo | null> {
     }
 }
 
+// Capgo's name for the JS baked into the binary; some plugin versions report it
+// as the bundle id, others as its version.
+const BUILTIN_BUNDLE = 'builtin'
+
+/**
+ * The Capgo bundle currently executing, when it is not the binary's own JS.
+ *
+ * Null on the builtin bundle so the binary's version stays the answer there:
+ * Capgo echoes the native version for builtin on some plugin versions and the
+ * literal "builtin" on others, and neither is worth preferring over App.getInfo().
+ */
+async function getOtaBundleVersion(): Promise<string | null> {
+    try {
+        const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+        const bundle = (await CapacitorUpdater.current())?.bundle
+        if (!bundle || bundle.id === BUILTIN_BUNDLE || bundle.version === BUILTIN_BUNDLE) return null
+        return bundle.version || null
+    } catch {
+        return null
+    }
+}
+
+/** What this install is actually running: the binary, plus the OTA layered on it. */
+export async function getRunningVersion(): Promise<RunningVersionInfo | null> {
+    const binary = await getBinaryInfo()
+    if (!binary) return null
+    return { ...binary, otaVersion: await getOtaBundleVersion() }
+}
+
 /**
  * How the app version reads on screen: `<major>.<build>.<ota>.<ci-build>`.
  *
- * The first three segments are `appVersion` verbatim — Peanut's release scheme
- * (scripts/release-version.mjs): major generation, native build counter, and
- * the OTA counter within that build. None of them may be replaced: overwriting
- * the third would name an OTA revision that never shipped.
+ * The first three segments are the release version of the code that is running
+ * — Peanut's scheme (scripts/release-version.mjs): major generation, native
+ * build counter, and the OTA counter within that build. On an OTA'd install
+ * that is the bundle's version, not the binary's: the binary is frozen at the
+ * `.0` it shipped with, so reporting it would name a revision the user stopped
+ * running the moment the OTA applied.
  *
  * The CI build number is appended as a fourth segment rather than parenthesised
  * so the whole identifier reads as one string a user can dictate. It is the
@@ -44,4 +80,8 @@ export function formatBinaryVersion({ appVersion, appBuild }: BinaryInfo): strin
     if (!appVersion) return appBuild
     if (!appBuild) return appVersion
     return `${appVersion}.${appBuild}`
+}
+
+export function formatRunningVersion({ appVersion, appBuild, otaVersion }: RunningVersionInfo): string {
+    return formatBinaryVersion({ appVersion: otaVersion || appVersion, appBuild })
 }


### PR DESCRIPTION
## Problem

About shows `Version 1.1.0.10048` on a device that has already taken the `1.1.2` OTA.

`useAppVersion` read `App.getInfo()`, which reports what the **binary** ships. Under our release scheme (`<major>.<build>.<ota>`, `scripts/release-version.mjs`) the binary is frozen at the `.0` it was built with — the OTA counter only ever moves in the Capgo bundle. So the one number a support conversation starts from names code the user stopped running the moment the update applied.

## Fix

`getRunningVersion()` reads the binary **and** the Capgo bundle currently executing (`CapacitorUpdater.current()`), and the release segments now come from the bundle when one is applied:

| install | before | after |
| --- | --- | --- |
| binary 1.1.0, builtin JS | `1.1.0.10048` | `1.1.0.10048` |
| binary 1.1.0, OTA 1.1.2 | `1.1.0.10048` | `1.1.2.10048` |
| web | `1.0.53` (package.json) | unchanged |

The fourth segment stays the binary's CI build number — it identifies which store build the bundle is layered on, which is exactly what the version alone can't say.

Builtin is explicitly excluded: Capgo echoes the native version for it on some plugin versions and the literal `"builtin"` on others, and neither beats `App.getInfo()`. An updater that can't answer (no OTA layer, older binary) degrades to the binary, as before.

## Notes

- This is a JS-only change, so it ships over OTA — the next bundle will make itself visible.
- `getBinaryInfo()` is unchanged and still used by `native-canary` and `locale-store`, which genuinely want the binary.

## Test plan

- `src/utils/__tests__/app-version.test.ts` — bundle preferred, both builtin shapes ignored, updater rejection falls back to the binary.
- `src/hooks/__tests__/useAppVersion.test.tsx` — OTA'd install reports the bundle; web keeps the package.json fallback.
- `pnpm typecheck` clean; `native-canary` / `locale-store` suites still green.
