### PR TITLE
fix(badges): keep permission records off share images, and filter on the server's flag

### DIFF
--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -31,6 +31,7 @@ import { useHostedVerification } from '@/hooks/useHostedVerification'
 import { useModalsContext } from '@/context/ModalsContext'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useSumsubReloadResume } from '@/hooks/useSumsubReloadResume'
+import { displayableBadges } from '@/constants/badges.consts'
 
 // localStorage key for the one-time celebration gate (per-device by design:
 // re-doing the funnel re-celebrates, see the eligibility-check effect below).
@@ -698,9 +699,12 @@ const CardPage: FC = () => {
                 // Share asset shows ALL earned badges, not just skip-badges.
                 // `user.user.badges` is the full collection from /get-user
                 // (with earnedAt) — fall back to cardInfo.skipBadges if it
-                // hasn't loaded yet so we still render something.
+                // hasn't loaded yet so we still render something. Filtered:
+                // this builds a shareable image, and permission records must
+                // never be stamped onto one.
+                const shareableBadges = user?.user?.badges && displayableBadges(user.user.badges)
                 const allBadges =
-                    user?.user?.badges?.map((b) => ({
+                    shareableBadges?.map((b) => ({
                         code: b.code,
                         iconUrl: b.iconUrl,
                         earnedAt: b.earnedAt,

--- a/src/app/(mobile-ui)/card/page.tsx
+++ b/src/app/(mobile-ui)/card/page.tsx
@@ -708,6 +708,7 @@ const CardPage: FC = () => {
                         code: b.code,
                         iconUrl: b.iconUrl,
                         earnedAt: b.earnedAt,
+                        isVisible: b.isVisible,
                     })) ?? cardInfo!.skipBadges.map((code) => ({ code }))
                 return (
                     <BadgeSkipCelebration

--- a/src/app/(mobile-ui)/history/page.tsx
+++ b/src/app/(mobile-ui)/history/page.tsx
@@ -326,7 +326,7 @@ const HistoryPage = () => {
                                     entry={item}
                                     position={position}
                                     username={user?.user?.username ?? undefined}
-                                    badges={user?.user?.badges}
+                                    badges={displayableBadges(user?.user?.badges ?? [])}
                                 />
                             ) : (
                                 (() => {

--- a/src/components/Card/CardUnlockDrawer.tsx
+++ b/src/components/Card/CardUnlockDrawer.tsx
@@ -29,7 +29,7 @@ interface Props {
     /** Full user-badges payload (with `earnedAt`) so the share asset can
      *  stamp every badge the user holds, not just the skip-the-line
      *  subset. Empty array → asset renders without stamps. */
-    badges?: Array<{ code: string; iconUrl?: string | null; earnedAt?: string | Date | null }>
+    badges?: Array<{ code: string; iconUrl?: string | null; earnedAt?: string | Date | null; isVisible?: boolean }>
 }
 
 export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, badges }) => {
@@ -46,10 +46,17 @@ export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, 
     }, [isOpen])
 
     // Normalize earnedAt: ScaledShareAsset's `ShareAssetBadge` expects
-    // `string | Date | undefined` — drop nulls.
+    // `string | Date | undefined` — drop nulls. `isVisible` rides along: it is
+    // how placeStamps refuses permission records, and rebuilding the object
+    // without it would hand the boundary an unmarked badge.
     const assetBadges = (badges ?? [])
         .filter((b) => !!b.code)
-        .map((b) => ({ code: b.code, iconUrl: b.iconUrl, earnedAt: b.earnedAt ?? undefined }))
+        .map((b) => ({
+            code: b.code,
+            iconUrl: b.iconUrl,
+            earnedAt: b.earnedAt ?? undefined,
+            isVisible: b.isVisible,
+        }))
 
     return (
         <Drawer open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/Card/CardUnlockHistoryItem.tsx
+++ b/src/components/Card/CardUnlockHistoryItem.tsx
@@ -28,7 +28,7 @@ interface Props {
     username?: string
     /** Full user-badges payload (with `earnedAt`) — drawer stamps every
      *  badge the user holds, not just the skip-the-line subset. */
-    badges?: Array<{ code: string; iconUrl?: string | null; earnedAt?: string | Date | null }>
+    badges?: Array<{ code: string; iconUrl?: string | null; earnedAt?: string | Date | null; isVisible?: boolean }>
 }
 
 const VIA_COPY_KEYS = {

--- a/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
+++ b/src/components/Card/share-asset/__tests__/shareAssetLayout.test.ts
@@ -8,6 +8,7 @@
  * regress here.
  */
 
+import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
 import { SeededRandom } from '../seededRandom'
 import {
     CANVAS_W,
@@ -62,6 +63,38 @@ describe('placeStamps', () => {
 
     it('returns 0 stamps for 0 badges', () => {
         expect(placeStamps([], rng())).toEqual([])
+    })
+
+    /*
+     * The asset is generated to be posted, so a permission record reaching it
+     * is worse than one on a profile row — it leaves the app entirely. Filtering
+     * at the call sites was missed twice; these pin the boundary itself.
+     */
+    describe('permission records never become stickers', () => {
+        it('drops PEANUT_TEAM, the badge any five-tap gesture awards', () => {
+            const placed = placeStamps([badge(PEANUT_TEAM_BADGE), badge('OG_2025_10_12')], rng())
+
+            expect(placed.map((s) => s.badge.code)).toEqual(['OG_2025_10_12'])
+        })
+
+        it('drops anything the server marked invisible, whatever its code', () => {
+            const placed = placeStamps([{ ...badge('SOME_FUTURE_RECORD'), isVisible: false }], rng())
+
+            expect(placed).toEqual([])
+        })
+
+        it('still stamps a badge the server marked visible', () => {
+            const placed = placeStamps([{ ...badge('ENS'), isVisible: true }], rng())
+
+            expect(placed.map((s) => s.badge.code)).toEqual(['ENS'])
+        })
+
+        it('lays out the survivors as if the record was never passed', () => {
+            const real = [badge('ENS', 2025), badge('OG_2025_10_12', 2024)]
+            const withRecord = [real[0], badge(PEANUT_TEAM_BADGE, 2026), real[1]]
+
+            expect(placeStamps(withRecord, rng())).toEqual(placeStamps(real, rng()))
+        })
     })
 
     it('returns N stamps for N badges (N ≤ 6)', () => {

--- a/src/components/Card/share-asset/shareAsset.types.ts
+++ b/src/components/Card/share-asset/shareAsset.types.ts
@@ -15,6 +15,9 @@ export interface ShareAssetBadge {
     /** Backend-owned presentation URL. Legacy responses may omit it. */
     iconUrl?: string | null
     earnedAt?: string | Date
+    /** Server's own answer on whether this badge is displayable at all.
+     *  Carried so placeStamps can refuse permission records. */
+    isVisible?: boolean
     /** Display label override. Unused by the share asset (we don't render
      *  text per stamp anymore) but kept for API compatibility. */
     name?: string

--- a/src/components/Card/share-asset/shareAssetLayout.ts
+++ b/src/components/Card/share-asset/shareAssetLayout.ts
@@ -13,6 +13,7 @@
 import { SeededRandom } from './seededRandom'
 import { getBadgeIcon } from '@/components/Badges/badge.utils'
 import type { ShareAssetBadge, ShareAssetStats } from './shareAsset.types'
+import { displayableBadges } from '@/constants/badges.consts'
 
 // ─── Canvas + element constants ─────────────────────────────────────────
 // 4:3 — postage-stamp-ish proportions. Was 16:9 (Twitter summary_large_image)
@@ -158,7 +159,13 @@ export function placeStamps(
     extraKeepouts: readonly KeepoutEllipse[] = [],
     pill: { x0: number; y0: number } = DEFAULT_PILL_KEEPOUT
 ): StampPlacement[] {
-    const sorted = [...badges].sort((a, b) => {
+    /*
+     * The choke point for every sticker on the asset. Permission records — a
+     * PEANUT_TEAM held by anyone who found the five-tap beta switch — must
+     * never reach an image that leaves the app, and filtering at each call
+     * site has already been missed twice: this is the boundary that cannot be.
+     */
+    const sorted = displayableBadges(badges).sort((a, b) => {
         const aT = a.earnedAt ? new Date(a.earnedAt).getTime() : 0
         const bT = b.earnedAt ? new Date(b.earnedAt).getTime() : 0
         return bT - aT

--- a/src/components/Home/HomeHistory.tsx
+++ b/src/components/Home/HomeHistory.tsx
@@ -487,7 +487,7 @@ const HomeHistory = ({
                                 entry={item}
                                 position={position}
                                 username={user?.user?.username ?? undefined}
-                                badges={user?.user?.badges}
+                                badges={displayableBadges(user?.user?.badges ?? [])}
                             />
                         )
                     }

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -17,9 +17,10 @@ import { useTranslations } from 'next-intl'
  * publishes to; leaving drops it back to the store bundle.
  *
  * Joining requires the PEANUT_TEAM badge, which the About screen awards on the
- * fifth tap. The badge is a record of who opted in and a handle to revoke it,
- * NOT an access boundary — anyone who performs the gesture can award it to
- * themselves. Capgo's channel self-assignment setting is the real boundary.
+ * fifth tap. The badge is a record of who opted in, NOT an access boundary —
+ * anyone who performs the gesture can award it to themselves, and deleting the
+ * row only holds until they tap again. Capgo's channel self-assignment setting
+ * is the real boundary.
  *
  * The badge gates the JOIN, never the card. An earlier version gated the whole
  * reveal on a PostHog cohort, so the flag never being created hid the switch

--- a/src/constants/__tests__/badges.consts.test.ts
+++ b/src/constants/__tests__/badges.consts.test.ts
@@ -11,6 +11,20 @@ it('drops the permission record', () => {
     expect(displayableBadges([{ code: PEANUT_TEAM_BADGE }])).toEqual([])
 })
 
+// The server's own answer, so a future record badge needs no client change.
+it('drops anything the server marked invisible, whatever its code', () => {
+    expect(displayableBadges([{ code: 'SOME_FUTURE_RECORD', isVisible: false }])).toEqual([])
+})
+
+// Rows awarded before the server started marking them invisible.
+it('still drops a legacy record row that came back visible', () => {
+    expect(displayableBadges([{ code: PEANUT_TEAM_BADGE, isVisible: true }])).toEqual([])
+})
+
+it('keeps a badge with no isVisible field, which is how most of them arrive', () => {
+    expect(displayableBadges([{ code: 'ENS' }])).toEqual([{ code: 'ENS' }])
+})
+
 it('keeps every real collectible, including the other insider badges', () => {
     const badges = [{ code: 'BETA_TESTER' }, { code: PEANUT_TEAM_BADGE }, { code: 'CARD_PIONEER' }]
 

--- a/src/constants/badges.consts.ts
+++ b/src/constants/badges.consts.ts
@@ -1,9 +1,10 @@
 /**
  * The badge that records a device's owner as having found the five-tap beta
  * switch on the About screen. The OTA card reads it back as permission to join
- * the `staging` channel — a record of who opted in and a handle to revoke it,
- * NOT an access boundary: anyone who performs the gesture awards it to
- * themselves. Capgo's channel self-assignment setting is the real boundary.
+ * the `staging` channel — a record of who opted in, NOT an access boundary:
+ * anyone who performs the gesture awards it to themselves, and deleting the
+ * row only holds until they tap again. Capgo's channel self-assignment setting
+ * is the real boundary.
  *
  * It is never rendered. It says "team" and is handed out on a gesture, so
  * showing it beside earned badges would let any customer wear Peanut staff

--- a/src/constants/badges.consts.ts
+++ b/src/constants/badges.consts.ts
@@ -14,17 +14,26 @@ export const PEANUT_TEAM_BADGE = 'PEANUT_TEAM'
 /**
  * Badges that are permission records rather than collectibles, and are never
  * shown to anyone — including their owner.
+ *
+ * This is the backstop, not the rule: `isVisible` below is what actually
+ * decides. A code only needs listing here if rows of it were awarded before
+ * the server started marking them invisible.
  */
 const NEVER_DISPLAYED = new Set<string>([PEANUT_TEAM_BADGE])
 
 /**
- * Drops the records from a badge list before it is rendered.
+ * Drops permission records from a badge list before it is rendered.
  *
- * The public profile response already omits them (the query filters on
- * `isVisible`), but `/users/me` deliberately does not — that is how the beta
- * switch reads its own permission. So every surface that renders the CALLER's
- * badges has to filter here, or the badge shows up on their own profile.
+ * The public profile response already omits them — that query filters on
+ * `isVisible` — but `/users/me` deliberately does not, since that is how the
+ * beta switch reads its own permission. So every surface rendering the
+ * CALLER's own badges has to filter here, or the record shows up on their own
+ * profile.
+ *
+ * `isVisible` is the server's own answer and covers every future record badge
+ * with no client change; the code list catches rows awarded before the server
+ * began setting it. Same convention the badge-earn toast already uses.
  */
-export function displayableBadges<T extends { code: string }>(badges: readonly T[]): T[] {
-    return badges.filter((badge) => !NEVER_DISPLAYED.has(badge.code))
+export function displayableBadges<T extends { code: string; isVisible?: boolean }>(badges: readonly T[]): T[] {
+    return badges.filter((badge) => badge.isVisible !== false && !NEVER_DISPLAYED.has(badge.code))
 }


### PR DESCRIPTION
## Why

Follow-up to [#2971](https://github.com/peanutprotocol/peanut-ui/pull/2971), which merged with only its first commit. These four were pushed to that branch afterwards and never landed. Findings raised by Chip on the paired API PR ([#1518](https://github.com/peanutprotocol/peanut-api-ts/pull/1518)).

`PEANUT_TEAM` records that an account found the five-tap beta switch. It is a permission record, not a collectible, and is meant to be invisible everywhere.

## What

**1. Filter on the server's flag, not a hardcoded code** (`f4598f322`)
`isVisible` rides on every badge in `/users/me`, and the badge-earn toast has filtered on it since it shipped. Keying the profile surfaces off a code list reinvented that convention and would need a client change for the next record badge. `displayableBadges()` now checks `isVisible !== false` first, keeping the code list only as a backstop for rows awarded before the server began setting it.

**2. Keep records off shareable card images** (`7ee62a923`)
Three surfaces passed the raw `/users/me` list into the share-asset path — `card/page.tsx` into `BadgeSkipCelebration` ("share asset shows ALL earned badges") and both history feeds into `CardUnlockHistoryItem`, whose drawer "stamps every badge the user holds". A customer who tapped five times and later got card access could generate and post an image wearing a Peanut Team sticker — worse than a profile row, since the image leaves the app.

**3. Stop calling the badge a revoke handle** (`1ff43bfde`)
Deleting the row removes the permission only until the same account taps five times again. The claim overstated what a self-award badge can be.

**4. Filter at the share-asset boundary** (`271c4c338`)
`placeStamps()` is the choke point every sticker passes through. Filtering there means a call site cannot leak a record onto a posted image even if it forgets — which had already been missed twice, once on the profile surfaces and once on the share-asset paths, because five places each had to remember. `ShareAssetBadge` carries `isVisible` so the boundary gets the server's answer, not just the code backstop. The call-site filters stay, keeping records out of the components entirely.

## Tests

`shareAssetLayout.test.ts` — `PEANUT_TEAM` dropped, any server-invisible badge dropped whatever its code, a server-visible one still stamped, and the survivors laid out exactly as if the record had never been passed. Verified load-bearing by reverting the filter: three of the four fail without it.

`badges.consts.test.ts` — the flag decides, the code list is a backstop, a badge with no `isVisible` field is kept, and the input is never mutated.

Local: 749 tests green across constants/Card/Badges/Profile/Home, typecheck clean, prettier clean repo-wide.

## Still open, deliberately

Durable revocation. A removed tester can tap five times and get the badge back. Fixing that needs a server-side tombstone the self-award path refuses to overwrite — which would make the badge the access control it is documented not to be, so it is a product decision rather than an oversight. Tracked with the owner; if wanted, it lands as its own PR with a revoke-then-reclaim test.
