### PR TITLE
feat: the avatar hand and the profile pill (TASK-22142)

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/foundations/icons/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/foundations/icons/page.tsx
@@ -30,6 +30,7 @@ const ALL_ICONS: IconName[] = [
     'clock',
     'copy',
     'currency',
+    'dice',
     'docs',
     'dollar',
     'double-check',

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -3,30 +3,34 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { updateUserById } from '@/app/actions/users'
-import { Button } from '@/components/0_Bruddle/Button'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '@/components/Global/Drawer'
+import StatusBadge from '@/components/Global/Badges/StatusBadge'
+import { Drawer, DrawerContent } from '@/components/Global/Drawer'
+import { Icon } from '@/components/Global/Icons/Icon'
 import { useAuth } from '@/context/authContext'
 import { twMerge } from '@/utils/tw'
-import { badgeAvatarKeys, offerBasics } from './avatar.utils'
+import { AVATAR_CAST } from './avatar.consts'
+import { badgeAvatarKeys, dealHand } from './avatar.utils'
 import { roveAvatarTiles } from './avatarPicker.utils'
 import { UserAvatar } from './UserAvatar'
 
 interface AvatarPickerProps {
     open: boolean
     onOpenChange: (open: boolean) => void
+    /** Badge code the first hand deals from — the badge-earned toast's deep link. */
+    prefer?: string
 }
 
 /**
- * The profile avatar picker (TASK-22142): what the user's badges unlocked,
- * then one row of the basics everyone has. A tap saves at once; the dice
- * rerolls the offered row and never the pick; "use my initial" clears it.
- * The API validates the pick against the same pool, so a locked key never
- * lands even if the manifest and the catalog drift.
+ * The profile avatar picker (TASK-22142): one hand of eight. Slot 1 is always
+ * the user's initial, slots 2-8 are dealt by `dealHand` (at least one earned
+ * badge avatar, the current pick kept, the rest from the basics) and slot 9
+ * rolls a new hand. A tap saves at once; rolling never changes the pick. The
+ * API validates the pick against the same pool, so a locked key never lands
+ * even if the manifest and the catalog drift.
  */
-export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
+export function AvatarPicker({ open, onOpenChange, prefer }: AvatarPickerProps) {
     const t = useTranslations('avatar')
-    const tCommon = useTranslations('common')
     const { user, fetchUser } = useAuth()
     const { toast } = useToast()
 
@@ -79,90 +83,86 @@ export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
         if (!draining.current) void drain()
     }
 
-    // the offered row of five basics: dealt on open, redealt by the dice
-    const [offer, setOffer] = useState<string[]>([])
+    // the hand: dealt on open, dealt again by the die; the pick never moves with it
+    const [hand, setHand] = useState<(string | null)[]>([])
+    const [turns, setTurns] = useState(0)
     useEffect(() => {
-        if (open) setOffer(offerBasics(saved))
-        // deal once per open; the pick joins the row by being picked from it
+        if (open) setHand(dealHand(saved, unlocked, { prefer }))
+        // deal once per open; the pick joins the hand by being picked from it
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open])
-    const rollDice = () => setOffer(offerBasics(pick))
+    const roll = () => {
+        setTurns((n) => n + 1)
+        setHand(dealHand(pick, unlocked))
+    }
 
-    // human labels: "Bug Whisperer · beetle" for a badge avatar, the slug for a basic
-    const label = (key: string) => {
+    // The sticker is the label. The accessible name is the cast name for a
+    // basic ("Jackpot Cherry" — the slugs predate the art), "Bug Whisperer ·
+    // beetle" for a badge avatar, and "Your initial" for slot 1.
+    const label = (key: string | null) => {
+        if (!key) return t('initial')
         const [kind, code, slug] = key.split('.')
-        return kind === 'badge' ? `${badgeName[code] ?? code} · ${slug}` : code
+        return kind === 'badge' ? `${badgeName[code] ?? code} · ${slug}` : (AVATAR_CAST[code] ?? code)
     }
 
-    const tiles = (keys: string[], groupLabel: string) => {
-        const focusIndex = Math.max(0, keys.indexOf(pick ?? ''))
-        return (
-            <div
-                role="radiogroup"
-                aria-label={groupLabel}
-                className="grid grid-cols-5 gap-2"
-                onKeyDown={roveAvatarTiles}
-            >
-                {keys.map((key, index) => {
-                    const checked = key === pick
-                    return (
-                        <button
-                            key={key}
-                            type="button"
-                            role="radio"
-                            aria-checked={checked}
-                            aria-label={label(key)}
-                            tabIndex={index === focusIndex ? 0 : -1}
-                            onClick={() => save(key)}
-                            className={twMerge(
-                                'flex min-h-11 items-center justify-center rounded-sm border border-border-disabled bg-background-default p-1 focus-visible:outline-[3px] focus-visible:outline-action-focus',
-                                checked && 'border-2 border-border-default shadow-4'
-                            )}
-                        >
-                            <UserAvatar name={username} avatarKey={key} size="small" />
-                        </button>
-                    )
-                })}
-            </div>
-        )
-    }
+    const focusIndex = Math.max(0, hand.indexOf(pick))
 
     return (
         <Drawer open={open} onOpenChange={onOpenChange}>
-            <DrawerContent className="p-4">
-                <DrawerHeader className="p-0 pb-4 text-left">
-                    <DrawerTitle className="text-heading-s text-foreground-primary">{t('title')}</DrawerTitle>
-                    <DrawerDescription>{t('description')}</DrawerDescription>
-                </DrawerHeader>
-                <div className="flex flex-col gap-6">
-                    <section className="flex flex-col gap-2">
-                        <div className="flex items-baseline justify-between text-label-m text-foreground-secondary uppercase">
-                            <span>{t('fromBadges')}</span>
-                            {unlocked.length > 0 && (
-                                <span className="normal-case">{t('unlocked', { count: unlocked.length })}</span>
+            <DrawerContent accessibleTitle={t('title')} className="p-4">
+                <div
+                    role="radiogroup"
+                    aria-label={t('title')}
+                    className="grid grid-cols-3 gap-2"
+                    onKeyDown={roveAvatarTiles}
+                >
+                    {hand.map((key, index) => {
+                        const checked = key === pick
+                        const earned = !!key?.startsWith('badge.')
+                        return (
+                            <button
+                                key={key ?? 'initial'}
+                                type="button"
+                                role="radio"
+                                aria-checked={checked}
+                                aria-label={label(key)}
+                                tabIndex={index === focusIndex ? 0 : -1}
+                                onClick={() => save(key)}
+                                className={twMerge(
+                                    'relative flex items-center justify-center rounded-sm border border-border-disabled bg-background-default p-4 focus-visible:outline-[3px] focus-visible:outline-action-focus',
+                                    // yellow marks an earned avatar, as on the badge-earned toast
+                                    earned && 'border-action-secondary',
+                                    checked && 'border-2 border-border-default shadow-4'
+                                )}
+                            >
+                                {earned && (
+                                    <StatusBadge
+                                        status="custom"
+                                        customText={t('earned')}
+                                        className="absolute top-1 right-1"
+                                    />
+                                )}
+                                <UserAvatar name={username} avatarKey={key} size="medium" />
+                            </button>
+                        )
+                    })}
+                    <button
+                        type="button"
+                        onClick={roll}
+                        aria-label={t('rollDie')}
+                        className="flex flex-col items-center justify-center gap-1 rounded-sm border border-dashed border-border-default bg-background-page p-4 text-button-s text-foreground-primary focus-visible:outline-[3px] focus-visible:outline-action-focus"
+                    >
+                        {/* one full turn per roll; class parity, so no inline style */}
+                        <Icon
+                            name="dice"
+                            size={24}
+                            className={twMerge(
+                                'motion-safe:transition-transform motion-safe:duration-slow motion-safe:ease-spring',
+                                turns % 2 ? 'rotate-360' : 'rotate-0'
                             )}
-                        </div>
-                        {unlocked.length > 0 ? (
-                            tiles(unlocked, t('fromBadges'))
-                        ) : (
-                            <p className="text-body-s text-foreground-secondary">{t('noBadgeAvatars')}</p>
-                        )}
-                    </section>
-                    <section className="flex flex-col gap-2">
-                        <div className="text-label-m text-foreground-secondary uppercase">{t('basics')}</div>
-                        {tiles(offer, t('basics'))}
-                    </section>
-                    <div className="flex flex-col gap-2">
-                        <Button variant="stroke" className="w-full" onClick={rollDice}>
-                            {t('rollDice')}
-                        </Button>
-                        <Button variant="purple" className="w-full" onClick={() => onOpenChange(false)}>
-                            {tCommon('done')}
-                        </Button>
-                        <Button variant="transparent" className="w-full" onClick={() => save(null)}>
-                            {t('useInitial')}
-                        </Button>
-                    </div>
+                        />
+                        {t('rollDie')}
+                    </button>
                 </div>
             </DrawerContent>
         </Drawer>

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -87,7 +87,9 @@ export function AvatarPicker({ open, onOpenChange, prefer }: AvatarPickerProps) 
     const [hand, setHand] = useState<(string | null)[]>([])
     const [turns, setTurns] = useState(0)
     useEffect(() => {
-        if (open) setHand(dealHand(saved, unlocked, { prefer }))
+        // deal from `pick`, not `saved`: reopening while a save is still in
+        // flight must keep the visibly selected avatar in the hand
+        if (open) setHand(dealHand(pick, unlocked, { prefer }))
         // deal once per open; the pick joins the hand by being picked from it
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open])

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -129,7 +129,8 @@ export function AvatarPicker({ open, onOpenChange, prefer }: AvatarPickerProps) 
                                 tabIndex={index === focusIndex ? 0 : -1}
                                 onClick={() => save(key)}
                                 className={twMerge(
-                                    'relative flex items-center justify-center rounded-sm border border-border-disabled bg-background-default p-4 focus-visible:outline-[3px] focus-visible:outline-action-focus',
+                                    // XL on top: the "Earned" chip sits in that band, clear of the sticker
+                                    'relative flex items-center justify-center rounded-sm border border-border-disabled bg-background-default px-4 pt-6 pb-4 focus-visible:outline-[3px] focus-visible:outline-action-focus',
                                     // yellow marks an earned avatar, as on the badge-earned toast
                                     earned && 'border-action-secondary',
                                     checked && 'border-2 border-border-default shadow-4'

--- a/src/components/Avatar/__tests__/AvatarPicker.test.tsx
+++ b/src/components/Avatar/__tests__/AvatarPicker.test.tsx
@@ -207,6 +207,28 @@ describe('AvatarPicker', () => {
         expect(radio(B)).toHaveAttribute('aria-checked', 'true')
     })
 
+    // Chip (#2989): the pill already shows the new avatar while the save
+    // drains, so a close/reopen in that window must deal from the pending pick
+    // — dealing from `saved` can drop it and leave no tile checked.
+    it('deals from the pending pick when reopened during an in-flight save', async () => {
+        const server = fakeServer()
+        const { rerender } = renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+
+        fireEvent.click(radio(B))
+        expect(server.posts.map((post) => post.key)).toEqual([KEY_B])
+
+        rerender(<AvatarPicker open={false} onOpenChange={jest.fn()} />)
+        rerender(<AvatarPicker open onOpenChange={jest.fn()} />)
+
+        expect(mockDealHand).toHaveBeenLastCalledWith(KEY_B, UNLOCKED, { prefer: undefined })
+        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
+
+        await server.settle(0)
+        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
+        expect(server.committed()).toBe(KEY_B)
+        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
+    })
+
     it('a rejected first save still lets the second go through and clears pending', async () => {
         const server = fakeServer()
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)

--- a/src/components/Avatar/__tests__/AvatarPicker.test.tsx
+++ b/src/components/Avatar/__tests__/AvatarPicker.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps, ReactNode } from 'react'
 import { renderWithIntl } from '@/test-utils/intl'
 import { AvatarPicker } from '../AvatarPicker'
+import { badgeAvatarKeys } from '../avatar.utils'
 
 jest.mock('next/image', () => ({
     __esModule: true,
@@ -12,6 +13,14 @@ jest.mock('next/image', () => ({
 jest.mock('@/components/Global/Drawer', () => ({
     Drawer: ({ open, children }: { open: boolean; children?: ReactNode }) => (open ? <div>{children}</div> : null),
     DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+// the deal is random and has its own suite (avatar.utils.test); here the hand
+// is fixed so every test knows what is on the table
+const mockDealHand = jest.fn()
+jest.mock('../avatar.utils', () => ({
+    ...jest.requireActual('../avatar.utils'),
+    dealHand: (...args: unknown[]) => mockDealHand(...args),
 }))
 
 const mockToast = jest.fn()
@@ -33,6 +42,10 @@ const A = 'Bug Whisperer · beetle'
 const B = 'Bug Whisperer · shell'
 const KEY_A = 'badge.BUG_WHISPERER.beetle'
 const KEY_B = 'badge.BUG_WHISPERER.shell'
+const KEY_C = 'badge.BUG_WHISPERER.peek'
+const UNLOCKED = badgeAvatarKeys(['BUG_WHISPERER'])
+const HAND = [null, KEY_C, KEY_B, KEY_A, 'basic.sun', 'basic.star', 'basic.planet', 'basic.mushroom']
+const HAND_WITH_APPLE = [null, KEY_C, 'basic.apple', KEY_B, KEY_A, 'basic.sun', 'basic.star', 'basic.planet']
 
 // A server model: every POST is recorded in order and settled by hand, in any
 // order; the last write the server COMMITS is what the refetch hands back.
@@ -60,15 +73,9 @@ function fakeServer() {
     }
 }
 
-// The deal is random. Pinned at 0.99, every draw takes the last candidate and
-// the shuffle is the identity, so with one Bug Whisperer badge the hand is
-// [initial, peek, shell, beetle, …basics] whatever the pick — A and B are
-// always on the table (dealHand fills basics first, then the earned avatars).
-let random: jest.SpyInstance<number, []>
-
 beforeEach(() => {
     jest.clearAllMocks()
-    random = jest.spyOn(Math, 'random').mockReturnValue(0.99)
+    mockDealHand.mockReturnValue(HAND)
     mockUpdateUserById.mockResolvedValue({ data: {} })
     mockFetchUser.mockResolvedValue(null)
     mockUser = {
@@ -81,20 +88,18 @@ beforeEach(() => {
     }
 })
 
-afterEach(() => random.mockRestore())
-
 describe('AvatarPicker', () => {
     it('deals one hand of eight behind the initial, earned avatars marked, the die ninth', () => {
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
+        expect(mockDealHand).toHaveBeenCalledWith(null, UNLOCKED, { prefer: undefined })
         const group = screen.getByRole('radiogroup', { name: 'Your avatar' })
         expect(group.querySelectorAll('[role="radio"]')).toHaveLength(8)
         expect(handOf()[0]).toBe('Your initial')
         expect(radio('Your initial')).toHaveAttribute('aria-checked', 'true')
-        // the three Bug Whisperer avatars, each tagged; nothing from badges not held
+        // the three Bug Whisperer avatars, each tagged
         expect(screen.getAllByText('Earned')).toHaveLength(3)
         expect(radio(A)).toBeInTheDocument()
-        expect(screen.queryByRole('radio', { name: /Offramp/ })).not.toBeInTheDocument()
         // basics carry their cast name, not their slug
         expect(radio('Bossy Goose')).toBeInTheDocument()
         expect(rollDie()).toBeInTheDocument()
@@ -102,19 +107,23 @@ describe('AvatarPicker', () => {
         expect(screen.getAllByRole('button')).toHaveLength(1)
     })
 
-    it('deals the initial plus seven basics to a user with no badges', () => {
+    it('deals nothing earned to a user with no badges', () => {
         mockUser.user.badges = []
+        mockDealHand.mockReturnValue([
+            null,
+            ...['sun', 'star', 'planet', 'moon', 'leaf', 'gem', 'frog'].map((s) => `basic.${s}`),
+        ])
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
+        expect(mockDealHand).toHaveBeenCalledWith(null, [], { prefer: undefined })
         expect(screen.getAllByRole('radio')).toHaveLength(8)
         expect(screen.queryByText('Earned')).not.toBeInTheDocument()
     })
 
     it('deals the first hand from the badge the deep link names', () => {
-        mockUser.user.badges.push({ code: 'OG_2025_10_12', name: 'OG' })
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} prefer="OG_2025_10_12" />)
+        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} prefer="BUG_WHISPERER" />)
 
-        expect(radio('OG · shades')).toBeInTheDocument()
+        expect(mockDealHand).toHaveBeenCalledWith(null, UNLOCKED, { prefer: 'BUG_WHISPERER' })
     })
 
     it('saves a tap at once and refreshes the user', async () => {
@@ -222,22 +231,34 @@ describe('AvatarPicker', () => {
 
     it('the die deals a new hand and never changes the pick or the initial', () => {
         mockUser.user.avatarKey = 'basic.apple'
+        const rolled = [
+            null,
+            'basic.apple',
+            KEY_A,
+            'basic.avocado',
+            'basic.cactus',
+            'basic.cloud',
+            'basic.cube',
+            'basic.donut',
+        ]
+        mockDealHand.mockReturnValueOnce(HAND_WITH_APPLE).mockReturnValueOnce(rolled)
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
         const before = handOf()
         expect(radio('Jackpot Cherry')).toHaveAttribute('aria-checked', 'true')
 
-        random.mockReturnValue(0)
         act(() => fireEvent.click(rollDie()))
 
+        // the roll deals from the pick, with no preference
+        expect(mockDealHand).toHaveBeenLastCalledWith('basic.apple', UNLOCKED)
         expect(handOf()).not.toEqual(before)
         expect(handOf()[0]).toBe('Your initial')
-        expect(handOf()).toContain('Jackpot Cherry')
         expect(radio('Jackpot Cherry')).toHaveAttribute('aria-checked', 'true')
         expect(mockUpdateUserById).not.toHaveBeenCalled()
     })
 
     it('tapping the initial clears the pick', () => {
         mockUser.user.avatarKey = 'basic.apple'
+        mockDealHand.mockReturnValue(HAND_WITH_APPLE)
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
         fireEvent.click(radio('Your initial'))

--- a/src/components/Avatar/__tests__/AvatarPicker.test.tsx
+++ b/src/components/Avatar/__tests__/AvatarPicker.test.tsx
@@ -9,16 +9,10 @@ jest.mock('next/image', () => ({
 }))
 
 // vaul needs a real layout; the picker's own logic is what is under test
-jest.mock('@/components/Global/Drawer', () => {
-    const Passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>
-    return {
-        Drawer: ({ open, children }: { open: boolean; children?: ReactNode }) => (open ? <div>{children}</div> : null),
-        DrawerContent: Passthrough,
-        DrawerHeader: Passthrough,
-        DrawerTitle: Passthrough,
-        DrawerDescription: Passthrough,
-    }
-})
+jest.mock('@/components/Global/Drawer', () => ({
+    Drawer: ({ open, children }: { open: boolean; children?: ReactNode }) => (open ? <div>{children}</div> : null),
+    DrawerContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
 
 const mockToast = jest.fn()
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => ({ toast: mockToast }) }))
@@ -33,6 +27,8 @@ let mockUser: {
 jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: mockUser, fetchUser: mockFetchUser }) }))
 
 const radio = (key: string) => screen.getByRole('radio', { name: key })
+const handOf = () => screen.getAllByRole('radio').map((el) => el.getAttribute('aria-label'))
+const rollDie = () => screen.getByRole('button', { name: 'Roll the die' })
 const A = 'Bug Whisperer · beetle'
 const B = 'Bug Whisperer · shell'
 const KEY_A = 'badge.BUG_WHISPERER.beetle'
@@ -64,8 +60,15 @@ function fakeServer() {
     }
 }
 
+// The deal is random. Pinned at 0.99, every draw takes the last candidate and
+// the shuffle is the identity, so with one Bug Whisperer badge the hand is
+// [initial, peek, shell, beetle, …basics] whatever the pick — A and B are
+// always on the table (dealHand fills basics first, then the earned avatars).
+let random: jest.SpyInstance<number, []>
+
 beforeEach(() => {
     jest.clearAllMocks()
+    random = jest.spyOn(Math, 'random').mockReturnValue(0.99)
     mockUpdateUserById.mockResolvedValue({ data: {} })
     mockFetchUser.mockResolvedValue(null)
     mockUser = {
@@ -78,24 +81,40 @@ beforeEach(() => {
     }
 })
 
+afterEach(() => random.mockRestore())
+
 describe('AvatarPicker', () => {
-    it('lists one row of five basics and only the avatars of badges the user holds', () => {
+    it('deals one hand of eight behind the initial, earned avatars marked, the die ninth', () => {
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
-        expect(screen.getAllByRole('radio')).toHaveLength(8)
-        // human labels, not keys: badge name + slug, or the slug alone
+        const group = screen.getByRole('radiogroup', { name: 'Your avatar' })
+        expect(group.querySelectorAll('[role="radio"]')).toHaveLength(8)
+        expect(handOf()[0]).toBe('Your initial')
+        expect(radio('Your initial')).toHaveAttribute('aria-checked', 'true')
+        // the three Bug Whisperer avatars, each tagged; nothing from badges not held
+        expect(screen.getAllByText('Earned')).toHaveLength(3)
         expect(radio(A)).toBeInTheDocument()
-        expect(screen.getByRole('radiogroup', { name: 'Basics' }).querySelectorAll('[role="radio"]')).toHaveLength(5)
         expect(screen.queryByRole('radio', { name: /Offramp/ })).not.toBeInTheDocument()
-        expect(screen.getByRole('radiogroup', { name: 'From your badges' })).toBeInTheDocument()
+        // basics carry their cast name, not their slug
+        expect(radio('Bossy Goose')).toBeInTheDocument()
+        expect(rollDie()).toBeInTheDocument()
+        // no title, no description, no button besides the die (tiles are radios)
+        expect(screen.getAllByRole('button')).toHaveLength(1)
     })
 
-    it('tells a user with no badges where avatars come from', () => {
+    it('deals the initial plus seven basics to a user with no badges', () => {
         mockUser.user.badges = []
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
-        expect(screen.getAllByRole('radio')).toHaveLength(5)
-        expect(screen.getByText('Earn a badge and its avatars appear here.')).toBeInTheDocument()
+        expect(screen.getAllByRole('radio')).toHaveLength(8)
+        expect(screen.queryByText('Earned')).not.toBeInTheDocument()
+    })
+
+    it('deals the first hand from the badge the deep link names', () => {
+        mockUser.user.badges.push({ code: 'OG_2025_10_12', name: 'OG' })
+        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} prefer="OG_2025_10_12" />)
+
+        expect(radio('OG · shades')).toBeInTheDocument()
     })
 
     it('saves a tap at once and refreshes the user', async () => {
@@ -197,45 +216,33 @@ describe('AvatarPicker', () => {
         expect(radio(B)).toHaveAttribute('aria-checked', 'true')
         // pending is cleared: a later refetch that says otherwise wins
         mockUser.user.avatarKey = KEY_A
-        fireEvent.click(screen.getByRole('button', { name: 'Roll the dice' }))
+        fireEvent.click(rollDie())
         expect(radio(A)).toHaveAttribute('aria-checked', 'true')
     })
 
-    it('the dice redeals the basics row and never changes the pick', () => {
+    it('the die deals a new hand and never changes the pick or the initial', () => {
         mockUser.user.avatarKey = 'basic.apple'
-        const random = jest.spyOn(Math, 'random').mockReturnValue(0)
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-        const rowOf = () =>
-            Array.from(screen.getByRole('radiogroup', { name: 'Basics' }).querySelectorAll('[role="radio"]')).map(
-                (el) => el.getAttribute('aria-label')
-            )
-        const before = rowOf()
+        const before = handOf()
+        expect(radio('Jackpot Cherry')).toHaveAttribute('aria-checked', 'true')
 
-        random.mockReturnValue(0.99)
-        act(() => fireEvent.click(screen.getByRole('button', { name: 'Roll the dice' })))
+        random.mockReturnValue(0)
+        act(() => fireEvent.click(rollDie()))
 
-        expect(rowOf()).not.toEqual(before)
-        expect(rowOf()).toContain('apple')
-        expect(radio('apple')).toHaveAttribute('aria-checked', 'true')
+        expect(handOf()).not.toEqual(before)
+        expect(handOf()[0]).toBe('Your initial')
+        expect(handOf()).toContain('Jackpot Cherry')
+        expect(radio('Jackpot Cherry')).toHaveAttribute('aria-checked', 'true')
         expect(mockUpdateUserById).not.toHaveBeenCalled()
-        random.mockRestore()
     })
 
-    it('clears the pick back to the initial', () => {
+    it('tapping the initial clears the pick', () => {
         mockUser.user.avatarKey = 'basic.apple'
         renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
 
-        fireEvent.click(screen.getByRole('button', { name: 'Use my initial instead' }))
+        fireEvent.click(radio('Your initial'))
 
+        expect(radio('Your initial')).toHaveAttribute('aria-checked', 'true')
         expect(mockUpdateUserById).toHaveBeenCalledWith({ userId: 'u1', avatarKey: null })
-    })
-
-    it('closes on done', () => {
-        const onOpenChange = jest.fn()
-        renderWithIntl(<AvatarPicker open onOpenChange={onOpenChange} />)
-
-        fireEvent.click(screen.getByRole('button', { name: 'Done' }))
-
-        expect(onOpenChange).toHaveBeenCalledWith(false)
     })
 })

--- a/src/components/Avatar/__tests__/avatar.utils.test.ts
+++ b/src/components/Avatar/__tests__/avatar.utils.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import badgeAssets from '@/types/badge-assets.json'
+import { AVATAR_CAST } from '../avatar.consts'
 import { avatarPool, avatarSrc, badgeAvatarKeys, basicAvatarKeys, dealHand, letterAvatarSrc } from '../avatar.utils'
 
 describe('avatar catalog', () => {
@@ -50,6 +51,13 @@ describe('avatar catalog', () => {
         expect(avatarPool(['OFFRAMP_USER'])).toHaveLength(23)
     })
 
+    // the cast name is a tile's accessible name; a basic without one would be
+    // announced by its slug, which does not match the drawing
+    it('names every basic in the cast table', () => {
+        for (const slug of badgeAssets.avatars.basics)
+            expect({ slug, name: AVATAR_CAST[slug] }).toEqual({ slug, name: expect.any(String) })
+    })
+
     it('maps keys to their art and rejects anything the manifest does not know', () => {
         expect(avatarSrc('basic.apple')).toBe('/avatars/basic/apple.webp')
         expect(avatarSrc('badge.OFFRAMP_USER.wink')).toBe('/avatars/badge/OFFRAMP_USER/wink.webp')
@@ -85,6 +93,12 @@ describe('dealHand', () => {
             // a worn badge avatar does not count: the guarantee is a second earned card
             expect(hand.filter((key) => isBadge(key) && key !== pick).length).toBeGreaterThan(0)
         }
+    })
+
+    it('does not deal a pick this manifest does not know', () => {
+        const hand = dealHand('basic.peanut', unlocked, { random: seeded(7) })
+        expect(hand).toHaveLength(8)
+        expect(hand).not.toContain('basic.peanut')
     })
 
     it('deals only basics to a user with no badges', () => {

--- a/src/components/Avatar/__tests__/avatar.utils.test.ts
+++ b/src/components/Avatar/__tests__/avatar.utils.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import badgeAssets from '@/types/badge-assets.json'
-import { avatarPool, avatarSrc, badgeAvatarKeys, basicAvatarKeys, letterAvatarSrc, offerBasics } from '../avatar.utils'
+import { avatarPool, avatarSrc, badgeAvatarKeys, basicAvatarKeys, dealHand, letterAvatarSrc } from '../avatar.utils'
 
 describe('avatar catalog', () => {
     // the manifest is the API's contract: every slug it names must be real art
@@ -63,22 +63,53 @@ describe('avatar catalog', () => {
         expect(avatarSrc(null)).toBeNull()
         expect(avatarSrc(undefined)).toBeNull()
     })
+})
 
-    it('offers one row of five basics that always holds the pick', () => {
-        const seeded = (seed: number) => () => (seed = (seed * 9301 + 49297) % 233280) / 233280
-        const row = offerBasics('basic.sun', 5, seeded(1))
-        expect(row).toHaveLength(5)
-        expect(row).toContain('basic.sun')
-        expect(new Set(row).size).toBe(5)
-        for (const key of row) expect(basicAvatarKeys()).toContain(key)
+describe('dealHand', () => {
+    const seeded = (seed: number) => () => (seed = (seed * 9301 + 49297) % 233280) / 233280
+    const unlocked = badgeAvatarKeys(['BUG_WHISPERER'])
+    const isBadge = (key: string | null) => !!key?.startsWith('badge.')
 
-        // the dice deals a different row and never touches the pick
-        const rerolled = offerBasics('basic.sun', 5, seeded(2))
-        expect(rerolled).not.toEqual(row)
-        expect(rerolled).toContain('basic.sun')
+    it('deals the initial first, then seven distinct keys from the pool', () => {
+        const hand = dealHand(null, unlocked, { random: seeded(1) })
+        expect(hand).toHaveLength(8)
+        expect(hand[0]).toBeNull()
+        expect(new Set(hand).size).toBe(8)
+        for (const key of hand.slice(1)) expect(avatarPool(['BUG_WHISPERER'])).toContain(key)
+    })
 
-        // a badge pick is not a basic: five random basics, nothing kept
-        expect(offerBasics('badge.BUG_WHISPERER.beetle', 5, seeded(3))).toHaveLength(5)
-        expect(offerBasics(null, 5, seeded(4))).toHaveLength(5)
+    it('keeps the pick in the hand and always deals at least one earned avatar', () => {
+        for (const pick of ['basic.sun', 'badge.BUG_WHISPERER.beetle']) {
+            const hand = dealHand(pick, unlocked, { random: seeded(2) })
+            expect(hand).toContain(pick)
+            // a worn badge avatar does not count: the guarantee is a second earned card
+            expect(hand.filter((key) => isBadge(key) && key !== pick).length).toBeGreaterThan(0)
+        }
+    })
+
+    it('deals only basics to a user with no badges', () => {
+        const hand = dealHand(null, [], { random: seeded(3) })
+        expect(hand).toHaveLength(8)
+        expect(hand.slice(1).every((key) => key?.startsWith('basic.'))).toBe(true)
+    })
+
+    it('prefers the named badge for the guaranteed card and falls back to any earned one', () => {
+        const both = badgeAvatarKeys(['BUG_WHISPERER', 'OG_2025_10_12'])
+        for (let seed = 1; seed <= 20; seed++) {
+            const hand = dealHand(null, both, { prefer: 'OG_2025_10_12', random: seeded(seed) })
+            expect(hand.some((key) => key?.startsWith('badge.OG_2025_10_12.'))).toBe(true)
+        }
+        // a badge with no art, or one the user does not hold, changes nothing
+        expect(dealHand(null, unlocked, { prefer: 'FIRST_INVITE', random: seeded(4) }).some(isBadge)).toBe(true)
+    })
+
+    it('is deterministic for a seed; the die deals a new hand and never touches the pick', () => {
+        const hand = dealHand('basic.sun', unlocked, { random: seeded(5) })
+        expect(dealHand('basic.sun', unlocked, { random: seeded(5) })).toEqual(hand)
+
+        const rolled = dealHand('basic.sun', unlocked, { random: seeded(6) })
+        expect(rolled).not.toEqual(hand)
+        expect(rolled).toContain('basic.sun')
+        expect(rolled[0]).toBeNull()
     })
 })

--- a/src/components/Avatar/__tests__/avatarPicker.utils.test.ts
+++ b/src/components/Avatar/__tests__/avatarPicker.utils.test.ts
@@ -1,0 +1,21 @@
+import { nextTileIndex } from '../avatarPicker.utils'
+
+// eight tiles in three columns: rows [0 1 2] [3 4 5] [6 7]
+describe('nextTileIndex', () => {
+    it('walks left and right through the whole hand and wraps at the ends', () => {
+        expect(nextTileIndex(3, 1, 8)).toBe(4)
+        expect(nextTileIndex(7, 1, 8)).toBe(0)
+        expect(nextTileIndex(0, -1, 8)).toBe(7)
+    })
+
+    it('keeps its column going up and down, wrapping within the column', () => {
+        expect(nextTileIndex(0, 3, 8)).toBe(3)
+        expect(nextTileIndex(6, 3, 8)).toBe(0)
+        expect(nextTileIndex(7, 3, 8)).toBe(1)
+        expect(nextTileIndex(5, 3, 8)).toBe(2)
+        expect(nextTileIndex(3, -3, 8)).toBe(0)
+        expect(nextTileIndex(0, -3, 8)).toBe(6)
+        expect(nextTileIndex(1, -3, 8)).toBe(7)
+        expect(nextTileIndex(2, -3, 8)).toBe(5)
+    })
+})

--- a/src/components/Avatar/avatar.consts.ts
+++ b/src/components/Avatar/avatar.consts.ts
@@ -1,8 +1,46 @@
-import { parseAsBoolean } from 'nuqs'
+import { parseAsBoolean, parseAsString } from 'nuqs'
 
 /** nuqs URL state of the profile avatar picker (TASK-22142). One source for
  *  the profile page, the badge-earned toast deep link and the fixtures. */
 export const AVATAR_PICKER_PARAM = 'avatarPicker'
+/** Badge code the first hand deals from — set by the badge-earned toast. */
+export const AVATAR_PICKER_BADGE_PARAM = 'badge'
 // clearOnDefault (nuqs 2 default) keeps the URL clean once the drawer closes
-export const avatarPickerParser = parseAsBoolean.withDefault(false)
+export const avatarPickerParsers = {
+    [AVATAR_PICKER_PARAM]: parseAsBoolean.withDefault(false),
+    [AVATAR_PICKER_BADGE_PARAM]: parseAsString,
+}
 export const AVATAR_PICKER_PATH = `/profile?${AVATAR_PICKER_PARAM}=true`
+/** The picker deep link, with the badge the first hand must deal from when given. */
+export const avatarPickerPath = (badgeCode?: string): string =>
+    badgeCode
+        ? `${AVATAR_PICKER_PATH}&${AVATAR_PICKER_BADGE_PARAM}=${encodeURIComponent(badgeCode)}`
+        : AVATAR_PICKER_PATH
+
+/**
+ * Display names of the basic avatars, keyed by slug, for a tile's accessible
+ * name. A UI table on purpose: the slugs predate the art (`frog` draws an
+ * axolotl) and the API-side rename of the slugs is still open.
+ */
+export const AVATAR_CAST: Readonly<Record<string, string>> = {
+    apple: 'Jackpot Cherry',
+    avocado: 'Watermelon Slice',
+    cactus: 'Bold Chili',
+    cloud: 'Grumpy Raincloud',
+    cube: 'Lucky Die',
+    donut: 'Glazed Donut',
+    drop: 'Boba Cup',
+    egg: 'Fortune Cookie',
+    fish: 'Puffy Pufferfish',
+    flower: 'Lucky Ladybug',
+    frog: 'Smiley Axolotl',
+    gem: 'Lucky Horseshoe',
+    ghost: 'Lucky Cat',
+    heart: 'Serene Capybara',
+    leaf: 'Twisted Pretzel',
+    moon: 'Ramen Bowl',
+    mushroom: 'Prickly Hedgehog',
+    planet: 'Sideways Crab',
+    star: 'Wishing Star',
+    sun: 'Bossy Goose',
+}

--- a/src/components/Avatar/avatar.utils.ts
+++ b/src/components/Avatar/avatar.utils.ts
@@ -40,10 +40,9 @@ const DEALT = 7
  * the hand so the selected state is on screen, and the rest is filled from
  * the basics plus the other unlocked badge avatars. Slots 2-8 are shuffled
  * together. Rolling deals again and never changes the pick (Split's
- * semantics: the die changes what is offered, not who you are).
- *
- * The fill pool is the basics first, then the earned avatars — the picker
- * tests pin `Math.random` and rely on that order.
+ * semantics: the die changes what is offered, not who you are). A pick this
+ * bundle's manifest does not know (a lagging native bundle after the API
+ * added a slug) is not dealt: it would render as a second initial tile.
  */
 export function dealHand(
     pick: string | null,
@@ -55,7 +54,7 @@ export function dealHand(
     const preferred = prefer ? earned.filter((key) => key.startsWith(`badge.${prefer}.`)) : []
     const hand: string[] = []
     if (earned.length) hand.push(draw(preferred.length ? [...preferred] : [...earned]))
-    if (pick) hand.push(pick)
+    if (pick && avatarSrc(pick)) hand.push(pick)
     const rest = [...basicAvatarKeys(), ...earned].filter((key) => !hand.includes(key))
     while (hand.length < DEALT && rest.length) hand.push(draw(rest))
     for (let i = hand.length - 1; i > 0; i--) {

--- a/src/components/Avatar/avatar.utils.ts
+++ b/src/components/Avatar/avatar.utils.ts
@@ -29,20 +29,40 @@ export const avatarPool = (heldCodes: readonly string[]): string[] => [
     ...badgeAvatarKeys(heldCodes),
 ]
 
+// slots 2-8 of the hand; slot 1 is the initial and slot 9 is the die
+const DEALT = 7
+
 /**
- * The basics row the picker offers: the current pick if it is a basic, then
- * random basics to fill `n`. The dice rerolls this row and never the pick
- * (Split's semantics: the dice changes what is offered, not who you are).
+ * The hand the picker deals: index 0 is always the initial (null) and never
+ * re-deals, then seven keys. One is guaranteed to be an earned badge avatar
+ * whenever the user holds a badge with art (`prefer` narrows that draw to one
+ * badge, for the badge-earned toast's deep link), the current pick stays in
+ * the hand so the selected state is on screen, and the rest is filled from
+ * the basics plus the other unlocked badge avatars. Slots 2-8 are shuffled
+ * together. Rolling deals again and never changes the pick (Split's
+ * semantics: the die changes what is offered, not who you are).
+ *
+ * The fill pool is the basics first, then the earned avatars — the picker
+ * tests pin `Math.random` and rely on that order.
  */
-export function offerBasics(pick: string | null, n = 5, random: () => number = Math.random): string[] {
-    const basics = basicAvatarKeys()
-    const keep = pick && basics.includes(pick) ? [pick] : []
-    const rest = basics.filter((key) => key !== pick)
-    for (let i = rest.length - 1; i > 0; i--) {
+export function dealHand(
+    pick: string | null,
+    unlocked: readonly string[],
+    { prefer, random = Math.random }: { prefer?: string; random?: () => number } = {}
+): (string | null)[] {
+    const draw = (pool: string[]) => pool.splice(Math.floor(random() * pool.length), 1)[0]
+    const earned = unlocked.filter((key) => key !== pick)
+    const preferred = prefer ? earned.filter((key) => key.startsWith(`badge.${prefer}.`)) : []
+    const hand: string[] = []
+    if (earned.length) hand.push(draw(preferred.length ? [...preferred] : [...earned]))
+    if (pick) hand.push(pick)
+    const rest = [...basicAvatarKeys(), ...earned].filter((key) => !hand.includes(key))
+    while (hand.length < DEALT && rest.length) hand.push(draw(rest))
+    for (let i = hand.length - 1; i > 0; i--) {
         const j = Math.floor(random() * (i + 1))
-        ;[rest[i], rest[j]] = [rest[j], rest[i]]
+        ;[hand[i], hand[j]] = [hand[j], hand[i]]
     }
-    return [...keep, ...rest].slice(0, n)
+    return [null, ...hand]
 }
 
 /** Public path of the avatar art, or null for a key the manifest does not know. */

--- a/src/components/Avatar/avatarPicker.utils.ts
+++ b/src/components/Avatar/avatarPicker.utils.ts
@@ -2,7 +2,12 @@ import type { KeyboardEvent } from 'react'
 
 export const AVATAR_PICKER_COLUMNS = 3
 
-/** One tab stop per radiogroup; arrows move between tiles and wrap. */
+/**
+ * One tab stop per radiogroup; arrows move between tiles and wrap. Left and
+ * right walk the whole hand; up and down stay in their column and wrap within
+ * it, so a hand whose size is not a multiple of the column count (eight tiles
+ * in three columns) never drifts sideways.
+ */
 export function roveAvatarTiles(event: KeyboardEvent<HTMLDivElement>): void {
     const step = {
         ArrowRight: 1,
@@ -15,5 +20,15 @@ export function roveAvatarTiles(event: KeyboardEvent<HTMLDivElement>): void {
     const index = radios.indexOf(document.activeElement as HTMLButtonElement)
     if (index < 0) return
     event.preventDefault()
-    radios[(index + step + radios.length) % radios.length].focus()
+    radios[nextTileIndex(index, step, radios.length)].focus()
+}
+
+/** The index an arrow lands on from `index`, for a grid of AVATAR_PICKER_COLUMNS columns. */
+export function nextTileIndex(index: number, step: number, count: number): number {
+    const cols = AVATAR_PICKER_COLUMNS
+    const next = index + step
+    if (Math.abs(step) === 1) return (next + count) % count
+    if (next >= count) return index % cols
+    if (next < 0) return index + cols * Math.floor((count - 1 - index) / cols)
+    return next
 }

--- a/src/components/Avatar/avatarPicker.utils.ts
+++ b/src/components/Avatar/avatarPicker.utils.ts
@@ -1,6 +1,6 @@
 import type { KeyboardEvent } from 'react'
 
-export const AVATAR_PICKER_COLUMNS = 5
+export const AVATAR_PICKER_COLUMNS = 3
 
 /** One tab stop per radiogroup; arrows move between tiles and wrap. */
 export function roveAvatarTiles(event: KeyboardEvent<HTMLDivElement>): void {

--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -28,7 +28,7 @@ import { useBadgeEarnToast } from '@/components/Badges/useBadgeEarnToast'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { BadgeImage } from '@/components/Badges/BadgeImage'
 import { badgeAvatarKeys } from '@/components/Avatar/avatar.utils'
-import { AVATAR_PICKER_PATH } from '@/components/Avatar/avatar.consts'
+import { avatarPickerPath } from '@/components/Avatar/avatar.consts'
 
 const HOME_PATH = '/home'
 
@@ -84,14 +84,15 @@ export default function BadgeEarnToast() {
         const label = count === 1 ? t('toastSingle', { name: newestName }) : t('toastMultiple', { count })
 
         // A badge that ships avatars (TASK-22142) announces the unlock and
-        // links to the picker. The badge tap keeps its detail view, so these
-        // are two controls.
+        // links to the picker, naming the newest such badge so its art is in
+        // the first hand. The badge tap keeps its detail view, so these are
+        // two controls.
         const avatarCount = badgeAvatarKeys(codes).length
         const chooseAvatar = () => {
             dismiss(toastId)
             liveToastIdRef.current = null
             posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_TAPPED, { count, target: 'avatar_picker' })
-            router.push(AVATAR_PICKER_PATH)
+            router.push(avatarPickerPath(codes.find((code) => badgeAvatarKeys([code]).length > 0)))
         }
 
         toast({

--- a/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
+++ b/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
@@ -128,7 +128,8 @@ describe('BadgeEarnToast', () => {
 
         act(() => fireEvent.click(screen.getByRole('button', { name: /Choose avatar/ })))
         expect(mockDismissToast).toHaveBeenCalledWith('badge-earn:BUG_WHISPERER')
-        expect(mockRouterPush).toHaveBeenCalledWith('/profile?avatarPicker=true')
+        // the badge rides along so the first hand holds its art
+        expect(mockRouterPush).toHaveBeenCalledWith('/profile?avatarPicker=true&badge=BUG_WHISPERER')
         expect(screen.queryByTestId('badge-detail-modal')).not.toBeInTheDocument()
     })
 

--- a/src/components/Global/Icons/Icon.tsx
+++ b/src/components/Global/Icons/Icon.tsx
@@ -29,6 +29,7 @@ import {
     ChevronDown,
     ChevronRight,
     ChevronUp,
+    Dices,
     DollarSign,
     Download,
     ExternalLink,
@@ -102,6 +103,7 @@ export type IconName =
     | 'meter'
     | 'cancel'
     | 'ban'
+    | 'dice'
     | 'download'
     | 'double-check'
     | 'eye'
@@ -286,6 +288,7 @@ const iconComponents: Record<IconName, ComponentType<SVGProps<SVGSVGElement>>> =
     star: (props) => <LucideWrapper Icon={Star} {...props} />,
     'user-plus': (props) => <LucideWrapper Icon={UserPlus} {...props} />,
     copy: (props) => <LucideWrapper Icon={Copy} {...props} />,
+    dice: (props) => <LucideWrapper Icon={Dices} {...props} />,
     cancel: (props) => <LucideWrapper Icon={X} {...props} />,
     ban: (props) => <LucideWrapper Icon={Ban} {...props} />,
     'qr-code': (props) => <LucideWrapper Icon={QrCode} boostKey="qr-code" {...props} />,

--- a/src/components/Global/ShareButton/index.tsx
+++ b/src/components/Global/ShareButton/index.tsx
@@ -18,6 +18,8 @@ type ShareButtonProps = {
     variant?: ButtonVariant
     iconPosition?: 'left' | 'right'
     showIcon?: boolean
+    /** Button shadow; `null` for a share control whose container draws the chrome (the profile pill). */
+    shadowSize?: React.ComponentProps<typeof Button>['shadowSize'] | null
 } & (
     | { url: string; generateUrl?: undefined; generateText?: undefined }
     | { generateUrl: () => Promise<string>; url?: undefined; generateText?: undefined }
@@ -40,6 +42,7 @@ const ShareButton = ({
     variant = 'purple',
     iconPosition = 'left',
     showIcon = true,
+    shadowSize = '4',
 }: ShareButtonProps) => {
     const t = useTranslations('global')
     const toast = useToast()
@@ -128,7 +131,7 @@ const ShareButton = ({
             className={`flex items-center justify-center gap-1 ${className}`}
             onClick={handleShare}
             shadowType="primary"
-            shadowSize="4"
+            shadowSize={shadowSize ?? undefined}
         >
             <span className="flex items-center gap-2">
                 {showIcon && iconPosition === 'left' && <Icon name="share" size={20} />}

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -109,6 +109,8 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         onClick={copyProfileUrl}
                         className={twMerge('flex h-full min-w-0 items-center pl-3', SEGMENT_FOCUS)}
                     >
+                        {/* the url alone reads as a link, not as an action */}
+                        <span className="sr-only">{tGlobal('copyToClipboard.copyProfileLink')}</span>
                         <span className="shrink-0 text-body-l whitespace-nowrap text-foreground-secondary">
                             {profileDomain}
                         </span>

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -1,6 +1,8 @@
 import { Icon } from '@/components/Global/Icons/Icon'
 import ShareButton from '@/components/Global/ShareButton'
+import { useToast } from '@/components/0_Bruddle/Toast'
 import { ANALYTICS_EVENTS, REFERRAL_SOURCES } from '@/constants/analytics.consts'
+import { copyTextToClipboard } from '@/utils/clipboard.utils'
 import { shareableUrl } from '@/utils/url.utils'
 import posthog from 'posthog-js'
 import React, { useEffect, useRef } from 'react'
@@ -13,6 +15,9 @@ import { useAuth } from '@/context/authContext'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 
 const REFERRAL_PILL_PROPS = { source: REFERRAL_SOURCES.PROFILE_HEADER, link_type: 'profile' } as const
+// the pill's segments are plain hit areas: the frame draws the border and the
+// shadow, each segment only keeps the DS focus ring
+const SEGMENT_FOCUS = 'focus-visible:outline-[3px] focus-visible:outline-action-focus'
 
 interface ProfileHeaderProps {
     name: string
@@ -36,6 +41,8 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
 }) => {
     const { user: authenticatedUser } = useAuth()
     const tAvatar = useTranslations('avatar')
+    const tGlobal = useTranslations('global')
+    const toast = useToast()
     // The self-profile verified badge means "this person's ID was confirmed" —
     // NOT "this person has an enabled payment rail." It reads identityVerification
     // (Sumsub-cleared), matching the counterparty badge logic (`isVerified` on
@@ -43,11 +50,20 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
     const { isVerified: selfIsIdentityVerified } = useIdentityVerification()
     const isAuthenticatedUserVerified = selfIsIdentityVerified && authenticatedUser?.user.username === username
     const isSelfProfile = authenticatedUser?.user.username?.toLowerCase() === username.toLowerCase()
-    const ownAvatar = <UserAvatar name={username} avatarKey={authenticatedUser?.user.avatarKey} size="large" />
+    const ownAvatar = (size: 'small' | 'large') => (
+        <UserAvatar name={username} avatarKey={authenticatedUser?.user.avatarKey} size={size} />
+    )
 
     // `shareableUrl` reads the live origin, so preview and staging share
     // themselves — the old BASE_URL import is non-null-asserted with no fallback.
     const profileUrl = shareableUrl(`/${username}`)
+    // the origin half of the pill label, sliced off the shared url so preview
+    // and staging read their own host — the handle is the remainder
+    const profileDomain = profileUrl.replace('https://', '').slice(0, -username.length)
+    const copyProfileUrl = async () => {
+        if (await copyTextToClipboard(profileUrl)) toast.info(tGlobal('shareButton.linkCopied'))
+        else toast.error(tGlobal('copyToClipboard.copyFailed'))
+    }
 
     // Once per continuous visibility, re-armed when the pill hides: the
     // [...recipient] route reuses this component instance across profile
@@ -65,68 +81,94 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
         posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_SHOWN, REFERRAL_PILL_PROPS)
     }, [pillVisible])
 
-    return (
-        <>
-            <div className={twMerge('space-y-2 flex flex-col items-center', className)}>
-                {/* Own profile shows the first letter of the username; someone
-                    else's public profile keeps initials (letters identify others).
-                    The generated face (497ab2a5e) is parked until avatar v2. */}
-                {isSelfProfile ? (
-                    onChangeAvatar ? (
+    // `isSelfProfile` guards wrong attribution: `showShareButton` defaults to
+    // true, so a caller on someone else's profile would share that other handle.
+    // On one's own profile the avatar, the name and the share pill said the
+    // same thing three times — they are one pill now, three hit areas inside
+    // one border, never a button nested in a button: the avatar opens the
+    // picker, the handle copies the link, the share icon shares it.
+    if (pillVisible) {
+        return (
+            <div className={twMerge('flex justify-center', className)}>
+                <div className="flex h-18 max-w-full items-center rounded-round border border-border-default bg-background-default shadow-4">
+                    {onChangeAvatar ? (
                         <button
                             type="button"
                             onClick={onChangeAvatar}
                             aria-label={tAvatar('change')}
-                            className="rounded-full focus-visible:outline-[3px] focus-visible:outline-action-focus"
+                            className={twMerge('flex h-full shrink-0 items-center pl-3', SEGMENT_FOCUS)}
                         >
-                            {ownAvatar}
+                            {ownAvatar('small')}
                         </button>
                     ) : (
-                        ownAvatar
-                    )
-                ) : (
-                    <AvatarWithBadge name={name || username} />
-                )}
-
-                {/* Name — dropped entirely when the caller has no name to show.
-                    On the self profile that is the no-full-name case, where the
-                    row used to fall back to the username and just repeat the
-                    handle the share pill already spells out. Callers without a
-                    pill (public profile, profile edit) always pass a name, so
-                    they keep the row. */}
-                {!!name && (
-                    <div className="flex items-center gap-1">
-                        <VerifiedUserLabel
-                            name={name}
-                            username={username}
-                            isVerified={isVerified}
-                            className="text-heading-s text-foreground-primary"
-                            iconSize={20}
-                            haveSentMoneyToUser={haveSentMoneyToUser}
-                            isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
-                        />
-                    </div>
-                )}
-                {/* `isSelfProfile` guards wrong attribution: `showShareButton`
-                    defaults to true, so a caller on someone else's profile would
-                    share that other handle. */}
-                {pillVisible && (
+                        <span className="flex h-full shrink-0 items-center pl-3">{ownAvatar('small')}</span>
+                    )}
+                    <button
+                        type="button"
+                        onClick={copyProfileUrl}
+                        className={twMerge('flex h-full min-w-0 items-center pl-3', SEGMENT_FOCUS)}
+                    >
+                        <span className="shrink-0 text-body-l whitespace-nowrap text-foreground-secondary">
+                            {profileDomain}
+                        </span>
+                        <span className="truncate text-heading-card text-foreground-primary">{username}</span>
+                        {isVerified && (
+                            <Icon name="check" size={16} className="ml-1 shrink-0 text-green-500" aria-hidden />
+                        )}
+                    </button>
                     <ShareButton
                         url={profileUrl}
                         title=""
-                        variant="primary-soft"
-                        showIcon={false}
+                        variant="transparent"
                         onSuccess={() => posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, REFERRAL_PILL_PROPS)}
-                        className="h-10 w-fit rounded-full py-3 pr-4 pl-6"
+                        className="h-full w-auto shrink-0 pr-6 pl-4 shadow-none active:translate-x-0 active:translate-y-0"
                     >
-                        <div className="text-label-l">{profileUrl.replace('https://', '')}</div>
-                        <div className="-ml-2">
-                            <Icon name="share" size={16} fill="black" />
-                        </div>
+                        <span className="sr-only">{tGlobal('shareButton.share')}</span>
                     </ShareButton>
-                )}
+                </div>
             </div>
-        </>
+        )
+    }
+
+    return (
+        <div className={twMerge('space-y-2 flex flex-col items-center', className)}>
+            {/* Own profile shows the first letter of the username; someone
+                else's public profile keeps initials (letters identify others).
+                The generated face (497ab2a5e) is parked until avatar v2. */}
+            {isSelfProfile ? (
+                onChangeAvatar ? (
+                    <button
+                        type="button"
+                        onClick={onChangeAvatar}
+                        aria-label={tAvatar('change')}
+                        className={twMerge('rounded-full', SEGMENT_FOCUS)}
+                    >
+                        {ownAvatar('large')}
+                    </button>
+                ) : (
+                    ownAvatar('large')
+                )
+            ) : (
+                <AvatarWithBadge name={name || username} />
+            )}
+
+            {/* Name — dropped entirely when the caller has no name to show.
+                Callers without a pill (public profile, profile edit) always
+                pass a name, so they keep the row. */}
+            {!!name && (
+                <div className="flex items-center gap-1">
+                    <VerifiedUserLabel
+                        name={name}
+                        username={username}
+                        isVerified={isVerified}
+                        className="text-heading-s text-foreground-primary"
+                        iconSize={20}
+                        haveSentMoneyToUser={haveSentMoneyToUser}
+                        isAuthenticatedUserVerified={isAuthenticatedUserVerified && isSelfProfile} // can be true only for self profile
+                    />
+                </div>
+            )}
+        </div>
     )
 }
 

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -42,6 +42,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
     const { user: authenticatedUser } = useAuth()
     const tAvatar = useTranslations('avatar')
     const tGlobal = useTranslations('global')
+    const tKyc = useTranslations('kyc')
     const toast = useToast()
     // The self-profile verified badge means "this person's ID was confirmed" —
     // NOT "this person has an enabled payment rail." It reads identityVerification
@@ -113,15 +114,20 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         </span>
                         <span className="truncate text-heading-card text-foreground-primary">{username}</span>
                         {isVerified && (
-                            <Icon name="check" size={16} className="ml-1 shrink-0 text-green-500" aria-hidden />
+                            <>
+                                <Icon name="check" size={16} className="ml-1 shrink-0 text-green-500" aria-hidden />
+                                <span className="sr-only">{tKyc('verified')}</span>
+                            </>
                         )}
                     </button>
+                    {/* the frame draws the chrome: no shadow of its own, no press translate */}
                     <ShareButton
                         url={profileUrl}
                         title=""
                         variant="transparent"
+                        shadowSize={null}
                         onSuccess={() => posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, REFERRAL_PILL_PROPS)}
-                        className="h-full w-auto shrink-0 pr-6 pl-4 shadow-none active:translate-x-0 active:translate-y-0"
+                        className="h-full w-auto shrink-0 pr-6 pl-4 active:translate-x-0 active:translate-y-0"
                     >
                         <span className="sr-only">{tGlobal('shareButton.share')}</span>
                     </ShareButton>

--- a/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
+++ b/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
@@ -57,7 +57,7 @@ afterAll(() => {
 })
 
 // the pill's three hit areas: the handle copies, the share icon shares, the avatar opens the picker
-const copyButton = () => screen.queryByRole('button', { name: /^peanut\.example\.org\/\s*satoshi$/ })
+const copyButton = () => screen.queryByRole('button', { name: /^Copy profile link peanut\.example\.org\/\s*satoshi$/ })
 const shareButton = () => screen.queryByRole('button', { name: 'Share' })
 
 describe('ProfileHeader pill', () => {
@@ -152,6 +152,16 @@ describe('ProfileHeader pill', () => {
             source: REFERRAL_SOURCES.PROFILE_HEADER,
             link_type: 'profile',
         })
+    })
+
+    // Chip (#2989): the url alone reads as a link, so the segment has to say
+    // what activating it does — and keep saying the url, and the verified state.
+    it('names the copy action, the url and the verified state in the accessible name', () => {
+        renderWithIntl(<ProfileHeader name="Satoshi" username="satoshi" showShareButton isVerified />)
+
+        expect(
+            screen.getByRole('button', { name: /^Copy profile link peanut\.example\.org\/\s*satoshi Verified$/ })
+        ).toBeInTheDocument()
     })
 
     // One border, three hit areas. Nesting the picker inside the share or the

--- a/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
+++ b/src/components/Profile/components/__tests__/ProfileHeader.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import posthog from 'posthog-js'
 import ProfileHeader from '../ProfileHeader'
@@ -7,6 +7,9 @@ import { renderWithIntl } from '@/test-utils/intl'
 
 let mockAuthUsername: string | undefined
 const mockShareButton = jest.fn()
+const mockCopy = jest.fn()
+const mockToastInfo = jest.fn()
+const mockToastError = jest.fn()
 
 jest.mock('@/context/authContext', () => ({
     useAuth: () => ({ user: mockAuthUsername ? { user: { username: mockAuthUsername } } : null }),
@@ -23,9 +26,12 @@ jest.mock('@/components/Global/ShareButton', () => ({
         return <button onClick={props.onSuccess}>{props.children}</button>
     },
 }))
+jest.mock('@/utils/clipboard.utils', () => ({ copyTextToClipboard: (...args: unknown[]) => mockCopy(...args) }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({
+    useToast: () => ({ info: mockToastInfo, error: mockToastError }),
+}))
 jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
 jest.mock('@/components/Profile/AvatarWithBadge', () => ({ __esModule: true, default: () => null }))
-jest.mock('@/components/Global/CopyToClipboard', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/UserHeader', () => ({
     VerifiedUserLabel: ({ name }: { name: string }) => <span data-testid="profile-name">{name}</span>,
 }))
@@ -43,15 +49,18 @@ beforeAll(() => {
 beforeEach(() => {
     jest.clearAllMocks()
     mockAuthUsername = 'satoshi'
+    mockCopy.mockResolvedValue(true)
 })
 
 afterAll(() => {
     Object.defineProperty(window, 'location', { value: originalLocation, writable: true })
 })
 
-const sharePill = () => screen.queryByRole('button', { name: 'peanut.example.org/satoshi' })
+// the pill's three hit areas: the handle copies, the share icon shares, the avatar opens the picker
+const copyButton = () => screen.queryByRole('button', { name: /^peanut\.example\.org\/\s*satoshi$/ })
+const shareButton = () => screen.queryByRole('button', { name: 'Share' })
 
-describe('ProfileHeader share pill', () => {
+describe('ProfileHeader pill', () => {
     // Wrong-attribution guard: `showShareButton` defaults to true, so a caller
     // on someone else's profile would otherwise hand out that other handle. The
     // unresolved case would show `peanut.me/anonymous`.
@@ -65,8 +74,10 @@ describe('ProfileHeader share pill', () => {
             mockAuthUsername = authUsername
             renderWithIntl(<ProfileHeader name="Satoshi" username={profileUsername} showShareButton />)
 
-            if (visible) expect(sharePill()).toBeInTheDocument()
-            else expect(screen.queryByRole('button')).not.toBeInTheDocument()
+            if (visible) {
+                expect(copyButton()).toBeInTheDocument()
+                expect(shareButton()).toBeInTheDocument()
+            } else expect(screen.queryByRole('button')).not.toBeInTheDocument()
         }
     )
 
@@ -91,19 +102,42 @@ describe('ProfileHeader share pill', () => {
         expect(shownCalls()).toHaveLength(2)
     })
 
-    // With no full name the row used to fall back to the username, printing the
-    // handle twice on a page whose pill already reads peanut.example.org/satoshi.
-    it('drops the name row when the caller has no name to show, keeping the pill', () => {
-        renderWithIntl(<ProfileHeader name="" username="satoshi" showShareButton />)
+    // You already know your own name: the pill spells out the handle and the
+    // full name lives one tap away in personal details.
+    it('shows the handle and never the full name on the self profile', () => {
+        renderWithIntl(<ProfileHeader name="Satoshi Nakamoto" username="satoshi" showShareButton />)
 
+        expect(copyButton()).toHaveTextContent('peanut.example.org/satoshi')
         expect(screen.queryByTestId('profile-name')).not.toBeInTheDocument()
-        expect(sharePill()).toBeInTheDocument()
+        expect(screen.queryByText('Satoshi Nakamoto')).not.toBeInTheDocument()
     })
 
-    it('keeps the name row when a full name is set', () => {
+    it('keeps the stacked header with the name row on someone else profile', () => {
+        mockAuthUsername = 'hal'
         renderWithIntl(<ProfileHeader name="Satoshi Nakamoto" username="satoshi" showShareButton />)
 
         expect(screen.getByTestId('profile-name')).toHaveTextContent('Satoshi Nakamoto')
+        expect(copyButton()).not.toBeInTheDocument()
+    })
+
+    it('copies the profile url from the handle and says so, without counting a share', async () => {
+        renderWithIntl(<ProfileHeader name="Satoshi" username="satoshi" showShareButton />)
+
+        fireEvent.click(copyButton()!)
+
+        expect(mockCopy).toHaveBeenCalledWith(`${ORIGIN}/satoshi`)
+        await waitFor(() => expect(mockToastInfo).toHaveBeenCalledWith('Link copied'))
+        expect(posthog.capture).not.toHaveBeenCalledWith(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, expect.anything())
+    })
+
+    it('says so when the copy fails', async () => {
+        mockCopy.mockResolvedValue(false)
+        renderWithIntl(<ProfileHeader name="Satoshi" username="satoshi" showShareButton />)
+
+        fireEvent.click(copyButton()!)
+
+        await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('Copy failed'))
+        expect(mockToastInfo).not.toHaveBeenCalled()
     })
 
     it('shares the profile url and captures the click only on a successful share', () => {
@@ -112,11 +146,30 @@ describe('ProfileHeader share pill', () => {
         expect(mockShareButton).toHaveBeenCalledWith(expect.objectContaining({ url: `${ORIGIN}/satoshi` }))
         expect(posthog.capture).not.toHaveBeenCalledWith(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, expect.anything())
 
-        fireEvent.click(sharePill()!)
+        fireEvent.click(shareButton()!)
 
         expect(posthog.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, {
             source: REFERRAL_SOURCES.PROFILE_HEADER,
             link_type: 'profile',
         })
+    })
+
+    // One border, three hit areas. Nesting the picker inside the share or the
+    // copy button would be invalid html and would hand the avatar's tap away.
+    it('keeps the avatar picker beside the copy and share buttons, not inside them', () => {
+        const onChangeAvatar = jest.fn()
+        renderWithIntl(
+            <ProfileHeader name="Satoshi" username="satoshi" showShareButton onChangeAvatar={onChangeAvatar} />
+        )
+
+        const picker = screen.getByRole('button', { name: 'Change avatar' })
+        expect(copyButton()!.contains(picker)).toBe(false)
+        expect(shareButton()!.contains(picker)).toBe(false)
+
+        fireEvent.click(picker)
+
+        expect(onChangeAvatar).toHaveBeenCalledTimes(1)
+        expect(mockCopy).not.toHaveBeenCalled()
+        expect(posthog.capture).not.toHaveBeenCalledWith(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, expect.anything())
     })
 })

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -18,9 +18,9 @@ import { useCardSurfaceAccess } from '@/hooks/useCardSurfaceAccess'
 import InviteFriendsModal from '../Global/InviteFriendsModal'
 import STAR_STRAIGHT_ICON from '@/assets/icons/starStraight.svg'
 import Image from 'next/image'
-import { useQueryState } from 'nuqs'
+import { useQueryStates } from 'nuqs'
 import { AvatarPicker } from '@/components/Avatar/AvatarPicker'
-import { AVATAR_PICKER_PARAM, avatarPickerParser } from '@/components/Avatar/avatar.consts'
+import { avatarPickerParsers } from '@/components/Avatar/avatar.consts'
 import { useOtaUpdate } from '@/context/OtaUpdateContext'
 import OtaUpdateModal from './components/OtaUpdateModal'
 import { openStore } from '@/utils/migration.utils'
@@ -30,8 +30,10 @@ import { isIOSNative } from '@/utils/capacitor'
 export const Profile = () => {
     const { logoutUser, isLoggingOut, user } = useAuth()
     const [isInviteFriendsModalOpen, setIsInviteFriendsModalOpen] = useState(false)
-    // URL state so the badge-earned toast can deep-link straight into the picker
-    const [avatarPickerOpen, setAvatarPickerOpen] = useQueryState(AVATAR_PICKER_PARAM, avatarPickerParser)
+    // URL state so the badge-earned toast can deep-link straight into the
+    // picker, naming the badge whose art the first hand must hold
+    const [{ avatarPicker: avatarPickerOpen, badge: preferredBadge }, setAvatarPickerState] =
+        useQueryStates(avatarPickerParsers)
     const router = useRouter()
     const onBack = useSafeBack('/home')
     // Profile "verified" reflects identity verification only (the human was ID-verified) — NOT
@@ -75,9 +77,16 @@ export const Profile = () => {
                     name={displayName}
                     username={username}
                     isVerified={isUserSumsubKycApproved}
-                    onChangeAvatar={() => setAvatarPickerOpen(true)}
+                    onChangeAvatar={() => setAvatarPickerState({ avatarPicker: true })}
                 />
-                <AvatarPicker open={avatarPickerOpen} onOpenChange={setAvatarPickerOpen} />
+                <AvatarPicker
+                    open={avatarPickerOpen}
+                    prefer={preferredBadge ?? undefined}
+                    // closing also drops the toast's badge, so a reopen deals a plain hand
+                    onOpenChange={(open) =>
+                        setAvatarPickerState(open ? { avatarPicker: true } : { avatarPicker: false, badge: null })
+                    }
+                />
                 <div className="space-y-4">
                     {/* IA from #2834: identity/products first, then social +
                         account, then app settings. Payment limits moved inline

--- a/src/dev/fixtures/registry.ts
+++ b/src/dev/fixtures/registry.ts
@@ -370,7 +370,7 @@ export const FIXTURES: Record<string, Fixture> = {
     },
     'avatar-picker': {
         route: AVATAR_PICKER_PATH,
-        about: 'Avatar picker open: three Bug Whisperer avatars unlocked above the twenty basics, beetle selected.',
+        about: 'Avatar picker open: a hand of eight with the initial first and a Bug Whisperer avatar guaranteed, beetle selected.',
         responses: {
             'GET /users/me': {
                 user: {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3647,13 +3647,9 @@
     },
     "avatar": {
         "title": "Your avatar",
-        "description": "Pick one, or roll the dice for a fresh row of basics.",
-        "fromBadges": "From your badges",
-        "basics": "Basics",
-        "unlocked": "{count} unlocked",
-        "noBadgeAvatars": "Earn a badge and its avatars appear here.",
-        "rollDice": "Roll the dice",
-        "useInitial": "Use my initial instead",
+        "initial": "Your initial",
+        "earned": "Earned",
+        "rollDie": "Roll the die",
         "change": "Change avatar",
         "saveFailed": "Could not save your avatar. Try again."
     }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3315,6 +3315,7 @@
         },
         "copyToClipboard": {
             "copyCode": "Copy code",
+            "copyProfileLink": "Copy profile link",
             "copyFailed": "Copy failed"
         },
         "copyField": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3647,13 +3647,9 @@
     },
     "avatar": {
         "title": "Tu avatar",
-        "description": "Elige uno o tira los dados para ver otros básicos.",
-        "fromBadges": "De tus insignias",
-        "basics": "Básicos",
-        "unlocked": "{count} desbloqueados",
-        "noBadgeAvatars": "Gana una insignia y sus avatares aparecen aquí.",
-        "rollDice": "Tirar los dados",
-        "useInitial": "Usar mi inicial",
+        "initial": "Tu inicial",
+        "earned": "Ganado",
+        "rollDie": "Tirar el dado",
         "change": "Cambiar avatar",
         "saveFailed": "No pudimos guardar tu avatar. Inténtalo de nuevo."
     }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3315,6 +3315,7 @@
         },
         "copyToClipboard": {
             "copyCode": "Copiar código",
+            "copyProfileLink": "Copiar enlace del perfil",
             "copyFailed": "No se pudo copiar"
         },
         "copyField": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3647,13 +3647,9 @@
     },
     "avatar": {
         "title": "Seu avatar",
-        "description": "Escolha um ou jogue os dados para ver outros básicos.",
-        "fromBadges": "Dos seus selos",
-        "basics": "Básicos",
-        "unlocked": "{count} desbloqueados",
-        "noBadgeAvatars": "Ganhe um selo e seus avatares aparecem aqui.",
-        "rollDice": "Jogar os dados",
-        "useInitial": "Usar minha inicial",
+        "initial": "Sua inicial",
+        "earned": "Conquistado",
+        "rollDie": "Jogar o dado",
         "change": "Trocar avatar",
         "saveFailed": "Não foi possível salvar seu avatar. Tente de novo."
     }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3315,6 +3315,7 @@
         },
         "copyToClipboard": {
             "copyCode": "Copiar código",
+            "copyProfileLink": "Copiar link do perfil",
             "copyFailed": "Não foi possível copiar"
         },
         "copyField": {


### PR DESCRIPTION
## Summary

Follow-up to #2929, from the "Avatar Hand" design (https://claude.ai/code/artifact/8e3ad40a-544f-48e7-ab5b-88e227b5320b). Three things the shipped v2 got wrong, fixed:

- **Self profile → one pill.** The avatar, the own name row and the share pill said the same thing three times. They are one 72px pill now, three hit areas inside one border and never a button nested in a button: the avatar opens the picker, the handle copies `peanut.me/<handle>` ("Link copied" toast), the share icon runs the existing `ShareButton` flow. Public profiles and the edit screen keep the stacked header.
- **Picker → a hand of eight.** No title, no description, no buttons. One 3×3 grid: slot 1 is always the user's initial, slots 2–8 are dealt by `dealHand` (at least one earned badge avatar when the user holds a badge with art, the current pick kept, the rest from the basics), slot 9 is the die. A tap saves at once (the serialized-save logic from #2929 is unchanged); rolling deals again and never changes the pick. "Use my initial" is now tile 1, not a button. Earned avatars carry a yellow border and an "Earned" chip.
- **Toast deep link carries the badge.** "Choose avatar" opens `/profile?avatarPicker=true&badge=CODE`, so the first hand is guaranteed to hold the new badge's art. Closing the drawer clears both params.

No API change: the pool the server validates a pick against is the same 20 basics plus what the user's badges unlock.

## Task

TASK-22142 — https://app.notion.com/p/peanutprotocol/Build-badge-linked-avatar-system-v2-3cf83811757981efa8afecf6667d2662

## Risks / breaking changes

- Behaviour change on the self profile only: the full name no longer renders in the header (it lives in Personal details); `REFERRAL_CTA_CLICKED` now fires on the share segment only — copy taps are not counted (impressions unchanged).
- `ShareButton` gains an optional `shadowSize` (default `'4'`, unchanged for every existing caller); the pill passes `null` so its ghost share segment draws no shadow of its own instead of covering the shadow class from the call site.
- Review fixes on the head (`/code-review high`): the "Earned" chip no longer overlaps the sticker (XL band above the art), arrow keys stay in their column in the 3-wide hand, a pick this bundle's manifest does not know is not dealt, the verified tick has an sr-only name. Not changed on purpose: the die inside the radiogroup (moving it out needs `display: contents`, which has its own screen-reader history), the alternating spin direction, and Chip's two minor threads.
- The API half (#1510) is on `main`; against an API without it the pill shows the initial and a pick fails with the friendly toast (same as #2929). Staging needs api#1519 (dev sync).
- i18n: `avatar.{initial,earned,rollDie}` added, seven keys dropped, mirrored in es-419 / pt-BR (translations are mine — native check welcome).

## Design — flagged, not changed (design.md "building or migrating a screen")

The artifact was written in raw px/hex; each value is snapped to the DS scale:

| Artifact | Built | Why |
|---|---|---|
| handle 17px/800, domain 17px/500 grey | `text-heading-card` + `text-body-l text-foreground-secondary` | 17px is off the type scale; never stack a weight on a token |
| pill `rounded-full bg-white border-black btn-shadow-primary-4` | `rounded-round bg-background-default border-border-default shadow-4` | semantic tokens only; 72px (`h-18`) is not a DS height — flagged |
| spacing 14 / 9 / 18 | 12 / 4 / 16 | spacing scale |
| share icon 18 | 20 | icon steps 16/20/24 |
| verified check `text-success-1` | `text-green-500` (what `VerifiedUserLabel` uses) | `success-1` is legacy palette (ratchet at 0); no semantic success foreground token exists — owed |
| earned fill `#FFF6CC` + 16px yellow bordered "Earned" pill, 8.5px caps | `border-action-secondary` (precedent: BadgeEarnToast) + `StatusBadge status="custom"` (Label/M) | no hex; no yellow tint token (`secondary-4` is legacy); 8.5px is below the 12px floor; "don't: custom colored pills with raw classes" |
| tile 100px tall | `p-4` + 64px sticker = 96px | off-scale height |
| roll tile dashed 1.5px, 36px die | `border border-dashed border-border-default`, `<Icon name="dice" size={24}>` | dashed has one precedent (receipt dividers) — flagged; new registry entry `dice` → lucide `Dices` |
| die spins a full turn (0.5s bezier) | class parity `rotate-360`/`rotate-0` + `motion-safe:duration-slow ease-spring` | motion tokens + reduced motion; an inline `style` would raise the `inlineStyle` ratchet (direction alternates per tap — accepted) |
| deal-in flip animation (mock CSS only) | skipped | decorative, not in the spec text |
| tile aria-labels from a cast table | `AVATAR_CAST` (slug → name), English like today's slug labels | the API-side slug rename is still open |

`scripts/ds-lint-counts.mjs --check` is green (two counts went down).

## QA

- Fixtures (no backend): `/profile?__fixture=profile` (the pill), `/profile?avatarPicker=true&__fixture=avatar-picker` (the hand, beetle selected, three Bug Whisperer tiles marked "Earned"), `/profile?avatarPicker=true&badge=BUG_WHISPERER&__fixture=avatar-picker` (deep link), `/home?__fixture=home-avatar` (unchanged). ds-shots diffs them per push.
- Sandbox: tap a basic, tap the initial, roll (die spins, pick stays), tap the handle (toast), tap the share icon, tap a badge tile without the badge (API 400 → toast + snap back).
- Tests: `dealHand` (length, initial first, pick kept, guarantee, prefer, seeded determinism), `AvatarPicker` (hand + earned chips, no-badge hand, deep-link prefer, save/snap-back/serialized saves, die, initial), `ProfileHeader` (visibility, impression, handle vs name, copy + toast, share capture, picker beside both buttons), `BadgeEarnToast` (deep link with badge). Full suite 465/465, typecheck, prettier, ds-lint ratchet all green locally.

## Screenshots

375 wide, fixtures (no backend), this head. Assets live on the `pr-assets-2989` branch, deleted after merge. ds-shots visual diff on the head commit: see the sticky comment on this PR.

| State | Shot |
| --- | --- |
| Self profile: the pill — avatar (opens the picker), `peanut.me/handle` + verified check (copies the link), share icon (share flow). `?__fixture=profile` | ![profile pill](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2989/profile-pill.png) |
| The hand: initial first, seven dealt, Bug Whisperer avatars marked "Earned", beetle selected, the die ninth. `?avatarPicker=true&__fixture=avatar-picker` | ![avatar hand](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-2989/avatar-hand.png) |

