### PR TITLE
feat(analytics): measure the iOS binary's web vitals, and name the device

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,6 +5,7 @@ import { inferSentryEnvironment } from '@/utils/sentry-env'
 import { withoutBrowserTracing } from '@/utils/sentry-integrations'
 import { posthogErrorMirror } from '@/utils/sentry-posthog-mirror'
 import { whenIdle } from '@/utils/defer-analytics'
+import { startWebVitalsShim } from '@/utils/web-vitals-shim'
 import { installPaymentNetworkGoogleAnalyticsGuard, isPaymentNetworkExplorerPath } from '@/utils/private-routes'
 
 // Same conditions as the GA bootstrap in app/layout.tsx: with no GA to disable
@@ -83,6 +84,12 @@ if (
     })
 
     whenIdle(() => posthog.startSessionRecording())
+
+    // No-ops unless the document is one PostHog refuses to measure (iOS native,
+    // served from capacitor://). Not deferred to idle like the recorder above:
+    // the INP observer has to exist before the taps it measures. `web-vitals`
+    // itself loads dynamically inside, so http(s) documents never fetch it.
+    startWebVitalsShim()
 
     // expose the instance like the official snippet does — console access for
     // QA (feature-flag overrides, e.g. pwa-sunset preview testing) and support

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
         "validator": "^13.12.0",
         "vaul": "^1.1.2",
         "viem": "^2.48.0",
-        "wagmi": "2.16.3"
+        "wagmi": "2.16.3",
+        "web-vitals": "6.1.1"
     },
     "devDependencies": {
         "@next/bundle-analyzer": "^16.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       wagmi:
         specifier: 2.16.3
         version: 2.16.3(@capacitor/preferences@8.0.1(@capacitor/core@8.2.0))(@tanstack/query-core@5.8.3)(@tanstack/react-query@5.8.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@18.3.27)(bufferutil@4.1.0)(immer@11.1.3)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.55.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+      web-vitals:
+        specifier: 6.1.1
+        version: 6.1.1
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^16.3.1
@@ -8390,6 +8393,9 @@ packages:
 
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
+
+  web-vitals@6.1.1:
+    resolution: {integrity: sha512-r93gKnR6ZC2O8F3JrS0AAGIQ0v0OhXuyg4DAj2oG7K+GPkwXfUSc3ZcWeu50AsV5yIc6xxnTjERipJ6EvSw2vg==}
 
   web3-utils@1.10.4:
     resolution: {integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==}
@@ -18905,6 +18911,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-vitals@5.1.0: {}
+
+  web-vitals@6.1.1: {}
 
   web3-utils@1.10.4:
     dependencies:

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/utils/general.utils'
 import { apiFetch } from '@/utils/api-fetch'
 import { useAppLocked } from '@/hooks/useAppLocked'
-import { currentAppLocale, currentDeviceContext } from '@/i18n/app/locale-store'
+import { currentAppLocale, currentDeviceContext, currentDeviceIdentity } from '@/i18n/app/locale-store'
 import { isCapacitor } from '@/utils/capacitor'
 import { clearAuthToken } from '@/utils/auth-token'
 import { resetCrispProxySessions } from '@/utils/crisp'
@@ -127,6 +127,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 // — covers the first session, where the startup locale resolves
                 // before identify.
                 ...(appLocale ? { app_locale: appLocale } : {}),
+                // Device identity is a super property, which reaches events but
+                // never the person profile. A visitor who was anonymous when it
+                // resolved got no $set, so without this the slow-device cohorts
+                // would omit everyone who identifies after startup.
+                ...(currentDeviceIdentity() ?? {}),
             })
             // Sentry: every error captured from here on inherits user context
             // as searchable Sentry tags. Closes the historical gap where FE

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -227,12 +227,28 @@ describe('emitDeviceContextToAnalytics', () => {
         expect(registered).not.toHaveProperty('binary_version')
     })
 
