### PR TITLE
fix(native): redact QR codes and other identifiers from deep-link telemetry (port to main, TASK-22039)

### DIFF
--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -165,4 +165,35 @@ describe('deep-link telemetry redaction', () => {
         expect(props.raw).toBe('https://peanut.me/claim')
         expect(props.mapped).toBe('/claim')
     })
+
+    // The code sits in a PATH segment, so dropping query and fragment left it
+    // fully readable in `raw`. Opening the link reaches captureLink before the
+    // user claims the QR, and the claim API binds a code to the first
+    // authenticated account that presents it — so a PostHog reader could race
+    // the intended owner and take the QR permanently.
+    it('never sends an unclaimed QR code to analytics', async () => {
+        launchUrl = 'https://peanut.me/qr/aB3xK9mQ2pL7vN4z'
+
+        renderHook(() => useNativeAppLinks())
+
+        await waitFor(() => expect(capture).toHaveBeenCalled())
+        const payloads = JSON.stringify(capture.mock.calls)
+        expect(payloads).not.toContain('aB3xK9mQ2pL7vN4z')
+
+        const [, props] = capture.mock.calls.find(([name]) => name === 'native_link_received') as [
+            string,
+            Record<string, unknown>,
+        ]
+        // The route family survives — that is the whole diagnostic value.
+        expect(props.raw).toBe('https://peanut.me/qr/:id')
+    })
+
+    it('redacts the QR code on the success sub-route too', async () => {
+        launchUrl = 'https://peanut.me/qr/aB3xK9mQ2pL7vN4z/success'
+
+        renderHook(() => useNativeAppLinks())
+
+        await waitFor(() => expect(capture).toHaveBeenCalled())
+        expect(JSON.stringify(capture.mock.calls)).not.toContain('aB3xK9mQ2pL7vN4z')
+    })
 })

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -6,7 +6,7 @@ import { focusManager } from '@tanstack/react-query'
 import posthog from 'posthog-js'
 import { captureMessage } from '@/utils/sentry-lazy'
 import { isCapacitor, openExternalUrl, closeInAppBrowser, markInAppBrowserClosed } from '@/utils/capacitor'
-import { deepLinkToNativePath } from '@/utils/native-routes'
+import { deepLinkToNativePath, redactNativePath } from '@/utils/native-routes'
 import { hasDeepLinkNavigated, markDeepLinkNavigated } from '@/utils/deep-link-state'
 import { sanitizeRedirectURL, saveToCookie } from '@/utils/cookie-url.utils'
 import { toInviteCode } from '@/utils/invite-code.utils'
