### PR TITLE
fix: review follow-ups — ds-lint font-(--x) weight, SupportDrawer hardware back, landing Log in link, claim receipt cancelledAt

### DIFF
--- a/scripts/__tests__/ds-lint-rules.test.ts
+++ b/scripts/__tests__/ds-lint-rules.test.ts
@@ -117,10 +117,12 @@ describe('fontWeightOnTypeToken (countWeightStacks)', () => {
             'font-[650.5]',
             'font-(weight:--my-weight)',
             'font-[weight:var(--my-font-weight)]',
+            // untyped custom property = font-weight in tailwind 4
+            'font-(--my-weight)',
         ]) {
             expect(countWeightStacks(`<p className="text-body-s ${w}" />`)).toBe(1)
         }
-        for (const notWeight of ['font-sans', 'font-roboto', 'font-(--brand-face)', 'font-blackout']) {
+        for (const notWeight of ['font-sans', 'font-roboto', 'font-(family-name:--brand-face)', 'font-blackout']) {
             expect(countWeightStacks(`<p className="text-body-s ${notWeight}" />`)).toBe(0)
         }
     })

--- a/scripts/ds-lint-rules.cjs
+++ b/scripts/ds-lint-rules.cjs
@@ -49,10 +49,11 @@ function countOffScaleSpacing(text) {
 // per-line pass over the remaining text.
 // stock weight names + the theme's own extraBlack (globals.css
 // --font-weight-extraBlack, registered in tw.ts) + arbitrary numeric brackets
-// (decimals included) + the font-(weight:…) custom-property form. bare
-// font-(--x) is a font-FAMILY custom property, not a weight — excluded.
+// (decimals included) + the font-(weight:…) and bare font-(--x) custom-property
+// forms: tailwind 4 compiles an untyped font-(--x) as font-WEIGHT, and a family
+// needs the family-name: hint, so only that typed form is excluded.
 const WEIGHT_STACK_RE =
-    /\bfont-(?:thin|extralight|light|normal|medium|semibold|extrabold|extraBlack|bold|black|\[[0-9]+(?:\.[0-9]+)?\]|\[weight:[^\]]+\]|\(weight:[^)]+\))(?![a-zA-Z0-9-])/
+    /\bfont-(?:thin|extralight|light|normal|medium|semibold|extrabold|extraBlack|bold|black|\[[0-9]+(?:\.[0-9]+)?\]|\[weight:[^\]]+\]|\(weight:[^)]+\)|\(--[^)]+\))(?![a-zA-Z0-9-])/
 const TYPE_TOKEN_RE = /\btext-(?:body|heading|label|button)-[a-z-]+\b/
 
 function classNameExpressions(text) {

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -165,6 +165,9 @@ export const Claim = ({}) => {
 
         // find the claimed event for timestamp
         const claimedEvent = claimLinkData.events?.find((e) => e.status === 'CLAIMED')
+        // the sender's cancel/reclaim stamp; the events fallback only carries a
+        // date when a claim attempt was recorded against the link
+        const cancelledStamp = claimLinkData.cancelledAt ?? claimLinkData.events?.[0]?.timestamp
 
         let details: Partial<TransactionDetails> = {
             id: claimLinkData.pubKey,
@@ -179,10 +182,7 @@ export const Claim = ({}) => {
             initials: getInitialsFromName(recipientName),
             memo: claimLinkData.textContent,
             attachmentUrl: claimLinkData.fileUrl,
-            cancelledDate:
-                status === 'cancelled' && claimLinkData.events?.[0]
-                    ? new Date(claimLinkData.events[0].timestamp)
-                    : undefined,
+            cancelledDate: status === 'cancelled' && cancelledStamp ? new Date(cancelledStamp) : undefined,
             txHash: claimLinkData.claim?.txHash,
             extraDataForDrawer: {
                 isLinkTransaction: true,

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -418,7 +418,8 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
 
     // A sender's cancel/reclaim leaves no SEND_LINK_CLAIM intent behind, so the
     // `events` fallback is empty and the receipt used to show no cancellation
-    // date at all; GET /send-links now carries the row's own cancelledAt.
+    // date at all. GET /send-links carries the row's own cancelledAt as of
+    // peanut-api-ts#1525; until that ships the fallback keeps today's behaviour.
     test('CANCELLED receipt shows the cancellation date from cancelledAt', async () => {
         mockUseAuth.mockReturnValue({
             user: { user: { userId: 'sender-123' } },

--- a/src/components/Claim/__tests__/claim-states.test.tsx
+++ b/src/components/Claim/__tests__/claim-states.test.tsx
@@ -165,8 +165,9 @@ jest.mock('@/components/TransactionDetails/transactionTransformer', () => ({
     REWARD_TOKENS: {},
 }))
 
+const mockReceipt = jest.fn((_props: any) => <div data-testid="transaction-details-receipt">Receipt</div>)
 jest.mock('@/components/TransactionDetails/TransactionDetailsReceipt', () => ({
-    TransactionDetailsReceipt: (_props: any) => <div data-testid="transaction-details-receipt">Receipt</div>,
+    TransactionDetailsReceipt: (props: any) => mockReceipt(props),
 }))
 
 jest.mock('@/context/ModalsContext', () => ({
@@ -413,6 +414,32 @@ describe('GROUP 3: Already Claimed / Cancelled', () => {
         await waitFor(() => {
             expect(screen.getByTestId('transaction-details-receipt')).toBeInTheDocument()
         })
+    })
+
+    // A sender's cancel/reclaim leaves no SEND_LINK_CLAIM intent behind, so the
+    // `events` fallback is empty and the receipt used to show no cancellation
+    // date at all; GET /send-links now carries the row's own cancelledAt.
+    test('CANCELLED receipt shows the cancellation date from cancelledAt', async () => {
+        mockUseAuth.mockReturnValue({
+            user: { user: { userId: 'sender-123' } },
+            isFetchingUser: false,
+            fetchUser: jest.fn(),
+        })
+        mockSendLinksApi.get.mockResolvedValue(
+            makeSendLink({
+                status: 'CANCELLED',
+                cancelledAt: '2026-04-20T12:00:00.000Z',
+                sender: { userId: 'sender-123', username: 'alice' },
+            })
+        )
+
+        renderClaim()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('transaction-details-receipt')).toBeInTheDocument()
+        })
+        const { transaction } = mockReceipt.mock.calls.at(-1)![0]
+        expect(transaction.cancelledDate).toEqual(new Date('2026-04-20T12:00:00.000Z'))
     })
 
     test('CLAIMING link (in progress) shows as already claimed', async () => {

--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -19,6 +19,7 @@ import { IntlWrapper } from '@/test-utils/intl'
 import SupportDrawer from '../index'
 import { isCapacitor } from '@/utils/capacitor'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
+import { dispatchBackPress, resetBackHandlersForTests } from '@/utils/back-handler'
 
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
@@ -40,10 +41,11 @@ const modalsState: { supportPrefilledMessage: string | undefined; isSupportModal
     supportPrefilledMessage: undefined,
     isSupportModalOpen: true,
 }
+const mockSetIsSupportModalOpen = jest.fn()
 jest.mock('@/context/ModalsContext', () => ({
     useModalsContext: () => ({
         isSupportModalOpen: modalsState.isSupportModalOpen,
-        setIsSupportModalOpen: jest.fn(),
+        setIsSupportModalOpen: mockSetIsSupportModalOpen,
         supportPrefilledMessage: modalsState.supportPrefilledMessage,
     }),
 }))
@@ -669,5 +671,44 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
 
         expect(nativeCrisp.openMessenger).not.toHaveBeenCalled()
         expect(nativeCrisp.sendMessage).not.toHaveBeenCalled()
+    })
+})
+
+// The hand-rolled overlay was left off the LIFO back stack PR #2920 gave the DS
+// Drawer and Modal, so Android back with the sheet open navigated the page
+// underneath instead of closing the sheet.
+describe('SupportDrawer — Android hardware back', () => {
+    beforeEach(() => {
+        mockUseCrispUserData.mockReset().mockReturnValue({})
+        mockUseCrispTokenId.mockReset().mockReturnValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
+        mockSetIsSupportModalOpen.mockReset()
+        resetBackHandlersForTests()
+    })
+
+    it('closes the sheet and consumes the press while open', () => {
+        modalsState.isSupportModalOpen = true
+        render(<SupportDrawer />)
+
+        let consumed = false
+        act(() => {
+            consumed = dispatchBackPress()
+        })
+
+        expect(consumed).toBe(true)
+        expect(mockSetIsSupportModalOpen).toHaveBeenCalledWith(false)
+    })
+
+    it('leaves the press to the page while closed', () => {
+        modalsState.isSupportModalOpen = false
+        render(<SupportDrawer />)
+
+        let consumed = true
+        act(() => {
+            consumed = dispatchBackPress()
+        })
+
+        expect(consumed).toBe(false)
+        expect(mockSetIsSupportModalOpen).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -6,6 +6,7 @@ import { useModalsContext } from '@/context/ModalsContext'
 import { useCrispUserData } from '@/hooks/useCrispUserData'
 import { useCrispTokenId } from '@/hooks/useCrispTokenId'
 import { useVisualViewport } from '@/hooks/useVisualViewport'
+import { useBackHandler } from '@/hooks/useBackHandler'
 import Loading from '../Loading'
 import { Button } from '@/components/0_Bruddle/Button'
 import {
@@ -388,6 +389,14 @@ const SupportDrawer = () => {
         window.addEventListener('message', handleMessage)
         return () => window.removeEventListener('message', handleMessage)
     }, [])
+
+    // Android hardware back closes the sheet instead of navigating the page
+    // underneath. Hand-rolled overlay, so it registers itself (the DS Drawer
+    // and Modal do this internally).
+    useBackHandler(() => {
+        setIsSupportModalOpen(false)
+        return true
+    }, isSupportModalOpen)
 
     // close on escape
     useEffect(() => {

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -93,11 +93,24 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
                             </Button>
                         </a>
                     ) : (
-                        <Link prefetch={false} href="/setup" className="pointer-events-auto block">
-                            <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
-                                {strings.signUpNow}
-                            </Button>
-                        </Link>
+                        <div className="pointer-events-auto flex items-center gap-4">
+                            <Link prefetch={false} href="/setup" className="block flex-1">
+                                <Button
+                                    variant="purple"
+                                    shadowSize="4"
+                                    className="w-full py-3 text-base font-extrabold"
+                                >
+                                    {strings.signUpNow}
+                                </Button>
+                            </Link>
+                            <Link
+                                prefetch={false}
+                                href="/setup?step=login"
+                                className="shrink-0 text-body-s text-n-1 underline"
+                            >
+                                {strings.logIn}
+                            </Link>
+                        </div>
                     )}
                 </div>
             }

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -240,6 +240,16 @@ export function Hero({
                 </span>
                 {primaryCta ? renderCTAButton(primaryCta, 'primary') : customCta ? renderCustomCta() : null}
                 {secondaryCta && renderCTAButton(secondaryCta, 'secondary')}
+                {/* Returning users with an expired session had no way back in from the
+                    marketing site: every CTA pointed at signup. `?step=login` lands on
+                    the passkey Log In step (setup-entry.ts). */}
+                <Link
+                    prefetch={false}
+                    href="/setup?step=login"
+                    className="mt-4 block text-center text-body-s text-n-1 underline"
+                >
+                    {strings.logIn}
+                </Link>
                 <AnimateOnView
                     className="absolute bottom-[-4%] left-[1%] w-8 sm:bottom-[11%] sm:left-[12%] md:bottom-[18%] md:left-[5%] md:w-12"
                     y="20px"

--- a/src/components/LandingPage/landingStrings.ts
+++ b/src/components/LandingPage/landingStrings.ts
@@ -6,6 +6,7 @@ import type { LandingProblemStrings, LandingSupportedRailsStrings } from './land
 // catalogs (same reason ContentLanding/HelpLanding take `strings`).
 export interface LandingStrings {
     signUp: string
+    logIn: string
     signUpNow: string
     sendNow: string
     sendMoney: string
@@ -48,6 +49,7 @@ export interface LandingStrings {
 export function landingStrings(i18n: Translations): LandingStrings {
     return {
         signUp: i18n.landingSignUp,
+        logIn: i18n.landingLogIn,
         signUpNow: i18n.landingSignUpNow,
         sendNow: i18n.landingSendNow,
         sendMoney: i18n.sendMoney,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -112,6 +112,7 @@
     "noContentResults": "Nothing matches your search.",
     "backTo": "Back to {name}",
     "landingSignUp": "SIGN UP",
+    "landingLogIn": "Log in",
     "landingLearnMore": "Learn more",
     "landingGlobalCashLine1": "GLOBAL CASH.",
     "landingGlobalCashLine2": "LOCAL FEEL",

--- a/src/i18n/es-419.json
+++ b/src/i18n/es-419.json
@@ -112,6 +112,7 @@
     "noContentResults": "Nada coincide con tu búsqueda.",
     "backTo": "Volver a {name}",
     "landingSignUp": "CREAR CUENTA",
+    "landingLogIn": "Iniciar sesión",
     "landingLearnMore": "Más información",
     "landingGlobalCashLine1": "DINERO GLOBAL.",
     "landingGlobalCashLine2": "SABOR LOCAL",

--- a/src/i18n/es-ar.json
+++ b/src/i18n/es-ar.json
@@ -112,6 +112,7 @@
     "noContentResults": "Nada coincide con tu búsqueda.",
     "backTo": "Volver a {name}",
     "landingSignUp": "CREAR CUENTA",
+    "landingLogIn": "Iniciar sesión",
     "landingLearnMore": "Más información",
     "landingGlobalCashLine1": "PLATA GLOBAL.",
     "landingGlobalCashLine2": "SABOR LOCAL",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -112,6 +112,7 @@
     "noContentResults": "Nada corresponde à sua busca.",
     "backTo": "Voltar para {name}",
     "landingSignUp": "CRIAR CONTA",
+    "landingLogIn": "Entrar",
     "landingLearnMore": "Saiba mais",
     "landingGlobalCashLine1": "DINHEIRO GLOBAL.",
     "landingGlobalCashLine2": "COM JEITO LOCAL",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -88,6 +88,7 @@ export interface Translations {
 
     // Landing page — shared chrome
     landingSignUp: string
+    landingLogIn: string
     landingLearnMore: string
 
     // Landing page — "global cash, local feel" section

--- a/src/services/services.types.ts
+++ b/src/services/services.types.ts
@@ -342,6 +342,8 @@ export type SendLink = {
      *  claim path is answered 202 before the broadcast, so this is the only
      *  thing a poller can read to tell a retryable outage from a dead end. */
     claimFailureCode?: string | null
+    /** Stamped on cancel/reclaim — the receipt's cancellation date. */
+    cancelledAt?: Date | string | null
     createdAt: Date
     senderAddress: string
     amount: bigint

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -856,6 +856,13 @@ describe('redactNativePath (deep-link telemetry)', () => {
         expect(redactNativePath('/not-a-declared-route/secret-value')).toBe('/:id/:id')
     })
 
+    // The authority can carry userinfo, which is attacker-controlled on a link
+    // and would otherwise survive into `raw` next to the redacted path.
+    it('drops userinfo from the authority', () => {
+        expect(redactNativePath('https://CLAIM_SECRET@peanut.me/qr/aB3xK9mQ2pL7vN4z')).toBe('https://peanut.me/qr/:id')
+        expect(redactNativePath('https://user:pass@peanut.me/home')).toBe('https://peanut.me/home')
+    })
+
     // A locale or other prefix must not shift the root out of a positional
     // window and turn the whole path into placeholders.
     it('finds the route family behind a prefix segment', () => {

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -370,9 +370,12 @@ const TELEMETRY_SAFE_SEGMENTS = new Set(['success', 'bank', 'manteca', 'crypto',
 export function redactNativePath(value: string): string {
     const beforeQuery = value.split('#')[0].split('?')[0]
     // Keep scheme://host so a peanut.me universal link stays distinguishable
-    // from a custom-scheme launch — neither carries an identifier.
-    const prefix = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
-    const path = beforeQuery.slice(prefix.length)
+    // from a custom-scheme launch — neither carries an identifier. Userinfo
+    // (`https://secret@peanut.me/…`) is dropped: it is attacker-controlled
+    // input on a link and would otherwise ride into telemetry intact.
+    const authority = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
+    const prefix = authority.replace(/\/\/[^/]*@/, '//')
+    const path = beforeQuery.slice(authority.length)
     const redacted = path
         .split('/')
         .map((segment) => {


### PR DESCRIPTION
Sweep of the small follow-ups filed off #2905 / #2920 / the sendlink-crash investigation. One commit per task.

## What

- **TASK-22101 — untyped `font-(--x)` bypassed the typography ratchet.** Tailwind 4 compiles a bare `font-(--value)` as `font-weight`; a family needs the `family-name:` hint. `WEIGHT_STACK_RE` excluded the untyped form as a family, so `text-body-s font-(--my-weight)` stacked an off-ramp weight while `countWeightStacks` returned 0. It now counts the untyped form and excludes only `font-(family-name:…)`; regression cases updated. No `font-(--` in `src/`, so the baseline is unchanged (`ds-lint --check` ok).
- **TASK-22118 — SupportDrawer off the hardware-back stack.** #2920 put the DS Drawer/Modal on the LIFO back stack; the hand-rolled support sheet was left out, so Android back with it open navigated the page underneath. It registers `useBackHandler` while open and consumes the press. Tests dispatch `dispatchBackPress()` open (closes, consumed) and closed (falls through).
- **TASK-22117 — no Log in on the marketing landing.** A returning user with an expired session had no visible way back in; every CTA pointed at signup. #2920 made `/setup?step=login` land on the passkey Log In step — this links to it from the hero (under the primary CTA) and from the sticky mobile CTA, with a `landingLogIn` string in en / es-419 / es-ar / pt-br (`messages.test` key-parity green). DS `text-body-s` token, no new ratchet debt.
- **TASK-22068 (FE half) — claim receipt never showed a cancellation date.** `Claim.tsx` derived `cancelledDate` from `events[0]`, which only holds a date when a claim *attempt* was recorded; a sender's cancel/reclaim leaves none. peanut-api-ts#1525 puts the row's own `cancelledAt` on `GET /send-links/:pubKey`; the receipt now prefers it and keeps the events fallback. Test asserts the receipt receives `cancelledDate` from `cancelledAt` on the cache-hit shape.

## Verification

- `tsc --noEmit` clean; `ds-lint-rules`, `SupportDrawer`, `i18n/messages`, `Claim/claim-states` suites green; `node scripts/ds-lint-counts.mjs --check` ok; prettier clean.
- Not verified in a browser: the hero/sticky link placement. Both use existing landing spacing; screenshots welcome if design wants to move it.