+    // Two registers on the first emit — the context, then the device identity as
+    // its own step so a bridge that never answers cannot take `platform` and
+    // `app_release` down with it. What must not repeat is the emit itself.
     it('emits once per session', async () => {
         setNavigatorLanguage('pt-BR')
         const store = freshStore()
         await store.emitDeviceContextToAnalytics()
+        const afterFirst = mockRegister.mock.calls.length
         await store.emitDeviceContextToAnalytics()
-        expect(mockRegister).toHaveBeenCalledTimes(1)
+        expect(mockRegister).toHaveBeenCalledTimes(afterFirst)
+    })
+
+    // The cached context is what authContext re-registers after posthog.reset()
+    // wipes super properties, so the identity has to be folded into it — not
+    // just registered — or a logout would silently drop device segmentation.
+    it('folds the device identity into the context it exposes for logout re-register', async () => {
+        setNavigatorLanguage('en-US')
+        const store = freshStore()
+        await store.emitDeviceContextToAnalytics()
+        expect(store.currentDeviceContext()).toEqual(
+            expect.objectContaining({ platform: 'web', device_class: expect.any(String) })
+        )
     })
 
     it('a posthog throw never propagates and leaves the context unset so a retry can register', async () => {

--- a/src/i18n/app/__tests__/locale-store.test.ts
+++ b/src/i18n/app/__tests__/locale-store.test.ts
@@ -251,6 +251,18 @@ describe('emitDeviceContextToAnalytics', () => {
         )
     })
 
+    // Super properties reach events, not the person profile. A visitor still
+    // anonymous when the identity resolved gets no $set, so authContext folds
+    // this into its identify payload — without it the cohort omits everyone who
+    // logs in after startup.
+    it('exposes the resolved identity for the identify payload', async () => {
+        setNavigatorLanguage('en-US')
+        const store = freshStore()
+        expect(store.currentDeviceIdentity()).toBeNull()
+        await store.emitDeviceContextToAnalytics()
+        expect(store.currentDeviceIdentity()).toEqual(expect.objectContaining({ device_class: expect.any(String) }))
+    })
+
     it('a posthog throw never propagates and leaves the context unset so a retry can register', async () => {
         setNavigatorLanguage('en-US')
         mockRegister.mockImplementationOnce(() => {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -141,11 +141,23 @@ async function registerDeviceIdentity(): Promise<void> {
     try {
         const identity = await resolveDeviceIdentity()
         posthog.register(identity)
+        // Covers the identity resolving after login. The other order — a login
+        // that lands after this — is covered by authContext folding
+        // currentDeviceIdentity() into its identify payload, because a visitor
+        // who was still anonymous here gets no $set at all.
         if (posthog._isIdentified()) posthog.setPersonProperties(identity)
+        deviceIdentity = identity
         if (deviceContext) deviceContext = { ...deviceContext, ...identity }
     } catch {
         // analytics failure degrades to missing data, never a broken app
     }
+}
+
+let deviceIdentity: DeviceIdentity | null = null
+
+/** Resolved device identity, for the identify payload; null until it resolves. */
+export function currentDeviceIdentity(): DeviceIdentity | null {
+    return deviceIdentity
 }
 
 async function resolveStartupLocale(): Promise<AppLocale> {

--- a/src/i18n/app/locale-store.ts
+++ b/src/i18n/app/locale-store.ts
@@ -7,6 +7,7 @@ import Cookies from 'js-cookie'
 import posthog from 'posthog-js'
 import { APP_RELEASE } from '@/constants/app-release'
 import { getPlatform, isCapacitor, isNativeBridge } from '@/utils/capacitor'
+import { resolveDeviceIdentity, type DeviceIdentity } from '@/utils/device-identity'
 import { readStoredValue, writeStoredValue } from '@/utils/safe-storage'
 import { resolveLocale, type AppLocale } from './config'
 
@@ -87,7 +88,7 @@ type DeviceContext = {
     app_release: string
     binary_version?: string
     binary_build?: string
-}
+} & Partial<DeviceIdentity>
 
 let deviceContext: DeviceContext | null = null
 
@@ -121,6 +122,27 @@ export async function emitDeviceContextToAnalytics(): Promise<void> {
         // set only after a successful register — a throw leaves this null so a
         // later call can retry, instead of silently disabling the emit forever
         deviceContext = context
+    } catch {
+        // analytics failure degrades to missing data, never a broken app
+    }
+
+    await registerDeviceIdentity()
+}
+
+/**
+ * Registered as its own step rather than folded into the context above: the
+ * native branch is a second bridge round-trip, and a binary whose plugin never
+ * answers would otherwise take `platform` and `app_release` down with it.
+ * Person properties as well as super properties — a cohort of slow devices is a
+ * person-level question, and `identified_only` means only identified users get
+ * a profile to write to.
+ */
+async function registerDeviceIdentity(): Promise<void> {
+    try {
+        const identity = await resolveDeviceIdentity()
+        posthog.register(identity)
+        if (posthog._isIdentified()) posthog.setPersonProperties(identity)
+        if (deviceContext) deviceContext = { ...deviceContext, ...identity }
     } catch {
         // analytics failure degrades to missing data, never a broken app
     }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -31,4 +31,12 @@ interface Navigator {
     }
     // Non-standard, iOS Safari only: true when running as an installed PWA.
     standalone?: boolean
+    // User-Agent Client Hints. Chromium only, and the only way to read a device
+    // model or OS version through Chrome's UA reduction, which otherwise
+    // collapses every Android to "Android 10; K".
+    userAgentData?: {
+        getHighEntropyValues?: (hints: string[]) => Promise<{ model?: string; platformVersion?: string }>
+    }
+    // Chromium only, and bucketed to 0.25/0.5/1/2/4/8 to limit fingerprinting.
+    deviceMemory?: number
 }

--- a/src/utils/__tests__/device-identity.test.ts
+++ b/src/utils/__tests__/device-identity.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Chrome's UA reduction leaves PostHog resolving every Android to the literal
+ * `$device` "Android" with no `$os_version` (4 of 19,151 events carried one in
+ * the 14 days to 2026-09-04), so a slow-device cohort cannot be built from the
+ * built-in context. These cover the two sources that see through it and the
+ * classifier's deliberate refusal to rank WebKit devices.
+ */
+
+import { classifyDevice } from '../device-identity'
+
+const mockIsNativeBridge = jest.fn()
+jest.mock('@/utils/capacitor', () => ({ isNativeBridge: () => mockIsNativeBridge() }))
+
+const mockGetInfo = jest.fn()
+jest.mock('@capacitor/device', () => ({ Device: { getInfo: (...a: unknown[]) => mockGetInfo(...a) } }))
+
+function stubNavigator(props: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(props)) {
+        Object.defineProperty(navigator, key, { value, configurable: true, writable: true })
+    }
+}
+
+/** Fresh registry per test — the resolved identity is memoized per document. */
+async function freshResolve() {
+    let resolve!: typeof import('../device-identity').resolveDeviceIdentity
+    jest.isolateModules(() => {
+        resolve = require('../device-identity').resolveDeviceIdentity
+    })
+    return resolve()
+}
+
+describe('classifyDevice', () => {
+    it.each([
+        [0.5, 'low'],
+        [2, 'low'],
+        [4, 'mid'],
+        [8, 'high'],
+    ])('buckets %s GB as %s', (memory, expected) => {
+        expect(classifyDevice(memory as number)).toBe(expected)
+    })
+
+    /*
+     * WebKit exposes no memory, and its core count is small on fast hardware —
+     * an iPhone reports fewer cores than a budget Android while turning in an
+     * INP p75 of 96 ms against that Android's 224 ms. Ranking iOS on either
+     * signal would file every iPhone as slow, so it stays unknown and is
+     * segmented by device_model / device_screen instead.
+     */
+    it('refuses to rank a device that reports no memory', () => {
+        expect(classifyDevice(undefined)).toBe('unknown')
+    })
+})
+
+describe('resolveDeviceIdentity', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsNativeBridge.mockReturnValue(false)
+        stubNavigator({ deviceMemory: undefined, hardwareConcurrency: 8, userAgentData: undefined })
+    })
+
+    it('reads the exact hardware from the native bridge', async () => {
+        mockIsNativeBridge.mockReturnValue(true)
+        mockGetInfo.mockResolvedValue({
+            model: 'iPhone14,3',
+            manufacturer: 'Apple',
+            osVersion: '18.5',
+            webViewVersion: '18.5',
+        })
+
+        await expect(freshResolve()).resolves.toEqual(
+            expect.objectContaining({
+                device_model: 'iPhone14,3',
+                device_manufacturer: 'Apple',
+                device_os_version: '18.5',
+                device_webview_version: '18.5',
+            })
+        )
+    })
+
+    // The point of the whole module: without high-entropy hints the model is
+    // unrecoverable on Android, which is the platform with the INP problem.
+    it('recovers the Android model and OS version from client hints', async () => {
+        const getHighEntropyValues = jest.fn().mockResolvedValue({ model: 'SM-A505G', platformVersion: '11.0.0' })
+        stubNavigator({ userAgentData: { getHighEntropyValues }, deviceMemory: 2 })
+
+        await expect(freshResolve()).resolves.toEqual(
+            expect.objectContaining({
+                device_model: 'SM-A505G',
+                device_os_version: '11.0.0',
+                device_memory_gb: 2,
+                device_class: 'low',
+            })
+        )
+        expect(getHighEntropyValues).toHaveBeenCalledWith(['model', 'platformVersion'])
+    })
+
+    // Desktop Chromium answers with an empty model rather than omitting it, and
+    // an empty string would read as a real value in a breakdown.
+    it('drops an empty model rather than reporting it', async () => {
+        stubNavigator({
+            userAgentData: {
+                getHighEntropyValues: jest.fn().mockResolvedValue({ model: '', platformVersion: '15.0' }),
+            },
+        })
+
+        const identity = await freshResolve()
+        expect(identity.device_model).toBeUndefined()
+        expect(identity.device_os_version).toBe('15.0')
+    })
+
+    // An older binary without the plugin, or a browser that refuses the hints:
+    // the buckets we already have are still worth reporting on their own.
+    it('keeps the browser-side buckets when the identity source throws', async () => {
+        mockIsNativeBridge.mockReturnValue(true)
+        mockGetInfo.mockRejectedValue(new Error('plugin not implemented'))
+        stubNavigator({ deviceMemory: 4, hardwareConcurrency: 4 })
+
+        await expect(freshResolve()).resolves.toEqual(
+            expect.objectContaining({ device_class: 'mid', device_memory_gb: 4, device_cores: 4 })
+        )
+    })
+
+    it('reports the screen so iOS PWAs are separable without a model', async () => {
+        Object.defineProperty(window, 'devicePixelRatio', { value: 3, configurable: true })
+        Object.defineProperty(window.screen, 'width', { value: 390, configurable: true })
+        Object.defineProperty(window.screen, 'height', { value: 844, configurable: true })
+
+        await expect(freshResolve()).resolves.toEqual(expect.objectContaining({ device_screen: '390x844@3' }))
+    })
+})

