### PR TITLE
fix(ds): neutral delete-account link + exchange widget shadow (in-app only)

### DIFF
--- a/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
+++ b/src/app/(mobile-ui)/profile/exchange-rate/page.tsx
@@ -99,6 +99,7 @@ export default function ExchangeRatePage() {
                         ctaLabel={goesToAddMoney ? t('addMoneyCta') : t('tryIt')}
                         ctaAction={handleCtaAction}
                         restrictToRoutable
+                        shadow={false}
                         labels={{
                             youSend: t('widget.youSend'),
                             recipientGets: t('widget.recipientGets'),

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -235,9 +235,10 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
 
     // no exchange-rate board exists in figma (checked 2026-08-20) — container
     // rebuilt on the DS Card primitive (board 17802:61536) as the conservative
-    // recipe; a dedicated board can restyle the internals later.
+    // recipe; a dedicated board can restyle the internals later. No shadow: not
+    // used anywhere else in the app (TASK-22121).
     return (
-        <Card shadowSize="4" className="mx-auto mt-12 h-fit w-full items-center justify-center gap-4 p-6 md:w-[420px]">
+        <Card className="mx-auto mt-12 h-fit w-full items-center justify-center gap-4 p-6 md:w-[420px]">
             <div className="w-full">
                 <h2 className="text-left text-body-s">{l.youSend}</h2>
                 <div className="mt-2 flex w-full items-center justify-center gap-4 rounded-sm border border-border-default bg-background-default p-4">

--- a/src/components/Global/ExchangeRateWidget/index.tsx
+++ b/src/components/Global/ExchangeRateWidget/index.tsx
@@ -53,6 +53,10 @@ interface IExchangeRateWidgetProps {
     // `?to=PLN` shows a rate the dropdown never offers and the CTA can only
     // route by falling back to the default pair.
     restrictToRoutable?: boolean
+    // Marketing/landing pages keep the hard drop shadow (matches the rest of
+    // that page's brutalist button styling); the in-app /profile/exchange-rate
+    // screen drops it — not used on any other in-app card (TASK-22121).
+    shadow?: boolean
 }
 
 const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
@@ -61,6 +65,7 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
     ctaAction,
     labels,
     restrictToRoutable = false,
+    shadow = true,
 }) => {
     const l = { ...DEFAULT_LABELS, ...labels }
     // shallow + history:'replace' uses window.history.replaceState — bypasses
@@ -235,10 +240,12 @@ const ExchangeRateWidget: FC<IExchangeRateWidgetProps> = ({
 
     // no exchange-rate board exists in figma (checked 2026-08-20) — container
     // rebuilt on the DS Card primitive (board 17802:61536) as the conservative
-    // recipe; a dedicated board can restyle the internals later. No shadow: not
-    // used anywhere else in the app (TASK-22121).
+    // recipe; a dedicated board can restyle the internals later.
     return (
-        <Card className="mx-auto mt-12 h-fit w-full items-center justify-center gap-4 p-6 md:w-[420px]">
+        <Card
+            shadowSize={shadow ? '4' : undefined}
+            className="mx-auto mt-12 h-fit w-full items-center justify-center gap-4 p-6 md:w-[420px]"
+        >
             <div className="w-full">
                 <h2 className="text-left text-body-s">{l.youSend}</h2>
                 <div className="mt-2 flex w-full items-center justify-center gap-4 rounded-sm border border-border-default bg-background-default p-4">

--- a/src/components/Settings/DeleteAccountButton.tsx
+++ b/src/components/Settings/DeleteAccountButton.tsx
@@ -145,8 +145,10 @@ const DeleteAccountButton: FC = () => {
 
     return (
         <>
-            {/* deliberate bigger size + destructive red kept; states come from LinkButton */}
-            <LinkButton onClick={open} className="w-full justify-center text-label-l text-foreground-error">
+            {/* design.md scopes red to the confirm modal's icon bubble only — no
+                red Button/link variant exists, so this rides LinkButton's own
+                neutral tokens (foreground-secondary → foreground-primary on hover). */}
+            <LinkButton onClick={open} className="w-full justify-center">
                 {t('button')}
             </LinkButton>
 


### PR DESCRIPTION
## Summary

- Delete-account trigger on `/profile` rides `LinkButton`'s own neutral tokens instead of a destructive-red override — design.md scopes red to the confirm modal's icon bubble only, no red Button/link variant exists.
- Exchange-rate widget card drops its hard drop shadow — but only in-app (`/profile/exchange-rate`); marketing/landing keeps it via a new `shadow` prop (default `true`) so each caller opts in/out explicitly. Not used on any other in-app card. TASK-22121.

## Test plan

- [x] `tsc --noEmit` clean on both touched areas
- [x] `jest --testPathPattern "exchange-rate-page|restrict-to-routable"` — 11/11 passing
- [x] Manually verified both DeleteAccountButton and ExchangeRateWidget (shadow on vs off) via an isolated local preview