@@ -62,14 +62,17 @@ export function useNativeAppLinks() {
         // Until this instrumentation, no deep link left any trace unless it
         // threw — "links don't work" was undiagnosable from telemetry.
         //
-        // Path only. A claim link carries its password in `#p=<password>`, which
-        // deepLinkToNativePath deliberately preserves (native-routes.ts) because
-        // the claim page needs it — and that password derives the private claim
-        // key, so anyone reading analytics could claim the funds. The query is
-        // dropped for the same reason (charge and request ids). Which route was
-        // opened and whether it navigated is the whole diagnostic value.
+        // Route family only. A claim link carries its password in
+        // `#p=<password>`, which deepLinkToNativePath deliberately preserves
+        // (native-routes.ts) because the claim page needs it — and that password
+        // derives the private claim key, so anyone reading analytics could claim
+        // the funds. The query is dropped for the same reason (charge and request
+        // ids), and path segments are normalized because identifiers travel there
+        // too: `/qr/<code>` is a bearer secret until the user claims the QR.
+        // Which route was opened and whether it navigated is the whole
+        // diagnostic value. See `redactNativePath`.
         const redactLink = <T extends string | null>(value: T): T =>
-            (value === null ? value : value.split('#')[0].split('?')[0]) as T
+            (value === null ? value : redactNativePath(value)) as T
 
         const captureLink = (source: string, raw: string, mapped: string | null, outcome: string) =>
             posthog.capture('native_link_received', {

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/utils/capacitor', () => ({
 const mockIsCapacitor = isCapacitor as jest.MockedFunction<typeof isCapacitor>
 
 import {
+    redactNativePath,
     profileUrl,
     sendUrl,
     requestUrl,
@@ -622,5 +623,43 @@ describe('native-routes', () => {
             const sample = SAMPLE_BY_ROOT[root] ?? `/${root}`
             expect(deepLinkToNativePath(`https://peanut.me${sample}`)).not.toBeNull()
         })
+    })
+})
+
+describe('redactNativePath (deep-link telemetry)', () => {
+    // The BLOCKING finding: the code lives in a path segment, so stripping
+    // only query and fragment left an unclaimed, claimable QR code readable
+    // in analytics.
+    it('replaces a QR code in the path with a placeholder', () => {
+        expect(redactNativePath('https://peanut.me/qr/aB3xK9mQ2pL7vN4z')).toBe('https://peanut.me/qr/:id')
+    })
+
+    it('replaces the code but keeps a known static sub-view', () => {
+        expect(redactNativePath('/qr/aB3xK9mQ2pL7vN4z/success')).toBe('/qr/:id/success')
+    })
+
+    it('still drops the query and the fragment', () => {
+        expect(redactNativePath('/claim?c=8453&v=v4.2#p=SUPERSECRET')).toBe('/claim')
+    })
+
+    it('redacts other identifier-bearing routes', () => {
+        expect(redactNativePath('/receipt/9f1c2b3a')).toBe('/receipt/:id')
+        expect(redactNativePath('/profile/somebody')).toBe('/profile/:id')
+        expect(redactNativePath('/claim/abc123')).toBe('/claim/:id')
+    })
+
+    it('keeps a bare route family unchanged', () => {
+        expect(redactNativePath('https://peanut.me/home')).toBe('https://peanut.me/home')
+        expect(redactNativePath('/settings')).toBe('/settings')
+    })
+
+    it('keeps the country placeholder out but preserves the view', () => {
+        expect(redactNativePath('/add-money/belgium/bank')).toBe('/add-money/:id/bank')
+    })
+
+    // Fail closed: a route that is not declared must degrade to a placeholder
+    // rather than pass an unknown identifier through.
+    it('redacts an undeclared root instead of trusting it', () => {
+        expect(redactNativePath('/not-a-declared-route/secret-value')).toBe('/:id/:id')
     })
 })

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -662,4 +662,11 @@ describe('redactNativePath (deep-link telemetry)', () => {
     it('redacts an undeclared root instead of trusting it', () => {
         expect(redactNativePath('/not-a-declared-route/secret-value')).toBe('/:id/:id')
     })
+
+    // The authority can carry userinfo, which is attacker-controlled on a link
+    // and would otherwise survive into `raw` next to the redacted path.
+    it('drops userinfo from the authority', () => {
+        expect(redactNativePath('https://CLAIM_SECRET@peanut.me/qr/aB3xK9mQ2pL7vN4z')).toBe('https://peanut.me/qr/:id')
+        expect(redactNativePath('https://user:pass@peanut.me/home')).toBe('https://peanut.me/home')
+    })
 })

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -265,6 +265,60 @@ const NATIVE_EXPORT_ROOTS = new Set([
     'withdraw',
 ])
 