--- a/src/utils/__tests__/web-vitals-shim.test.ts
+++ b/src/utils/__tests__/web-vitals-shim.test.ts
@@ -10,6 +10,7 @@
 import {
     createWebVitalsReporter,
     postHogCapturesWebVitals,
+    postHogWebVitalsExplicitlyDisabled,
     postHogWebVitalsSettings,
     type WebVitalsReporter,
     type WebVitalsSettings,
@@ -24,7 +25,7 @@ jest.mock('posthog-js', () => ({
 
 const mockGetProperty = posthog.get_property as jest.Mock
 
-const metric = (name: string, value: number): Metric =>
+const metric = (name: string, value: number, navigationURL?: string): Metric =>
     ({
         name,
         value,
@@ -33,6 +34,7 @@ const metric = (name: string, value: number): Metric =>
         id: `v1-${name}`,
         navigationType: 'navigate',
         navigationId: 1,
+        navigationURL,
         entries: [],
     }) as Metric
 
@@ -79,6 +81,32 @@ describe('postHogWebVitalsSettings', () => {
 
         mockGetProperty.mockReturnValue(undefined)
         expect(postHogWebVitalsSettings().allowed).toEqual(['CLS', 'FCP', 'INP', 'LCP'])
+    })
+})
+
+describe('postHogWebVitalsExplicitlyDisabled', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        posthog.config = {} as typeof posthog.config
+    })
+
+    // An absent flag is a device that has never seen a remote config, not an
+    // opt-out — treating it as one would leave every first session unmeasured.
+    it('is false before any remote config has been persisted', () => {
+        mockGetProperty.mockReturnValue(undefined)
+        expect(postHogWebVitalsExplicitlyDisabled()).toBe(false)
+    })
+
+    it('is true once the remote config has switched vitals off', () => {
+        mockGetProperty.mockImplementation((key: string) =>
+            key === '$web_vitals_enabled_server_side' ? false : undefined
+        )
+        expect(postHogWebVitalsExplicitlyDisabled()).toBe(true)
+    })
+
+    it('is true when client config switches them off', () => {
+        posthog.config = { capture_performance: { web_vitals: false } } as unknown as typeof posthog.config
+        expect(postHogWebVitalsExplicitlyDisabled()).toBe(true)
     })
 })
 
@@ -149,6 +177,26 @@ describe('createWebVitalsReporter', () => {
 
         expect(capture.mock.calls[0][1]).toEqual(
             expect.objectContaining({ $current_url: 'capacitor://localhost/home', $pathname: '/home' })
+        )
+    })
+
+    /*
+     * LCP and INP are reported well after the navigation they belong to, so on a
+     * soft navigation the callback fires when location.href already names the
+     * next screen. web-vitals carries the navigation the metric actually
+     * belongs to; reading location at callback time misfiles it.
+     */
+    it('uses the metric’s own navigation URL when the app has already moved on', () => {
+        url = 'capacitor://localhost/send'
+        reporter.record(metric('LCP', 2400, 'capacitor://localhost/home'))
+        jest.advanceTimersByTime(5000)
+
+        const [, properties] = capture.mock.calls[0]
+        expect(properties).toEqual(
+            expect.objectContaining({ $current_url: 'capacitor://localhost/home', $pathname: '/home' })
+        )
+        expect(properties.$web_vitals_LCP_event).toEqual(
+            expect.objectContaining({ navigationURL: 'capacitor://localhost/home' })
         )
     })
 

