### PR TITLE
fix(drawer): use a white drawer surface instead of the themed background

### DIFF
--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -47,7 +47,7 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
             <DrawerPrimitive.Content
                 ref={ref}
                 className={twMerge(
-                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] border bg-background',
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-[10px] border bg-white',
                     className
                 )}
                 aria-describedby={undefined}


### PR DESCRIPTION
## Summary
- The shared `Drawer`/`DrawerContent` primitive (`src/components/Global/Drawer/index.tsx`) rendered its sheet with `bg-background`, which resolves to the app's themed cream/dark background instead of a clean white surface.
- Since ~20 feature drawers across the app (card unlock, transaction details, support, QR scan/paste, KYC status, contributors, cancel link, choose network, badge status, token selector, receipt, withdraw retry, etc.) all build on this shared component, the fix applies consistently app-wide.
- Changed the drawer sheet's background from `bg-background` to `bg-white`.

## Test plan
- [x] Confirmed the only change is the background utility class on `DrawerContent` (`bg-background` → `bg-white`); no other drawer behavior changed.
- [ ] Visually spot-check a few drawers (e.g. transaction details, token selector) in the running app to confirm the white surface renders as expected in both light and dark mode.

Recreates #2982 under my own authorship.
