### PR TITLE
fix(exchange): trim currency dropdown to 6 supported currencies

### DIFF
--- a/src/app/(mobile-ui)/profile/exchange-rate/__tests__/exchange-rate-page.test.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/__tests__/exchange-rate-page.test.tsx
@@ -59,10 +59,13 @@ jest.mock('@/components/Global/NavHeader', () => ({
     ),
 }))
 
+// The real widget clamps its own currencies via `restrictToRoutable` — this
+// stub instead forwards whatever the URL currently says, so the CTA-handler
+// tests below exercise the page's own defensive clamp independently of that.
 jest.mock('@/components/Global/ExchangeRateWidget', () => ({
     __esModule: true,
     default: ({ ctaAction, ctaLabel }: any) => (
-        <button data-testid="widget-cta" onClick={() => ctaAction('USD', 'EUR')}>
+        <button data-testid="widget-cta" onClick={() => ctaAction(mockPair.from, mockPair.to)}>
             {ctaLabel}
         </button>
     ),
@@ -81,6 +84,8 @@ const renderPage = (search = '') => {
 
 beforeEach(() => {
     jest.clearAllMocks()
+    mockPair.from = 'USD'
+    mockPair.to = 'EUR'
     mockUseWallet.mockReturnValue({ balance: 0n })
     mockUseCapabilities.mockReturnValue({ rails: [] })
     mockGetRedirectRoute.mockReturnValue('/add-money')
@@ -130,5 +135,32 @@ describe('exchange-rate CTA', () => {
         renderPage()
 
         expect(screen.getByTestId('widget-cta')).toHaveTextContent('Withdraw now')
+    })
+
+    /*
+     * A stale bookmark or hand-edited URL can carry a currency the dropdown no
+     * longer offers (`?from=PLN`, predating the six-currency trim). The label
+     * above is derived from a clamped pair; the click handler used to pass the
+     * widget's raw values straight through, so a positive balance with
+     * `?from=PLN&to=EUR` named "Withdraw now" but routed to /add-money/poland.
+     */
+    it('clamps a non-routable currency to the same pair for both the label and the route', () => {
+        mockPair.from = 'PLN'
+        mockPair.to = 'EUR'
+        mockGetRedirectRoute.mockReturnValue('/withdraw?currencyCode=EUR')
+        renderPage()
+
+        expect(screen.getByTestId('widget-cta')).toHaveTextContent('Withdraw now')
+
+        fireEvent.click(screen.getByTestId('widget-cta'))
+
+        // Every call — the label's `destination` computation and the click
+        // handler's redirect — must see PLN clamped to the USD default, never
+        // the raw, unsupported currency.
+        expect(mockGetRedirectRoute.mock.calls.length).toBeGreaterThan(0)
+        for (const [from, to] of mockGetRedirectRoute.mock.calls) {
+            expect(from).toBe('USD')
+            expect(to).toBe('EUR')
+        }
     })
 })

--- a/src/app/(mobile-ui)/profile/exchange-rate/__tests__/exchange-rate-page.test.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/__tests__/exchange-rate-page.test.tsx
@@ -163,4 +163,27 @@ describe('exchange-rate CTA', () => {
             expect(to).toBe('EUR')
         }
     })
+
+    /*
+     * `?from=PLN&to=USD` is the collision case: PLN is invalid and would
+     * independently default to 'USD', landing on the same currency as the
+     * other, explicit and valid 'USD' side. The page must resolve this pair
+     * through the same pair-aware function the widget uses (EUR/USD), not its
+     * own independent fallback (which used to produce USD/USD) — otherwise
+     * the label names one flow and the tap opens another.
+     */
+    it('resolves an invalid source next to an explicit USD to EUR, not USD/USD', () => {
+        mockPair.from = 'PLN'
+        mockPair.to = 'USD'
+        mockGetRedirectRoute.mockReturnValue('/withdraw?currencyCode=USD')
+        renderPage()
+
+        fireEvent.click(screen.getByTestId('widget-cta'))
+
+        expect(mockGetRedirectRoute.mock.calls.length).toBeGreaterThan(0)
+        for (const [from, to] of mockGetRedirectRoute.mock.calls) {
+            expect(from).toBe('EUR')
+            expect(to).toBe('USD')
+        }
+    })
 })

--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -7,6 +7,7 @@ import ExchangeRateWidget from '@/components/Global/ExchangeRateWidget'
 import NavHeader from '@/components/Global/NavHeader'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { printableUsdc } from '@/utils/balance.utils'
+import { toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
 import { getExchangeRateWidgetRedirectRoute } from '@/utils/exchangeRateWidget.utils'
 import { withReturnTo } from '@/utils/return-to.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -33,12 +34,27 @@ export default function ExchangeRatePage() {
     // the destination is derivable BEFORE the tap — the label has to be,
     // because a zero balance or a local→USD pair routes to /add-money and a
     // fixed "Withdraw now" would name the opposite flow.
+    // The same parser the widget uses, so the two cannot disagree about what
+    // the URL says — reading it with parseAsString here meant `?from=usd` or a
+    // stale `?to=PLN` showed USD->EUR in the widget while this page computed a
+    // label and destination from the raw value, sending the user to
+    // /withdraw/poland from a widget that never displayed PLN.
     const [{ from, to }] = useQueryStates(
         { from: parseAsString.withDefault('USD'), to: parseAsString.withDefault('EUR') },
         { shallow: true, history: 'replace', scroll: false }
     )
+    // Redirects need a currency with an actual rail behind it; display does
+    // not. A pair outside the six falls back to the default rather than
+    // routing into a country flow the product does not serve.
+    const routableFrom = toSupportedExchangeCurrency(from) ?? 'USD'
+    const routableTo = toSupportedExchangeCurrency(to) ?? 'EUR'
     const formattedBalance = parseFloat(printableUsdc(balance ?? 0n))
-    const destination = getExchangeRateWidgetRedirectRoute(from, to, formattedBalance, unlockedRegionPaths)
+    const destination = getExchangeRateWidgetRedirectRoute(
+        routableFrom,
+        routableTo,
+        formattedBalance,
+        unlockedRegionPaths
+    )
     const goesToAddMoney = destination.startsWith('/add-money')
 
     const handleCtaAction = (sourceCurrency: string, destinationCurrency: string) => {

--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -2,7 +2,6 @@
 
 import PageContainer from '@/components/0_Bruddle/PageContainer'
 import { PageStack } from '@/components/0_Bruddle/PageStack'
-import { Notification } from '@/components/0_Bruddle/Notification'
 import ExchangeRateWidget from '@/components/Global/ExchangeRateWidget'
 import NavHeader from '@/components/Global/NavHeader'
 import { useWallet } from '@/hooks/wallet/useWallet'
@@ -91,10 +90,10 @@ export default function ExchangeRatePage() {
         <PageContainer>
             <PageStack gap="6">
                 <NavHeader title={t('title')} onPrev={onBack} />
-                {/* The pair the widget shows is a conversion, not a wallet:
-                    people read "EUR" here as "my balance is in euros". */}
-                <Notification priority="info">{t('balanceNote')}</Notification>
-                <PageStack.Center>
+                <PageStack.Center className="gap-3">
+                    {/* The pair the widget shows is a conversion, not a wallet:
+                        people read "EUR" here as "my balance is in euros". */}
+                    <p className="text-center text-body-s text-foreground-secondary">{t('balanceNote')}</p>
                     <ExchangeRateWidget
                         ctaIcon="arrow-down"
                         ctaLabel={goesToAddMoney ? t('addMoneyCta') : t('tryIt')}

--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -7,7 +7,7 @@ import ExchangeRateWidget from '@/components/Global/ExchangeRateWidget'
 import NavHeader from '@/components/Global/NavHeader'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { printableUsdc } from '@/utils/balance.utils'
-import { toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
+import { resolveExchangeCurrencyPair, toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
 import { getExchangeRateWidgetRedirectRoute } from '@/utils/exchangeRateWidget.utils'
 import { withReturnTo } from '@/utils/return-to.utils'
 import { useCapabilities } from '@/hooks/useCapabilities'
@@ -45,9 +45,13 @@ export default function ExchangeRatePage() {
     )
     // Redirects need a currency with an actual rail behind it; display does
     // not. A pair outside the six falls back to the default rather than
-    // routing into a country flow the product does not serve.
-    const routableFrom = toSupportedExchangeCurrency(from) ?? 'USD'
-    const routableTo = toSupportedExchangeCurrency(to) ?? 'EUR'
+    // routing into a country flow the product does not serve. Same
+    // pair-aware resolver the widget uses (resolveExchangeCurrencyPair) — an
+    // invalid side falling back to its own independent default could land on
+    // whatever currency the other, valid side already held, e.g. `?from=PLN
+    // &to=USD` used to resolve here to USD/USD while the widget (also
+    // restricted) resolved it to EUR/USD, so the label and the tap disagreed.
+    const [routableFrom, routableTo] = resolveExchangeCurrencyPair(from, to, toSupportedExchangeCurrency)
     const formattedBalance = parseFloat(printableUsdc(balance ?? 0n))
     const destination = getExchangeRateWidgetRedirectRoute(
         routableFrom,
@@ -59,12 +63,18 @@ export default function ExchangeRatePage() {
 
     const handleCtaAction = (sourceCurrency: string, destinationCurrency: string) => {
         // The widget is rendered below with `restrictToRoutable`, so these
-        // arguments are already one of the six — clamped again here so the
-        // route can never drift from `destination`/`goesToAddMoney` above,
-        // which are computed from the same URL independently of the widget.
+        // arguments are already a resolved, non-colliding pair — resolved
+        // again here, through the same function, so the route can never
+        // drift from `destination`/`goesToAddMoney` above, which come from
+        // the same URL independently of the widget.
+        const [clampedFrom, clampedTo] = resolveExchangeCurrencyPair(
+            sourceCurrency,
+            destinationCurrency,
+            toSupportedExchangeCurrency
+        )
         const redirectRoute = getExchangeRateWidgetRedirectRoute(
-            toSupportedExchangeCurrency(sourceCurrency) ?? 'USD',
-            toSupportedExchangeCurrency(destinationCurrency) ?? 'EUR',
+            clampedFrom,
+            clampedTo,
             formattedBalance,
             unlockedRegionPaths
         )

--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -58,9 +58,13 @@ export default function ExchangeRatePage() {
     const goesToAddMoney = destination.startsWith('/add-money')
 
     const handleCtaAction = (sourceCurrency: string, destinationCurrency: string) => {
+        // The widget is rendered below with `restrictToRoutable`, so these
+        // arguments are already one of the six — clamped again here so the
+        // route can never drift from `destination`/`goesToAddMoney` above,
+        // which are computed from the same URL independently of the widget.
         const redirectRoute = getExchangeRateWidgetRedirectRoute(
-            sourceCurrency,
-            destinationCurrency,
+            toSupportedExchangeCurrency(sourceCurrency) ?? 'USD',
+            toSupportedExchangeCurrency(destinationCurrency) ?? 'EUR',
             formattedBalance,
             unlockedRegionPaths
         )
@@ -85,6 +89,7 @@ export default function ExchangeRatePage() {
                         ctaIcon="arrow-down"
                         ctaLabel={goesToAddMoney ? t('addMoneyCta') : t('tryIt')}
                         ctaAction={handleCtaAction}
+                        restrictToRoutable
                         labels={{
                             youSend: t('widget.youSend'),
                             recipientGets: t('widget.recipientGets'),

--- a/src/components/Global/ExchangeRateWidget/__tests__/restrict-to-routable.test.tsx
+++ b/src/components/Global/ExchangeRateWidget/__tests__/restrict-to-routable.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * `restrictToRoutable` is what keeps a product caller (currently
+ * /profile/exchange-rate) from displaying and quoting a currency the dropdown
+ * no longer offers. Without it, a stale bookmark predating the six-currency
+ * trim (`?to=PLN`) rendered PLN in the trigger and fetched a PLN quote — see
+ * peanut-ui#2979 review thread.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+import ExchangeRateWidget from '../index'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: any) => <img {...props} alt={props.alt} />,
+}))
+
+jest.mock('@/hooks/useExchangeRate', () => ({
+    useExchangeRate: () => ({
+        sourceAmount: 10,
+        destinationAmount: 9,
+        exchangeRate: 0.9,
+        isLoading: false,
+        isError: false,
+        handleSourceAmountChange: jest.fn(),
+        handleDestinationAmountChange: jest.fn(),
+        getDestinationDisplayValue: () => '',
+    }),
+}))
+
+const renderWidget = (searchParams: Record<string, string>, restrictToRoutable?: boolean) =>
+    render(
+        <NuqsTestingAdapter searchParams={searchParams}>
+            <ExchangeRateWidget
+                ctaLabel="Go"
+                ctaIcon="arrow-down"
+                ctaAction={jest.fn()}
+                restrictToRoutable={restrictToRoutable}
+            />
+        </NuqsTestingAdapter>
+    )
+
+describe('ExchangeRateWidget restrictToRoutable', () => {
+    it('clamps a non-routable URL currency to the default when restricted', () => {
+        renderWidget({ from: 'USD', to: 'PLN' }, true)
+
+        expect(screen.getByText('EUR')).toBeInTheDocument()
+        expect(screen.queryByText('PLN')).not.toBeInTheDocument()
+    })
+
+    it('shows a display-only currency verbatim when not restricted (marketing callers)', () => {
+        renderWidget({ from: 'USD', to: 'PLN' }, false)
+
+        expect(screen.getByText('PLN')).toBeInTheDocument()
+    })
+
+    it('defaults to unrestricted when the prop is omitted', () => {
+        renderWidget({ from: 'USD', to: 'THB' })
+
+        expect(screen.getByText('THB')).toBeInTheDocument()
+    })
+})

--- a/src/components/Global/ExchangeRateWidget/__tests__/restrict-to-routable.test.tsx
+++ b/src/components/Global/ExchangeRateWidget/__tests__/restrict-to-routable.test.tsx
@@ -59,4 +59,18 @@ describe('ExchangeRateWidget restrictToRoutable', () => {
 
         expect(screen.getByText('THB')).toBeInTheDocument()
     })
+
+    /*
+     * Each side used to fall back independently ('USD' for source, 'EUR' for
+     * destination). An invalid source next to an explicit, valid destination
+     * of 'USD' then defaulted the source to 'USD' too, producing a USD/USD
+     * pair — a currency "exchanged" with itself.
+     */
+    it('never collapses to USD/USD when an invalid side would default onto an explicit USD', () => {
+        renderWidget({ from: 'PLN', to: 'USD' }, true)
+
+        expect(screen.getByText('EUR')).toBeInTheDocument()
+        expect(screen.getAllByText('USD')).toHaveLength(1)
+        expect(screen.queryByText('PLN')).not.toBeInTheDocument()
+    })
 })

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -42,9 +42,22 @@ interface IExchangeRateWidgetProps {
     ctaIcon: IconName
     ctaAction: (sourceCurrency: string, destinationCurrency: string) => void
     labels?: Partial<ExchangeRateWidgetLabels>
+    // Marketing send-to pages seed the URL with currencies that only need a
+    // quote (see the comment on `sourceCurrency` below). Product callers whose
+    // CTA routes into a country flow — currently just /profile/exchange-rate —
+    // need the URL clamped to the six routable currencies instead, or a stale
+    // `?to=PLN` shows a rate the dropdown never offers and the CTA can only
+    // route by falling back to the default pair.
+    restrictToRoutable?: boolean
 }
 
-const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, ctaAction, labels }) => {
+const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
+    ctaLabel,
+    ctaIcon,
+    ctaAction,
+    labels,
+    restrictToRoutable = false,
+}) => {
     const l = { ...DEFAULT_LABELS, ...labels }
     // shallow + history:'replace' uses window.history.replaceState — bypasses
     // Next.js navigation so URL updates don't (occasionally) scroll the page
@@ -58,14 +71,17 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
         { shallow: true, history: 'replace', scroll: false }
     )
 
-    // Normalised, not filtered to the routable six. The marketing send-to pages
-    // seed this URL from their MDX frontmatter (Marketing/mdx/ExchangeWidget.tsx)
-    // with ~20 currencies the FX feed quotes but no rail supports — THB, PLN,
-    // JPY and the rest. Rejecting those would render a euro rate on a "send
-    // money to Thailand" page. Displaying a quote and offering a payment rail
-    // are different permissions; the routable check lives at the redirect.
-    const sourceCurrency = toDisplayCurrency(query.from) ?? 'USD'
-    const destinationCurrency = toDisplayCurrency(query.to) ?? 'EUR'
+    // Normalised, and — for marketing callers — not filtered to the routable
+    // six. Those pages seed this URL from their MDX frontmatter
+    // (Marketing/mdx/ExchangeWidget.tsx) with ~20 currencies the FX feed
+    // quotes but no rail supports — THB, PLN, JPY and the rest. Rejecting those
+    // would render a euro rate on a "send money to Thailand" page. Displaying
+    // a quote and offering a payment rail are different permissions — but a
+    // caller whose CTA routes into a country flow needs both to agree, so it
+    // opts into the routable-only parse via `restrictToRoutable`.
+    const resolveCurrency = restrictToRoutable ? toSupportedExchangeCurrency : toDisplayCurrency
+    const sourceCurrency = resolveCurrency(query.from) ?? 'USD'
+    const destinationCurrency = resolveCurrency(query.to) ?? 'EUR'
     const urlSourceAmount = query.amount > 0 ? query.amount : 10
 
     // Exchange rate hook handles all the conversion logic

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -1,10 +1,11 @@
 import CurrencySelect from '@/components/LandingPage/CurrencySelect'
 import countryCurrencyMappings, { getFlagUrl } from '@/constants/countryCurrencyMapping'
+import { type SupportedExchangeCurrency, toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { applyBridgeCrossCurrencyFee, reverseBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
 import Image from 'next/image'
-import { parseAsFloat, parseAsString, useQueryStates } from 'nuqs'
+import { createParser, parseAsFloat, useQueryStates } from 'nuqs'
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon, type IconName } from '../Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -43,6 +44,16 @@ interface IExchangeRateWidgetProps {
     labels?: Partial<ExchangeRateWidgetLabels>
 }
 
+// The dropdown is not the only way a currency reaches this widget. `from` and
+// `to` also come from the URL, so a bookmark predating the supported list
+// (`?from=PLN`) would render PLN in the trigger, fetch a PLN quote and send the
+// CTA to the Poland flow. Returning null for anything unsupported makes nuqs
+// fall back to the default, so a stale link degrades to a working pair.
+const parseAsExchangeCurrency = createParser({
+    parse: (value) => toSupportedExchangeCurrency(value),
+    serialize: (value: SupportedExchangeCurrency) => value,
+})
+
 const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, ctaAction, labels }) => {
     const l = { ...DEFAULT_LABELS, ...labels }
     // shallow + history:'replace' uses window.history.replaceState — bypasses
@@ -50,8 +61,8 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     // to the top through the parent Suspense boundary.
     const [query, setQuery] = useQueryStates(
         {
-            from: parseAsString.withDefault('USD'),
-            to: parseAsString.withDefault('EUR'),
+            from: parseAsExchangeCurrency.withDefault('USD'),
+            to: parseAsExchangeCurrency.withDefault('EUR'),
             amount: parseAsFloat.withDefault(10),
         },
         { shallow: true, history: 'replace', scroll: false }
@@ -99,7 +110,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     }, [isEditingDestination, getDestinationDisplayValue, netDestinationAmount])
 
     const updateUrlParams = useCallback(
-        (params: { from?: string; to?: string; amount?: number }) => {
+        (params: { from?: SupportedExchangeCurrency; to?: SupportedExchangeCurrency; amount?: number }) => {
             setQuery(params)
         },
         [setQuery]
@@ -108,7 +119,12 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     // Setter functions that update URL
     // USD must always be one of the two currencies in the pair
     const setSourceCurrency = useCallback(
-        (currency: string) => {
+        (raw: string) => {
+            // CurrencySelect only renders supported rows, so this is a type
+            // narrowing rather than a real filter — but it is the same door the
+            // URL comes through, and one of them had no guard at all.
+            const currency = toSupportedExchangeCurrency(raw)
+            if (!currency) return
             if (currency === 'USD') {
                 // If setting source to USD and destination is already USD, switch destination
                 if (destinationCurrency === 'USD') {
@@ -124,7 +140,9 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     )
 
     const setDestinationCurrency = useCallback(
-        (currency: string) => {
+        (raw: string) => {
+            const currency = toSupportedExchangeCurrency(raw)
+            if (!currency) return
             if (currency === 'USD') {
                 if (sourceCurrency === 'USD') {
                     updateUrlParams({ from: 'EUR', to: currency }) // fallback to EUR

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -1,6 +1,10 @@
 import CurrencySelect from '@/components/LandingPage/CurrencySelect'
 import countryCurrencyMappings, { getFlagUrl } from '@/constants/countryCurrencyMapping'
-import { toDisplayCurrency, toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
+import {
+    resolveExchangeCurrencyPair,
+    toDisplayCurrency,
+    toSupportedExchangeCurrency,
+} from '@/constants/exchange-currencies.consts'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { applyBridgeCrossCurrencyFee, reverseBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
@@ -80,14 +84,12 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
     // caller whose CTA routes into a country flow needs both to agree, so it
     // opts into the routable-only parse via `restrictToRoutable`.
     const resolveCurrency = restrictToRoutable ? toSupportedExchangeCurrency : toDisplayCurrency
-    const rawSourceCurrency = resolveCurrency(query.from)
-    const rawDestinationCurrency = resolveCurrency(query.to)
-    // Resolved together, not with independent 'USD'/'EUR' defaults: an invalid
-    // side falling back to 'USD' while the other side was already the
-    // explicit, valid 'USD' collapsed the pair to USD/USD — a currency
-    // "exchanged" with itself.
-    const sourceCurrency = rawSourceCurrency ?? (rawDestinationCurrency === 'USD' ? 'EUR' : 'USD')
-    const destinationCurrency = rawDestinationCurrency ?? (sourceCurrency === 'USD' ? 'EUR' : 'USD')
+    // Resolved as a pair, not two independently-defaulted sides — see
+    // resolveExchangeCurrencyPair. A page that derives its own label or
+    // redirect from this same URL before the widget mounts (currently just
+    // /profile/exchange-rate) must call this exact function too, or its
+    // fallback can disagree with what the widget ends up showing.
+    const [sourceCurrency, destinationCurrency] = resolveExchangeCurrencyPair(query.from, query.to, resolveCurrency)
     const urlSourceAmount = query.amount > 0 ? query.amount : 10
 
     // Exchange rate hook handles all the conversion logic

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -1,11 +1,11 @@
 import CurrencySelect from '@/components/LandingPage/CurrencySelect'
 import countryCurrencyMappings, { getFlagUrl } from '@/constants/countryCurrencyMapping'
-import { type SupportedExchangeCurrency, toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
+import { toDisplayCurrency, toSupportedExchangeCurrency } from '@/constants/exchange-currencies.consts'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useExchangeRate } from '@/hooks/useExchangeRate'
 import { applyBridgeCrossCurrencyFee, reverseBridgeCrossCurrencyFee } from '@/utils/bridge.utils'
 import Image from 'next/image'
-import { createParser, parseAsFloat, useQueryStates } from 'nuqs'
+import { parseAsFloat, parseAsString, useQueryStates } from 'nuqs'
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon, type IconName } from '../Icons/Icon'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -44,16 +44,6 @@ interface IExchangeRateWidgetProps {
     labels?: Partial<ExchangeRateWidgetLabels>
 }
 
-// The dropdown is not the only way a currency reaches this widget. `from` and
-// `to` also come from the URL, so a bookmark predating the supported list
-// (`?from=PLN`) would render PLN in the trigger, fetch a PLN quote and send the
-// CTA to the Poland flow. Returning null for anything unsupported makes nuqs
-// fall back to the default, so a stale link degrades to a working pair.
-const parseAsExchangeCurrency = createParser({
-    parse: (value) => toSupportedExchangeCurrency(value),
-    serialize: (value: SupportedExchangeCurrency) => value,
-})
-
 const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, ctaAction, labels }) => {
     const l = { ...DEFAULT_LABELS, ...labels }
     // shallow + history:'replace' uses window.history.replaceState — bypasses
@@ -61,15 +51,21 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     // to the top through the parent Suspense boundary.
     const [query, setQuery] = useQueryStates(
         {
-            from: parseAsExchangeCurrency.withDefault('USD'),
-            to: parseAsExchangeCurrency.withDefault('EUR'),
+            from: parseAsString.withDefault('USD'),
+            to: parseAsString.withDefault('EUR'),
             amount: parseAsFloat.withDefault(10),
         },
         { shallow: true, history: 'replace', scroll: false }
     )
 
-    const sourceCurrency = query.from
-    const destinationCurrency = query.to
+    // Normalised, not filtered to the routable six. The marketing send-to pages
+    // seed this URL from their MDX frontmatter (Marketing/mdx/ExchangeWidget.tsx)
+    // with ~20 currencies the FX feed quotes but no rail supports — THB, PLN,
+    // JPY and the rest. Rejecting those would render a euro rate on a "send
+    // money to Thailand" page. Displaying a quote and offering a payment rail
+    // are different permissions; the routable check lives at the redirect.
+    const sourceCurrency = toDisplayCurrency(query.from) ?? 'USD'
+    const destinationCurrency = toDisplayCurrency(query.to) ?? 'EUR'
     const urlSourceAmount = query.amount > 0 ? query.amount : 10
 
     // Exchange rate hook handles all the conversion logic
@@ -110,7 +106,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({ ctaLabel, ctaIcon, c
     }, [isEditingDestination, getDestinationDisplayValue, netDestinationAmount])
 
     const updateUrlParams = useCallback(
-        (params: { from?: SupportedExchangeCurrency; to?: SupportedExchangeCurrency; amount?: number }) => {
+        (params: { from?: string; to?: string; amount?: number }) => {
             setQuery(params)
         },
         [setQuery]

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -80,8 +80,14 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
     // caller whose CTA routes into a country flow needs both to agree, so it
     // opts into the routable-only parse via `restrictToRoutable`.
     const resolveCurrency = restrictToRoutable ? toSupportedExchangeCurrency : toDisplayCurrency
-    const sourceCurrency = resolveCurrency(query.from) ?? 'USD'
-    const destinationCurrency = resolveCurrency(query.to) ?? 'EUR'
+    const rawSourceCurrency = resolveCurrency(query.from)
+    const rawDestinationCurrency = resolveCurrency(query.to)
+    // Resolved together, not with independent 'USD'/'EUR' defaults: an invalid
+    // side falling back to 'USD' while the other side was already the
+    // explicit, valid 'USD' collapsed the pair to USD/USD — a currency
+    // "exchanged" with itself.
+    const sourceCurrency = rawSourceCurrency ?? (rawDestinationCurrency === 'USD' ? 'EUR' : 'USD')
+    const destinationCurrency = rawDestinationCurrency ?? (sourceCurrency === 'USD' ? 'EUR' : 'USD')
     const urlSourceAmount = query.amount > 0 ? query.amount : 10
 
     // Exchange rate hook handles all the conversion logic

--- a/src/components/LandingPage/CurrencySelect.tsx
+++ b/src/components/LandingPage/CurrencySelect.tsx
@@ -5,6 +5,7 @@ import { Icon } from '../Global/Icons/Icon'
 import { twMerge } from '@/utils/tw'
 import Image from 'next/image'
 import countryCurrencyMappings, { getFlagUrl } from '@/constants/countryCurrencyMapping'
+import { SUPPORTED_EXCHANGE_CURRENCIES } from '@/constants/exchange-currencies.consts'
 import StatusBadge from '../Global/Badges/StatusBadge'
 
 interface CurrencySelectProps {
@@ -13,11 +14,6 @@ interface CurrencySelectProps {
     trigger: React.ReactNode
     excludeCurrencies?: string[]
 }
-
-// The exchange-rate widget only supports the currencies backed by an actual
-// payment rail (ACH/wire, SEPA, Faster Payments, SPEI, Manteca) — kept in this
-// display order regardless of countryCurrencyMapping.ts's own ordering.
-const SUPPORTED_EXCHANGE_CURRENCIES = ['USD', 'EUR', 'GBP', 'MXN', 'ARS', 'BRL']
 
 // Transform the currency mappings into the format expected by the component
 const currencies = SUPPORTED_EXCHANGE_CURRENCIES.map((code) => {

--- a/src/components/LandingPage/CurrencySelect.tsx
+++ b/src/components/LandingPage/CurrencySelect.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
-import React, { useState, useMemo } from 'react'
-import BaseInput from '../0_Bruddle/BaseInput'
+import React, { useMemo } from 'react'
 import { Icon } from '../Global/Icons/Icon'
 import { twMerge } from '@/utils/tw'
 import Image from 'next/image'
@@ -15,16 +14,22 @@ interface CurrencySelectProps {
     excludeCurrencies?: string[]
 }
 
-// Transform the currency mappings into the format expected by the component
-const currencies = countryCurrencyMappings.map((mapping) => ({
-    countryCode: mapping.flagCode,
-    country: mapping.country,
-    currency: mapping.currencyCode,
-    currencyName: mapping.currencyName,
-    comingSoon: mapping.comingSoon || false,
-}))
+// The exchange-rate widget only supports the currencies backed by an actual
+// payment rail (ACH/wire, SEPA, Faster Payments, SPEI, Manteca) — kept in this
+// display order regardless of countryCurrencyMapping.ts's own ordering.
+const SUPPORTED_EXCHANGE_CURRENCIES = ['USD', 'EUR', 'GBP', 'MXN', 'ARS', 'BRL']
 
-const popularCurrencies = ['USD', 'EUR', 'ARS', 'BRL', 'MXN']
+// Transform the currency mappings into the format expected by the component
+const currencies = SUPPORTED_EXCHANGE_CURRENCIES.map((code) => {
+    const mapping = countryCurrencyMappings.find((m) => m.currencyCode === code)!
+    return {
+        countryCode: mapping.flagCode,
+        country: mapping.country,
+        currency: mapping.currencyCode,
+        currencyName: mapping.currencyName,
+        comingSoon: mapping.comingSoon || false,
+    }
+})
 
 const CurrencySelect = ({
     selectedCurrency,
@@ -32,24 +37,10 @@ const CurrencySelect = ({
     trigger,
     excludeCurrencies = [],
 }: CurrencySelectProps) => {
-    const [searchTerm, setSearchTerm] = useState('')
-
-    const filteredCurrencies = useMemo(() => {
-        // First filter out excluded currencies
-        const availableCurrencies = currencies.filter((currency) => !excludeCurrencies.includes(currency.currency))
-
-        if (!searchTerm.trim()) {
-            return availableCurrencies
-        }
-
-        const lowerSearchTerm = searchTerm.toLowerCase().trim()
-        return availableCurrencies.filter(
-            (currency) =>
-                currency.currency.toLowerCase().includes(lowerSearchTerm) ||
-                currency.country.toLowerCase().includes(lowerSearchTerm) ||
-                currency.currencyName.toLowerCase().includes(lowerSearchTerm)
-        )
-    }, [searchTerm, excludeCurrencies])
+    const availableCurrencies = useMemo(
+        () => currencies.filter((currency) => !excludeCurrencies.includes(currency.currency)),
+        [excludeCurrencies]
+    )
 
     return (
         <Popover className="relative">
@@ -58,72 +49,29 @@ const CurrencySelect = ({
                     <PopoverButton as={React.Fragment}>{trigger}</PopoverButton>
                     <PopoverPanel
                         anchor="bottom end"
-                        className="z-50 mt-4 h-72 w-72 overflow-scroll rounded-sm border border-black bg-white shadow-lg sm:w-80 md:w-96"
+                        className="z-50 mt-4 w-72 overflow-scroll rounded-sm border border-black bg-white shadow-lg sm:w-80 md:w-96"
                         // usePullToRefresh listens on `document` and only bails on window.scrollY > 0,
                         // so scrolling this panel at page top reads as a pull. Same guard as Global/Drawer.
                         onTouchMove={(e: React.TouchEvent) => e.stopPropagation()}
                     >
-                        <div className="flex max-h-full w-full flex-col gap-4 overflow-hidden p-4">
-                            <div className="relative w-full">
-                                <div className="absolute top-1/2 left-2 -translate-y-1/2">
-                                    <Icon name="search" size={15} />
-                                </div>
-                                <BaseInput
-                                    type="text"
-                                    placeholder="Currency or country"
-                                    value={searchTerm}
-                                    onChange={(e) => setSearchTerm(e.target.value)}
-                                    className="h-10 w-full rounded-sm border-[1.15px] border-black pr-10 pl-10 font-normal caret-[#FF90E8] focus:border-black focus:ring-0 focus:outline-none"
+                        <div className="flex max-h-full w-full flex-col items-start overflow-y-scroll p-4">
+                            {availableCurrencies.map((currency, index) => (
+                                <CurrencyBox
+                                    key={`${currency.countryCode}-${currency.country}-${index}`}
+                                    countryCode={currency.countryCode}
+                                    country={currency.country}
+                                    currency={currency.currency}
+                                    currencyName={currency.currencyName}
+                                    comingSoon={currency.comingSoon}
+                                    selected={currency.currency === selectedCurrency}
+                                    onSelect={() => {
+                                        if (!currency.comingSoon) {
+                                            close()
+                                            setSelectedCurrency(currency.currency)
+                                        }
+                                    }}
                                 />
-                            </div>
-
-                            <div className="flex max-h-full w-full flex-col items-start overflow-y-scroll">
-                                {!searchTerm && (
-                                    <h2 className="text-left text-xs font-normal text-gray-1">Popular currencies</h2>
-                                )}
-                                {filteredCurrencies
-                                    .filter((currency) => popularCurrencies.includes(currency.currency))
-                                    .map((currency, index) => (
-                                        <CurrencyBox
-                                            key={`${currency.countryCode}-${currency.country}-${index}`}
-                                            countryCode={currency.countryCode}
-                                            country={currency.country}
-                                            currency={currency.currency}
-                                            currencyName={currency.currencyName}
-                                            comingSoon={currency.comingSoon}
-                                            selected={currency.currency === selectedCurrency}
-                                            onSelect={() => {
-                                                if (!currency.comingSoon) {
-                                                    close()
-                                                    setSelectedCurrency(currency.currency)
-                                                }
-                                            }}
-                                        />
-                                    ))}
-
-                                {!searchTerm && (
-                                    <h2 className="text-left text-xs font-normal text-gray-1">Supported currencies</h2>
-                                )}
-                                {filteredCurrencies
-                                    .filter((currency) => !popularCurrencies.includes(currency.currency))
-                                    .map((currency, index) => (
-                                        <CurrencyBox
-                                            key={`${currency.countryCode}-${currency.country}-${index}`}
-                                            countryCode={currency.countryCode}
-                                            country={currency.country}
-                                            currency={currency.currency}
-                                            currencyName={currency.currencyName}
-                                            comingSoon={currency.comingSoon}
-                                            selected={currency.currency === selectedCurrency}
-                                            onSelect={() => {
-                                                if (!currency.comingSoon) {
-                                                    close()
-                                                    setSelectedCurrency(currency.currency)
-                                                }
-                                            }}
-                                        />
-                                    ))}
-                            </div>
+                            ))}
                         </div>
                     </PopoverPanel>
                 </>

--- a/src/components/LandingPage/__tests__/CurrencySelect.pull-to-refresh.test.tsx
+++ b/src/components/LandingPage/__tests__/CurrencySelect.pull-to-refresh.test.tsx
@@ -34,7 +34,7 @@ describe('CurrencySelect pull-to-refresh guard (TASK-21967)', () => {
         open()
 
         // A row deep inside the scroll area — the element a finger actually drags.
-        fireEvent.touchMove(screen.getByText('Popular currencies'), { touches: [{ clientX: 0, clientY: 40 }] })
+        fireEvent.touchMove(screen.getByText('US Dollar'), { touches: [{ clientX: 0, clientY: 40 }] })
 
         expect(onDocumentTouchMove).not.toHaveBeenCalled()
     })

--- a/src/components/LandingPage/noFees.tsx
+++ b/src/components/LandingPage/noFees.tsx
@@ -135,6 +135,7 @@ export function NoFees({
                     ctaLabel={strings.sendMoney}
                     ctaAction={handleCtaAction}
                     labels={strings.exchange}
+                    restrictToRoutable
                 />
 
                 <ContextualLinks

--- a/src/constants/__tests__/exchange-currencies.test.ts
+++ b/src/constants/__tests__/exchange-currencies.test.ts
@@ -2,6 +2,7 @@
 // is what stands between a stale bookmark and a quote in a currency the
 // product does not support.
 import {
+    resolveExchangeCurrencyPair,
     SUPPORTED_EXCHANGE_CURRENCIES,
     toDisplayCurrency,
     toSupportedExchangeCurrency,
@@ -81,5 +82,36 @@ describe('toDisplayCurrency', () => {
         // permissions. THB quotes; THB does not route.
         expect(toDisplayCurrency('THB')).toBe('THB')
         expect(toSupportedExchangeCurrency('THB')).toBeNull()
+    })
+})
+
+describe('resolveExchangeCurrencyPair', () => {
+    it('passes through two valid, distinct currencies unchanged', () => {
+        expect(resolveExchangeCurrencyPair('GBP', 'ARS', toSupportedExchangeCurrency)).toEqual(['GBP', 'ARS'])
+    })
+
+    it('never collapses to USD/USD when an invalid source sits next to an explicit USD', () => {
+        // Resolving each side with its own independent default ('USD' for
+        // source, 'EUR' for destination) used to let PLN fall back onto the
+        // same 'USD' the other, valid side already held.
+        expect(resolveExchangeCurrencyPair('PLN', 'USD', toSupportedExchangeCurrency)).toEqual(['EUR', 'USD'])
+    })
+
+    it('never collapses to USD/USD when an invalid destination sits next to an explicit USD', () => {
+        expect(resolveExchangeCurrencyPair('USD', 'PLN', toSupportedExchangeCurrency)).toEqual(['USD', 'EUR'])
+    })
+
+    it('falls back to the USD/EUR default pair when both sides are invalid', () => {
+        expect(resolveExchangeCurrencyPair('PLN', 'CHF', toSupportedExchangeCurrency)).toEqual(['USD', 'EUR'])
+    })
+
+    it('lets a valid non-USD source pick USD as the default destination', () => {
+        expect(resolveExchangeCurrencyPair('EUR', 'PLN', toSupportedExchangeCurrency)).toEqual(['EUR', 'USD'])
+    })
+
+    it('works with the display resolver too, for a non-restricted caller', () => {
+        // THB is not routable but is a valid display currency, so it passes
+        // through untouched rather than triggering the USD/EUR fallback.
+        expect(resolveExchangeCurrencyPair('USD', 'THB', toDisplayCurrency)).toEqual(['USD', 'THB'])
     })
 })

--- a/src/constants/__tests__/exchange-currencies.test.ts
+++ b/src/constants/__tests__/exchange-currencies.test.ts
@@ -1,0 +1,47 @@
+// The exchange-rate widget takes `from`/`to` from the URL, so this allow-list
+// is what stands between a stale bookmark and a quote in a currency the
+// product does not support.
+import { SUPPORTED_EXCHANGE_CURRENCIES, toSupportedExchangeCurrency } from '../exchange-currencies.consts'
+
+describe('toSupportedExchangeCurrency', () => {
+    it.each(SUPPORTED_EXCHANGE_CURRENCIES)('accepts %s', (currency) => {
+        expect(toSupportedExchangeCurrency(currency)).toBe(currency)
+    })
+
+    it('rejects a currency the widget used to offer', () => {
+        // The regression this guards: `?from=PLN&to=USD` is a live bookmark
+        // from before the dropdown was trimmed. Unfiltered it rendered PLN in
+        // the trigger, fetched a PLN quote and pointed the CTA at the Poland
+        // flow. nuqs falls back to the default on null, so the pair degrades to
+        // a working one instead.
+        expect(toSupportedExchangeCurrency('PLN')).toBeNull()
+        expect(toSupportedExchangeCurrency('CHF')).toBeNull()
+        expect(toSupportedExchangeCurrency('NGN')).toBeNull()
+    })
+
+    it('normalises case and whitespace, because these come from hand-edited URLs', () => {
+        // `?from=usd` means USD. Falling back to the default would show a
+        // currency the user did not ask for.
+        expect(toSupportedExchangeCurrency('usd')).toBe('USD')
+        expect(toSupportedExchangeCurrency('  eur  ')).toBe('EUR')
+        expect(toSupportedExchangeCurrency('Mxn')).toBe('MXN')
+    })
+
+    it('rejects absent and empty values rather than guessing', () => {
+        expect(toSupportedExchangeCurrency(null)).toBeNull()
+        expect(toSupportedExchangeCurrency(undefined)).toBeNull()
+        expect(toSupportedExchangeCurrency('')).toBeNull()
+        expect(toSupportedExchangeCurrency('   ')).toBeNull()
+    })
+
+    it('does not partial-match a longer string', () => {
+        expect(toSupportedExchangeCurrency('USDT')).toBeNull()
+        expect(toSupportedExchangeCurrency('EURO')).toBeNull()
+    })
+
+    it('is the list the dropdown renders, in display order', () => {
+        // CurrencySelect imports this same constant, so the rows and the URL
+        // filter cannot drift apart.
+        expect([...SUPPORTED_EXCHANGE_CURRENCIES]).toEqual(['USD', 'EUR', 'GBP', 'MXN', 'ARS', 'BRL'])
+    })
+})

--- a/src/constants/__tests__/exchange-currencies.test.ts
+++ b/src/constants/__tests__/exchange-currencies.test.ts
@@ -1,7 +1,11 @@
 // The exchange-rate widget takes `from`/`to` from the URL, so this allow-list
 // is what stands between a stale bookmark and a quote in a currency the
 // product does not support.
-import { SUPPORTED_EXCHANGE_CURRENCIES, toSupportedExchangeCurrency } from '../exchange-currencies.consts'
+import {
+    SUPPORTED_EXCHANGE_CURRENCIES,
+    toDisplayCurrency,
+    toSupportedExchangeCurrency,
+} from '../exchange-currencies.consts'
 
 describe('toSupportedExchangeCurrency', () => {
     it.each(SUPPORTED_EXCHANGE_CURRENCIES)('accepts %s', (currency) => {
@@ -43,5 +47,39 @@ describe('toSupportedExchangeCurrency', () => {
         // CurrencySelect imports this same constant, so the rows and the URL
         // filter cannot drift apart.
         expect([...SUPPORTED_EXCHANGE_CURRENCIES]).toEqual(['USD', 'EUR', 'GBP', 'MXN', 'ARS', 'BRL'])
+    })
+})
+
+describe('toDisplayCurrency', () => {
+    it('keeps the currencies the marketing send-to pages seed', () => {
+        // Marketing/mdx/ExchangeWidget.tsx seeds ?to=<destinationCurrency> from
+        // MDX frontmatter, and the published pages use ~20 codes the FX feed
+        // quotes but no rail supports. Filtering those to the routable six
+        // rendered a euro rate on a "send money to Thailand" page.
+        for (const currency of ['THB', 'PLN', 'JPY', 'TRY', 'IDR', 'MYR', 'ZAR', 'CAD', 'AUD', 'KES']) {
+            expect(toDisplayCurrency(currency)).toBe(currency)
+        }
+    })
+
+    it('still normalises case and whitespace', () => {
+        expect(toDisplayCurrency('  thb ')).toBe('THB')
+    })
+
+    it('rejects anything that is not a currency code', () => {
+        // Permissive about which currency, not about what a currency looks
+        // like: this value reaches an FX lookup and a URL.
+        expect(toDisplayCurrency('<script>')).toBeNull()
+        expect(toDisplayCurrency('USDT')).toBeNull()
+        expect(toDisplayCurrency('US')).toBeNull()
+        expect(toDisplayCurrency('12')).toBeNull()
+        expect(toDisplayCurrency('')).toBeNull()
+        expect(toDisplayCurrency(null)).toBeNull()
+    })
+
+    it('is broader than the routable list, which is the whole point', () => {
+        // Displaying a quote and offering a payment rail are different
+        // permissions. THB quotes; THB does not route.
+        expect(toDisplayCurrency('THB')).toBe('THB')
+        expect(toSupportedExchangeCurrency('THB')).toBeNull()
     })
 })

--- a/src/constants/exchange-currencies.consts.ts
+++ b/src/constants/exchange-currencies.consts.ts
@@ -22,3 +22,19 @@ export function toSupportedExchangeCurrency(value: string | null | undefined): S
     const normalized = value?.trim().toUpperCase()
     return SUPPORTED_EXCHANGE_CURRENCIES.find((currency) => currency === normalized) ?? null
 }
+
+// Any well-formed ISO-4217-shaped code, for the DISPLAY path only.
+//
+// The widget takes its pair from the URL and nothing else, and the marketing
+// send-to pages seed that URL from their MDX frontmatter — PLN, TRY, JPY, THB,
+// IDR, MYR, ZAR, CAD, AUD and a dozen more, across en/es-419/pt-BR. The FX feed
+// quotes all of them, so those pages showed a real rate; filtering the URL to
+// the six routable currencies would have rendered a euro rate on a "send money
+// to Thailand" page. Displaying a quote and offering a payment rail are
+// different permissions, so they get different lists.
+const CURRENCY_CODE = /^[A-Z]{3}$/
+
+export function toDisplayCurrency(value: string | null | undefined): string | null {
+    const normalized = value?.trim().toUpperCase()
+    return normalized && CURRENCY_CODE.test(normalized) ? normalized : null
+}

--- a/src/constants/exchange-currencies.consts.ts
+++ b/src/constants/exchange-currencies.consts.ts
@@ -38,3 +38,27 @@ export function toDisplayCurrency(value: string | null | undefined): string | nu
     const normalized = value?.trim().toUpperCase()
     return normalized && CURRENCY_CODE.test(normalized) ? normalized : null
 }
+
+/**
+ * Resolves a `from`/`to` URL pair through the given resolver, falling back to
+ * USD/EUR — but as a pair, not two independent sides.
+ *
+ * Resolving each side on its own with its own default ('USD' for source,
+ * 'EUR' for destination) let an invalid side fall back onto whatever currency
+ * the *other*, valid side already held — an invalid source next to an
+ * explicit `to=USD` produced a USD/USD pair, a currency "exchanged" with
+ * itself. This is the one place that decision is made, so every caller
+ * (the widget, and any page that independently derives a label or a redirect
+ * from the same URL before the widget mounts) sees the same pair.
+ */
+export function resolveExchangeCurrencyPair(
+    rawSource: string | null | undefined,
+    rawDestination: string | null | undefined,
+    resolve: (value: string | null | undefined) => string | null
+): [string, string] {
+    const resolvedSource = resolve(rawSource)
+    const resolvedDestination = resolve(rawDestination)
+    const sourceCurrency = resolvedSource ?? (resolvedDestination === 'USD' ? 'EUR' : 'USD')
+    const destinationCurrency = resolvedDestination ?? (sourceCurrency === 'USD' ? 'EUR' : 'USD')
+    return [sourceCurrency, destinationCurrency]
+}

--- a/src/constants/exchange-currencies.consts.ts
+++ b/src/constants/exchange-currencies.consts.ts
@@ -1,0 +1,24 @@
+// The currencies the exchange-rate widget supports — those backed by an actual
+// payment rail (ACH/wire, SEPA, Faster Payments, SPEI, Manteca) — kept in this
+// display order regardless of countryCurrencyMapping.ts's own ordering.
+//
+// Shared rather than local to CurrencySelect because the dropdown is not the
+// only way a currency reaches the widget: `from` and `to` also arrive from the
+// URL, and a bookmark predating this list (`?from=PLN`) would otherwise render
+// PLN in the trigger, fetch a PLN quote and point the CTA at the Poland flow —
+// a currency the product does not support.
+export const SUPPORTED_EXCHANGE_CURRENCIES = ['USD', 'EUR', 'GBP', 'MXN', 'ARS', 'BRL'] as const
+
+export type SupportedExchangeCurrency = (typeof SUPPORTED_EXCHANGE_CURRENCIES)[number]
+
+/**
+ * The supported currency this value names, or null.
+ *
+ * Case- and whitespace-insensitive because these come from URLs people paste
+ * and edit by hand: `?from=usd` means USD, and silently falling back to the
+ * default would show a currency the user did not ask for.
+ */
+export function toSupportedExchangeCurrency(value: string | null | undefined): SupportedExchangeCurrency | null {
+    const normalized = value?.trim().toUpperCase()
+    return SUPPORTED_EXCHANGE_CURRENCIES.find((currency) => currency === normalized) ?? null
+}

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Exchange rate & fees",
-        "balanceNote": "Your Peanut balance is held in a single currency. Where a local bank rail is supported, you can withdraw in that local currency.",
+        "balanceNote": "Your Peanut balance is held in USD. Where a local bank rail is supported, you can withdraw in that local currency.",
         "tryIt": "Withdraw now",
         "addMoneyCta": "Add money",
         "widget": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Exchange rate & fees",
-        "balanceNote": "Your Peanut balance is held in USD. Where a local bank rail is supported, you can withdraw in that local currency.",
+        "balanceNote": "Your Peanut balance is shown in USD. Where a local bank rail is supported, you can withdraw in that local currency.",
         "tryIt": "Withdraw now",
         "addMoneyCta": "Add money",
         "widget": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Tipo de cambio y comisiones",
-        "balanceNote": "Tu saldo de Peanut se mantiene en una sola moneda. Donde haya un canal bancario local disponible, puedes retirar en esa moneda local.",
+        "balanceNote": "Tu saldo de Peanut se mantiene en USD. Donde haya un canal bancario local disponible, puedes retirar en esa moneda local.",
         "tryIt": "Retirar ahora",
         "addMoneyCta": "Agregar dinero",
         "widget": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Tipo de cambio y comisiones",
-        "balanceNote": "Tu saldo de Peanut se mantiene en USD. Donde haya un canal bancario local disponible, puedes retirar en esa moneda local.",
+        "balanceNote": "Tu saldo de Peanut se muestra en USD. Donde haya un canal bancario local disponible, puedes retirar en esa moneda local.",
         "tryIt": "Retirar ahora",
         "addMoneyCta": "Agregar dinero",
         "widget": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -392,7 +392,7 @@
             "youSend": "Vos enviás",
             "recipientGets": "Recibís"
         },
-        "balanceNote": "Tu saldo de Peanut se mantiene en USD. Donde haya un canal bancario local disponible, podés retirar en esa moneda local."
+        "balanceNote": "Tu saldo de Peanut se muestra en USD. Donde haya un canal bancario local disponible, podés retirar en esa moneda local."
     },
     "setup": {
         "steps": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -392,7 +392,7 @@
             "youSend": "Vos enviás",
             "recipientGets": "Recibís"
         },
-        "balanceNote": "Tu saldo de Peanut se mantiene en una sola moneda. Donde haya un canal bancario local disponible, podés retirar en esa moneda local."
+        "balanceNote": "Tu saldo de Peanut se mantiene en USD. Donde haya un canal bancario local disponible, podés retirar en esa moneda local."
     },
     "setup": {
         "steps": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Câmbio e taxas",
-        "balanceNote": "Seu saldo na Peanut fica em USD. Onde houver um canal bancário local disponível, você pode sacar nessa moeda local.",
+        "balanceNote": "Seu saldo na Peanut é exibido em USD. Onde houver um canal bancário local disponível, você pode sacar nessa moeda local.",
         "tryIt": "Sacar agora",
         "addMoneyCta": "Adicionar dinheiro",
         "widget": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -656,7 +656,7 @@
     },
     "exchangeRate": {
         "title": "Câmbio e taxas",
-        "balanceNote": "Seu saldo na Peanut fica em uma única moeda. Onde houver um canal bancário local disponível, você pode sacar nessa moeda local.",
+        "balanceNote": "Seu saldo na Peanut fica em USD. Onde houver um canal bancário local disponível, você pode sacar nessa moeda local.",
         "tryIt": "Sacar agora",
         "addMoneyCta": "Adicionar dinheiro",
         "widget": {


### PR DESCRIPTION
## Summary
- Trims the exchange-rate widget's currency dropdown to the 6 currencies actually backed by a payment rail: USD (ACH/wire), EUR (SEPA), GBP (Faster Payments), MXN (SPEI), ARS (Manteca), BRL (Manteca/Pix).
- Removes the search box — with only 6 options it's a plain dropdown now, no filtering needed.
- Scoped to `CurrencySelect.tsx` only; `constants/countryCurrencyMapping.ts` is untouched since it's also used by the add-money/withdraw country pickers and non-EUR SEPA country checks, unrelated to this widget.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on the changed file
- [x] `prettier --check` clean
- [x] Verified live in a dev server: the dropdown on both the homepage exchange widget and `/profile/exchange-rate` shows exactly USD/EUR/GBP/MXN/ARS/BRL with no search input, and selecting a currency (tested GBP) correctly updates the pair