--- a/src/utils/__tests__/web-vitals-shim.test.ts
+++ b/src/utils/__tests__/web-vitals-shim.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The shim exists because posthog-js gates web vitals on `location.protocol`
+ * being http(s) — which the iOS binary, served from `capacitor://localhost`,
+ * never is. These guard the two things that make the shim safe to ship: it
+ * stays out of the documents PostHog already covers, and the rows it does emit
+ * carry PostHog's own property names so they merge into the existing series.
+ */
+
+import { createWebVitalsReporter, postHogCapturesWebVitals, type WebVitalsReporter } from '../web-vitals-shim'
+import type { Metric } from 'web-vitals'
+
+const metric = (name: string, value: number): Metric =>
+    ({
+        name,
+        value,
+        rating: 'good',
+        delta: value,
+        id: `v1-${name}`,
+        navigationType: 'navigate',
+        navigationId: 1,
+        entries: [],
+    }) as Metric
+
+describe('postHogCapturesWebVitals', () => {
+    it.each(['http:', 'https:'])('leaves %s documents to posthog-js', (protocol) => {
+        expect(postHogCapturesWebVitals(protocol)).toBe(true)
+    })
+
+    // The whole reason the shim exists: iOS Capacitor serves capacitor://, and
+    // posthog-js disables web vitals on it before reading any config. Android
+    // Capacitor serves https://localhost, which is why only iOS went dark.
+    it.each(['capacitor:', 'ionic:', 'file:', undefined])('claims %s documents for the shim', (protocol) => {
+        expect(postHogCapturesWebVitals(protocol)).toBe(false)
+    })
+})
+
+describe('createWebVitalsReporter', () => {
+    let capture: jest.Mock
+    let url: string
+    let reporter: WebVitalsReporter
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        capture = jest.fn()
+        url = 'capacitor://localhost/home'
+        reporter = createWebVitalsReporter(capture, () => url)
+    })
+
+    afterEach(() => jest.useRealTimers())
+
+    it('batches a screen’s metrics into one event using posthog’s property names', () => {
+        reporter.record(metric('LCP', 2400))
+        reporter.record(metric('INP', 180))
+        expect(capture).not.toHaveBeenCalled()
+
+        jest.advanceTimersByTime(5000)
+
+        expect(capture).toHaveBeenCalledTimes(1)
+        const [event, properties] = capture.mock.calls[0]
+        expect(event).toBe('$web_vitals')
+        expect(properties).toEqual(expect.objectContaining({ $web_vitals_LCP_value: 2400, $web_vitals_INP_value: 180 }))
+        expect(properties.$web_vitals_LCP_event).toEqual(
+            expect.objectContaining({ name: 'LCP', value: 2400, rating: 'good' })
+        )
+    })
+
+    // The raw PerformanceEntry list is the bulk of the payload and nothing reads
+    // it — on a WebView that matters more than parity with PostHog's shape.
+    it('omits the PerformanceEntry list from the event blob', () => {
+        reporter.record(metric('FCP', 900))
+        jest.advanceTimersByTime(5000)
+        expect(capture.mock.calls[0][1].$web_vitals_FCP_event).not.toHaveProperty('entries')
+    })
+
+    // Without this an SPA route change would blend two screens' metrics into one
+    // row, and neither screen's number would mean anything.
+    it('closes the open batch when the URL changes', () => {
+        reporter.record(metric('LCP', 2400))
+        url = 'capacitor://localhost/send'
+        reporter.record(metric('LCP', 900))
+
+        expect(capture).toHaveBeenCalledTimes(1)
+        expect(capture.mock.calls[0][1].$web_vitals_LCP_value).toBe(2400)
+
+        jest.advanceTimersByTime(5000)
+        expect(capture).toHaveBeenCalledTimes(2)
+        expect(capture.mock.calls[1][1].$web_vitals_LCP_value).toBe(900)
+    })
+
+    it('drops implausible values rather than poisoning the percentiles', () => {
+        reporter.record(metric('LCP', 15 * 60 * 1000))
+        jest.advanceTimersByTime(5000)
+        expect(capture).not.toHaveBeenCalled()
+    })
+
+    it('sends nothing when no metric arrived', () => {
+        reporter.flush()
+        expect(capture).not.toHaveBeenCalled()
+    })
+
+    // pagehide calls flush directly; a second flush must not re-send the batch.
+    it('does not double-send a batch already flushed', () => {
+        reporter.record(metric('FCP', 900))
+        reporter.flush()
+        jest.advanceTimersByTime(5000)
+        expect(capture).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/utils/__tests__/web-vitals-shim.test.ts
+++ b/src/utils/__tests__/web-vitals-shim.test.ts
@@ -10,7 +10,6 @@
 import {
     createWebVitalsReporter,
     postHogCapturesWebVitals,
-    postHogWebVitalsExplicitlyDisabled,
     postHogWebVitalsSettings,
     type WebVitalsReporter,
     type WebVitalsSettings,
@@ -81,32 +80,6 @@ describe('postHogWebVitalsSettings', () => {
 
         mockGetProperty.mockReturnValue(undefined)
         expect(postHogWebVitalsSettings().allowed).toEqual(['CLS', 'FCP', 'INP', 'LCP'])
-    })
-})
-
-describe('postHogWebVitalsExplicitlyDisabled', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        posthog.config = {} as typeof posthog.config
-    })
-
-    // An absent flag is a device that has never seen a remote config, not an
-    // opt-out — treating it as one would leave every first session unmeasured.
-    it('is false before any remote config has been persisted', () => {
-        mockGetProperty.mockReturnValue(undefined)
-        expect(postHogWebVitalsExplicitlyDisabled()).toBe(false)
-    })
-
-    it('is true once the remote config has switched vitals off', () => {
-        mockGetProperty.mockImplementation((key: string) =>
-            key === '$web_vitals_enabled_server_side' ? false : undefined
-        )
-        expect(postHogWebVitalsExplicitlyDisabled()).toBe(true)
-    })
-
-    it('is true when client config switches them off', () => {
-        posthog.config = { capture_performance: { web_vitals: false } } as unknown as typeof posthog.config
-        expect(postHogWebVitalsExplicitlyDisabled()).toBe(true)
     })
 })
 

--- a/src/utils/__tests__/web-vitals-shim.test.ts
+++ b/src/utils/__tests__/web-vitals-shim.test.ts
@@ -1,13 +1,28 @@
 /**
  * The shim exists because posthog-js gates web vitals on `location.protocol`
  * being http(s) — which the iOS binary, served from `capacitor://localhost`,
- * never is. These guard the two things that make the shim safe to ship: it
- * stays out of the documents PostHog already covers, and the rows it does emit
- * carry PostHog's own property names so they merge into the existing series.
+ * never is. These guard the three things that make it safe to ship: it stays
+ * out of the documents PostHog already covers, it obeys PostHog's own
+ * enablement rather than only the protocol, and the rows it emits carry
+ * PostHog's property names and the URL they were actually measured on.
  */
 
-import { createWebVitalsReporter, postHogCapturesWebVitals, type WebVitalsReporter } from '../web-vitals-shim'
+import {
+    createWebVitalsReporter,
+    postHogCapturesWebVitals,
+    postHogWebVitalsSettings,
+    type WebVitalsReporter,
+    type WebVitalsSettings,
+} from '../web-vitals-shim'
 import type { Metric } from 'web-vitals'
+import posthog from 'posthog-js'
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { config: {}, get_property: jest.fn() },
+}))
+
+const mockGetProperty = posthog.get_property as jest.Mock
 
 const metric = (name: string, value: number): Metric =>
     ({
@@ -34,16 +49,51 @@ describe('postHogCapturesWebVitals', () => {
     })
 })
 