+/**
+ * Static sub-view segments that carry diagnostic value and no identifier.
+ * Everything NOT here and not a route root is treated as an identifier.
+ */
+const TELEMETRY_SAFE_SEGMENTS = new Set(['success', 'bank', 'manteca', 'crypto', 'us'])
+
+/**
+ * The route FAMILY of a deep link, safe to put in telemetry.
+ *
+ * Dropping the query and the fragment is not enough: identifiers also travel
+ * in path segments, and some of them are bearer secrets. `/qr/<16-char code>`
+ * reaches telemetry before the user has claimed the QR, and the claim API
+ * binds a code to the first authenticated account that presents it — so a
+ * reader of the analytics stream could race the intended owner and take the
+ * QR permanently. `/claim/<id>`, `/receipt/<id>` and `/profile/<username>`
+ * are the same shape with lower stakes.
+ *
+ * Fail closed: a segment is kept only when it is a known route root
+ * (NATIVE_EXPORT_ROOTS, which the AASA drift test already pins) or a known
+ * static sub-view. Anything else becomes `:id`. A route added to
+ * NATIVE_EXPORT_ROOTS is therefore covered here the moment it is declared,
+ * and a route that is NOT declared degrades to `:id` rather than leaking.
+ *
+ * Position is not used: a locale or other prefix must not shift a root out of
+ * the window and silently turn the whole path into placeholders.
+ *
+ * @param value - A deep-link URL or path, with or without scheme, query or
+ *   fragment.
+ * @returns The same shape with query and fragment removed and every
+ *   identifier-bearing path segment replaced by `:id`.
+ *
+ * @example
+ * redactNativePath('https://peanut.me/qr/aB3xK9mQ2pL7vN4z')  // => 'https://peanut.me/qr/:id'
+ * redactNativePath('/claim?c=8453#p=SECRET')                 // => '/claim'
+ * redactNativePath('/add-money/belgium/bank')                // => '/add-money/:id/bank'
+ * redactNativePath('/qr/aB3xK9mQ2pL7vN4z/success')           // => '/qr/:id/success'
+ */
+export function redactNativePath(value: string): string {
+    const beforeQuery = value.split('#')[0].split('?')[0]
+    // Keep scheme://host so a peanut.me universal link stays distinguishable
+    // from a custom-scheme launch — neither carries an identifier.
+    const prefix = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
+    const path = beforeQuery.slice(prefix.length)
+    const redacted = path
+        .split('/')
+        .map((segment) => {
+            if (segment === '') return segment
+            if (NATIVE_EXPORT_ROOTS.has(segment) || TELEMETRY_SAFE_SEGMENTS.has(segment)) return segment
+            return ':id'
+        })
+        .join('/')
+    return `${prefix}${redacted}`
+}
+
 function appendParams(base: string, params: string): string {
     if (!params) return base
     return `${base}${base.includes('?') ? '&' : '?'}${params}`

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -305,9 +305,12 @@ const TELEMETRY_SAFE_SEGMENTS = new Set(['success', 'bank', 'manteca', 'crypto',
 export function redactNativePath(value: string): string {
     const beforeQuery = value.split('#')[0].split('?')[0]
     // Keep scheme://host so a peanut.me universal link stays distinguishable
-    // from a custom-scheme launch — neither carries an identifier.
-    const prefix = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
-    const path = beforeQuery.slice(prefix.length)
+    // from a custom-scheme launch — neither carries an identifier. Userinfo
+    // (`https://secret@peanut.me/…`) is dropped: it is attacker-controlled
+    // input on a link and would otherwise ride into telemetry intact.
+    const authority = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
+    const prefix = authority.replace(/\/\/[^/]*@/, '//')
+    const path = beforeQuery.slice(authority.length)
     const redacted = path
         .split('/')
         .map((segment) => {


### PR DESCRIPTION
**Production fix, main-targeted on purpose.** The deep-link telemetry redactor (`redactLink` in `useNativeAppLinks.ts`) removes only the query and the fragment. `/qr/<16-character code>` carries the code in the *path*, so opening a QR deep link sends the unclaimed code to PostHog in `raw` — and the claim API binds a code to the first authenticated account that presents it, so anyone reading PostHog can race the intended owner and take the QR permanently. Shipped to production in `3d8dd6a17` (Sprint 158). Chip BLOCKING finding on #2888; TASK-22039 (P1).

`dev` already has the fix — it landed inside the Sprint 158 back-merge commit (`62bc0a725`), which is why it can't be cherry-picked cleanly. This is a hand-port of exactly that change:

- `redactNativePath(value)` in `native-routes.ts`: keeps `scheme://host`, drops query + fragment, and keeps a path segment only when it is a known route root (`NATIVE_EXPORT_ROOTS`, already pinned by the AASA drift test) or a known static sub-view (`success`, `bank`, `manteca`, `crypto`, `us`). Every other segment becomes `:id`. Fails closed: an undeclared root degrades to `:id` rather than leaking.
- `captureLink` redacts through it, so `raw` / `mapped` carry the route family only (`https://peanut.me/qr/:id`).
- Tests: 7 unit cases on `redactNativePath` (QR, sub-view, query/fragment, receipt/profile/claim ids, bare family, country placeholder, undeclared root) and two hook-level cases asserting the code never appears anywhere in the captured payload.

## Verification

- `native-routes.test` + `useNativeAppLinks.test`: 134/134 green on this branch.
- `tsc --noEmit`: no errors in the touched files. prettier clean.
- The next dev→main back-merge sees identical content on both sides (same as the `cae7a4c12` union), so no conflict is expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Improved deep-link telemetry redaction to prevent QR codes, receipt IDs, usernames, and other identifiers from appearing in analytics data.
  * Removed query strings, fragments, and sensitive URL credentials from captured links.
  * Preserved safe route structure while redacting unknown or identifier-bearing path segments.

* **Tests**
  * Added coverage for sensitive identifiers across QR, receipt, profile, and claim routes.
  * Added safeguards ensuring unknown route segments are redacted by default.
  * Verified safe routes remain recognizable in analytics data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->