### PR TITLE
fix(drawer): use a white drawer surface instead of the themed background

### DIFF
--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -103,10 +103,10 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
             <DrawerPrimitive.Content
                 ref={ref}
                 className={twMerge(
-                    // chrome per the TX Details board (17490:115877): page background,
+                    // chrome per the TX Details board (17490:115877): white background,
                     // no border, handle 32x5 sitting 8px from the top with 24px below.
                     // tx-details board 17835:84492: 16px top corners (was a hardcoded 10px)
-                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-background-page',
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-white',
                     className
                 )}
                 aria-describedby={undefined}


### PR DESCRIPTION
## Summary
- The shared `Drawer`/`DrawerContent` primitive (`src/components/Global/Drawer/index.tsx`) rendered its sheet with `bg-background-page`, which resolves to the app's themed cream/dark background instead of a clean white surface.
- Since ~20 feature drawers across the app (card unlock, transaction details, support, QR scan/paste, KYC status, contributors, cancel link, choose network, badge status, token selector, receipt, withdraw retry, etc.) all build on this shared component, the fix applies consistently app-wide.
- Changed the drawer sheet's background from `bg-background-page` to `bg-white`; updated the adjacent chrome comment to match.

**Note:** `dev` had already diverged from where this fix was first written against `main` — the background class had been intentionally set to `bg-background-page` on 2026-08-19/27 citing a specific Figma board ("chrome per the TX Details board 17490:115877: page background..."). This PR overrides that board reference; flagging in case that decision needs revisiting with design.

## Test plan
- [x] Confirmed the only change is the background utility class on `DrawerContent` (`bg-background-page` → `bg-white`); no other drawer behavior changed.
- [ ] Visually spot-check a few drawers (e.g. transaction details, token selector) in the running app to confirm the white surface renders as expected in both light and dark mode.

Rebased/reapplied version of #2983 against `dev`.
