### PR TITLE
fix(badges): filter PEANUT_TEAM on every own-profile surface

### DIFF
--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -40,6 +40,7 @@ import { completeHistoryEntry, dedupeHistoryEntriesByUuid } from '@/utils/histor
 import { twMerge } from '@/utils/tw'
 import { formatUnits } from 'viem'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
+import { displayableBadges } from '@/constants/badges.consts'
 
 /**
  * displays the user's transaction history with infinite scrolling and date grouping.
@@ -186,7 +187,7 @@ const HistoryPage = () => {
         ]
 
         // inject badge items from user profile, placed by earnedAt
-        const badges = user?.user?.badges ?? []
+        const badges = displayableBadges(user?.user?.badges ?? [])
         badges.forEach((b) => {
             if (!b.earnedAt) return
             entries.push({

--- a/src/components/Badges/BadgesRow.tsx
+++ b/src/components/Badges/BadgesRow.tsx
@@ -8,7 +8,7 @@ import { twMerge } from '@/utils/tw'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon } from '../Global/Icons/Icon'
 import { getBadgeIcon } from './badge.utils'
-import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
+import { displayableBadges } from '@/constants/badges.consts'
 import { useBadgeCopy } from './useBadgeCopy'
 import { BadgeImage } from './BadgeImage'
 
@@ -50,13 +50,11 @@ const BadgesRow = ({ badges, className, isSelfProfile = true }: BadgesRowProps) 
     // record, not a collectible — hidden on one's own profile too, since the
     // beta switch appearing is the feedback that the tap worked.
     const sortedBadges = useMemo(() => {
-        return badges
-            .filter((badge) => badge.code !== PEANUT_TEAM_BADGE)
-            .sort((a, b) => {
-                const at = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
-                const bt = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
-                return bt - at
-            })
+        return displayableBadges(badges).sort((a, b) => {
+            const at = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
+            const bt = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
+            return bt - at
+        })
     }, [badges])
 
     // calculate how many badges can fit in the viewport

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -15,6 +15,7 @@ import { useUserStore } from '@/redux/hooks'
 import { ListItem } from '@/components/0_Bruddle/ListItem'
 import { useAuth } from '@/context/authContext'
 import { BadgeImage } from './BadgeImage'
+import { displayableBadges } from '@/constants/badges.consts'
 
 type BadgeView = { code: string; title: string; description: string; logo: string | StaticImageData }
 
@@ -35,7 +36,7 @@ export const Badges = () => {
     // map api badges to view badges
     const badges: BadgeView[] = useMemo(() => {
         // get badges from user object and map to card fields
-        const raw = authUser?.user?.badges || []
+        const raw = displayableBadges(authUser?.user?.badges || [])
         return raw.map((b) => {
             const copy = badgeCopy(b.code, b.name, b.description)
             return {

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -40,7 +40,7 @@ import { formatUnits } from 'viem'
 import { useAppHaptic } from '@/hooks/useAppHaptic'
 import { PEANUT_WALLET_TOKEN_DECIMALS } from '@/constants/zerodev.consts'
 import { Icon } from '../Global/Icons/Icon'
-import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
+import { displayableBadges } from '@/constants/badges.consts'
 
 /** Kinds that affect the user's wallet balance. Hoisted to module scope to avoid re-allocation. */
 const BALANCE_AFFECTING_KINDS: ReadonlySet<IntentKind> = new Set<IntentKind>([
@@ -202,11 +202,8 @@ const HomeHistory = ({
 
                 // inject badge entries using user's badges (newest first) and earnedAt chronology
                 // filter out beta tester badge — it creates confusing first impressions for new users
-                // filter out PEANUT_TEAM — a permission record for the beta switch, never displayed
                 if (isViewingOwnHistory) {
-                    const badges = (user?.user?.badges ?? []).filter(
-                        (b) => b.code !== 'BETA_TESTER' && b.code !== PEANUT_TEAM_BADGE
-                    )
+                    const badges = displayableBadges(user?.user?.badges ?? []).filter((b) => b.code !== 'BETA_TESTER')
                     badges.forEach((b) => {
                         if (!b.earnedAt) return
                         entries.push({

--- a/src/constants/__tests__/badges.consts.test.ts
+++ b/src/constants/__tests__/badges.consts.test.ts
@@ -1,0 +1,36 @@
+/**
+ * PEANUT_TEAM is a permission record, not a collectible. The public profile
+ * response already omits it (that query filters on isVisible), but /users/me
+ * returns it so the beta switch can read its own permission — which means
+ * every surface rendering the CALLER's own badges has to filter it out, or a
+ * customer who tapped five times sees "Peanut Team" on their own profile.
+ */
+import { displayableBadges, PEANUT_TEAM_BADGE } from '../badges.consts'
+
+it('drops the permission record', () => {
+    expect(displayableBadges([{ code: PEANUT_TEAM_BADGE }])).toEqual([])
+})
+
+it('keeps every real collectible, including the other insider badges', () => {
+    const badges = [{ code: 'BETA_TESTER' }, { code: PEANUT_TEAM_BADGE }, { code: 'CARD_PIONEER' }]
+
+    expect(displayableBadges(badges)).toEqual([{ code: 'BETA_TESTER' }, { code: 'CARD_PIONEER' }])
+})
+
+it('preserves the caller order and the full badge shape', () => {
+    const badges = [
+        { code: 'OG_2025_10_12', earnedAt: '2026-01-01', name: 'OG' },
+        { code: PEANUT_TEAM_BADGE, earnedAt: '2026-02-01', name: 'Peanut Team' },
+        { code: 'ENS', earnedAt: '2026-03-01', name: 'ENS' },
+    ]
+
+    expect(displayableBadges(badges).map((b) => b.name)).toEqual(['OG', 'ENS'])
+})
+
+it('does not mutate the list it is given', () => {
+    const badges = [{ code: PEANUT_TEAM_BADGE }, { code: 'ENS' }]
+
+    displayableBadges(badges)
+
+    expect(badges).toHaveLength(2)
+})

--- a/src/constants/badges.consts.ts
+++ b/src/constants/badges.consts.ts
@@ -10,3 +10,21 @@
  * colours in a payments app.
  */
 export const PEANUT_TEAM_BADGE = 'PEANUT_TEAM'
+
+/**
+ * Badges that are permission records rather than collectibles, and are never
+ * shown to anyone — including their owner.
+ */
+const NEVER_DISPLAYED = new Set<string>([PEANUT_TEAM_BADGE])
+
+/**
+ * Drops the records from a badge list before it is rendered.
+ *
+ * The public profile response already omits them (the query filters on
+ * `isVisible`), but `/users/me` deliberately does not — that is how the beta
+ * switch reads its own permission. So every surface that renders the CALLER's
+ * badges has to filter here, or the badge shows up on their own profile.
+ */
+export function displayableBadges<T extends { code: string }>(badges: readonly T[]): T[] {
+    return badges.filter((badge) => !NEVER_DISPLAYED.has(badge.code))
+}


### PR DESCRIPTION
## Why

Follow-up to [#2956](https://github.com/peanutprotocol/peanut-ui/pull/2956), which merged before this fix was written. Raised by Chip on the paired API PR ([#1518](https://github.com/peanutprotocol/peanut-api-ts/pull/1518)).

`PEANUT_TEAM` is a permission record, not a collectible — the five-tap beta switch reads it as permission to join the `staging` OTA channel, and it is meant to be invisible everywhere. The API side keeps it off the **public** profile by persisting the row `isVisible: false`, which `/users/username/:username` filters on.

But `/users/me` deliberately does **not** filter — that is how the switch reads its own permission. So every surface rendering the **caller's own** badges has to filter in the app, and #2956 only covered three of five. Two still showed it:

- `src/components/Badges/index.tsx` — the "Your Badges" page off the profile menu.
- `src/app/(mobile-ui)/history/page.tsx` — the full history page, which injects badges as feed entries. #2956 fixed `HomeHistory` (the top-5 home feed) but not this one; the two duplicate each other's logic, which is how the miss happened.

A customer who tapped five times would find "Peanut Team" on their own profile and in their history. Not public-facing — the public profile was already covered — but wrong.

## What

Move the rule into one place rather than patching the two sites:

```ts
displayableBadges(badges)   // src/constants/badges.consts.ts
```

Now used at all four call sites, so the next surface that renders a badge list inherits the rule instead of re-deciding it — five places each making their own call is the actual defect here.

The home feed keeps its separate `BETA_TESTER` rule, which is about first impressions for new users rather than about permission records, so the two concerns stay distinct.

## Tests

`src/constants/__tests__/badges.consts.test.ts` — drops the permission record, keeps every real collectible (including the other insider badges), preserves caller order and the full badge shape, and does not mutate the input.

Local: 212 tests green across constants/Badges/Profile/Home, typecheck clean, prettier clean.

## Note on ordering

#2956 merged ahead of the API PR, so on `dev` the app currently POSTs `/badge/team` against an API that does not serve it yet: the claim 404s, the card still reveals, and joining stays blocked with copy telling the tester to tap again. Degraded by design, not broken — it resolves when [#1518](https://github.com/peanutprotocol/peanut-api-ts/pull/1518) lands.