+describe('postHogWebVitalsSettings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        posthog.config = {} as typeof posthog.config
+    })
+
+    // Turning web vitals off server-side has to stop iOS too, or the switch
+    // silently only applies to the http(s) clients.
+    it('follows the persisted remote-config flag', () => {
+        mockGetProperty.mockImplementation((key: string) => key === '$web_vitals_enabled_server_side')
+        expect(postHogWebVitalsSettings().enabled).toBe(true)
+
+        mockGetProperty.mockReturnValue(undefined)
+        expect(postHogWebVitalsSettings().enabled).toBe(false)
+    })
+
+    it('lets explicit client config outrank the remote flag, as PostHog does', () => {
+        mockGetProperty.mockImplementation((key: string) => key === '$web_vitals_enabled_server_side')
+        posthog.config = { capture_performance: { web_vitals: false } } as unknown as typeof posthog.config
+        expect(postHogWebVitalsSettings().enabled).toBe(false)
+    })
+
+    it('honours a configured metric allowlist, falling back to all four', () => {
+        mockGetProperty.mockImplementation((key: string) =>
+            key === '$web_vitals_allowed_metrics' ? ['LCP'] : undefined
+        )
+        expect(postHogWebVitalsSettings().allowed).toEqual(['LCP'])
+
+        mockGetProperty.mockReturnValue(undefined)
+        expect(postHogWebVitalsSettings().allowed).toEqual(['CLS', 'FCP', 'INP', 'LCP'])
+    })
+})
+
 describe('createWebVitalsReporter', () => {
     let capture: jest.Mock
     let url: string
+    let settings: WebVitalsSettings
     let reporter: WebVitalsReporter
 
     beforeEach(() => {
         jest.useFakeTimers()
         capture = jest.fn()
         url = 'capacitor://localhost/home'
-        reporter = createWebVitalsReporter(capture, () => url)
+        settings = { enabled: true, allowed: ['CLS', 'FCP', 'INP', 'LCP'] }
+        reporter = createWebVitalsReporter({ capture, currentUrl: () => url, settings: () => settings })
     })
 
     afterEach(() => jest.useRealTimers())
@@ -85,6 +135,46 @@ describe('createWebVitalsReporter', () => {
         jest.advanceTimersByTime(5000)
         expect(capture).toHaveBeenCalledTimes(2)
         expect(capture.mock.calls[1][1].$web_vitals_LCP_value).toBe(900)
+    })
+
+    /*
+     * A route change alone does not flush — only a later metric or the timer
+     * does. PostHog stamps the event with wherever the app is at capture time,
+     * so without carrying the batch's own URL, /home's LCP is filed under /send.
+     */
+    it('attributes a batch to the screen it was measured on, not the one navigated to', () => {
+        reporter.record(metric('LCP', 2400))
+        url = 'capacitor://localhost/send'
+        jest.advanceTimersByTime(5000)
+
+        expect(capture.mock.calls[0][1]).toEqual(
+            expect.objectContaining({ $current_url: 'capacitor://localhost/home', $pathname: '/home' })
+        )
+    })
+
+    it('sends nothing while PostHog has web vitals switched off', () => {
+        settings = { enabled: false, allowed: ['CLS', 'FCP', 'INP', 'LCP'] }
+        reporter.record(metric('LCP', 2400))
+        jest.advanceTimersByTime(5000)
+        expect(capture).not.toHaveBeenCalled()
+    })
+
+    it('drops metrics outside the configured allowlist', () => {
+        settings = { enabled: true, allowed: ['LCP'] }
+        reporter.record(metric('LCP', 2400))
+        reporter.record(metric('INP', 180))
+        jest.advanceTimersByTime(5000)
+
+        const [, properties] = capture.mock.calls[0]
+        expect(properties).toHaveProperty('$web_vitals_LCP_value')
+        expect(properties).not.toHaveProperty('$web_vitals_INP_value')
+    })
+
+    it('sends no event at all when the allowlist excludes everything buffered', () => {
+        settings = { enabled: true, allowed: ['CLS'] }
+        reporter.record(metric('LCP', 2400))
+        jest.advanceTimersByTime(5000)
+        expect(capture).not.toHaveBeenCalled()
     })
 
     it('drops implausible values rather than poisoning the percentiles', () => {

--- a/src/utils/device-identity.ts
+++ b/src/utils/device-identity.ts
@@ -1,0 +1,93 @@
+// Device identity for performance segmentation. PostHog's own device context is
+// derived from the User-Agent, which Chrome's UA reduction has hollowed out:
+// every Android resolves to the literal `$device` "Android" and `$os_version` is
+// absent on all but a handful of events, so a slow-device cohort cannot be built
+// from it. These properties restore the model and OS version from sources the
+// reduction doesn't touch.
+
+import { isNativeBridge } from '@/utils/capacitor'
+
+export type DeviceClass = 'low' | 'mid' | 'high' | 'unknown'
+
+export type DeviceIdentity = {
+    device_class: DeviceClass
+    device_model?: string
+    device_manufacturer?: string
+    device_os_version?: string
+    device_webview_version?: string
+    device_memory_gb?: number
+    device_cores?: number
+    device_screen?: string
+}
+
+/**
+ * Memory is the only capability signal available across enough of the fleet to
+ * rank devices against one another: Chromium reports it in fixed buckets
+ * (0.25–8 GB), which is the split that separates a budget Android from a
+ * flagship. WebKit exposes neither it nor a usable substitute — an iPhone's
+ * `hardwareConcurrency` is small on fast hardware — so iOS deliberately stays
+ * `unknown` instead of being ranked by a signal that would read every iPhone as
+ * slow. Segment iOS by `device_model` (native) or `device_screen` (PWA).
+ */
+export function classifyDevice(memoryGb: number | undefined): DeviceClass {
+    if (memoryGb === undefined) return 'unknown'
+    if (memoryGb <= 2) return 'low'
+    if (memoryGb <= 4) return 'mid'
+    return 'high'
+}
+
+function screenDescriptor(): string | undefined {
+    const { width, height } = window.screen ?? {}
+    if (!width || !height) return undefined
+    return `${width}x${height}@${Math.round((window.devicePixelRatio || 1) * 100) / 100}`
+}
+
+async function nativeIdentity(): Promise<Partial<DeviceIdentity>> {
+    const { Device } = await import('@capacitor/device')
+    const info = await Device.getInfo()
+    return {
+        device_model: info.model || undefined,
+        device_manufacturer: info.manufacturer || undefined,
+        device_os_version: info.osVersion || undefined,
+        device_webview_version: info.webViewVersion || undefined,
+    }
+}
+
+async function clientHintIdentity(): Promise<Partial<DeviceIdentity>> {
+    const uaData = navigator.userAgentData
+    if (!uaData?.getHighEntropyValues) return {}
+    const hints = await uaData.getHighEntropyValues(['model', 'platformVersion'])
+    // Desktop Chromium answers with an empty model rather than omitting it.
+    return {
+        device_model: hints.model || undefined,
+        device_os_version: hints.platformVersion || undefined,
+    }
+}
+
+async function readIdentity(): Promise<DeviceIdentity> {
+    const memoryGb = navigator.deviceMemory
+    const base: DeviceIdentity = {
+        device_class: classifyDevice(memoryGb),
+        device_memory_gb: memoryGb,
+        device_cores: navigator.hardwareConcurrency || undefined,
+        device_screen: screenDescriptor(),
+    }
+    try {
+        // The bridge names the exact hardware (`iPhone14,3`, `SM-A505G`); client
+        // hints are the only way to see through the UA reduction on the web.
+        return { ...base, ...(await (isNativeBridge() ? nativeIdentity() : clientHintIdentity())) }
+    } catch {
+        // an older binary without the plugin, or a browser that refuses the
+        // hints — the buckets below are still worth reporting on their own
+        return base
+    }
+}
+
+let identity: Promise<DeviceIdentity> | null = null
+
+/** Resolved once per document; the native branch costs a bridge round-trip. */
+export function resolveDeviceIdentity(): Promise<DeviceIdentity> {
+    if (typeof window === 'undefined') return Promise.resolve({ device_class: 'unknown' })
+    if (!identity) identity = readIdentity()
+    return identity
+}

--- a/src/utils/web-vitals-shim.ts
+++ b/src/utils/web-vitals-shim.ts
@@ -68,12 +68,12 @@ export function createWebVitalsReporter(options: {
             $current_url: pending.url,
             ...pathnameOf(pending.url),
             ...metrics.reduce<Record<string, unknown>>(
-                (acc, { name, value, rating, delta, id, navigationType }) => ({
+                (acc, { name, value, rating, delta, id, navigationType, navigationURL }) => ({
                     ...acc,
                     // `entries` is dropped: PostHog keeps the whole metric here,
                     // but the raw PerformanceEntry list is the bulk of the
                     // payload and nothing reads it.
-                    [`$web_vitals_${name}_event`]: { name, value, rating, delta, id, navigationType },
+                    [`$web_vitals_${name}_event`]: { name, value, rating, delta, id, navigationType, navigationURL },
                     [`$web_vitals_${name}_value`]: value,
                 }),
                 {}
@@ -84,7 +84,10 @@ export function createWebVitalsReporter(options: {
     const record = (metric: Metric): void => {
         if (metric.value >= MAX_PLAUSIBLE_VALUE_MS) return
 
-        const url = currentUrl()
+        // The metric's own navigation URL, not wherever the app is now: LCP and
+        // INP are reported well after the navigation they belong to, so on a
+        // soft navigation `location.href` already names the next screen.
+        const url = metric.navigationURL ?? currentUrl()
         // One event per URL, so an SPA route change closes the previous screen's
         // batch instead of mixing two screens' metrics into one row.
         if (buffered && buffered.url !== url) flush()
@@ -115,15 +118,36 @@ function pathnameOf(url: string): { $pathname?: string } {
  */
 type PerformanceConfig = boolean | { web_vitals?: boolean; web_vitals_allowed_metrics?: string[] } | undefined
 
+function clientOptIn(performance: PerformanceConfig): boolean | undefined {
+    return typeof performance === 'object' ? performance?.web_vitals : performance
+}
+
+function performanceConfig(): PerformanceConfig {
+    return (posthog.config as { capture_performance?: PerformanceConfig }).capture_performance
+}
+
+/**
+ * Only an explicit "off" is worth skipping the observers for. An absent flag is
+ * the first session on this device, before any remote config has been
+ * persisted — starting there and letting the flush gate decide is what keeps a
+ * first session measurable.
+ */
+export function postHogWebVitalsExplicitlyDisabled(): boolean {
+    const fromClient = clientOptIn(performanceConfig())
+    if (typeof fromClient === 'boolean') return !fromClient
+    return posthog.get_property(WEB_VITALS_ENABLED_SERVER_SIDE) === false
+}
+
 export function postHogWebVitalsSettings(): WebVitalsSettings {
-    const performance = (posthog.config as { capture_performance?: PerformanceConfig }).capture_performance
-    const clientOptIn = typeof performance === 'object' ? performance?.web_vitals : performance
+    const performance = performanceConfig()
     const clientAllowed = typeof performance === 'object' ? performance?.web_vitals_allowed_metrics : undefined
+
+    const fromClient = clientOptIn(performance)
 
     return {
         enabled:
-            typeof clientOptIn === 'boolean'
-                ? clientOptIn
+            typeof fromClient === 'boolean'
+                ? fromClient
                 : posthog.get_property(WEB_VITALS_ENABLED_SERVER_SIDE) === true,
         allowed:
             clientAllowed ??
@@ -137,6 +161,7 @@ let started = false
 export function startWebVitalsShim(): void {
     if (started || typeof window === 'undefined') return
     if (postHogCapturesWebVitals(window.location.protocol)) return
+    if (postHogWebVitalsExplicitlyDisabled()) return
     started = true
 
     const { record, flush } = createWebVitalsReporter({

--- a/src/utils/web-vitals-shim.ts
+++ b/src/utils/web-vitals-shim.ts
@@ -9,8 +9,10 @@
  *
  * This covers exactly the documents PostHog opts out of, emitting PostHog's own
  * `$web_vitals` shape so the rows land in the existing series rather than a
- * parallel one. CLS stays absent on WebKit, which has no Layout Instability
- * API — the same gap the iOS PWA already shows.
+ * parallel one. Everything except the protocol gate is deferred to PostHog's
+ * own switches, so turning web vitals off server-side turns iOS off too. CLS
+ * stays absent on WebKit, which has no Layout Instability API — the same gap
+ * the iOS PWA already shows.
  */
 
 import type { Metric } from 'web-vitals'
@@ -21,16 +23,29 @@ const FLUSH_DELAY_MS = 5000
 // not a slow page.
 const MAX_PLAUSIBLE_VALUE_MS = 15 * 60 * 1000
 
+const WEB_VITALS_ENABLED_SERVER_SIDE = '$web_vitals_enabled_server_side'
+const WEB_VITALS_ALLOWED_METRICS = '$web_vitals_allowed_metrics'
+const DEFAULT_ALLOWED_METRICS = ['CLS', 'FCP', 'INP', 'LCP']
+
 /** True when posthog-js captures vitals itself and the shim must stay out. */
 export function postHogCapturesWebVitals(protocol: string | undefined): boolean {
     return protocol === 'http:' || protocol === 'https:'
 }
 
+export type WebVitalsSettings = { enabled: boolean; allowed: string[] }
+
 type Capture = (event: string, properties: Record<string, unknown>) => void
 
 export type WebVitalsReporter = { record: (metric: Metric) => void; flush: () => void }
 
-export function createWebVitalsReporter(capture: Capture, currentUrl: () => string): WebVitalsReporter {
+export function createWebVitalsReporter(options: {
+    capture: Capture
+    currentUrl: () => string
+    /* Read at flush, not at start: remote config lands after init, and the
+       observers have to exist before the interactions they measure. */
+    settings: () => WebVitalsSettings
+}): WebVitalsReporter {
+    const { capture, currentUrl, settings } = options
     let buffered: { url: string; metrics: Metric[] } | null = null
     let flushTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -41,9 +56,18 @@ export function createWebVitalsReporter(capture: Capture, currentUrl: () => stri
         buffered = null
         if (!pending?.metrics.length) return
 
-        capture(
-            '$web_vitals',
-            pending.metrics.reduce<Record<string, unknown>>(
+        const { enabled, allowed } = settings()
+        if (!enabled) return
+        const metrics = pending.metrics.filter((metric) => allowed.includes(metric.name))
+        if (!metrics.length) return
+
+        capture('$web_vitals', {
+            // The URL the metrics were measured on. PostHog stamps the event
+            // with wherever the app is at capture time, so a route change during
+            // the flush window would otherwise credit /home's LCP to /send.
+            $current_url: pending.url,
+            ...pathnameOf(pending.url),
+            ...metrics.reduce<Record<string, unknown>>(
                 (acc, { name, value, rating, delta, id, navigationType }) => ({
                     ...acc,
                     // `entries` is dropped: PostHog keeps the whole metric here,
@@ -53,8 +77,8 @@ export function createWebVitalsReporter(capture: Capture, currentUrl: () => stri
                     [`$web_vitals_${name}_value`]: value,
                 }),
                 {}
-            )
-        )
+            ),
+        })
     }
 
     const record = (metric: Metric): void => {
@@ -74,6 +98,40 @@ export function createWebVitalsReporter(capture: Capture, currentUrl: () => stri
     return { record, flush }
 }
 
+/** Omitted rather than sent as undefined, which would blank PostHog's own value. */
+function pathnameOf(url: string): { $pathname?: string } {
+    try {
+        return { $pathname: new URL(url).pathname }
+    } catch {
+        return {}
+    }
+}
+
+/*
+ * `capture_performance` is absent from posthog-js's published types in 1.360.0,
+ * so the client-side override is read through a local shape rather than left
+ * unhonoured — the precedence then matches WebVitalsAutocapture's own: explicit
+ * client config first, the persisted remote-config value otherwise.
+ */
+type PerformanceConfig = boolean | { web_vitals?: boolean; web_vitals_allowed_metrics?: string[] } | undefined
+
+export function postHogWebVitalsSettings(): WebVitalsSettings {
+    const performance = (posthog.config as { capture_performance?: PerformanceConfig }).capture_performance
+    const clientOptIn = typeof performance === 'object' ? performance?.web_vitals : performance
+    const clientAllowed = typeof performance === 'object' ? performance?.web_vitals_allowed_metrics : undefined
+
+    return {
+        enabled:
+            typeof clientOptIn === 'boolean'
+                ? clientOptIn
+                : posthog.get_property(WEB_VITALS_ENABLED_SERVER_SIDE) === true,
+        allowed:
+            clientAllowed ??
+            (posthog.get_property(WEB_VITALS_ALLOWED_METRICS) as string[] | undefined) ??
+            DEFAULT_ALLOWED_METRICS,
+    }
+}
+
 let started = false
 
 export function startWebVitalsShim(): void {
@@ -81,10 +139,11 @@ export function startWebVitalsShim(): void {
     if (postHogCapturesWebVitals(window.location.protocol)) return
     started = true
 
-    const { record, flush } = createWebVitalsReporter(
-        (event, properties) => posthog.capture(event, properties),
-        () => window.location.href
-    )
+    const { record, flush } = createWebVitalsReporter({
+        capture: (event, properties) => posthog.capture(event, properties),
+        currentUrl: () => window.location.href,
+        settings: postHogWebVitalsSettings,
+    })
 
     // A metric that arrives as the app goes away would otherwise sit in the
     // buffer until a flush timer the WebView never runs.

--- a/src/utils/web-vitals-shim.ts
+++ b/src/utils/web-vitals-shim.ts
@@ -41,8 +41,13 @@ export type WebVitalsReporter = { record: (metric: Metric) => void; flush: () =>
 export function createWebVitalsReporter(options: {
     capture: Capture
     currentUrl: () => string
-    /* Read at flush, not at start: remote config lands after init, and the
-       observers have to exist before the interactions they measure. */
+    /*
+     * Read at flush, never at start. The observers are installed regardless and
+     * suppressed here instead: enablement is only knowable once remote config
+     * lands, and a start-time check would read the value persisted by the last
+     * session — leaving a document that was re-enabled mid-flight blind for its
+     * whole 12-hour lifetime (useStaleDeploymentReload), not just a moment.
+     */
     settings: () => WebVitalsSettings
 }): WebVitalsReporter {
     const { capture, currentUrl, settings } = options
@@ -126,18 +131,6 @@ function performanceConfig(): PerformanceConfig {
     return (posthog.config as { capture_performance?: PerformanceConfig }).capture_performance
 }
 
-/**
- * Only an explicit "off" is worth skipping the observers for. An absent flag is
- * the first session on this device, before any remote config has been
- * persisted — starting there and letting the flush gate decide is what keeps a
- * first session measurable.
- */
-export function postHogWebVitalsExplicitlyDisabled(): boolean {
-    const fromClient = clientOptIn(performanceConfig())
-    if (typeof fromClient === 'boolean') return !fromClient
-    return posthog.get_property(WEB_VITALS_ENABLED_SERVER_SIDE) === false
-}
-
 export function postHogWebVitalsSettings(): WebVitalsSettings {
     const performance = performanceConfig()
     const clientAllowed = typeof performance === 'object' ? performance?.web_vitals_allowed_metrics : undefined
@@ -161,7 +154,6 @@ let started = false
 export function startWebVitalsShim(): void {
     if (started || typeof window === 'undefined') return
     if (postHogCapturesWebVitals(window.location.protocol)) return
-    if (postHogWebVitalsExplicitlyDisabled()) return
     started = true
 
     const { record, flush } = createWebVitalsReporter({

--- a/src/utils/web-vitals-shim.ts
+++ b/src/utils/web-vitals-shim.ts
@@ -1,0 +1,103 @@
+/*
+ * posthog-js refuses to capture web vitals on any document that is not http(s):
+ * `extensions/web-vitals/index.ts` returns false from `isEnabled` on the
+ * protocol alone, before it ever consults the remote config. Capacitor serves
+ * iOS from `capacitor://localhost` and Android from `https://localhost`, so the
+ * entire iOS binary reports no vitals while Android reports normally — 115 iOS
+ * pageviews and 0 `$web_vitals` events over the 14 days to 2026-09-04, against
+ * ~1.9 vitals per pageview on Android.
+ *
+ * This covers exactly the documents PostHog opts out of, emitting PostHog's own
+ * `$web_vitals` shape so the rows land in the existing series rather than a
+ * parallel one. CLS stays absent on WebKit, which has no Layout Instability
+ * API — the same gap the iOS PWA already shows.
+ */
+
+import type { Metric } from 'web-vitals'
+import posthog from 'posthog-js'
+
+const FLUSH_DELAY_MS = 5000
+// Matches PostHog's own ceiling: an LCP over fifteen minutes is a broken clock,
+// not a slow page.
+const MAX_PLAUSIBLE_VALUE_MS = 15 * 60 * 1000
+
+/** True when posthog-js captures vitals itself and the shim must stay out. */
+export function postHogCapturesWebVitals(protocol: string | undefined): boolean {
+    return protocol === 'http:' || protocol === 'https:'
+}
+
+type Capture = (event: string, properties: Record<string, unknown>) => void
+
+export type WebVitalsReporter = { record: (metric: Metric) => void; flush: () => void }
+
+export function createWebVitalsReporter(capture: Capture, currentUrl: () => string): WebVitalsReporter {
+    let buffered: { url: string; metrics: Metric[] } | null = null
+    let flushTimer: ReturnType<typeof setTimeout> | undefined
+
+    const flush = (): void => {
+        clearTimeout(flushTimer)
+        flushTimer = undefined
+        const pending = buffered
+        buffered = null
+        if (!pending?.metrics.length) return
+
+        capture(
+            '$web_vitals',
+            pending.metrics.reduce<Record<string, unknown>>(
+                (acc, { name, value, rating, delta, id, navigationType }) => ({
+                    ...acc,
+                    // `entries` is dropped: PostHog keeps the whole metric here,
+                    // but the raw PerformanceEntry list is the bulk of the
+                    // payload and nothing reads it.
+                    [`$web_vitals_${name}_event`]: { name, value, rating, delta, id, navigationType },
+                    [`$web_vitals_${name}_value`]: value,
+                }),
+                {}
+            )
+        )
+    }
+
+    const record = (metric: Metric): void => {
+        if (metric.value >= MAX_PLAUSIBLE_VALUE_MS) return
+
+        const url = currentUrl()
+        // One event per URL, so an SPA route change closes the previous screen's
+        // batch instead of mixing two screens' metrics into one row.
+        if (buffered && buffered.url !== url) flush()
+        if (!buffered) {
+            buffered = { url, metrics: [] }
+            flushTimer = setTimeout(flush, FLUSH_DELAY_MS)
+        }
+        buffered.metrics.push(metric)
+    }
+
+    return { record, flush }
+}
+
+let started = false
+
+export function startWebVitalsShim(): void {
+    if (started || typeof window === 'undefined') return
+    if (postHogCapturesWebVitals(window.location.protocol)) return
+    started = true
+
+    const { record, flush } = createWebVitalsReporter(
+        (event, properties) => posthog.capture(event, properties),
+        () => window.location.href
+    )
+
+    // A metric that arrives as the app goes away would otherwise sit in the
+    // buffer until a flush timer the WebView never runs.
+    window.addEventListener('pagehide', flush)
+
+    void import('web-vitals')
+        .then(({ onCLS, onFCP, onINP, onLCP }) => {
+            onCLS(record)
+            onFCP(record)
+            onINP(record)
+            onLCP(record)
+        })
+        .catch(() => {
+            started = false
+        })
+}


### PR DESCRIPTION
## Why

We could not answer "is the app slow, and for whom?" because of two independent gaps in the telemetry.

### 1. The iOS binary has never reported a web vital

posthog-js disables web vitals on any document that is not http(s). From `posthog-js@1.360.0`, `src/extensions/web-vitals/index.ts`:

```ts
public get isEnabled(): boolean {
    // Always disable web vitals if we're not on http or https
    const protocol = location?.protocol
    if (protocol !== 'http:' && protocol !== 'https:') { ... return false }
    // ... remote config is only consulted after this
}
```

Capacitor's default `iosScheme` is `capacitor` and its default `androidScheme` is `https`, and we set no `server` block — so the two shells land on opposite sides of that gate. Confirmed in production over the 14 days to 2026-09-04:

| platform | URL scheme | pageviews | `$web_vitals` |
|---|---|---|---|
| android-native | `https://localhost` | 725 | ~1.9 per pageview |
| ios-native | `capacitor://localhost` | 115 | **0** |

This is not an OS-support problem: ios-pwa on iOS 18 turns in 6,305 pageviews and 9,471 vitals on the same WebKit. `$web_vitals_enabled_server_side` is `true` on 109 of 112 iOS pageviews — the flag is persisted from the config response regardless, and `isEnabled` short-circuits above it, which is why it read as a red herring.

`server.iosScheme: 'https'` would also clear the gate, but it moves the WebView origin — orphaning every existing install's storage partition — and needs a store release. Rejected for a telemetry fix. The shim ships by OTA.

### 2. Chrome's UA reduction hollowed out the device context

PostHog derives its device properties from the User-Agent, and the reduction leaves nothing to segment on — on exactly the platform with the problem:

| | Android | iOS |
|---|---|---|
| `$device` | the literal `"Android"` for 1,303 of 1,317 people | — |
| `$os_version` | present on **4** of 19,151 events | 100% |
| INP p75 | **224 ms** (Google's "poor" band) | 96 ms |

High-entropy client hints see through the reduction on the web; the native bridge names the hardware outright. `@capacitor/device` is already a dependency and already linked into both binaries, so this ships by OTA too.

## What this adds

- `src/utils/web-vitals-shim.ts` — subscribes `onCLS/onFCP/onINP/onLCP` and emits PostHog's own `$web_vitals` shape (`$web_vitals_<NAME>_value` / `_event`), with the same 5s per-URL batching, so rows merge into the existing series rather than a parallel one. Gated on precisely the condition that disables the built-in capture, so it can never double-count. `web-vitals` loads dynamically, so http(s) documents never fetch it.
- `src/utils/device-identity.ts` — `device_model`, `device_manufacturer`, `device_os_version`, `device_webview_version`, `device_memory_gb`, `device_cores`, `device_screen`, and a derived `device_class`.
- Registered as super **and** person properties, so `device_class = 'low'` is a one-line cohort definition and can target a feature flag.

## Notes for review

- **`device_class` returns `unknown` on WebKit by design.** Memory is the only cross-fleet capability signal, and Chromium buckets it (0.25–8 GB). WebKit exposes neither it nor a usable substitute — an iPhone's `hardwareConcurrency` is small on fast hardware — so ranking iOS on core count would file every iPhone as slow while its INP p75 is 96 ms. iOS is segmented by `device_model` (native) or `device_screen` (PWA) instead.
- **Identity registers as its own step**, after the existing context rather than folded into it: the native branch is a second bridge round-trip, and a binary whose plugin never answers would otherwise take `platform` and `app_release` down with it. It is also merged into the cached context, because that is what `authContext` re-registers after `posthog.reset()` wipes super properties on logout.
- `entries` is dropped from the `_event` blob — PostHog keeps the whole metric, but the raw `PerformanceEntry` list is the bulk of the payload and nothing reads it.
- CLS will stay absent on iOS. WebKit has no Layout Instability API; the iOS PWA already shows 0 CLS rows out of 9,680.
- The existing `emits once per session` test now asserts the call count is unchanged by a second emit, rather than pinning it to exactly one register — the first emit legitimately registers twice now.

## Expectations

iOS-native is 16 people and 115 pageviews per 14 days, so this makes the surface *measurable*, not statistically rich. The larger win is device segmentation across the ~700 ios-pwa and ~1,300 Android users who already report vitals.

## Test plan

- `src/utils/__tests__/web-vitals-shim.test.ts` (protocol gate both ways, batching, per-URL flush, implausible-value drop, double-flush)
- `src/utils/__tests__/device-identity.test.ts` (native bridge, client hints, empty-model handling, throwing source, screen descriptor, classifier bands)
- `src/i18n/app/__tests__/locale-store.test.ts` updated for the second register and the folded-in identity
- `tsc --noEmit` clean; prettier and eslint clean on touched files
