### PR TITLE
feat(card): on card / off card — split line, On card screen, pre-tap card-pull notice (TASK-22293)

### DIFF
--- a/src/app/(mobile-ui)/card/on-card/page.tsx
+++ b/src/app/(mobile-ui)/card/on-card/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { type FC } from 'react'
+import ActiveCardGate from '@/components/Card/ActiveCardGate'
+import OnCardScreen from '@/components/Card/OnCardScreen'
+
+const OnCardPage: FC = () => (
+    <ActiveCardGate noCardMessageKey="onCard.noActiveCard">
+        {(card, onBack) => <OnCardScreen cardId={card.id} onPrev={onBack} />}
+    </ActiveCardGate>
+)
+
+export default OnCardPage

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -93,6 +93,7 @@ import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { useLimits } from '@/hooks/useLimits'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 const MAX_QR_PAYMENT_AMOUNT = '2000'
 const MIN_QR_PAYMENT_AMOUNT = '0.1'
@@ -1855,6 +1856,8 @@ export default function QRPayPage() {
                             hideBottomBorder
                         />
                     </Card>
+
+                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} />}
 
                     {/* Send Button */}
                     <Button

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -14,6 +14,7 @@ import Card from '@/components/Global/Card'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
 import { mantecaApi } from '@/services/manteca'
+import { armRainCooldownFromSuccess } from '@/services/rain'
 import type { QrPayment, QrPaymentLock } from '@/services/manteca'
 import NavHeader from '@/components/Global/NavHeader'
 import { MERCADO_PAGO, PIX } from '@/assets/payment-apps'
@@ -961,6 +962,8 @@ export default function QRPayPage() {
                               : {}),
                       } as const)
             const qrPayment = await mantecaApi.completeQrPaymentWithSignedTx(requestBody)
+            // a card pull consumed the withdrawal signature: start the countdown
+            armRainCooldownFromSuccess(qrPayment.cooldownSec)
             // clear the timer since we got a response
             if (payingStateTimerRef.current) {
                 clearTimeout(payingStateTimerRef.current)
@@ -1857,7 +1860,7 @@ export default function QRPayPage() {
                         />
                     </Card>
 
-                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} />}
+                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} collateralOnlyAllowed />}
 
                     {/* Send Button */}
                     <Button

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -516,7 +516,9 @@ export default function WithdrawBankPage() {
                         <PaymentInfoRow hideBottomBorder label={t('bank.fee')} value={`$ 0.00`} />
                     </Card>
 
-                    {!submittedTxHash && !balanceErrorMessage && <CollateralPullNotice amountUsd={amountToWithdraw} />}
+                    {!submittedTxHash && !balanceErrorMessage && (
+                        <CollateralPullNotice amountUsd={amountToWithdraw} collateralOnlyAllowed />
+                    )}
 
                     {submittedTxHash ? (
                         // On-chain leg already fired. Even if confirmOfframp failed

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -57,6 +57,7 @@ import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
 import { useLocale, useTranslations } from 'next-intl'
 import { localizedCountryTitle } from '@/utils/country-name.utils'
 import { resolveSettledTxHash } from '@/utils/settled-tx-hash.utils'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 type View = 'INITIAL' | 'SUCCESS'
 
@@ -514,6 +515,8 @@ export default function WithdrawBankPage() {
                         />
                         <PaymentInfoRow hideBottomBorder label={t('bank.fee')} value={`$ 0.00`} />
                     </Card>
+
+                    {!submittedTxHash && !balanceErrorMessage && <CollateralPullNotice amountUsd={amountToWithdraw} />}
 
                     {submittedTxHash ? (
                         // On-chain leg already fired. Even if confirmOfframp failed

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -77,6 +77,7 @@ import { MantecaTransfersMaintenanceView } from '@/components/Global/Banner/Mant
 import { useLocale, useTranslations } from 'next-intl'
 import { localizedCountryTitle } from '@/utils/country-name.utils'
 import { loadingStateKey } from '@/i18n/app/loading-states'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 type MantecaWithdrawStep = 'amountInput' | 'bankDetails' | 'review' | 'success' | 'failure'
 
@@ -790,6 +791,8 @@ function MantecaBankWithdrawFlow() {
                             />
                         )
                     })()}
+
+                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} />}
 
                     <Button
                         variant="purple"

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -22,6 +22,7 @@ import { Icon } from '@/components/Global/Icons/Icon'
 import Loading from '@/components/Global/Loading'
 import RateGateScreen from '@/components/Global/RateUnavailable/RateGateScreen'
 import { mantecaApi, type WithdrawPriceLock } from '@/services/manteca'
+import { armRainCooldownFromSuccess } from '@/services/rain'
 import { useCurrency } from '@/hooks/useCurrency'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { countryData } from '@/components/AddMoney/consts'
@@ -492,6 +493,8 @@ function MantecaBankWithdrawFlow() {
                 return
             }
 
+            // a card pull consumed the withdrawal signature: start the countdown
+            armRainCooldownFromSuccess(result.data?.cooldownSec)
             setStep('success')
             posthog.capture(ANALYTICS_EVENTS.WITHDRAW_COMPLETED, {
                 amount_usd: usdAmount,
@@ -792,7 +795,7 @@ function MantecaBankWithdrawFlow() {
                         )
                     })()}
 
-                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} />}
+                    {!balanceErrorMessage && <CollateralPullNotice amountUsd={usdAmount} collateralOnlyAllowed />}
 
                     <Button
                         variant="purple"

--- a/src/components/Card/CardLimitEditModal.tsx
+++ b/src/components/Card/CardLimitEditModal.tsx
@@ -7,7 +7,6 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import ActionModal from '@/components/Global/ActionModal'
 import { rainApi, type RainCardLimit, type RainLimitFrequency } from '@/services/rain'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
-import { useReturnExcessCollateral } from '@/hooks/wallet/useReturnExcessCollateral'
 
 export const CARD_LIMITS_QUERY_KEY = 'rain-card-limits'
 
@@ -23,7 +22,6 @@ interface Props {
 const CardLimitEditModal: FC<Props> = ({ cardId, frequency, label, initialAmountCents, isOpen, onClose }) => {
     const t = useTranslations('card.limits')
     const queryClient = useQueryClient()
-    const { returnExcess } = useReturnExcessCollateral()
     const [value, setValue] = useState<string>(initialAmountCents != null ? (initialAmountCents / 100).toFixed(2) : '')
     const [saving, setSaving] = useState(false)
     const [error, setError] = useState<string | null>(null)
@@ -51,33 +49,8 @@ const CardLimitEditModal: FC<Props> = ({ cardId, frequency, label, initialAmount
         try {
             const payload: RainCardLimit[] = [{ amount: amountCents, frequency }]
             await rainApi.updateCardLimits(cardId, payload)
-            // The card's backing tracks the per-transaction limit. If it now
-            // holds more than the new limit, return the difference to the
-            // user's wallet — surfaced only as a passkey prompt. Ordering
-            // matters: the PATCH above must land first so the auto-balancer's
-            // target is already lowered and can't race the withdrawal by
-            // topping the collateral back up.
-            // Non-fatal: the limit change itself succeeded, the unified
-            // displayed balance is identical either way, and re-saving the
-            // limit retries the return — so a cancelled passkey or withdrawal
-            // cooldown never blocks the modal.
-            if (frequency === 'perAuthorization') {
-                try {
-                    const returnedCents = await returnExcess(amountCents)
-                    if (returnedCents > 0) {
-                        posthog.capture(ANALYTICS_EVENTS.CARD_LIMIT_EXCESS_RETURNED, {
-                            returned_cents: returnedCents,
-                            new_limit_cents: amountCents,
-                        })
-                    }
-                } catch (excessError) {
-                    posthog.capture(ANALYTICS_EVENTS.CARD_LIMIT_EXCESS_RETURN_FAILED, {
-                        new_limit_cents: amountCents,
-                        error_kind: (excessError as Error)?.name ?? 'unknown',
-                        error_message: (excessError as Error)?.message,
-                    })
-                }
-            }
+            // The purchase limit is a Rain control only. What stays on the card
+            // is its own setting (the On card screen), so no collateral moves here.
             await Promise.all([
                 queryClient.invalidateQueries({ queryKey: [CARD_LIMITS_QUERY_KEY, cardId] }),
                 queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] }),

--- a/src/components/Card/OnCardScreen.tsx
+++ b/src/components/Card/OnCardScreen.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { type FC, useCallback, useEffect, useState } from 'react'
+import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTranslations } from 'next-intl'
 import posthog from 'posthog-js'
@@ -250,9 +250,15 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
         }
     }
 
+    // One key per tap, kept until the attempt settles: a retry after a lost
+    // response replays the first move server-side instead of moving twice.
+    const moveKeyRef = useRef<string | null>(null)
     const moveToCard = async (cents: number) => {
+        const idempotencyKey = moveKeyRef.current ?? `${cardId.slice(0, 8)}-${cents}-${crypto.randomUUID()}`
+        moveKeyRef.current = idempotencyKey
         try {
-            const res = await rainApi.moveToCard(cardId, cents)
+            const res = await rainApi.moveToCard(cardId, { amountCents: cents, idempotencyKey })
+            moveKeyRef.current = null
             posthog.capture(ANALYTICS_EVENTS.CARD_MOVE_TO_CARD, { amount_cents: res.amountCents })
             toast.success(t('moveToCardDone', { amount: formatDollars(res.amountCents) }))
         } catch (e) {

--- a/src/components/Card/OnCardScreen.tsx
+++ b/src/components/Card/OnCardScreen.tsx
@@ -10,6 +10,7 @@ import { ListGroup } from '@/components/0_Bruddle/ListGroup'
 import { ListItem } from '@/components/0_Bruddle/ListItem'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { Button } from '@/components/0_Bruddle/Button'
+import { Card } from '@/components/0_Bruddle/Card'
 import { Notification } from '@/components/0_Bruddle/Notification'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import ActionModal from '@/components/Global/ActionModal'
@@ -114,7 +115,7 @@ const AmountModal: FC<AmountModalProps> = ({
                     <label htmlFor="on-card-amount-input" className="text-label-l">
                         {label}
                     </label>
-                    <div className="flex items-center gap-2 rounded-sm border border-border-default bg-background-default px-3 py-2">
+                    <Card className="flex-row items-center gap-2 px-3 py-2">
                         <span className="text-foreground-secondary">$</span>
                         <input
                             id="on-card-amount-input"
@@ -137,7 +138,7 @@ const AmountModal: FC<AmountModalProps> = ({
                                 {t('max')}
                             </button>
                         )}
-                    </div>
+                    </Card>
                     {hint && <p className="text-body-s text-foreground-secondary">{hint}</p>}
                     {error && <p className="text-body-s text-foreground-error">{error}</p>}
                 </div>
@@ -426,12 +427,12 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
 }
 
 const BalanceTile: FC<{ label: string; cents: number | null }> = ({ label, cents }) => (
-    <div className="rounded-sm border border-border-default bg-background-default px-4 py-3">
+    <Card className="px-4 py-3">
         <div className="text-body-s text-foreground-secondary">{label}</div>
         <div className="text-heading-s text-foreground-primary tabular-nums">
             {cents === null ? '—' : formatDollars(cents)}
         </div>
-    </div>
+    </Card>
 )
 
 export default OnCardScreen

--- a/src/components/Card/OnCardScreen.tsx
+++ b/src/components/Card/OnCardScreen.tsx
@@ -11,6 +11,9 @@ import { ListItem } from '@/components/0_Bruddle/ListItem'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
+import { BaseInput } from '@/components/0_Bruddle/BaseInput'
+import { FieldColumn } from '@/components/0_Bruddle/FieldColumn'
+import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { Notification } from '@/components/0_Bruddle/Notification'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import ActionModal from '@/components/Global/ActionModal'
@@ -34,6 +37,12 @@ const MAX_TARGET_CENTS = 10_000_000
 const MAX_FLOOR_CENTS = 1_000_000
 /** Server-side floor for a move-to-card. */
 const MIN_MOVE_CENTS = 100
+
+/** `crypto.randomUUID` needs a secure context and is missing on older WebViews and jsdom. */
+const randomKey = () =>
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`
 
 const formatDollars = (cents: number) => `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
 
@@ -115,32 +124,28 @@ const AmountModal: FC<AmountModalProps> = ({
                     <label htmlFor="on-card-amount-input" className="text-label-l">
                         {label}
                     </label>
-                    <Card className="flex-row items-center gap-2 px-3 py-2">
-                        <span className="text-foreground-secondary">$</span>
-                        <input
+                    <FieldColumn error={error}>
+                        <BaseInput
                             id="on-card-amount-input"
                             type="number"
                             inputMode="decimal"
                             value={value}
                             onChange={(e) => setValue(e.target.value)}
-                            className="w-full bg-transparent text-body-m focus:outline-none"
                             min={0}
                             step="0.01"
+                            placeholder="0.00"
                             disabled={saving}
+                            state={error ? 'error' : 'default'}
+                            rightContent={
+                                maxCents != null ? (
+                                    <LinkButton onClick={() => setValue((maxCents / 100).toFixed(2))} disabled={saving}>
+                                        {t('max')}
+                                    </LinkButton>
+                                ) : undefined
+                            }
                         />
-                        {maxCents != null && (
-                            <button
-                                type="button"
-                                className="text-label-l text-foreground-secondary"
-                                onClick={() => setValue((maxCents / 100).toFixed(2))}
-                                disabled={saving}
-                            >
-                                {t('max')}
-                            </button>
-                        )}
-                    </Card>
+                    </FieldColumn>
                     {hint && <p className="text-body-s text-foreground-secondary">{hint}</p>}
-                    {error && <p className="text-body-s text-foreground-error">{error}</p>}
                 </div>
             }
             ctas={[
@@ -168,7 +173,10 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
     const t = useTranslations('card.onCard')
     const queryClient = useQueryClient()
     const toast = useToast()
-    const { card, policy, onCardCents, offCardCents, isLoading } = useBalanceSplit()
+    // `onCardCents` is LANDED spending power: what the card can spend and what
+    // can be moved off it. In-transit top-ups are shown as pending, never
+    // offered as movable.
+    const { card, policy, onCardCents, pendingToCardCents, offCardCents, isLoading } = useBalanceSplit()
     const { moveOffCard } = useMoveOffCard()
     const [modal, setModal] = useState<Modal | null>(null)
     const [togglingLoadAll, setTogglingLoadAll] = useState(false)
@@ -250,12 +258,15 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
         }
     }
 
-    // One key per tap, kept until the attempt settles: a retry after a lost
-    // response replays the first move server-side instead of moving twice.
-    const moveKeyRef = useRef<string | null>(null)
+    // One key per (tap, amount), kept until the attempt succeeds: an exact
+    // retry after a lost response replays the first move server-side instead
+    // of moving twice, while an edited amount is a new request with its own
+    // key — the old key must never carry a different amount.
+    const moveKeyRef = useRef<{ key: string; cents: number } | null>(null)
     const moveToCard = async (cents: number) => {
-        const idempotencyKey = moveKeyRef.current ?? `${cardId.slice(0, 8)}-${cents}-${crypto.randomUUID()}`
-        moveKeyRef.current = idempotencyKey
+        const reuse = moveKeyRef.current?.cents === cents ? moveKeyRef.current.key : null
+        const idempotencyKey = reuse ?? `${cardId.slice(0, 8)}-${cents}-${randomKey()}`
+        moveKeyRef.current = { key: idempotencyKey, cents }
         try {
             const res = await rainApi.moveToCard(cardId, { amountCents: cents, idempotencyKey })
             moveKeyRef.current = null
@@ -272,16 +283,25 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
     }
 
     const moveOff = async (cents: number) => {
-        // Pin the target below what stays on the card FIRST, or the balancer
-        // tops the card straight back up. The inflow debounce also holds the
+        // Pin the target below what stays on the card FIRST — and switch
+        // load-everything off, which ignores the target — or the balancer
+        // sweeps the returned money straight back. One awaited PATCH; if it
+        // fails nothing is withdrawn. The inflow debounce also holds the
         // returned money off the card for a few minutes.
         const remaining = Math.max(0, (onCardCents ?? 0) - cents)
-        if (policy && remaining < policy.targetCents) {
-            await patch({ collateralTargetCents: remaining }, 'target')
+        if (policy && (policy.loadAllToCard || remaining < policy.targetCents)) {
+            await patch(
+                {
+                    collateralTargetCents: Math.min(remaining, policy.targetCents),
+                    ...(policy.loadAllToCard ? { loadAllToCard: false } : {}),
+                },
+                'target'
+            )
             posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_TARGET_CHANGED, {
                 old_cents: policy.targetCents,
-                new_cents: remaining,
+                new_cents: Math.min(remaining, policy.targetCents),
                 reason: 'move_off_card',
+                load_all_disabled: policy.loadAllToCard,
             })
         }
         const moved = await moveOffCard(cents)
@@ -307,7 +327,15 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
             ) : (
                 <>
                     <div className="grid grid-cols-2 gap-3">
-                        <BalanceTile label={t('onCard')} cents={onCardCents} />
+                        <BalanceTile
+                            label={t('onCard')}
+                            cents={onCardCents}
+                            note={
+                                pendingToCardCents > 0
+                                    ? t('pending', { amount: formatDollars(pendingToCardCents) })
+                                    : undefined
+                            }
+                        />
                         <BalanceTile label={t('offCard')} cents={offCardCents} />
                     </div>
                     <p className="text-body-s text-foreground-secondary">{t('summary')}</p>
@@ -432,12 +460,13 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
     )
 }
 
-const BalanceTile: FC<{ label: string; cents: number | null }> = ({ label, cents }) => (
+const BalanceTile: FC<{ label: string; cents: number | null; note?: string }> = ({ label, cents, note }) => (
     <Card className="px-4 py-3">
         <div className="text-body-s text-foreground-secondary">{label}</div>
         <div className="text-heading-s text-foreground-primary tabular-nums">
             {cents === null ? '—' : formatDollars(cents)}
         </div>
+        {note && <div className="text-body-s text-foreground-secondary">{note}</div>}
     </Card>
 )
 

--- a/src/components/Card/OnCardScreen.tsx
+++ b/src/components/Card/OnCardScreen.tsx
@@ -283,28 +283,37 @@ const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
     }
 
     const moveOff = async (cents: number) => {
-        // Pin the target below what stays on the card FIRST — and switch
-        // load-everything off, which ignores the target — or the balancer
-        // sweeps the returned money straight back. One awaited PATCH; if it
-        // fails nothing is withdrawn. The inflow debounce also holds the
-        // returned money off the card for a few minutes.
+        // The target has to sit below what stays on the card — and
+        // load-everything, which ignores the target, has to be off — before
+        // the withdrawal lands, or the balancer sweeps the returned money
+        // straight back. That PATCH runs between the passkey and the
+        // broadcast: a cancelled passkey leaves the policy untouched, a
+        // failed PATCH leaves the signed withdrawal unsent. `pinTarget:
+        // false` keeps an auto-sized card auto-sized — this is a lowering
+        // the move forces, not a number the user chose. The inflow debounce
+        // also holds the returned money off the card for a few minutes.
         const remaining = Math.max(0, (onCardCents ?? 0) - cents)
-        if (policy && (policy.loadAllToCard || remaining < policy.targetCents)) {
-            await patch(
-                {
-                    collateralTargetCents: Math.min(remaining, policy.targetCents),
-                    ...(policy.loadAllToCard ? { loadAllToCard: false } : {}),
-                },
-                'target'
-            )
-            posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_TARGET_CHANGED, {
-                old_cents: policy.targetCents,
-                new_cents: Math.min(remaining, policy.targetCents),
-                reason: 'move_off_card',
-                load_all_disabled: policy.loadAllToCard,
-            })
-        }
-        const moved = await moveOffCard(cents)
+        const lowerTarget =
+            policy && (policy.loadAllToCard || remaining < policy.targetCents)
+                ? async () => {
+                      const nextTarget = Math.min(remaining, policy.targetCents)
+                      await patch(
+                          {
+                              collateralTargetCents: nextTarget,
+                              pinTarget: false,
+                              ...(policy.loadAllToCard ? { loadAllToCard: false } : {}),
+                          },
+                          'target'
+                      )
+                      posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_TARGET_CHANGED, {
+                          old_cents: policy.targetCents,
+                          new_cents: nextTarget,
+                          reason: 'move_off_card',
+                          load_all_disabled: policy.loadAllToCard,
+                      })
+                  }
+                : undefined
+        const moved = await moveOffCard(cents, { beforeSubmit: lowerTarget })
         if (moved <= 0) throw new Error(t('moveFailed'))
         posthog.capture(ANALYTICS_EVENTS.CARD_MOVE_OFF_CARD, { amount_cents: moved, reason: 'manual' })
         toast.success(t('moveOffCardDone', { amount: formatDollars(moved) }))

--- a/src/components/Card/OnCardScreen.tsx
+++ b/src/components/Card/OnCardScreen.tsx
@@ -1,0 +1,437 @@
+'use client'
+import { type FC, useCallback, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslations } from 'next-intl'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { PageStack } from '@/components/0_Bruddle/PageStack'
+import { Section } from '@/components/0_Bruddle/Section'
+import { ListGroup } from '@/components/0_Bruddle/ListGroup'
+import { ListItem } from '@/components/0_Bruddle/ListItem'
+import { Toggle } from '@/components/0_Bruddle/Toggle'
+import { Button } from '@/components/0_Bruddle/Button'
+import { Notification } from '@/components/0_Bruddle/Notification'
+import { useToast } from '@/components/0_Bruddle/Toast'
+import ActionModal from '@/components/Global/ActionModal'
+import NavHeader from '@/components/Global/NavHeader'
+import Loading from '@/components/Global/Loading'
+import { rainApi } from '@/services/rain'
+import { RAIN_CARD_OVERVIEW_QUERY_KEY } from '@/hooks/useRainCardOverview'
+import { useBalanceSplit } from '@/hooks/wallet/useBalanceSplit'
+import { useMoveOffCard } from '@/hooks/wallet/useMoveOffCard'
+import { EXCESS_COLLATERAL_MIN_CENTS } from '@/utils/balance.utils'
+
+interface Props {
+    cardId: string
+    onPrev?: () => void
+}
+
+type Modal = 'target' | 'floor' | 'toCard' | 'offCard'
+
+/** Bounds mirrored from the backend's PATCH schema. */
+const MAX_TARGET_CENTS = 10_000_000
+const MAX_FLOOR_CENTS = 1_000_000
+/** Server-side floor for a move-to-card. */
+const MIN_MOVE_CENTS = 100
+
+const formatDollars = (cents: number) => `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+
+interface AmountModalProps {
+    isOpen: boolean
+    title: string
+    label: string
+    hint?: string
+    initialCents?: number
+    minCents: number
+    maxCents?: number
+    ctaLabel: string
+    onSave: (cents: number) => Promise<void>
+    onClose: () => void
+}
+
+/** One dollar-amount prompt for all four edits — same input the limit modal uses. */
+const AmountModal: FC<AmountModalProps> = ({
+    isOpen,
+    title,
+    label,
+    hint,
+    initialCents,
+    minCents,
+    maxCents,
+    ctaLabel,
+    onSave,
+    onClose,
+}) => {
+    const t = useTranslations('card.onCard')
+    const [value, setValue] = useState('')
+    const [saving, setSaving] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (isOpen) {
+            setValue(initialCents != null ? (initialCents / 100).toFixed(2) : '')
+            setError(null)
+        }
+    }, [isOpen, initialCents])
+
+    const save = async () => {
+        const dollars = Number(value)
+        if (!Number.isFinite(dollars) || dollars < 0) {
+            setError(t('invalidAmount'))
+            return
+        }
+        const cents = Math.round(dollars * 100)
+        if (cents < minCents) {
+            setError(t('minAmount', { amount: formatDollars(minCents) }))
+            return
+        }
+        if (maxCents != null && cents > maxCents) {
+            setError(t('maxAmount', { amount: formatDollars(maxCents) }))
+            return
+        }
+        setSaving(true)
+        setError(null)
+        try {
+            await onSave(cents)
+            onClose()
+        } catch (e) {
+            setError(e instanceof Error && e.message ? e.message : t('saveFailed'))
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return (
+        <ActionModal
+            visible={isOpen}
+            onClose={onClose}
+            preventClose={saving}
+            hideModalCloseButton={saving}
+            icon="credit-card"
+            title={title}
+            content={
+                <div className="flex w-full flex-col gap-2 text-left">
+                    <label htmlFor="on-card-amount-input" className="text-label-l">
+                        {label}
+                    </label>
+                    <div className="flex items-center gap-2 rounded-sm border border-border-default bg-background-default px-3 py-2">
+                        <span className="text-foreground-secondary">$</span>
+                        <input
+                            id="on-card-amount-input"
+                            type="number"
+                            inputMode="decimal"
+                            value={value}
+                            onChange={(e) => setValue(e.target.value)}
+                            className="w-full bg-transparent text-body-m focus:outline-none"
+                            min={0}
+                            step="0.01"
+                            disabled={saving}
+                        />
+                        {maxCents != null && (
+                            <button
+                                type="button"
+                                className="text-label-l text-foreground-secondary"
+                                onClick={() => setValue((maxCents / 100).toFixed(2))}
+                                disabled={saving}
+                            >
+                                {t('max')}
+                            </button>
+                        )}
+                    </div>
+                    {hint && <p className="text-body-s text-foreground-secondary">{hint}</p>}
+                    {error && <p className="text-body-s text-foreground-error">{error}</p>}
+                </div>
+            }
+            ctas={[
+                {
+                    text: ctaLabel,
+                    variant: 'purple',
+                    shadowSize: '4',
+                    onClick: save,
+                    loading: saving,
+                    disabled: saving,
+                },
+            ]}
+        />
+    )
+}
+
+/**
+ * "On card" — the two halves of the balance and the rules that move money
+ * between them (TASK-22293). On card is what the card spends from; off card
+ * is instant for every in-app transfer and never subject to the card's
+ * withdrawal lock. The purchase limit is a separate screen and a separate
+ * Rain control.
+ */
+const OnCardScreen: FC<Props> = ({ cardId, onPrev }) => {
+    const t = useTranslations('card.onCard')
+    const queryClient = useQueryClient()
+    const toast = useToast()
+    const { card, policy, onCardCents, offCardCents, isLoading } = useBalanceSplit()
+    const { moveOffCard } = useMoveOffCard()
+    const [modal, setModal] = useState<Modal | null>(null)
+    const [togglingLoadAll, setTogglingLoadAll] = useState(false)
+
+    useEffect(() => {
+        posthog.capture(ANALYTICS_EVENTS.CARD_ON_CARD_VIEWED, {
+            on_card_cents: onCardCents,
+            off_card_cents: offCardCents,
+        })
+        // one view event per mount — the balances refresh on their own
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const refresh = useCallback(
+        () =>
+            Promise.all([
+                queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] }),
+                queryClient.invalidateQueries({ queryKey: ['balance'] }),
+            ]),
+        [queryClient]
+    )
+
+    const patch = useCallback(
+        async (input: Parameters<typeof rainApi.updateCollateralSettings>[1], event: string) => {
+            try {
+                await rainApi.updateCollateralSettings(cardId, input)
+            } catch (e) {
+                posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_SETTING_FAILED, {
+                    setting: event,
+                    error_message: e instanceof Error ? e.message : String(e),
+                })
+                throw e
+            }
+        },
+        [cardId]
+    )
+
+    const saveTarget = async (cents: number) => {
+        const previous = policy?.targetCents ?? null
+        await patch({ collateralTargetCents: cents }, 'target')
+        posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_TARGET_CHANGED, { old_cents: previous, new_cents: cents })
+        // Lowering the target never withdraws on its own — offer the excess
+        // back as one passkey prompt, non-fatal (the target change already
+        // landed, and re-saving retries the return).
+        if (onCardCents !== null && onCardCents - cents >= EXCESS_COLLATERAL_MIN_CENTS) {
+            try {
+                const moved = await moveOffCard(onCardCents - cents)
+                if (moved > 0) {
+                    posthog.capture(ANALYTICS_EVENTS.CARD_MOVE_OFF_CARD, { amount_cents: moved, reason: 'target' })
+                    toast.success(t('moveOffCardDone', { amount: formatDollars(moved) }))
+                }
+            } catch (e) {
+                posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_SETTING_FAILED, {
+                    setting: 'target_excess_return',
+                    error_message: e instanceof Error ? e.message : String(e),
+                })
+            }
+        }
+        await refresh()
+    }
+
+    const saveFloor = async (cents: number) => {
+        const previous = policy?.walletFloorCents ?? null
+        await patch({ walletFloorCents: cents }, 'floor')
+        posthog.capture(ANALYTICS_EVENTS.CARD_WALLET_FLOOR_CHANGED, { old_cents: previous, new_cents: cents })
+        await refresh()
+    }
+
+    const toggleLoadAll = async (next: boolean) => {
+        setTogglingLoadAll(true)
+        try {
+            await patch({ loadAllToCard: next }, 'load_all')
+            posthog.capture(ANALYTICS_EVENTS.CARD_LOAD_ALL_TOGGLED, { enabled: next })
+            await refresh()
+        } catch {
+            toast.error(t('saveFailed'))
+        } finally {
+            setTogglingLoadAll(false)
+        }
+    }
+
+    const moveToCard = async (cents: number) => {
+        try {
+            const res = await rainApi.moveToCard(cardId, cents)
+            posthog.capture(ANALYTICS_EVENTS.CARD_MOVE_TO_CARD, { amount_cents: res.amountCents })
+            toast.success(t('moveToCardDone', { amount: formatDollars(res.amountCents) }))
+        } catch (e) {
+            posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_SETTING_FAILED, {
+                setting: 'move_to_card',
+                error_message: e instanceof Error ? e.message : String(e),
+            })
+            throw new Error(t('moveFailed'))
+        }
+        await refresh()
+    }
+
+    const moveOff = async (cents: number) => {
+        // Pin the target below what stays on the card FIRST, or the balancer
+        // tops the card straight back up. The inflow debounce also holds the
+        // returned money off the card for a few minutes.
+        const remaining = Math.max(0, (onCardCents ?? 0) - cents)
+        if (policy && remaining < policy.targetCents) {
+            await patch({ collateralTargetCents: remaining }, 'target')
+            posthog.capture(ANALYTICS_EVENTS.CARD_COLLATERAL_TARGET_CHANGED, {
+                old_cents: policy.targetCents,
+                new_cents: remaining,
+                reason: 'move_off_card',
+            })
+        }
+        const moved = await moveOffCard(cents)
+        if (moved <= 0) throw new Error(t('moveFailed'))
+        posthog.capture(ANALYTICS_EVENTS.CARD_MOVE_OFF_CARD, { amount_cents: moved, reason: 'manual' })
+        toast.success(t('moveOffCardDone', { amount: formatDollars(moved) }))
+        await refresh()
+    }
+
+    const closeModal = () => setModal(null)
+    const loadAll = policy?.loadAllToCard ?? false
+    const canMoveToCard = !!card?.hasWithdrawApproval && (offCardCents ?? 0) >= MIN_MOVE_CENTS
+    const canMoveOffCard = (onCardCents ?? 0) >= EXCESS_COLLATERAL_MIN_CENTS
+
+    return (
+        <PageStack gap="6">
+            <NavHeader title={t('navTitle')} onPrev={onPrev} />
+
+            {isLoading || !policy ? (
+                <div className="flex justify-center py-8">
+                    <Loading />
+                </div>
+            ) : (
+                <>
+                    <div className="grid grid-cols-2 gap-3">
+                        <BalanceTile label={t('onCard')} cents={onCardCents} />
+                        <BalanceTile label={t('offCard')} cents={offCardCents} />
+                    </div>
+                    <p className="text-body-s text-foreground-secondary">{t('summary')}</p>
+
+                    {!policy.autoBalanceEnabled && (
+                        <Notification priority="attention">{t('autoBalanceOff')}</Notification>
+                    )}
+
+                    <div className="space-y-4">
+                        <Section title={t('autoTitle')}>
+                            <ListGroup>
+                                <ListItem
+                                    title={t('keepOnCard')}
+                                    body={loadAll ? t('loadAllActive') : policy.targetPinned ? t('pinned') : t('tuned')}
+                                    trailing={
+                                        <span className="text-body-m-semibold tabular-nums">
+                                            {formatDollars(policy.targetCents)}
+                                        </span>
+                                    }
+                                    chevron
+                                    disabled={loadAll}
+                                    onClick={() => setModal('target')}
+                                />
+                                <ListItem
+                                    title={t('keepOffCard')}
+                                    body={t('keepOffCardHint')}
+                                    trailing={
+                                        <span className="text-body-m-semibold tabular-nums">
+                                            {formatDollars(policy.walletFloorCents)}
+                                        </span>
+                                    }
+                                    chevron
+                                    disabled={loadAll}
+                                    onClick={() => setModal('floor')}
+                                />
+                                <ListItem
+                                    title={t('loadAll')}
+                                    body={t('loadAllHint')}
+                                    trailing={
+                                        <Toggle
+                                            checked={loadAll}
+                                            disabled={togglingLoadAll}
+                                            onChange={(next) => void toggleLoadAll(next)}
+                                            aria-label={t('loadAll')}
+                                        />
+                                    }
+                                />
+                            </ListGroup>
+                        </Section>
+
+                        <Section title={t('moveTitle')}>
+                            <div className="grid grid-cols-2 gap-3">
+                                <Button
+                                    variant="purple"
+                                    shadowSize="4"
+                                    disabled={!canMoveToCard}
+                                    onClick={() => setModal('toCard')}
+                                >
+                                    {t('moveToCard')}
+                                </Button>
+                                <Button variant="stroke" disabled={!canMoveOffCard} onClick={() => setModal('offCard')}>
+                                    {t('moveOffCard')}
+                                </Button>
+                            </div>
+                            {!card?.hasWithdrawApproval && (
+                                <p className="mt-2 text-body-s text-foreground-secondary">{t('setupRequired')}</p>
+                            )}
+                        </Section>
+
+                        <Notification priority="info">{t('lockNote')}</Notification>
+                    </div>
+
+                    <AmountModal
+                        isOpen={modal === 'target'}
+                        title={t('editTargetTitle')}
+                        label={t('keepOnCard')}
+                        hint={t('keepOnCardHint')}
+                        initialCents={policy.targetCents}
+                        minCents={0}
+                        maxCents={MAX_TARGET_CENTS}
+                        ctaLabel={t('save')}
+                        onSave={saveTarget}
+                        onClose={closeModal}
+                    />
+                    <AmountModal
+                        isOpen={modal === 'floor'}
+                        title={t('editFloorTitle')}
+                        label={t('keepOffCard')}
+                        hint={t('keepOffCardHint')}
+                        initialCents={policy.walletFloorCents}
+                        minCents={0}
+                        maxCents={MAX_FLOOR_CENTS}
+                        ctaLabel={t('save')}
+                        onSave={saveFloor}
+                        onClose={closeModal}
+                    />
+                    <AmountModal
+                        isOpen={modal === 'toCard'}
+                        title={t('moveToCardTitle')}
+                        label={t('amountLabel')}
+                        hint={t('moveToCardHint')}
+                        minCents={MIN_MOVE_CENTS}
+                        maxCents={offCardCents ?? undefined}
+                        ctaLabel={t('moveToCard')}
+                        onSave={moveToCard}
+                        onClose={closeModal}
+                    />
+                    <AmountModal
+                        isOpen={modal === 'offCard'}
+                        title={t('moveOffCardTitle')}
+                        label={t('amountLabel')}
+                        hint={t('moveOffCardHint')}
+                        minCents={EXCESS_COLLATERAL_MIN_CENTS}
+                        maxCents={onCardCents ?? undefined}
+                        ctaLabel={t('moveOffCard')}
+                        onSave={moveOff}
+                        onClose={closeModal}
+                    />
+                </>
+            )}
+        </PageStack>
+    )
+}
+
+const BalanceTile: FC<{ label: string; cents: number | null }> = ({ label, cents }) => (
+    <div className="rounded-sm border border-border-default bg-background-default px-4 py-3">
+        <div className="text-body-s text-foreground-secondary">{label}</div>
+        <div className="text-heading-s text-foreground-primary tabular-nums">
+            {cents === null ? '—' : formatDollars(cents)}
+        </div>
+    </div>
+)
+
+export default OnCardScreen

--- a/src/components/Card/YourCardScreen.tsx
+++ b/src/components/Card/YourCardScreen.tsx
@@ -135,6 +135,7 @@ const YourCardScreen: FC<Props> = ({ overview, card, onPrev }) => {
             <div className="space-y-4">
                 <Section title={t('managementTitle')}>
                     <ListGroup>
+                        <ProfileMenuItem icon="arrow-exchange" label={t('onCard')} href="/card/on-card" />
                         <ProfileMenuItem icon="more-horizontal" label={t('pin')} href="/card/pin" />
                         <ProfileMenuItem icon="meter" label={t('spendingLimit')} href="/card/limit" />
                         <ProfileMenuItem icon="credit-card" label={t('physicalCard')} href="/card/physical" />

--- a/src/components/Card/__tests__/OnCardScreen.test.tsx
+++ b/src/components/Card/__tests__/OnCardScreen.test.tsx
@@ -3,10 +3,13 @@
  * balancer's shared policy. These pin its orchestration, not the hooks:
  *  1. move-to-card's idempotency key is bound to the amount — an exact retry
  *     reuses it, an edited amount gets a new one,
- *  2. move-off-card pins the target (and switches load-all off) BEFORE the
- *     withdrawal, and a failed pin aborts the withdrawal,
+ *  2. move-off-card lowers the target (unpinned, and switches load-all off)
+ *     between the passkey and the broadcast: a cancelled passkey changes no
+ *     policy, and a failed lowering does not report a move,
  *  3. lowering the target offers exactly the excess back, and a failure
- *     there is swallowed (the target already landed).
+ *     there is swallowed (the target already landed),
+ *  4. the load-all toggle and the off-card floor PATCH their own field, and
+ *     a rejected toggle is reported without flipping the switch.
  */
 import React from 'react'
 import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
@@ -78,10 +81,16 @@ async function submitAmount(buttonLabel: string, dollars: string, ctaLabel = but
     fireEvent.click(ctas[ctas.length - 1]!)
 }
 
+type MoveOffOptions = { beforeSubmit?: () => Promise<void> }
+
 beforeEach(() => {
     jest.clearAllMocks()
     mockPatch.mockResolvedValue(undefined)
-    mockMoveOffCard.mockResolvedValue(0)
+    // the real hook runs `beforeSubmit` after the passkey and before the broadcast
+    mockMoveOffCard.mockImplementation(async (cents: number, opts?: MoveOffOptions) => {
+        await opts?.beforeSubmit?.()
+        return cents
+    })
     mockMoveToCard.mockResolvedValue({ ok: true, amountCents: 1_000, userOpHash: '0x1' })
 })
 
@@ -113,32 +122,64 @@ describe('OnCardScreen — move to card idempotency key', () => {
 })
 
 describe('OnCardScreen — move off card', () => {
-    it('pins the target below the remaining amount before withdrawing, and turns load-all off', async () => {
+    it('lowers the target (unpinned) and turns load-all off after the passkey, before the broadcast', async () => {
         const order: string[] = []
         mockPatch.mockImplementation(async () => {
             order.push('patch')
         })
-        mockMoveOffCard.mockImplementation(async (cents: number) => {
-            order.push('withdraw')
+        mockMoveOffCard.mockImplementation(async (cents: number, opts?: MoveOffOptions) => {
+            order.push('passkey')
+            await opts?.beforeSubmit?.()
+            order.push('broadcast')
             return cents
         })
         setup({ onCard: 10_000, policy: policy({ loadAllToCard: true }) })
 
         await submitAmount('Move off card', '40')
-        await waitFor(() => expect(mockMoveOffCard).toHaveBeenCalledWith(4_000))
+        await waitFor(() => expect(order).toContain('broadcast'))
 
-        expect(mockPatch).toHaveBeenCalledWith(CARD_ID, { collateralTargetCents: 6_000, loadAllToCard: false })
-        expect(order).toEqual(['patch', 'withdraw'])
+        expect(mockMoveOffCard).toHaveBeenCalledWith(
+            4_000,
+            expect.objectContaining({ beforeSubmit: expect.any(Function) })
+        )
+        expect(mockPatch).toHaveBeenCalledWith(CARD_ID, {
+            collateralTargetCents: 6_000,
+            pinTarget: false,
+            loadAllToCard: false,
+        })
+        expect(order).toEqual(['passkey', 'patch', 'broadcast'])
     })
 
-    it('does not withdraw when the pin fails', async () => {
+    it('a cancelled passkey leaves the balancing policy untouched', async () => {
+        // the real hook throws from the passkey step without ever calling beforeSubmit
+        mockMoveOffCard.mockRejectedValueOnce(new Error('passkey cancelled'))
+        setup({ onCard: 10_000 })
+
+        await submitAmount('Move off card', '40')
+        await screen.findByText('passkey cancelled')
+
+        expect(mockPatch).not.toHaveBeenCalled()
+        expect(mockToast.success).not.toHaveBeenCalled()
+    })
+
+    it('a failed lowering aborts the move and reports the error', async () => {
         mockPatch.mockRejectedValueOnce(new Error('offline'))
         setup({ onCard: 10_000 })
 
         await submitAmount('Move off card', '40')
         await screen.findByText('offline')
 
-        expect(mockMoveOffCard).not.toHaveBeenCalled()
+        expect(mockToast.success).not.toHaveBeenCalled()
+    })
+
+    it('does not touch the target when the remainder still covers it', async () => {
+        setup({ onCard: 10_000, policy: policy({ targetCents: 5_000 }) })
+
+        await submitAmount('Move off card', '40')
+        await waitFor(() => expect(mockToast.success).toHaveBeenCalled())
+
+        expect(mockPatch).not.toHaveBeenCalled()
+        expect(mockMoveOffCard).toHaveBeenCalledWith(4_000, { beforeSubmit: undefined })
     })
 
     it('offers only landed collateral, never the amount still moving to the card', async () => {
@@ -167,5 +208,42 @@ describe('OnCardScreen — keep on card', () => {
         await waitFor(() => expect(mockMoveOffCard).toHaveBeenCalledWith(7_000))
         // the modal closed: the target change stood even though the return failed
         await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+    })
+})
+
+describe('OnCardScreen — load everything to card', () => {
+    it('switching it on PATCHes only that flag', async () => {
+        setup()
+
+        fireEvent.click(screen.getByRole('switch', { name: 'Load everything to card' }))
+
+        await waitFor(() => expect(mockPatch).toHaveBeenCalledWith(CARD_ID, { loadAllToCard: true }))
+        expect(mockToast.error).not.toHaveBeenCalled()
+    })
+
+    it('a rejected PATCH reports the failure and leaves the switch off and usable', async () => {
+        mockPatch.mockRejectedValueOnce(new Error('offline'))
+        setup()
+
+        const toggle = screen.getByRole('switch', { name: 'Load everything to card' })
+        fireEvent.click(toggle)
+
+        await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("Couldn't save. Please try again."))
+        expect(toggle).toHaveAttribute('aria-checked', 'false')
+        await waitFor(() => expect(toggle).not.toBeDisabled())
+    })
+})
+
+describe('OnCardScreen — keep off card', () => {
+    it('saving the floor PATCHes only walletFloorCents', async () => {
+        setup()
+
+        fireEvent.click(screen.getByRole('button', { name: /^Keep off card/ }))
+        const input = await screen.findByLabelText(/^Keep off card/)
+        fireEvent.change(input, { target: { value: '10' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        await waitFor(() => expect(mockPatch).toHaveBeenCalledWith(CARD_ID, { walletFloorCents: 1_000 }))
+        expect(mockMoveOffCard).not.toHaveBeenCalled()
     })
 })

--- a/src/components/Card/__tests__/OnCardScreen.test.tsx
+++ b/src/components/Card/__tests__/OnCardScreen.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * OnCardScreen is the one screen that both moves money and mutates the
+ * balancer's shared policy. These pin its orchestration, not the hooks:
+ *  1. move-to-card's idempotency key is bound to the amount — an exact retry
+ *     reuses it, an edited amount gets a new one,
+ *  2. move-off-card pins the target (and switches load-all off) BEFORE the
+ *     withdrawal, and a failed pin aborts the withdrawal,
+ *  3. lowering the target offers exactly the excess back, and a failure
+ *     there is swallowed (the target already landed).
+ */
+import React from 'react'
+import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { IntlWrapper } from '@/test-utils/intl'
+import OnCardScreen from '@/components/Card/OnCardScreen'
+import { rainApi } from '@/services/rain'
+import { useBalanceSplit } from '@/hooks/wallet/useBalanceSplit'
+import { useMoveOffCard } from '@/hooks/wallet/useMoveOffCard'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/services/rain', () => ({
+    rainApi: { moveToCard: jest.fn(), updateCollateralSettings: jest.fn() },
+}))
+jest.mock('@/hooks/useRainCardOverview', () => ({ RAIN_CARD_OVERVIEW_QUERY_KEY: 'rain-card-overview' }))
+jest.mock('@/hooks/wallet/useBalanceSplit', () => ({ useBalanceSplit: jest.fn() }))
+jest.mock('@/hooks/wallet/useMoveOffCard', () => ({ useMoveOffCard: jest.fn() }))
+const mockToast = { success: jest.fn(), error: jest.fn() }
+jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => mockToast }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+
+const mockMoveToCard = rainApi.moveToCard as jest.Mock
+const mockPatch = rainApi.updateCollateralSettings as jest.Mock
+const mockUseBalanceSplit = useBalanceSplit as jest.Mock
+const mockUseMoveOffCard = useMoveOffCard as jest.Mock
+const mockMoveOffCard = jest.fn()
+
+const CARD_ID = '11111111-2222-3333-4444-555555555555'
+
+function policy(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+        targetCents: 10_000,
+        targetPinned: false,
+        walletFloorCents: 2_500,
+        loadAllToCard: false,
+        cardLimitCents: 25_000,
+        autoBalanceEnabled: true,
+        ...overrides,
+    }
+}
+
+function setup(opts: { onCard?: number; offCard?: number; pending?: number; policy?: ReturnType<typeof policy> } = {}) {
+    const p = opts.policy ?? policy()
+    mockUseBalanceSplit.mockReturnValue({
+        card: { id: CARD_ID, status: 'ACTIVE', hasWithdrawApproval: true, collateral: p },
+        hasActiveCard: true,
+        policy: p,
+        onCardCents: opts.onCard ?? 10_000,
+        pendingToCardCents: opts.pending ?? 0,
+        offCardCents: opts.offCard ?? 5_000,
+        offCardUnits: BigInt((opts.offCard ?? 5_000) * 10_000),
+        isLoading: false,
+    })
+    mockUseMoveOffCard.mockReturnValue({ moveOffCard: mockMoveOffCard })
+    return rtlRender(
+        <QueryClientProvider client={new QueryClient()}>
+            <OnCardScreen cardId={CARD_ID} />
+        </QueryClientProvider>,
+        { wrapper: IntlWrapper }
+    )
+}
+
+async function submitAmount(buttonLabel: string, dollars: string, ctaLabel = buttonLabel) {
+    // the screen-level button is first in document order; a closing modal's CTA may still be leaving
+    fireEvent.click(screen.getAllByRole('button', { name: buttonLabel })[0]!)
+    const input = await screen.findByLabelText(/Amount/i)
+    fireEvent.change(input, { target: { value: dollars } })
+    const ctas = screen.getAllByRole('button', { name: ctaLabel })
+    fireEvent.click(ctas[ctas.length - 1]!)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockPatch.mockResolvedValue(undefined)
+    mockMoveOffCard.mockResolvedValue(0)
+    mockMoveToCard.mockResolvedValue({ ok: true, amountCents: 1_000, userOpHash: '0x1' })
+})
+
+describe('OnCardScreen — move to card idempotency key', () => {
+    it('reuses the key for an exact retry after a failure, and mints a new one when the amount changes', async () => {
+        mockMoveToCard.mockRejectedValueOnce(new Error('timeout'))
+        setup()
+
+        await submitAmount('Move to card', '10')
+        await waitFor(() => expect(mockMoveToCard).toHaveBeenCalledTimes(1))
+        const firstKey = mockMoveToCard.mock.calls[0]![1].idempotencyKey as string
+        expect(firstKey).toContain('-1000-')
+
+        // the failure is shown and the CTA re-enabled before the exact retry
+        await screen.findByText(/Couldn't move the money/)
+        const ctas = screen.getAllByRole('button', { name: 'Move to card' })
+        fireEvent.click(ctas[ctas.length - 1]!)
+        await waitFor(() => expect(mockMoveToCard).toHaveBeenCalledTimes(2))
+        expect(mockMoveToCard.mock.calls[1]![1].idempotencyKey).toBe(firstKey)
+
+        // edited amount after success → the modal closed; open again with a new amount
+        await submitAmount('Move to card', '15')
+        await waitFor(() => expect(mockMoveToCard).toHaveBeenCalledTimes(3))
+        const thirdKey = mockMoveToCard.mock.calls[2]![1].idempotencyKey as string
+        expect(thirdKey).not.toBe(firstKey)
+        expect(thirdKey).toContain('-1500-')
+        expect(mockMoveToCard.mock.calls[2]![1].amountCents).toBe(1_500)
+    })
+})
+
+describe('OnCardScreen — move off card', () => {
+    it('pins the target below the remaining amount before withdrawing, and turns load-all off', async () => {
+        const order: string[] = []
+        mockPatch.mockImplementation(async () => {
+            order.push('patch')
+        })
+        mockMoveOffCard.mockImplementation(async (cents: number) => {
+            order.push('withdraw')
+            return cents
+        })
+        setup({ onCard: 10_000, policy: policy({ loadAllToCard: true }) })
+
+        await submitAmount('Move off card', '40')
+        await waitFor(() => expect(mockMoveOffCard).toHaveBeenCalledWith(4_000))
+
+        expect(mockPatch).toHaveBeenCalledWith(CARD_ID, { collateralTargetCents: 6_000, loadAllToCard: false })
+        expect(order).toEqual(['patch', 'withdraw'])
+    })
+
+    it('does not withdraw when the pin fails', async () => {
+        mockPatch.mockRejectedValueOnce(new Error('offline'))
+        setup({ onCard: 10_000 })
+
+        await submitAmount('Move off card', '40')
+        await screen.findByText('offline')
+
+        expect(mockMoveOffCard).not.toHaveBeenCalled()
+    })
+
+    it('offers only landed collateral, never the amount still moving to the card', async () => {
+        setup({ onCard: 2_000, pending: 8_000 })
+
+        await submitAmount('Move off card', '50')
+        await screen.findByText(/maximum is \$20\.00/i)
+
+        expect(mockMoveOffCard).not.toHaveBeenCalled()
+        expect(mockPatch).not.toHaveBeenCalled()
+    })
+})
+
+describe('OnCardScreen — keep on card', () => {
+    it('lowering the target returns exactly the excess, and a failed return does not undo the target', async () => {
+        mockMoveOffCard.mockRejectedValueOnce(new Error('passkey cancelled'))
+        setup({ onCard: 10_000 })
+
+        // the row is a ListItem with role=button; its accessible name starts with the title
+        fireEvent.click(screen.getByRole('button', { name: /^Keep on card/ }))
+        const input = await screen.findByLabelText(/^Keep on card/)
+        fireEvent.change(input, { target: { value: '30' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        await waitFor(() => expect(mockPatch).toHaveBeenCalledWith(CARD_ID, { collateralTargetCents: 3_000 }))
+        await waitFor(() => expect(mockMoveOffCard).toHaveBeenCalledWith(7_000))
+        // the modal closed: the target change stood even though the return failed
+        await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).toBeNull())
+    })
+})

--- a/src/components/Card/cardState.utils.ts
+++ b/src/components/Card/cardState.utils.ts
@@ -8,7 +8,9 @@ import type { RainCardOverview, RainCardSummary } from '@/services/rain'
  * target a CANCELED card's id. Returns the newest non-canceled card, or null.
  */
 export function findActiveCard(overview: RainCardOverview | undefined): RainCardSummary | null {
-    return overview?.cards.find((c) => c.status !== 'CANCELED') ?? null
+    // `cards` is optional at runtime: a partial or older cached overview
+    // (and several test fixtures) carry only `balance`.
+    return overview?.cards?.find((c) => c.status !== 'CANCELED') ?? null
 }
 
 /**

--- a/src/components/Global/CollateralPullNotice.tsx
+++ b/src/components/Global/CollateralPullNotice.tsx
@@ -8,6 +8,8 @@ import { formatLockRemaining } from '@/utils/collateralPull.utils'
 
 interface Props {
     amountUsd: string | number | null | undefined
+    /** False for multi-call flows (cross-chain), which can only pull the shortfall. */
+    collateralOnlyAllowed?: boolean
     className?: string
 }
 
@@ -32,9 +34,9 @@ function LockCountdown({ endsAt }: { endsAt: number }) {
  * card, for amounts the off-card balance covers, and for true shortfalls
  * (the insufficient-balance error owns those).
  */
-export function CollateralPullNotice({ amountUsd, className }: Props) {
+export function CollateralPullNotice({ amountUsd, collateralOnlyAllowed, className }: Props) {
     const t = useTranslations('global.collateralPull')
-    const { visible, fromCardCents, cooldownEndsAt } = useCollateralPullPreview(amountUsd)
+    const { visible, fromCardCents, cooldownEndsAt } = useCollateralPullPreview(amountUsd, { collateralOnlyAllowed })
     if (!visible) return null
     return (
         <div className={className} data-testid="collateral-pull-notice">

--- a/src/components/Global/CollateralPullNotice.tsx
+++ b/src/components/Global/CollateralPullNotice.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Notification } from '@/components/0_Bruddle/Notification'
+import { useCollateralPullPreview } from '@/hooks/wallet/useCollateralPullPreview'
+import { formatLockRemaining } from '@/utils/collateralPull.utils'
+
+interface Props {
+    amountUsd: string | number | null | undefined
+    className?: string
+}
+
+const formatDollars = (cents: number) => `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
+
+function LockCountdown({ endsAt }: { endsAt: number }) {
+    const t = useTranslations('global.collateralPull')
+    const [now, setNow] = useState(() => Date.now())
+    useEffect(() => {
+        const id = window.setInterval(() => setNow(Date.now()), 1000)
+        return () => window.clearInterval(id)
+    }, [])
+    const remaining = endsAt - now
+    if (remaining <= 0) return null
+    return <> {t('lockActive', { time: formatLockRemaining(remaining) })}</>
+}
+
+/**
+ * Drop-in for any amount / review step: says, before the passkey, that this
+ * spend will pull from the card balance, and how long the card's withdrawal
+ * lock still has to run if one is armed. Renders nothing for users without a
+ * card, for amounts the off-card balance covers, and for true shortfalls
+ * (the insufficient-balance error owns those).
+ */
+export function CollateralPullNotice({ amountUsd, className }: Props) {
+    const t = useTranslations('global.collateralPull')
+    const { visible, fromCardCents, cooldownEndsAt } = useCollateralPullPreview(amountUsd)
+    if (!visible) return null
+    return (
+        <div className={className} data-testid="collateral-pull-notice">
+            <Notification priority={cooldownEndsAt ? 'attention' : 'info'}>
+                {t('fromCard', { amount: formatDollars(fromCardCents) })}
+                {cooldownEndsAt && <LockCountdown endsAt={cooldownEndsAt} />}
+            </Notification>
+        </div>
+    )
+}
+
+export default CollateralPullNotice

--- a/src/components/Global/CollateralPullNotice.tsx
+++ b/src/components/Global/CollateralPullNotice.tsx
@@ -8,8 +8,13 @@ import { formatLockRemaining } from '@/utils/collateralPull.utils'
 
 interface Props {
     amountUsd: string | number | null | undefined
-    /** False for multi-call flows (cross-chain), which can only pull the shortfall. */
-    collateralOnlyAllowed?: boolean
+    /**
+     * How the flow will execute — mirrors `useSpendBundle`'s routing so the
+     * preview cannot drift from it. True for a single transfer (`sendMoney`,
+     * `signSpend`): the whole amount can leave the card. False for a
+     * multi-call UserOp (send links, cross-chain): only the shortfall can.
+     */
+    collateralOnlyAllowed: boolean
     className?: string
 }
 

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -25,6 +25,7 @@ import AmountInput from '../../../Global/AmountInput'
 import { usePendingTransactions } from '@/hooks/wallet/usePendingTransactions'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 // Below the smallest fiat minimum the recipient loses every fiat claim rail
 // (bank / Pix / Mercado Pago all reject at claim time) and is left with only
@@ -289,6 +290,8 @@ const LinkSendInitialView = () => {
                     {t('link.minFiatClaimWarning', { amount: MIN_FIAT_CLAIM_AMOUNT })}
                 </Notification>
             )}
+
+            {!errorState?.showError && <CollateralPullNotice amountUsd={tokenValue} />}
 
             <div className="flex flex-col gap-4">
                 {/* only a flow (submit-time) error flips the CTA to retry — a

--- a/src/components/Send/link/views/Initial.link.send.view.tsx
+++ b/src/components/Send/link/views/Initial.link.send.view.tsx
@@ -291,7 +291,8 @@ const LinkSendInitialView = () => {
                 </Notification>
             )}
 
-            {!errorState?.showError && <CollateralPullNotice amountUsd={tokenValue} />}
+            {/* a link is an approve + deposit bundle: only the shortfall can leave the card */}
+            {!errorState?.showError && <CollateralPullNotice amountUsd={tokenValue} collateralOnlyAllowed={false} />}
 
             <div className="flex flex-col gap-4">
                 {/* only a flow (submit-time) error flips the CTA to retry — a

--- a/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
+++ b/src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx
@@ -64,6 +64,10 @@ jest.mock('@/components/Global/PeanutActionCard', () => ({
     default: () => <div data-testid="action-card" />,
 }))
 
+// needs the wallet + Rain overview providers this view test does not mount
+jest.mock('@/components/Global/CollateralPullNotice', () => ({
+    CollateralPullNotice: () => null,
+}))
 jest.mock('@/components/Global/FileUploadInput', () => ({
     __esModule: true,
     default: () => <div data-testid="file-upload" />,

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -206,7 +206,9 @@ export default function ConfirmWithdrawView({
 
                 {showHighFeeWarning && <Notification priority="info">{t('confirm.highFeeWarning')}</Notification>}
 
-                {!insufficientBalance && !error && <CollateralPullNotice amountUsd={payAmount ?? amount} />}
+                {!insufficientBalance && !error && (
+                    <CollateralPullNotice amountUsd={payAmount ?? amount} collateralOnlyAllowed={!isCrossChain} />
+                )}
 
                 {error ? (
                     <Button

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -15,6 +15,7 @@ import type { ChainWithTokens } from '@/interfaces/chain-meta'
 import { useMemo } from 'react'
 import { ROUTE_NOT_FOUND_ERROR } from '@/constants/general.consts'
 import { useTranslations } from 'next-intl'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 interface WithdrawConfirmViewProps {
     amount: string
@@ -204,6 +205,8 @@ export default function ConfirmWithdrawView({
                 </Card>
 
                 {showHighFeeWarning && <Notification priority="info">{t('confirm.highFeeWarning')}</Notification>}
+
+                {!insufficientBalance && !error && <CollateralPullNotice amountUsd={payAmount ?? amount} />}
 
                 {error ? (
                     <Button

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -279,6 +279,17 @@ export const ANALYTICS_EVENTS = {
     // (useReturnExcessCollateral). FAILED is non-fatal — limit change stuck.
     CARD_LIMIT_EXCESS_RETURNED: 'card_limit_excess_returned',
     CARD_LIMIT_EXCESS_RETURN_FAILED: 'card_limit_excess_return_failed',
+    // On card / off card (TASK-22293): the target the balancer keeps on the
+    // card, the floor it leaves off, manual moves, and the pre-tap notice that
+    // a spend will pull from the card.
+    CARD_ON_CARD_VIEWED: 'card_on_card_viewed',
+    CARD_COLLATERAL_TARGET_CHANGED: 'card_collateral_target_changed',
+    CARD_WALLET_FLOOR_CHANGED: 'card_wallet_floor_changed',
+    CARD_LOAD_ALL_TOGGLED: 'card_load_all_toggled',
+    CARD_MOVE_TO_CARD: 'card_move_to_card',
+    CARD_MOVE_OFF_CARD: 'card_move_off_card',
+    CARD_COLLATERAL_SETTING_FAILED: 'card_collateral_setting_failed',
+    COLLATERAL_PULL_NOTICE_SHOWN: 'collateral_pull_notice_shown',
     CARD_LOCK_OPENED: 'card_lock_opened',
     CARD_LOCKED: 'card_locked',
     CARD_UNLOCKED: 'card_unlocked',

--- a/src/context/RainCooldownContext.tsx
+++ b/src/context/RainCooldownContext.tsx
@@ -89,7 +89,9 @@ export function RainCooldownProvider({ children }: { children: ReactNode }) {
             const next = !isFresh && prev > endsAt ? prev : endsAt
             cooldownEndsAtRef.current = next
             setCooldownEndsAt(next)
-            if (isFresh) setShowIntroModal(true)
+            // A lock armed from a successful pull is expected — the pill is
+            // enough; the intro modal is for the user who just hit the wall.
+            if (isFresh && !detail.silent) setShowIntroModal(true)
         }
         window.addEventListener('rain:cooldown', handler)
         return () => window.removeEventListener('rain:cooldown', handler)

--- a/src/context/RainCooldownContext.tsx
+++ b/src/context/RainCooldownContext.tsx
@@ -144,3 +144,12 @@ export function useRainCooldown(): RainCooldownContextType {
     if (!ctx) throw new Error('useRainCooldown must be used within RainCooldownProvider')
     return ctx
 }
+
+/**
+ * Same state, but `null` outside the provider instead of a throw. For
+ * advisory surfaces (the pre-tap card-pull notice) that must never take a
+ * payment screen down because a layout or a test mounted them bare.
+ */
+export function useRainCooldownOptional(): RainCooldownContextType | null {
+    return useContext(RainCooldownContext) ?? null
+}

--- a/src/context/__tests__/RainCooldownContext.test.tsx
+++ b/src/context/__tests__/RainCooldownContext.test.tsx
@@ -11,6 +11,12 @@ function fireCooldown(retryAfterSec: number, message = 'cooling down') {
     window.dispatchEvent(new CustomEvent('rain:cooldown', { detail: { retryAfterSec, message } }))
 }
 
+// The event `armRainCooldownFromSuccess` dispatches after a successful pull:
+// a server-confirmed lock the user did not run into.
+function fireSilentCooldown(retryAfterSec: number) {
+    window.dispatchEvent(new CustomEvent('rain:cooldown', { detail: { retryAfterSec, message: '', silent: true } }))
+}
+
 // The countdown pill renders localized copy, so the provider is required.
 const wrapper = ({ children }: { children: React.ReactNode }) => (
     <IntlWrapper>
@@ -80,6 +86,26 @@ describe('RainCooldownContext', () => {
         // Simulate the user retrying during the existing cooldown.
         act(() => fireCooldown(280))
         expect(result.current.showIntroModal).toBe(false)
+    })
+
+    it('a silent (success-armed) event starts the countdown without the intro modal', () => {
+        const { result } = renderHook(() => useRainCooldown(), { wrapper })
+        act(() => fireSilentCooldown(150))
+        expect(result.current.cooldownEndsAt).not.toBeNull()
+        expect(result.current.cooldownEndsAt! - Date.now()).toBeGreaterThan(140_000)
+        expect(result.current.showIntroModal).toBe(false)
+    })
+
+    it('a silent event mid-cooldown keeps the countdown and still does not pop the modal', () => {
+        const { result } = renderHook(() => useRainCooldown(), { wrapper })
+        act(() => fireSilentCooldown(300))
+        const firstEnd = result.current.cooldownEndsAt!
+        act(() => fireSilentCooldown(120))
+        expect(result.current.cooldownEndsAt).toBeGreaterThanOrEqual(firstEnd - 5)
+        expect(result.current.showIntroModal).toBe(false)
+        // the user then hits the wall for real: that is the moment the modal is for
+        act(() => fireCooldown(100))
+        expect(result.current.showIntroModal).toBe(false) // still mid-cooldown, not a fresh one
     })
 
     it('re-pops the intro modal for a brand-new cooldown after the previous one cleared', () => {

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -34,6 +34,7 @@ export function HomePage() {
         spendableBalance,
         isFetchingSpendableBalance,
         isSpendableBalanceStale,
+        balanceSplit,
         isBalanceHidden,
         toggleBalanceVisibility,
     } = useHomeFlow()
@@ -50,6 +51,7 @@ export function HomePage() {
                     balance={spendableBalance}
                     isFetching={isFetchingSpendableBalance}
                     isStale={isSpendableBalanceStale}
+                    split={balanceSplit}
                     isHidden={isBalanceHidden}
                     onToggleVisibility={toggleBalanceVisibility}
                 />

--- a/src/features/home/__tests__/useHomeFlow.test.ts
+++ b/src/features/home/__tests__/useHomeFlow.test.ts
@@ -13,8 +13,9 @@ let mockUser: any = null
 let mockIsFetchingUser = false
 let mockWagmiConnected = false
 
+let mockOverview: unknown = undefined
 jest.mock('@/hooks/wallet/useWallet', () => ({
-    useWallet: () => ({ spendableBalance: 123n, isFetchingSpendableBalance: false }),
+    useWallet: () => ({ spendableBalance: 123n, isFetchingSpendableBalance: false, balance: 2_840_000n }),
 }))
 jest.mock('@/redux/hooks', () => ({
     useUserStore: () => ({ user: mockUser }),
@@ -30,6 +31,9 @@ jest.mock('@/context/ClaimBankFlowContext', () => ({
 }))
 jest.mock('@/context/WithdrawFlowContext', () => ({
     useWithdrawFlow: () => ({ resetWithdrawFlow: mockResetWithdrawFlow }),
+}))
+jest.mock('@/hooks/useRainCardOverview', () => ({
+    useRainCardOverview: () => ({ overview: mockOverview }),
 }))
 jest.mock('@/hooks/useCardInfo', () => ({
     useCardInfo: jest.fn(() => ({})),
@@ -50,6 +54,7 @@ describe('useHomeFlow', () => {
         mockUser = null
         mockIsFetchingUser = false
         mockWagmiConnected = false
+        mockOverview = undefined
     })
 
     it('gates the page on first user fetch only', () => {
@@ -96,5 +101,31 @@ describe('useHomeFlow', () => {
 
         mockUser = userWith({})
         expect(renderHook(() => useHomeFlow()).result.current.avatarKey).toBeNull()
+    })
+
+    it('hides the on card / off card line until the user has an active card and both halves are known', () => {
+        mockUser = userWith({})
+        const { result } = renderHook(() => useHomeFlow())
+        expect(result.current.balanceSplit).toBeNull()
+    })
+
+    it('splits the total into on card and off card for a card holder', () => {
+        mockUser = userWith({})
+        mockOverview = {
+            status: { hasApplication: true },
+            balanceUnavailable: false,
+            balance: {
+                creditLimit: 0,
+                pendingCharges: 0,
+                postedCharges: 0,
+                balanceDue: 0,
+                spendingPower: 10_000,
+                inTransitToCollateralCents: 250,
+            },
+            cards: [{ id: 'c1', status: 'ACTIVE', hasWithdrawApproval: true }],
+        }
+        const { result } = renderHook(() => useHomeFlow())
+        // $102.50 on card (landed + in transit), $2.84 off card (smart wallet)
+        expect(result.current.balanceSplit).toEqual({ onCardCents: 10_250, offCardCents: 284 })
     })
 })

--- a/src/features/home/__tests__/useHomeFlow.test.ts
+++ b/src/features/home/__tests__/useHomeFlow.test.ts
@@ -125,7 +125,7 @@ describe('useHomeFlow', () => {
             cards: [{ id: 'c1', status: 'ACTIVE', hasWithdrawApproval: true }],
         }
         const { result } = renderHook(() => useHomeFlow())
-        // $102.50 on card (landed + in transit), $2.84 off card (smart wallet)
-        expect(result.current.balanceSplit).toEqual({ onCardCents: 10_250, offCardCents: 284 })
+        // $100 landed on card, $2.50 still moving to it, $2.84 off card (smart wallet, floored)
+        expect(result.current.balanceSplit).toEqual({ onCardCents: 10_000, pendingToCardCents: 250, offCardCents: 284 })
     })
 })

--- a/src/features/home/useHomeFlow.ts
+++ b/src/features/home/useHomeFlow.ts
@@ -6,8 +6,10 @@ import { useWithdrawFlow } from '@/context/WithdrawFlowContext'
 import { useActivationStatus } from '@/hooks/useActivationStatus'
 import { useCardInfo } from '@/hooks/useCardInfo'
 import { useWallet } from '@/hooks/wallet/useWallet'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { computeBalanceSplit } from '@/hooks/wallet/useBalanceSplit'
 import { useUserStore } from '@/redux/hooks'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useAccount, useDisconnect } from 'wagmi'
 import { useBalanceVisibility } from './useBalanceVisibility'
 
@@ -16,7 +18,8 @@ import { useBalanceVisibility } from './useBalanceVisibility'
  * stay dumb (same model as features/payments/flows/semantic-request).
  */
 export function useHomeFlow() {
-    const { spendableBalance, isFetchingSpendableBalance, isSpendableBalanceStale } = useWallet()
+    const { spendableBalance, isFetchingSpendableBalance, isSpendableBalanceStale, balance } = useWallet()
+    const { overview: rainOverview } = useRainCardOverview()
     const { user } = useUserStore()
     const { isFetchingUser, fetchUser } = useAuth()
     const { isActivated, activationStep, dismissCardStep } = useActivationStatus()
@@ -55,6 +58,10 @@ export function useHomeFlow() {
     // which the top nav seeds from the username, never the display name
     const avatarKey = user?.user.avatarKey ?? null
 
+    // "$100 on card · $28 off card" under the total — only for card holders,
+    // and only once both halves are known (TASK-22293)
+    const balanceSplit = useMemo(() => computeBalanceSplit(balance, rainOverview), [balance, rainOverview])
+
     return {
         isPageLoading: isFetchingUser && !username,
         username,
@@ -65,6 +72,7 @@ export function useHomeFlow() {
         spendableBalance,
         isFetchingSpendableBalance,
         isSpendableBalanceStale,
+        balanceSplit,
         isBalanceHidden,
         toggleBalanceVisibility,
     }

--- a/src/features/home/views/BalanceSection.tsx
+++ b/src/features/home/views/BalanceSection.tsx
@@ -10,6 +10,7 @@ import { useTranslations } from 'next-intl'
 import { useAppTranslations } from '@/i18n/app/useAppTranslations'
 import Link from 'next/link'
 import { useHomeDrawer, type HomeDrawer } from '../useHomeDrawer'
+import type { BalanceSplit } from '@/hooks/wallet/useBalanceSplit'
 
 interface BalanceSectionProps {
     balance: bigint | undefined
@@ -17,9 +18,13 @@ interface BalanceSectionProps {
     /** balance is the persisted last-known-good while the live sum is still
      *  pending — dim it rather than asserting it as current */
     isStale?: boolean
+    /** on card / off card halves for card holders; null hides the line */
+    split?: BalanceSplit | null
     isHidden: boolean
     onToggleVisibility: () => void
 }
+
+const formatCents = (cents: number) => `$${(cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2 })}`
 
 // home IA (figma section 17609:2334): add + send open a bottom drawer,
 // request navigates directly (a Link, so it keeps prefetch + anchor semantics)
@@ -35,7 +40,14 @@ const SUBMENU_ACTIONS: Array<{ key: 'add' | 'send' | 'request'; icon: IconName; 
  * visibility toggle, plus the add / send / request submenu underneath.
  * submenu states per component 17533:117867 (default / pressed).
  */
-export function BalanceSection({ balance, isFetching, isStale, isHidden, onToggleVisibility }: BalanceSectionProps) {
+export function BalanceSection({
+    balance,
+    isFetching,
+    isStale,
+    split,
+    isHidden,
+    onToggleVisibility,
+}: BalanceSectionProps) {
     const t = useAppTranslations('home')
     const tNav = useTranslations('navigation')
     const { triggerHaptic } = useAppHaptic()
@@ -75,6 +87,23 @@ export function BalanceSection({ balance, isFetching, isStale, isHidden, onToggl
                     </button>
                 )}
             </div>
+            {split && !isFetching && (
+                <Link
+                    href="/card/on-card"
+                    className={twMerge(
+                        '-mt-4 text-center text-body-s text-foreground-secondary tabular-nums',
+                        isStale && 'opacity-50'
+                    )}
+                    data-testid="balance-split"
+                >
+                    {isHidden
+                        ? t('splitHidden')
+                        : t('split', {
+                              onCard: formatCents(split.onCardCents),
+                              offCard: formatCents(split.offCardCents),
+                          })}
+                </Link>
+            )}
             <div className="flex items-start justify-between px-10">
                 {SUBMENU_ACTIONS.map((action) => {
                     const inner = (

--- a/src/features/home/views/BalanceSection.tsx
+++ b/src/features/home/views/BalanceSection.tsx
@@ -102,6 +102,14 @@ export function BalanceSection({
                               onCard: formatCents(split.onCardCents),
                               offCard: formatCents(split.offCardCents),
                           })}
+                    {split.pendingToCardCents > 0 && (
+                        <>
+                            {' · '}
+                            {isHidden
+                                ? t('splitPendingHidden')
+                                : t('splitPending', { amount: formatCents(split.pendingToCardCents) })}
+                        </>
+                    )}
                 </Link>
             )}
             <div className="flex items-start justify-between px-10">

--- a/src/features/payments/flows/direct-send/views/SendInputView.tsx
+++ b/src/features/payments/flows/direct-send/views/SendInputView.tsx
@@ -87,7 +87,9 @@ export function SendInputView() {
                         hideCurrencyToggle={true}
                     />
                     {isInsufficientBalance && <FieldError>{t('errors.insufficientPayment')}</FieldError>}
-                    {isLoggedIn && !isInsufficientBalance && <CollateralPullNotice amountUsd={amount} />}
+                    {isLoggedIn && !isInsufficientBalance && (
+                        <CollateralPullNotice amountUsd={amount} collateralOnlyAllowed />
+                    )}
                 </div>
 
                 {/* message input */}

--- a/src/features/payments/flows/direct-send/views/SendInputView.tsx
+++ b/src/features/payments/flows/direct-send/views/SendInputView.tsx
@@ -26,6 +26,7 @@ import { useAuth } from '@/context/authContext'
 import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPeanutCta'
 import { PaymentMethodActionList } from '@/features/payments/shared/components/PaymentMethodActionList'
 import { useTranslations } from 'next-intl'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 export function SendInputView() {
     const onBack = useSafeBack('/home')
@@ -86,6 +87,7 @@ export function SendInputView() {
                         hideCurrencyToggle={true}
                     />
                     {isInsufficientBalance && <FieldError>{t('errors.insufficientPayment')}</FieldError>}
+                    {isLoggedIn && !isInsufficientBalance && <CollateralPullNotice amountUsd={amount} />}
                 </div>
 
                 {/* message input */}

--- a/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
+++ b/src/features/payments/flows/semantic-request/useSemanticRequestFlow.ts
@@ -616,6 +616,8 @@ export function useSemanticRequestFlow() {
         // state
         amount,
         usdAmount,
+        /** Cross-chain: principal + Rhino fee — the amount the kernel actually spends. */
+        payAmount: calculatedPayAmount,
         currentView,
         parsedUrl,
         recipient,

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
@@ -31,6 +31,7 @@ import PeanutActionDetailsCard, {
 import { useSearchParams, useRouter } from 'next/navigation'
 import SendWithPeanutCta from '@/features/payments/shared/components/SendWithPeanutCta'
 import { useTranslations } from 'next-intl'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 export function SemanticRequestConfirmView() {
     const router = useRouter()
@@ -251,6 +252,8 @@ export function SemanticRequestConfirmView() {
 
                     {!isCardPioneer && <PaymentInfoRow hideBottomBorder label={tCommon('peanutFee')} value="$ 0.00" />}
                 </Card>
+
+                <CollateralPullNotice amountUsd={usdAmount || amount} />
 
                 {/* buttons and error */}
                 <div className="flex flex-col gap-4">

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
@@ -43,6 +43,7 @@ export function SemanticRequestConfirmView() {
     const {
         amount,
         usdAmount,
+        payAmount,
         recipient,
         charge,
         attachment,
@@ -253,7 +254,12 @@ export function SemanticRequestConfirmView() {
                     {!isCardPioneer && <PaymentInfoRow hideBottomBorder label={tCommon('peanutFee')} value="$ 0.00" />}
                 </Card>
 
-                <CollateralPullNotice amountUsd={usdAmount || amount} />
+                {/* cross-chain pays `payAmount` (principal + Rhino fee) through
+                    a multi-call userOp, so only the shortfall can leave the card */}
+                <CollateralPullNotice
+                    amountUsd={isCrossChainPayment ? (payAmount ?? usdAmount ?? amount) : usdAmount || amount}
+                    collateralOnlyAllowed={!isCrossChainPayment}
+                />
 
                 {/* buttons and error */}
                 <div className="flex flex-col gap-4">

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
@@ -30,6 +30,7 @@ import { printableAddress, areEvmAddressesEqual } from '@/utils/general.utils'
 import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
 import { useTranslations } from 'next-intl'
+import { CollateralPullNotice } from '@/components/Global/CollateralPullNotice'
 
 export function SemanticRequestInputView() {
     const onBack = useSafeBack('/')
@@ -181,6 +182,7 @@ export function SemanticRequestInputView() {
                         disabled={isAmountFromUrl || !!chargeIdFromUrl}
                     />
                     {isInsufficientBalance && <FieldError>{t('errors.insufficientPayment')}</FieldError>}
+                    {!isInsufficientBalance && <CollateralPullNotice amountUsd={amount} />}
                 </div>
 
                 {/* token selector for chain/token selection (not for USERNAME) */}

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
@@ -184,7 +184,9 @@ export function SemanticRequestInputView() {
                         disabled={isAmountFromUrl || !!chargeIdFromUrl}
                     />
                     {isInsufficientBalance && <FieldError>{t('errors.insufficientPayment')}</FieldError>}
-                    {!isInsufficientBalance && (
+                    {/* a token-denominated request holds `amount` in token units; its USD debit is
+                        only known once the route prices it, so the confirm step previews that one */}
+                    {!isInsufficientBalance && !isTokenDenominated && (
                         <CollateralPullNotice amountUsd={amount} collateralOnlyAllowed={!(isXChain || isDiffToken)} />
                     )}
                 </div>

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestInputView.tsx
@@ -50,6 +50,8 @@ export function SemanticRequestInputView() {
         isLoading,
         isLoggedIn,
         isConnected,
+        isXChain,
+        isDiffToken,
         setAmount,
         handlePayment,
         setCurrentView,
@@ -182,7 +184,9 @@ export function SemanticRequestInputView() {
                         disabled={isAmountFromUrl || !!chargeIdFromUrl}
                     />
                     {isInsufficientBalance && <FieldError>{t('errors.insufficientPayment')}</FieldError>}
-                    {!isInsufficientBalance && <CollateralPullNotice amountUsd={amount} />}
+                    {!isInsufficientBalance && (
+                        <CollateralPullNotice amountUsd={amount} collateralOnlyAllowed={!(isXChain || isDiffToken)} />
+                    )}
                 </div>
 
                 {/* token selector for chain/token selection (not for USERNAME) */}

--- a/src/hooks/wallet/__tests__/useMoveOffCard.test.tsx
+++ b/src/hooks/wallet/__tests__/useMoveOffCard.test.tsx
@@ -10,7 +10,10 @@
  *     would pick smart-only — a self-transfer no-op — whenever the smart
  *     wallet covers the amount) and submitted for exactly the amount, capped
  *     at what the card actually holds,
- *  3. a missing wallet address fails closed before any signing.
+ *  3. a missing wallet address fails closed before any signing,
+ *  4. `beforeSubmit` (the caller's target-lowering PATCH) runs after the
+ *     passkey and before the broadcast: never on a cancelled passkey, and
+ *     its failure leaves the signed withdrawal unsent.
  */
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -120,6 +123,51 @@ describe('useMoveOffCard', () => {
         await act(async () => {
             await expect(result.current.moveOffCard(5_000)).rejects.toThrow('user cancelled')
         })
+        expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
+    })
+
+    it('runs beforeSubmit after the passkey and before the broadcast', async () => {
+        const order: string[] = []
+        mockSignSpend.mockImplementation(async () => {
+            order.push('sign')
+            return { strategy: 'collateral-only', rainWithdrawal: RAIN_WITHDRAWAL }
+        })
+        mockSubmitWithdrawal.mockImplementation(async () => {
+            order.push('submit')
+            return { txHash: '0xhash' }
+        })
+        const { result } = setup()
+        await act(async () => {
+            expect(
+                await result.current.moveOffCard(5_000, {
+                    beforeSubmit: async () => {
+                        order.push('before')
+                    },
+                })
+            ).toBe(5_000)
+        })
+        expect(order).toEqual(['sign', 'before', 'submit'])
+    })
+
+    it('a failed beforeSubmit leaves the signed withdrawal unsent', async () => {
+        const { result } = setup()
+        await act(async () => {
+            await expect(
+                result.current.moveOffCard(5_000, { beforeSubmit: async () => Promise.reject(new Error('offline')) })
+            ).rejects.toThrow('offline')
+        })
+        expect(mockSignSpend).toHaveBeenCalled()
+        expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
+    })
+
+    it('never runs beforeSubmit when the passkey is cancelled', async () => {
+        mockSignSpend.mockRejectedValue(new Error('user cancelled'))
+        const beforeSubmit = jest.fn(async () => undefined)
+        const { result } = setup()
+        await act(async () => {
+            await expect(result.current.moveOffCard(5_000, { beforeSubmit })).rejects.toThrow('user cancelled')
+        })
+        expect(beforeSubmit).not.toHaveBeenCalled()
         expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
     })
 })

--- a/src/hooks/wallet/__tests__/useMoveOffCard.test.tsx
+++ b/src/hooks/wallet/__tests__/useMoveOffCard.test.tsx
@@ -1,20 +1,21 @@
 /**
- * Contract tests for useReturnExcessCollateral — the hook that, after a card
- * limit decrease, returns the collateral held above the new limit to the
- * user's smart wallet.
+ * Contract tests for useMoveOffCard — the hook that returns collateral to the
+ * user's smart wallet on request (the "Move off card" action and the excess
+ * after lowering the on-card target).
  *
  * The contracts locked down here:
- *  1. below-threshold / no-excess cases return 0 WITHOUT any signing or
+ *  1. below-threshold / nothing-on-card cases return 0 WITHOUT any signing or
  *     submission (the user must not see a passkey prompt),
- *  2. an excess is signed via the FORCED collateral-only strategy (routing
+ *  2. the move is signed via the FORCED collateral-only strategy (routing
  *     would pick smart-only — a self-transfer no-op — whenever the smart
- *     wallet covers the amount) and submitted for exactly the excess,
+ *     wallet covers the amount) and submitted for exactly the amount, capped
+ *     at what the card actually holds,
  *  3. a missing wallet address fails closed before any signing.
  */
 import { renderHook, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { useReturnExcessCollateral } from '../useReturnExcessCollateral'
+import { useMoveOffCard } from '../useMoveOffCard'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
@@ -42,8 +43,6 @@ const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
 )
 
-// `null` sentinels model the not-loaded states (a destructuring default would
-// silently swallow an explicit `undefined`).
 const setup = ({
     spendingPower = 20_000,
     address = WALLET,
@@ -56,7 +55,7 @@ const setup = ({
     })
     mockUseWallet.mockReturnValue({ address: address === null ? undefined : address })
     mockUseSignSpendBundle.mockReturnValue({ signSpend: mockSignSpend })
-    return renderHook(() => useReturnExcessCollateral(), { wrapper })
+    return renderHook(() => useMoveOffCard(), { wrapper })
 }
 
 beforeEach(() => {
@@ -65,11 +64,11 @@ beforeEach(() => {
     mockSubmitWithdrawal.mockResolvedValue({ txHash: '0xhash' })
 })
 
-describe('useReturnExcessCollateral', () => {
-    it('skips (no prompt, no submit) when the collateral does not exceed the new limit', async () => {
-        const { result } = setup({ spendingPower: 5_000 })
+describe('useMoveOffCard', () => {
+    it('skips (no prompt, no submit) below the $1 threshold', async () => {
+        const { result } = setup()
         await act(async () => {
-            expect(await result.current.returnExcess(20_000)).toBe(0)
+            expect(await result.current.moveOffCard(50)).toBe(0)
         })
         expect(mockSignSpend).not.toHaveBeenCalled()
         expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
@@ -78,16 +77,15 @@ describe('useReturnExcessCollateral', () => {
     it('skips when the overview has not loaded (no spending power)', async () => {
         const { result } = setup({ spendingPower: null })
         await act(async () => {
-            expect(await result.current.returnExcess(5_000)).toBe(0)
+            expect(await result.current.moveOffCard(5_000)).toBe(0)
         })
         expect(mockSignSpend).not.toHaveBeenCalled()
     })
 
-    it('signs a FORCED collateral-only withdrawal of exactly the excess, to the smart wallet, then submits', async () => {
+    it('signs a FORCED collateral-only withdrawal of exactly the amount, to the smart wallet, then submits', async () => {
         const { result } = setup({ spendingPower: 20_000 })
         await act(async () => {
-            // $200 backing, limit lowered to $50 → $150 excess
-            expect(await result.current.returnExcess(5_000)).toBe(15_000)
+            expect(await result.current.moveOffCard(15_000)).toBe(15_000)
         })
         expect(mockSignSpend).toHaveBeenCalledWith({
             requiredUsdcAmount: 150_000_000n, // 15000 cents → 6dp USDC units
@@ -99,10 +97,18 @@ describe('useReturnExcessCollateral', () => {
         expect(mockSubmitWithdrawal).toHaveBeenCalledWith(RAIN_WITHDRAWAL)
     })
 
+    it('caps the move at what the card actually holds', async () => {
+        const { result } = setup({ spendingPower: 4_200 })
+        await act(async () => {
+            expect(await result.current.moveOffCard(10_000)).toBe(4_200)
+        })
+        expect(mockSignSpend).toHaveBeenCalledWith(expect.objectContaining({ requiredUsdcAmount: 42_000_000n }))
+    })
+
     it('fails closed before signing when the wallet address is not ready', async () => {
         const { result } = setup({ address: null })
         await act(async () => {
-            await expect(result.current.returnExcess(5_000)).rejects.toThrow('Wallet not ready')
+            await expect(result.current.moveOffCard(5_000)).rejects.toThrow('Wallet not ready')
         })
         expect(mockSignSpend).not.toHaveBeenCalled()
         expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
@@ -112,7 +118,7 @@ describe('useReturnExcessCollateral', () => {
         mockSignSpend.mockRejectedValue(new Error('user cancelled'))
         const { result } = setup()
         await act(async () => {
-            await expect(result.current.returnExcess(5_000)).rejects.toThrow('user cancelled')
+            await expect(result.current.moveOffCard(5_000)).rejects.toThrow('user cancelled')
         })
         expect(mockSubmitWithdrawal).not.toHaveBeenCalled()
     })

--- a/src/hooks/wallet/useBalanceSplit.ts
+++ b/src/hooks/wallet/useBalanceSplit.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useWallet } from './useWallet'
+import { useRainCardOverview } from '@/hooks/useRainCardOverview'
+import { findActiveCard } from '@/components/Card/cardState.utils'
+import { isRainBalanceKnown, usdcUnitsToRainCents } from '@/utils/balance.utils'
+
+/**
+ * The two halves of the unified balance (TASK-22293): what sits ON the card
+ * (Rain spending power plus top-ups in transit) and what sits OFF it (the
+ * smart wallet — instant, passkey-only). Both in cents; `null` while either
+ * side is not known yet, so a missing Rain read never paints as $0 on card.
+ */
+export interface BalanceSplit {
+    onCardCents: number
+    offCardCents: number
+}
+
+/**
+ * Pure split for callers that already hold the wallet balance and the Rain
+ * overview (the Home flow hook does — it must not mount `useWallet` twice).
+ * Null until the user has an active card and both halves are known.
+ */
+export function computeBalanceSplit(
+    balance: bigint | undefined,
+    overview: Parameters<typeof findActiveCard>[0]
+): BalanceSplit | null {
+    if (!findActiveCard(overview)) return null
+    if (balance === undefined || !isRainBalanceKnown(overview)) return null
+    const b = overview?.balance
+    return {
+        onCardCents: Math.max(0, (b?.spendingPower ?? 0) + (b?.inTransitToCollateralCents ?? 0)),
+        offCardCents: Number(usdcUnitsToRainCents(balance)),
+    }
+}
+
+export function useBalanceSplit() {
+    const { balance } = useWallet()
+    const { overview, isLoading } = useRainCardOverview()
+    const card = findActiveCard(overview)
+
+    const onCardCents = useMemo(() => {
+        if (!isRainBalanceKnown(overview)) return null
+        const b = overview?.balance
+        return Math.max(0, (b?.spendingPower ?? 0) + (b?.inTransitToCollateralCents ?? 0))
+    }, [overview])
+
+    const offCardCents = useMemo(
+        () => (balance === undefined ? null : Number(usdcUnitsToRainCents(balance))),
+        [balance]
+    )
+
+    return {
+        card,
+        hasActiveCard: !!card,
+        policy: card?.collateral ?? null,
+        onCardCents,
+        offCardCents,
+        offCardUnits: balance,
+        isLoading: isLoading || balance === undefined,
+    }
+}

--- a/src/hooks/wallet/useBalanceSplit.ts
+++ b/src/hooks/wallet/useBalanceSplit.ts
@@ -56,7 +56,10 @@ export function useBalanceSplit() {
         return Math.max(0, Math.floor(overview?.balance?.spendingPower ?? 0))
     }, [overview])
     const pendingToCardCents = useMemo(
-        () => (isRainBalanceKnown(overview) ? Math.max(0, Math.floor(overview?.balance?.inTransitToCollateralCents ?? 0)) : 0),
+        () =>
+            isRainBalanceKnown(overview)
+                ? Math.max(0, Math.floor(overview?.balance?.inTransitToCollateralCents ?? 0))
+                : 0,
         [overview]
     )
 

--- a/src/hooks/wallet/useBalanceSplit.ts
+++ b/src/hooks/wallet/useBalanceSplit.ts
@@ -4,7 +4,11 @@ import { useMemo } from 'react'
 import { useWallet } from './useWallet'
 import { useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { findActiveCard } from '@/components/Card/cardState.utils'
-import { isRainBalanceKnown, usdcUnitsToRainCents } from '@/utils/balance.utils'
+import { isRainBalanceKnown } from '@/utils/balance.utils'
+
+/** Display / bound conversion: floor to the cent. `usdcUnitsToRainCents` rounds
+ *  UP for Rain withdrawal inputs and must not size a Max the wallet cannot fund. */
+export const usdcUnitsToDisplayCents = (units: bigint): number => Number(units / 10_000n)
 
 /**
  * The two halves of the unified balance (TASK-22293): what sits ON the card
@@ -13,7 +17,10 @@ import { isRainBalanceKnown, usdcUnitsToRainCents } from '@/utils/balance.utils'
  * side is not known yet, so a missing Rain read never paints as $0 on card.
  */
 export interface BalanceSplit {
+    /** Landed Rain spending power — what the card can spend right now. */
     onCardCents: number
+    /** Top-ups that left the wallet but Rain has not credited yet. */
+    pendingToCardCents: number
     offCardCents: number
 }
 
@@ -30,8 +37,9 @@ export function computeBalanceSplit(
     if (balance === undefined || !isRainBalanceKnown(overview)) return null
     const b = overview?.balance
     return {
-        onCardCents: Math.max(0, (b?.spendingPower ?? 0) + (b?.inTransitToCollateralCents ?? 0)),
-        offCardCents: Number(usdcUnitsToRainCents(balance)),
+        onCardCents: Math.max(0, Math.floor(b?.spendingPower ?? 0)),
+        pendingToCardCents: Math.max(0, Math.floor(b?.inTransitToCollateralCents ?? 0)),
+        offCardCents: usdcUnitsToDisplayCents(balance),
     }
 }
 
@@ -40,22 +48,26 @@ export function useBalanceSplit() {
     const { overview, isLoading } = useRainCardOverview()
     const card = findActiveCard(overview)
 
+    // Landed only: what the card can spend and what can be moved off it.
+    // In-transit top-ups are reported separately — they are neither spendable
+    // by the card nor withdrawable until Rain credits them.
     const onCardCents = useMemo(() => {
         if (!isRainBalanceKnown(overview)) return null
-        const b = overview?.balance
-        return Math.max(0, (b?.spendingPower ?? 0) + (b?.inTransitToCollateralCents ?? 0))
+        return Math.max(0, Math.floor(overview?.balance?.spendingPower ?? 0))
     }, [overview])
-
-    const offCardCents = useMemo(
-        () => (balance === undefined ? null : Number(usdcUnitsToRainCents(balance))),
-        [balance]
+    const pendingToCardCents = useMemo(
+        () => (isRainBalanceKnown(overview) ? Math.max(0, Math.floor(overview?.balance?.inTransitToCollateralCents ?? 0)) : 0),
+        [overview]
     )
+
+    const offCardCents = useMemo(() => (balance === undefined ? null : usdcUnitsToDisplayCents(balance)), [balance])
 
     return {
         card,
         hasActiveCard: !!card,
         policy: card?.collateral ?? null,
         onCardCents,
+        pendingToCardCents,
         offCardCents,
         offCardUnits: balance,
         isLoading: isLoading || balance === undefined,

--- a/src/hooks/wallet/useCollateralPullPreview.ts
+++ b/src/hooks/wallet/useCollateralPullPreview.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { useRainCooldown } from '@/context/RainCooldownContext'
+import { computeCollateralPull } from '@/utils/collateralPull.utils'
+import { useBalanceSplit } from './useBalanceSplit'
+
+/**
+ * Tells a review step, before the passkey, whether the amount being entered
+ * will pull from the card balance — and whether the card's withdrawal lock is
+ * still running (TASK-22293). Today the lock only surfaces as a 425 after the
+ * tap; `RainCooldownContext` already knows `cooldownEndsAt`, this reads it
+ * ahead of time. Captures one analytics event per notice appearance.
+ */
+export function useCollateralPullPreview(amountUsd: string | number | null | undefined) {
+    const { hasActiveCard, offCardUnits, onCardCents } = useBalanceSplit()
+    const { cooldownEndsAt } = useRainCooldown()
+
+    const pull = useMemo(
+        () => (hasActiveCard ? computeCollateralPull({ amountUsd, offCardUnits, onCardCents }) : null),
+        [hasActiveCard, amountUsd, offCardUnits, onCardCents]
+    )
+    const visible = !!pull?.pullsFromCard
+    const lockActive = visible && cooldownEndsAt !== null && cooldownEndsAt > Date.now()
+
+    const capturedRef = useRef(false)
+    useEffect(() => {
+        if (!visible) {
+            capturedRef.current = false
+            return
+        }
+        if (capturedRef.current) return
+        capturedRef.current = true
+        posthog.capture(ANALYTICS_EVENTS.COLLATERAL_PULL_NOTICE_SHOWN, {
+            from_card_cents: pull?.fromCardCents ?? 0,
+            lock_active: lockActive,
+        })
+    }, [visible, lockActive, pull?.fromCardCents])
+
+    return {
+        visible,
+        fromCardCents: pull?.fromCardCents ?? 0,
+        cooldownEndsAt: lockActive ? cooldownEndsAt : null,
+    }
+}

--- a/src/hooks/wallet/useCollateralPullPreview.ts
+++ b/src/hooks/wallet/useCollateralPullPreview.ts
@@ -16,7 +16,7 @@ import { useBalanceSplit } from './useBalanceSplit'
  */
 export function useCollateralPullPreview(
     amountUsd: string | number | null | undefined,
-    options: { collateralOnlyAllowed?: boolean } = {}
+    options: { collateralOnlyAllowed: boolean }
 ) {
     const { hasActiveCard, offCardUnits, onCardCents } = useBalanceSplit()
     // Advisory only: no provider (a bare layout or a view test) reads as "no lock".

--- a/src/hooks/wallet/useCollateralPullPreview.ts
+++ b/src/hooks/wallet/useCollateralPullPreview.ts
@@ -14,14 +14,25 @@ import { useBalanceSplit } from './useBalanceSplit'
  * tap; `RainCooldownContext` already knows `cooldownEndsAt`, this reads it
  * ahead of time. Captures one analytics event per notice appearance.
  */
-export function useCollateralPullPreview(amountUsd: string | number | null | undefined) {
+export function useCollateralPullPreview(
+    amountUsd: string | number | null | undefined,
+    options: { collateralOnlyAllowed?: boolean } = {}
+) {
     const { hasActiveCard, offCardUnits, onCardCents } = useBalanceSplit()
     // Advisory only: no provider (a bare layout or a view test) reads as "no lock".
     const cooldownEndsAt = useRainCooldownOptional()?.cooldownEndsAt ?? null
 
     const pull = useMemo(
-        () => (hasActiveCard ? computeCollateralPull({ amountUsd, offCardUnits, onCardCents }) : null),
-        [hasActiveCard, amountUsd, offCardUnits, onCardCents]
+        () =>
+            hasActiveCard
+                ? computeCollateralPull({
+                      amountUsd,
+                      offCardUnits,
+                      onCardCents,
+                      collateralOnlyAllowed: options.collateralOnlyAllowed,
+                  })
+                : null,
+        [hasActiveCard, amountUsd, offCardUnits, onCardCents, options.collateralOnlyAllowed]
     )
     const visible = !!pull?.pullsFromCard
     const lockActive = visible && cooldownEndsAt !== null && cooldownEndsAt > Date.now()

--- a/src/hooks/wallet/useCollateralPullPreview.ts
+++ b/src/hooks/wallet/useCollateralPullPreview.ts
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { useRainCooldown } from '@/context/RainCooldownContext'
+import { useRainCooldownOptional } from '@/context/RainCooldownContext'
 import { computeCollateralPull } from '@/utils/collateralPull.utils'
 import { useBalanceSplit } from './useBalanceSplit'
 
@@ -16,7 +16,8 @@ import { useBalanceSplit } from './useBalanceSplit'
  */
 export function useCollateralPullPreview(amountUsd: string | number | null | undefined) {
     const { hasActiveCard, offCardUnits, onCardCents } = useBalanceSplit()
-    const { cooldownEndsAt } = useRainCooldown()
+    // Advisory only: no provider (a bare layout or a view test) reads as "no lock".
+    const cooldownEndsAt = useRainCooldownOptional()?.cooldownEndsAt ?? null
 
     const pull = useMemo(
         () => (hasActiveCard ? computeCollateralPull({ amountUsd, offCardUnits, onCardCents }) : null),

--- a/src/hooks/wallet/useMoveOffCard.ts
+++ b/src/hooks/wallet/useMoveOffCard.ts
@@ -18,10 +18,13 @@ import { EXCESS_COLLATERAL_MIN_CENTS, rainCentsToUsdcUnits } from '@/utils/balan
  * INTERNAL_TRANSFER, hidden from history), and the unified total never
  * changes.
  *
- * Callers that lower the on-card target MUST PATCH it first: the balancer
- * tops the card up to the target, so a return ahead of the PATCH races it
- * straight back. The inflow debounce also holds the returned money off the
- * card for a few minutes regardless.
+ * Callers that lower the on-card target MUST land that PATCH before the
+ * broadcast: the balancer tops the card up to the target, so a return ahead
+ * of the PATCH races it straight back. They pass it as `beforeSubmit`, which
+ * runs AFTER the passkey and BEFORE the withdrawal is submitted — a
+ * cancelled passkey therefore changes nothing, and a failed PATCH aborts
+ * the move with the signed withdrawal unsent. The inflow debounce also holds
+ * the returned money off the card for a few minutes regardless.
  *
  * Returns the cents actually moved (0 = nothing to move, no prompt shown).
  */
@@ -32,7 +35,7 @@ export const useMoveOffCard = () => {
     const queryClient = useQueryClient()
 
     const moveOffCard = useCallback(
-        async (amountCents: number): Promise<number> => {
+        async (amountCents: number, options: { beforeSubmit?: () => Promise<void> } = {}): Promise<number> => {
             const spendingPowerCents = overview?.balance?.spendingPower
             if (spendingPowerCents == null || !Number.isFinite(spendingPowerCents) || spendingPowerCents <= 0) return 0
             if (!Number.isFinite(amountCents)) return 0
@@ -56,6 +59,7 @@ export const useMoveOffCard = () => {
             if (artifact.strategy !== 'collateral-only') {
                 throw new Error('Unexpected withdrawal strategy')
             }
+            await options.beforeSubmit?.()
             await rainApi.submitWithdrawal(artifact.rainWithdrawal)
 
             // Funds moved collateral → smart wallet; refresh both buckets so the

--- a/src/hooks/wallet/useMoveOffCard.ts
+++ b/src/hooks/wallet/useMoveOffCard.ts
@@ -7,34 +7,39 @@ import { rainApi } from '@/services/rain'
 import { RAIN_CARD_OVERVIEW_QUERY_KEY, useRainCardOverview } from '@/hooks/useRainCardOverview'
 import { useWallet } from '@/hooks/wallet/useWallet'
 import { useSignSpendBundle } from '@/hooks/wallet/useSignSpendBundle'
-import { computeExcessCollateralCents, rainCentsToUsdcUnits } from '@/utils/balance.utils'
+import { EXCESS_COLLATERAL_MIN_CENTS, rainCentsToUsdcUnits } from '@/utils/balance.utils'
 
 /**
- * After a card-limit decrease, returns the collateral held above the new
- * limit to the user's smart wallet so the card's backing always matches the
- * limit. The user sees exactly one thing: the passkey prompt for the admin
- * EIP-712 signature — the backend broadcasts via the stored session key, the
- * movement is collateral↔wallet (kind AUTO_REBALANCE → INTERNAL_TRANSFER,
- * hidden from history), and the unified displayed balance never changes.
+ * Moves money OFF the card — a collateral→smart-wallet return the user
+ * chose (the "Move off card" action, or the excess after lowering the
+ * on-card target). The user sees exactly one thing: the passkey prompt for
+ * the admin EIP-712 signature — the backend broadcasts via the stored
+ * session key, the movement is collateral↔wallet (kind AUTO_REBALANCE →
+ * INTERNAL_TRANSFER, hidden from history), and the unified total never
+ * changes.
  *
- * MUST run only AFTER the limit PATCH has succeeded: the auto-balancer
- * targets the DB cardLimit, so withdrawing first would race it topping the
- * collateral straight back up.
+ * Callers that lower the on-card target MUST PATCH it first: the balancer
+ * tops the card up to the target, so a return ahead of the PATCH races it
+ * straight back. The inflow debounce also holds the returned money off the
+ * card for a few minutes regardless.
  *
- * Returns the cents actually returned (0 = nothing above the threshold, no
- * prompt shown).
+ * Returns the cents actually moved (0 = nothing to move, no prompt shown).
  */
-export const useReturnExcessCollateral = () => {
+export const useMoveOffCard = () => {
     const { overview } = useRainCardOverview()
     const { address: smartWalletAddress } = useWallet()
     const { signSpend } = useSignSpendBundle()
     const queryClient = useQueryClient()
 
-    const returnExcess = useCallback(
-        async (newLimitCents: number): Promise<number> => {
+    const moveOffCard = useCallback(
+        async (amountCents: number): Promise<number> => {
             const spendingPowerCents = overview?.balance?.spendingPower
-            const excessCents = computeExcessCollateralCents(spendingPowerCents, newLimitCents)
-            if (excessCents <= 0) return 0
+            if (spendingPowerCents == null || !Number.isFinite(spendingPowerCents) || spendingPowerCents <= 0) return 0
+            if (!Number.isFinite(amountCents)) return 0
+            // Floor both sides so we never sign for more than the collateral can
+            // cover — sub-cent dust stays put.
+            const cents = Math.min(Math.floor(amountCents), Math.floor(spendingPowerCents))
+            if (cents < EXCESS_COLLATERAL_MIN_CENTS) return 0
             if (!smartWalletAddress) {
                 throw new Error('Wallet not ready — please retry in a moment')
             }
@@ -42,7 +47,7 @@ export const useReturnExcessCollateral = () => {
             // Force collateral-only: routing would pick smart-only (a
             // self-transfer no-op) whenever the smart wallet covers the amount.
             const artifact = await signSpend({
-                requiredUsdcAmount: rainCentsToUsdcUnits(excessCents),
+                requiredUsdcAmount: rainCentsToUsdcUnits(cents),
                 recipient: smartWalletAddress as Address,
                 rainSpendingPower: rainCentsToUsdcUnits(spendingPowerCents),
                 kind: 'AUTO_REBALANCE',
@@ -59,10 +64,10 @@ export const useReturnExcessCollateral = () => {
                 queryClient.invalidateQueries({ queryKey: [RAIN_CARD_OVERVIEW_QUERY_KEY] }),
                 queryClient.invalidateQueries({ queryKey: ['balance'] }),
             ])
-            return excessCents
+            return cents
         },
         [overview, smartWalletAddress, signSpend, queryClient]
     )
 
-    return { returnExcess }
+    return { moveOffCard }
 }

--- a/src/hooks/wallet/useSignSpendBundle.ts
+++ b/src/hooks/wallet/useSignSpendBundle.ts
@@ -171,7 +171,12 @@ export const useSignSpendBundle = () => {
             }
 
             onStrategyDecided?.(strategy)
-            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, { strategy, kind, flow: 'sign-only' })
+            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, {
+                strategy,
+                kind,
+                flow: 'sign-only',
+                amount_cents: Number(usdcUnitsToRainCents(requiredUsdcAmount)),
+            })
 
             // Failure-capture parity with useSpendBundle's catch: without this,
             // a failed migration/grant/signing in the sign-then-broadcast flow

--- a/src/hooks/wallet/useSpendBundle.ts
+++ b/src/hooks/wallet/useSpendBundle.ts
@@ -165,7 +165,11 @@ export const useSpendBundle = () => {
             })
 
             onStrategyDecided?.(strategy)
-            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, { strategy, kind })
+            posthog.capture(ANALYTICS_EVENTS.CARD_WITHDRAW_ATTEMPTED, {
+                strategy,
+                kind,
+                amount_cents: Number(usdcUnitsToRainCents(requiredUsdcAmount)),
+            })
 
             try {
                 // Shared collateral pre-flights (root-validator migration gate +

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1671,7 +1671,7 @@
             "summary": "Card payments spend from what's on the card. Everything off the card is instant for sends, QR payments and withdrawals, and never waits for the card's lock.",
             "autoTitle": "Automatic top-ups",
             "keepOnCard": "Keep on card",
-            "keepOnCardHint": "Topped up from your off-card balance whenever the card dips below this. Card purchases above it still go through: the card refills and the retry works.",
+            "keepOnCardHint": "Topped up from your off-card balance whenever the card dips below this. A card purchase above it is declined once: the card tops itself up and the purchase usually works if you try again after a minute or two.",
             "keepOffCard": "Keep off card",
             "keepOffCardHint": "Never moved to the card automatically, so it's always ready to send.",
             "loadAll": "Load everything to card",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -280,7 +280,9 @@
             "withdrawToOwnAccountsDescription": "Bank, Mercado, Crypto"
         },
         "split": "{onCard} on card · {offCard} off card",
-        "splitHidden": "**** on card · **** off card"
+        "splitHidden": "**** on card · **** off card",
+        "splitPending": "{amount} moving to card",
+        "splitPendingHidden": "**** moving to card"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1684,7 +1686,7 @@
             "moveOffCardTitle": "Move off card",
             "moveToCardHint": "Arrives on the card in about a minute. No passkey needed.",
             "moveOffCardHint": "Needs your passkey. The card allows one move off it every few minutes.",
-            "amountLabel": "Amount",
+            "amountLabel": "Amount (USD)",
             "max": "Max",
             "editTargetTitle": "Keep on card",
             "editFloorTitle": "Keep off card",
@@ -1698,7 +1700,8 @@
             "moveOffCardDone": "{amount} moved off the card",
             "setupRequired": "Finish setting up your card to move money to it.",
             "autoBalanceOff": "Automatic top-ups are off for this card. Move money to the card by hand before paying.",
-            "lockNote": "Money on the card is instant for card payments. Moving it off the card needs your passkey and is limited to one move every few minutes."
+            "lockNote": "Money on the card is instant for card payments. Moving it off the card needs your passkey and is limited to one move every few minutes.",
+            "pending": "{amount} on its way to the card"
         }
     },
     "addMoney": {
@@ -3496,7 +3499,7 @@
         },
         "collateralPull": {
             "fromCard": "{amount} of this comes off your card balance.",
-            "lockActive": "The card is locked for {time} after its last pull — this payment will wait for it."
+            "lockActive": "The card is locked for {time} after its last pull — you can pay once it clears."
         }
     },
     "errors": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -278,7 +278,9 @@
             "sendToFriendsDescription": "Link, Contacts, Bank, Crypto",
             "withdrawToOwnAccounts": "Withdraw to own accounts",
             "withdrawToOwnAccountsDescription": "Bank, Mercado, Crypto"
-        }
+        },
+        "split": "{onCard} on card · {offCard} off card",
+        "splitHidden": "**** on card · **** off card"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1494,13 +1496,13 @@
             "retryDetails": "Retry showing card details"
         },
         "limits": {
-            "navTitle": "Card limit",
-            "subtitle": "Set your per-transaction spending limit.",
-            "perTransaction": "Per transaction",
+            "navTitle": "Per-purchase limit",
+            "subtitle": "The most a single card purchase can be. It doesn't change how much stays on the card.",
+            "perTransaction": "Per purchase",
             "loadFailed": "Failed to load card limit.",
             "noLimitSet": "No limit set",
             "edit": "Edit",
-            "editTitle": "Change limit",
+            "editTitle": "Change per-purchase limit",
             "invalidAmount": "Enter a valid amount",
             "saveFailed": "Failed to save limit",
             "saveChanges": "Save changes",
@@ -1600,12 +1602,13 @@
             "payAsCreditBody": "When a terminal asks debit or credit, choose credit — your Peanut card runs on the credit network.",
             "managementTitle": "Card management",
             "pin": "Pin",
-            "spendingLimit": "Spending limit",
+            "spendingLimit": "Per-purchase limit",
             "physicalCard": "Physical card",
             "redZone": "Red zone",
             "lockCard": "Lock card",
             "unlockCard": "Unlock card",
-            "cancelCard": "Cancel card"
+            "cancelCard": "Cancel card",
+            "onCard": "On card"
         },
         "page": {
             "loadFailed": "Failed to load card info. Please try again.",
@@ -1657,6 +1660,45 @@
             "noActiveCard": "No active card found on this account — please contact support.",
             "regrantFailed": "Re-enabling did not complete — please try again or contact support.",
             "diagnostics": "Diagnostics: nonce {nonce} / floor {floor}"
+        },
+        "onCard": {
+            "navTitle": "On card",
+            "noActiveCard": "No active card to manage.",
+            "onCard": "On card",
+            "offCard": "Off card",
+            "summary": "Card payments spend from what's on the card. Everything off the card is instant for sends, QR payments and withdrawals, and never waits for the card's lock.",
+            "autoTitle": "Automatic top-ups",
+            "keepOnCard": "Keep on card",
+            "keepOnCardHint": "Topped up from your off-card balance whenever the card dips below this. Card purchases above it still go through: the card refills and the retry works.",
+            "keepOffCard": "Keep off card",
+            "keepOffCardHint": "Never moved to the card automatically, so it's always ready to send.",
+            "loadAll": "Load everything to card",
+            "loadAllHint": "Moves your whole balance to the card. Sends and QR payments will then pull from the card and wait for its short lock between pulls.",
+            "loadAllActive": "Everything goes to the card",
+            "pinned": "Set by you",
+            "tuned": "Sized from your recent card purchases",
+            "moveTitle": "Move money",
+            "moveToCard": "Move to card",
+            "moveOffCard": "Move off card",
+            "moveToCardTitle": "Move to card",
+            "moveOffCardTitle": "Move off card",
+            "moveToCardHint": "Arrives on the card in about a minute. No passkey needed.",
+            "moveOffCardHint": "Needs your passkey. The card allows one move off it every few minutes.",
+            "amountLabel": "Amount",
+            "max": "Max",
+            "editTargetTitle": "Keep on card",
+            "editFloorTitle": "Keep off card",
+            "save": "Save",
+            "invalidAmount": "Enter a valid amount",
+            "minAmount": "The minimum is {amount}",
+            "maxAmount": "The maximum is {amount}",
+            "saveFailed": "Couldn't save. Please try again.",
+            "moveFailed": "Couldn't move the money. Please try again.",
+            "moveToCardDone": "{amount} is on its way to your card",
+            "moveOffCardDone": "{amount} moved off the card",
+            "setupRequired": "Finish setting up your card to move money to it.",
+            "autoBalanceOff": "Automatic top-ups are off for this card. Move money to the card by hand before paying.",
+            "lockNote": "Money on the card is instant for card payments. Moving it off the card needs your passkey and is limited to one move every few minutes."
         }
     },
     "addMoney": {
@@ -3254,7 +3296,7 @@
         },
         "rainCooldownIntroModal": {
             "title": "Please wait",
-            "description": "Your card needs a short cool-down between back-to-back spends. To avoid this in the future, you can lower your card limit to be below your wallet balance; the extra will always be available.",
+            "description": "Your card allows one pull every few minutes. Money kept off the card goes through right away — change how much stays on the card from the Card screen.",
             "readMore": "Read more"
         },
         "staleCardApprovalModal": {
@@ -3451,6 +3493,10 @@
         "countryCombobox": {
             "noResults": "No countries match",
             "clear": "Clear search"
+        },
+        "collateralPull": {
+            "fromCard": "{amount} of this comes off your card balance.",
+            "lockActive": "The card is locked for {time} after its last pull — this payment will wait for it."
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -278,7 +278,9 @@
             "sendToFriendsDescription": "Link, contactos, banco, cripto",
             "withdrawToOwnAccounts": "Retirar a tus cuentas",
             "withdrawToOwnAccountsDescription": "Banco, Mercado, cripto"
-        }
+        },
+        "split": "{onCard} en la tarjeta · {offCard} fuera de la tarjeta",
+        "splitHidden": "**** en la tarjeta · **** fuera de la tarjeta"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1494,13 +1496,13 @@
             "retryDetails": "Reintentar mostrar los datos de la tarjeta"
         },
         "limits": {
-            "navTitle": "Límite de la tarjeta",
-            "subtitle": "Define tu límite de gasto por transacción.",
-            "perTransaction": "Por transacción",
+            "navTitle": "Límite por compra",
+            "subtitle": "El máximo de una sola compra con tarjeta. No cambia cuánto se queda en la tarjeta.",
+            "perTransaction": "Por compra",
             "loadFailed": "No se pudo cargar el límite de la tarjeta.",
             "noLimitSet": "Sin límite definido",
             "edit": "Editar",
-            "editTitle": "Cambiar límite",
+            "editTitle": "Cambiar límite por compra",
             "invalidAmount": "Ingresa un monto válido",
             "saveFailed": "No se pudo guardar el límite",
             "saveChanges": "Guardar cambios",
@@ -1600,12 +1602,13 @@
             "payAsCreditBody": "Cuando la terminal pregunte débito o crédito, elige crédito — tu tarjeta Peanut corre en la red de crédito.",
             "managementTitle": "Gestión de la tarjeta",
             "pin": "Pin",
-            "spendingLimit": "Límite de gasto",
+            "spendingLimit": "Límite por compra",
             "physicalCard": "Tarjeta física",
             "redZone": "Zona roja",
             "lockCard": "Bloquear tarjeta",
             "unlockCard": "Desbloquear tarjeta",
-            "cancelCard": "Cancelar tarjeta"
+            "cancelCard": "Cancelar tarjeta",
+            "onCard": "En la tarjeta"
         },
         "page": {
             "loadFailed": "No se pudo cargar la información de la tarjeta. Inténtalo de nuevo.",
@@ -1657,6 +1660,45 @@
             "noActiveCard": "No se encontró una tarjeta activa en esta cuenta. Contacta al soporte.",
             "regrantFailed": "La reactivación no se completó. Inténtalo de nuevo o contacta al soporte.",
             "diagnostics": "Diagnóstico: nonce {nonce} / piso {floor}"
+        },
+        "onCard": {
+            "navTitle": "En la tarjeta",
+            "noActiveCard": "No tienes una tarjeta activa para gestionar.",
+            "onCard": "En la tarjeta",
+            "offCard": "Fuera de la tarjeta",
+            "summary": "Los pagos con tarjeta usan lo que está en la tarjeta. Todo lo que está fuera de la tarjeta es instantáneo para envíos, pagos QR y retiros, y nunca espera el bloqueo de la tarjeta.",
+            "autoTitle": "Recargas automáticas",
+            "keepOnCard": "Mantener en la tarjeta",
+            "keepOnCardHint": "Se recarga desde tu saldo fuera de la tarjeta cada vez que la tarjeta baja de este monto. Las compras mayores igual pasan: la tarjeta se recarga y el reintento funciona.",
+            "keepOffCard": "Mantener fuera de la tarjeta",
+            "keepOffCardHint": "Nunca se mueve a la tarjeta automáticamente, así que siempre está listo para enviar.",
+            "loadAll": "Cargar todo a la tarjeta",
+            "loadAllHint": "Mueve todo tu saldo a la tarjeta. Los envíos y pagos QR tomarán el dinero de la tarjeta y esperarán su breve bloqueo entre retiros.",
+            "loadAllActive": "Todo va a la tarjeta",
+            "pinned": "Definido por ti",
+            "tuned": "Ajustado según tus compras recientes con tarjeta",
+            "moveTitle": "Mover dinero",
+            "moveToCard": "Mover a la tarjeta",
+            "moveOffCard": "Sacar de la tarjeta",
+            "moveToCardTitle": "Mover a la tarjeta",
+            "moveOffCardTitle": "Sacar de la tarjeta",
+            "moveToCardHint": "Llega a la tarjeta en aproximadamente un minuto. No necesita passkey.",
+            "moveOffCardHint": "Necesita tu passkey. La tarjeta permite un retiro cada pocos minutos.",
+            "amountLabel": "Monto",
+            "max": "Máx.",
+            "editTargetTitle": "Mantener en la tarjeta",
+            "editFloorTitle": "Mantener fuera de la tarjeta",
+            "save": "Guardar",
+            "invalidAmount": "Ingresa un monto válido",
+            "minAmount": "El mínimo es {amount}",
+            "maxAmount": "El máximo es {amount}",
+            "saveFailed": "No se pudo guardar. Inténtalo de nuevo.",
+            "moveFailed": "No se pudo mover el dinero. Inténtalo de nuevo.",
+            "moveToCardDone": "{amount} va en camino a tu tarjeta",
+            "moveOffCardDone": "{amount} salió de la tarjeta",
+            "setupRequired": "Termina de configurar tu tarjeta para mover dinero a ella.",
+            "autoBalanceOff": "Las recargas automáticas están desactivadas para esta tarjeta. Mueve dinero a la tarjeta manualmente antes de pagar.",
+            "lockNote": "El dinero en la tarjeta es instantáneo para pagos con tarjeta. Sacarlo necesita tu passkey y está limitado a un retiro cada pocos minutos."
         }
     },
     "addMoney": {
@@ -3254,7 +3296,7 @@
         },
         "rainCooldownIntroModal": {
             "title": "Espera un momento",
-            "description": "Tu tarjeta necesita un breve tiempo de espera entre gastos seguidos. Para evitar esto en el futuro, puedes bajar el límite de tu tarjeta por debajo del saldo de tu wallet; el resto siempre estará disponible.",
+            "description": "Tu tarjeta permite un retiro cada pocos minutos. El dinero fuera de la tarjeta se envía al instante; cambia cuánto se queda en la tarjeta desde la pantalla de la tarjeta.",
             "readMore": "Leer más"
         },
         "staleCardApprovalModal": {
@@ -3451,6 +3493,10 @@
         "countryCombobox": {
             "noResults": "Ningún país coincide",
             "clear": "Borrar búsqueda"
+        },
+        "collateralPull": {
+            "fromCard": "{amount} de este pago sale de tu saldo en la tarjeta.",
+            "lockActive": "La tarjeta queda bloqueada {time} después de su último retiro: este pago esperará."
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -280,7 +280,9 @@
             "withdrawToOwnAccountsDescription": "Banco, Mercado, cripto"
         },
         "split": "{onCard} en la tarjeta · {offCard} fuera de la tarjeta",
-        "splitHidden": "**** en la tarjeta · **** fuera de la tarjeta"
+        "splitHidden": "**** en la tarjeta · **** fuera de la tarjeta",
+        "splitPending": "{amount} en camino a la tarjeta",
+        "splitPendingHidden": "**** en camino a la tarjeta"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1684,7 +1686,7 @@
             "moveOffCardTitle": "Sacar de la tarjeta",
             "moveToCardHint": "Llega a la tarjeta en aproximadamente un minuto. No necesita passkey.",
             "moveOffCardHint": "Necesita tu passkey. La tarjeta permite un retiro cada pocos minutos.",
-            "amountLabel": "Monto",
+            "amountLabel": "Monto (USD)",
             "max": "Máx.",
             "editTargetTitle": "Mantener en la tarjeta",
             "editFloorTitle": "Mantener fuera de la tarjeta",
@@ -1698,7 +1700,8 @@
             "moveOffCardDone": "{amount} salió de la tarjeta",
             "setupRequired": "Termina de configurar tu tarjeta para mover dinero a ella.",
             "autoBalanceOff": "Las recargas automáticas están desactivadas para esta tarjeta. Mueve dinero a la tarjeta manualmente antes de pagar.",
-            "lockNote": "El dinero en la tarjeta es instantáneo para pagos con tarjeta. Sacarlo necesita tu passkey y está limitado a un retiro cada pocos minutos."
+            "lockNote": "El dinero en la tarjeta es instantáneo para pagos con tarjeta. Sacarlo necesita tu passkey y está limitado a un retiro cada pocos minutos.",
+            "pending": "{amount} en camino a la tarjeta"
         }
     },
     "addMoney": {
@@ -3496,7 +3499,7 @@
         },
         "collateralPull": {
             "fromCard": "{amount} de este pago sale de tu saldo en la tarjeta.",
-            "lockActive": "La tarjeta queda bloqueada {time} después de su último retiro: este pago esperará."
+            "lockActive": "La tarjeta queda bloqueada {time} después de su último retiro: podrás pagar cuando termine."
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1671,7 +1671,7 @@
             "summary": "Los pagos con tarjeta usan lo que está en la tarjeta. Todo lo que está fuera de la tarjeta es instantáneo para envíos, pagos QR y retiros, y nunca espera el bloqueo de la tarjeta.",
             "autoTitle": "Recargas automáticas",
             "keepOnCard": "Mantener en la tarjeta",
-            "keepOnCardHint": "Se recarga desde tu saldo fuera de la tarjeta cada vez que la tarjeta baja de este monto. Las compras mayores igual pasan: la tarjeta se recarga y el reintento funciona.",
+            "keepOnCardHint": "Se recarga desde tu saldo fuera de la tarjeta cada vez que la tarjeta baja de este monto. Una compra mayor se rechaza una vez: la tarjeta se recarga sola y, si volvés a intentar en uno o dos minutos, normalmente pasa.",
             "keepOffCard": "Mantener fuera de la tarjeta",
             "keepOffCardHint": "Nunca se mueve a la tarjeta automáticamente, así que siempre está listo para enviar.",
             "loadAll": "Cargar todo a la tarjeta",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -802,7 +802,7 @@
             "holdAriaLabel": "Mantené presionado para revisar si calificás"
         },
         "limits": {
-            "subtitle": "Definí tu límite de gasto por transacción.",
+            "subtitle": "El máximo de una sola compra con tarjeta. No cambia cuánto se queda en la tarjeta.",
             "invalidAmount": "Ingresá un monto válido",
             "noActiveCard": "No tenés una tarjeta activa para gestionar límites."
         },
@@ -844,6 +844,15 @@
         "recovery": {
             "failed": "Falló la recuperación — intentalo de nuevo",
             "title": "Recuperá el colateral de tu tarjeta"
+        },
+        "onCard": {
+            "noActiveCard": "No tenés una tarjeta activa para gestionar.",
+            "pinned": "Definido por vos",
+            "invalidAmount": "Ingresá un monto válido",
+            "saveFailed": "No se pudo guardar. Intentá de nuevo.",
+            "moveFailed": "No se pudo mover el dinero. Intentá de nuevo.",
+            "setupRequired": "Terminá de configurar tu tarjeta para mover dinero a ella.",
+            "autoBalanceOff": "Las recargas automáticas están desactivadas para esta tarjeta. Mové dinero a la tarjeta manualmente antes de pagar."
         }
     },
     "addMoney": {
@@ -1446,7 +1455,7 @@
         },
         "rainCooldownIntroModal": {
             "title": "Esperá un momento",
-            "description": "Tu tarjeta necesita un breve tiempo de espera entre gastos seguidos. Para evitar esto en el futuro, podés bajar el límite de tu tarjeta por debajo del saldo de tu wallet; el resto siempre estará disponible."
+            "description": "Tu tarjeta permite un retiro cada pocos minutos. El dinero fuera de la tarjeta se envía al instante; cambiá cuánto se queda en la tarjeta desde la pantalla de la tarjeta."
         },
         "staleCardApprovalModal": {
             "description": "Necesitás volver a habilitar tu tarjeta antes de retirar. Solo toma un toque con tu passkey.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -280,7 +280,9 @@
             "withdrawToOwnAccountsDescription": "Banco, Mercado, cripto"
         },
         "split": "{onCard} no cartão · {offCard} fora do cartão",
-        "splitHidden": "**** no cartão · **** fora do cartão"
+        "splitHidden": "**** no cartão · **** fora do cartão",
+        "splitPending": "{amount} a caminho do cartão",
+        "splitPendingHidden": "**** a caminho do cartão"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1684,7 +1686,7 @@
             "moveOffCardTitle": "Tirar do cartão",
             "moveToCardHint": "Chega ao cartão em cerca de um minuto. Não precisa de passkey.",
             "moveOffCardHint": "Precisa da sua passkey. O cartão permite um saque a cada poucos minutos.",
-            "amountLabel": "Valor",
+            "amountLabel": "Valor (USD)",
             "max": "Máx.",
             "editTargetTitle": "Manter no cartão",
             "editFloorTitle": "Manter fora do cartão",
@@ -1698,7 +1700,8 @@
             "moveOffCardDone": "{amount} saiu do cartão",
             "setupRequired": "Termine de configurar seu cartão para mover dinheiro para ele.",
             "autoBalanceOff": "As recargas automáticas estão desligadas para este cartão. Mova dinheiro para o cartão manualmente antes de pagar.",
-            "lockNote": "O dinheiro no cartão é instantâneo para pagamentos com cartão. Tirá-lo do cartão precisa da sua passkey e é limitado a um saque a cada poucos minutos."
+            "lockNote": "O dinheiro no cartão é instantâneo para pagamentos com cartão. Tirá-lo do cartão precisa da sua passkey e é limitado a um saque a cada poucos minutos.",
+            "pending": "{amount} a caminho do cartão"
         }
     },
     "addMoney": {
@@ -3496,7 +3499,7 @@
         },
         "collateralPull": {
             "fromCard": "{amount} deste pagamento sai do seu saldo no cartão.",
-            "lockActive": "O cartão fica bloqueado por {time} após o último saque: este pagamento vai esperar."
+            "lockActive": "O cartão fica bloqueado por {time} após o último saque: você poderá pagar quando terminar."
         }
     },
     "errors": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1671,7 +1671,7 @@
             "summary": "Pagamentos com cartão usam o que está no cartão. Tudo que está fora do cartão é instantâneo para envios, pagamentos QR e saques, e nunca espera o bloqueio do cartão.",
             "autoTitle": "Recargas automáticas",
             "keepOnCard": "Manter no cartão",
-            "keepOnCardHint": "Recarregado do seu saldo fora do cartão sempre que o cartão ficar abaixo deste valor. Compras maiores ainda passam: o cartão recarrega e a nova tentativa funciona.",
+            "keepOnCardHint": "Recarregado do seu saldo fora do cartão sempre que o cartão ficar abaixo deste valor. Uma compra maior é recusada uma vez: o cartão se recarrega e, se você tentar de novo em um ou dois minutos, normalmente passa.",
             "keepOffCard": "Manter fora do cartão",
             "keepOffCardHint": "Nunca vai para o cartão automaticamente, então está sempre pronto para enviar.",
             "loadAll": "Carregar tudo no cartão",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -278,7 +278,9 @@
             "sendToFriendsDescription": "Link, contatos, banco, cripto",
             "withdrawToOwnAccounts": "Sacar para suas contas",
             "withdrawToOwnAccountsDescription": "Banco, Mercado, cripto"
-        }
+        },
+        "split": "{onCard} no cartão · {offCard} fora do cartão",
+        "splitHidden": "**** no cartão · **** fora do cartão"
     },
     "profile": {
         "showFullNameConfirm": {
@@ -1494,13 +1496,13 @@
             "retryDetails": "Tentar mostrar os dados do cartão de novo"
         },
         "limits": {
-            "navTitle": "Limite do cartão",
-            "subtitle": "Defina seu limite de gasto por transação.",
-            "perTransaction": "Por transação",
+            "navTitle": "Limite por compra",
+            "subtitle": "O máximo de uma única compra com o cartão. Não muda quanto fica no cartão.",
+            "perTransaction": "Por compra",
             "loadFailed": "Não foi possível carregar o limite do cartão.",
             "noLimitSet": "Nenhum limite definido",
             "edit": "Editar",
-            "editTitle": "Alterar limite",
+            "editTitle": "Alterar limite por compra",
             "invalidAmount": "Informe um valor válido",
             "saveFailed": "Não foi possível salvar o limite",
             "saveChanges": "Salvar alterações",
@@ -1600,12 +1602,13 @@
             "payAsCreditBody": "Quando a maquininha perguntar débito ou crédito, escolha crédito — seu cartão Peanut roda na rede de crédito.",
             "managementTitle": "Gerenciar cartão",
             "pin": "Pin",
-            "spendingLimit": "Limite de gasto",
+            "spendingLimit": "Limite por compra",
             "physicalCard": "Cartão físico",
             "redZone": "Zona vermelha",
             "lockCard": "Bloquear cartão",
             "unlockCard": "Desbloquear cartão",
-            "cancelCard": "Cancelar cartão"
+            "cancelCard": "Cancelar cartão",
+            "onCard": "No cartão"
         },
         "page": {
             "loadFailed": "Não foi possível carregar as informações do cartão. Tente de novo.",
@@ -1657,6 +1660,45 @@
             "noActiveCard": "Nenhum cartão ativo encontrado nesta conta — entre em contato com o suporte.",
             "regrantFailed": "A reativação não foi concluída — tente novamente ou entre em contato com o suporte.",
             "diagnostics": "Diagnóstico: nonce {nonce} / piso {floor}"
+        },
+        "onCard": {
+            "navTitle": "No cartão",
+            "noActiveCard": "Nenhum cartão ativo para gerenciar.",
+            "onCard": "No cartão",
+            "offCard": "Fora do cartão",
+            "summary": "Pagamentos com cartão usam o que está no cartão. Tudo que está fora do cartão é instantâneo para envios, pagamentos QR e saques, e nunca espera o bloqueio do cartão.",
+            "autoTitle": "Recargas automáticas",
+            "keepOnCard": "Manter no cartão",
+            "keepOnCardHint": "Recarregado do seu saldo fora do cartão sempre que o cartão ficar abaixo deste valor. Compras maiores ainda passam: o cartão recarrega e a nova tentativa funciona.",
+            "keepOffCard": "Manter fora do cartão",
+            "keepOffCardHint": "Nunca vai para o cartão automaticamente, então está sempre pronto para enviar.",
+            "loadAll": "Carregar tudo no cartão",
+            "loadAllHint": "Move todo o seu saldo para o cartão. Envios e pagamentos QR passarão a usar o cartão e esperar o breve bloqueio entre saques.",
+            "loadAllActive": "Tudo vai para o cartão",
+            "pinned": "Definido por você",
+            "tuned": "Ajustado pelas suas compras recentes com o cartão",
+            "moveTitle": "Mover dinheiro",
+            "moveToCard": "Mover para o cartão",
+            "moveOffCard": "Tirar do cartão",
+            "moveToCardTitle": "Mover para o cartão",
+            "moveOffCardTitle": "Tirar do cartão",
+            "moveToCardHint": "Chega ao cartão em cerca de um minuto. Não precisa de passkey.",
+            "moveOffCardHint": "Precisa da sua passkey. O cartão permite um saque a cada poucos minutos.",
+            "amountLabel": "Valor",
+            "max": "Máx.",
+            "editTargetTitle": "Manter no cartão",
+            "editFloorTitle": "Manter fora do cartão",
+            "save": "Salvar",
+            "invalidAmount": "Informe um valor válido",
+            "minAmount": "O mínimo é {amount}",
+            "maxAmount": "O máximo é {amount}",
+            "saveFailed": "Não foi possível salvar. Tente de novo.",
+            "moveFailed": "Não foi possível mover o dinheiro. Tente de novo.",
+            "moveToCardDone": "{amount} está a caminho do seu cartão",
+            "moveOffCardDone": "{amount} saiu do cartão",
+            "setupRequired": "Termine de configurar seu cartão para mover dinheiro para ele.",
+            "autoBalanceOff": "As recargas automáticas estão desligadas para este cartão. Mova dinheiro para o cartão manualmente antes de pagar.",
+            "lockNote": "O dinheiro no cartão é instantâneo para pagamentos com cartão. Tirá-lo do cartão precisa da sua passkey e é limitado a um saque a cada poucos minutos."
         }
     },
     "addMoney": {
@@ -3254,7 +3296,7 @@
         },
         "rainCooldownIntroModal": {
             "title": "Aguarde um momento",
-            "description": "Seu cartão precisa de um breve intervalo entre gastos seguidos. Para evitar isso no futuro, você pode baixar o limite do cartão para menos que o saldo da sua wallet; o restante fica sempre disponível.",
+            "description": "Seu cartão permite um saque a cada poucos minutos. O dinheiro fora do cartão é enviado na hora; mude quanto fica no cartão na tela do cartão.",
             "readMore": "Leia mais"
         },
         "staleCardApprovalModal": {
@@ -3451,6 +3493,10 @@
         "countryCombobox": {
             "noResults": "Nenhum país encontrado",
             "clear": "Limpar busca"
+        },
+        "collateralPull": {
+            "fromCard": "{amount} deste pagamento sai do seu saldo no cartão.",
+            "lockActive": "O cartão fica bloqueado por {time} após o último saque: este pagamento vai esperar."
         }
     },
     "errors": {

--- a/src/services/__tests__/rain-cooldown-arming.test.ts
+++ b/src/services/__tests__/rain-cooldown-arming.test.ts
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+/**
+ * `armRainCooldownFromSuccess` is a writer into the app-wide Rain cooldown —
+ * the state that gates every later collateral pull. It is fed from four
+ * success paths, two of which (QR pay, Manteca off-ramp) carry `cooldownSec`
+ * as a hand-declared optional field, so `undefined` is a real runtime value.
+ * A guard slip would arm a lock after every successful payment.
+ */
+import { armRainCooldownFromSuccess, type RainCooldownEventDetail } from '@/services/rain'
+
+jest.mock('js-cookie', () => ({ __esModule: true, default: { get: () => 'jwt-abc' } }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+
+function captureEvents() {
+    const details: RainCooldownEventDetail[] = []
+    const handler = (e: Event) => details.push((e as CustomEvent<RainCooldownEventDetail>).detail)
+    window.addEventListener('rain:cooldown', handler)
+    return { details, stop: () => window.removeEventListener('rain:cooldown', handler) }
+}
+
+describe('armRainCooldownFromSuccess', () => {
+    it('dispatches a silent cooldown for a positive number of seconds', () => {
+        const { details, stop } = captureEvents()
+        armRainCooldownFromSuccess(120)
+        stop()
+        expect(details).toEqual([{ retryAfterSec: 120, message: '', silent: true }])
+    })
+
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['zero', 0],
+        ['negative', -5],
+        ['NaN', Number.NaN],
+        ['Infinity', Number.POSITIVE_INFINITY],
+        ['a numeric string', '120'],
+        ['an object', { cooldownSec: 120 }],
+    ])('dispatches nothing for %s', (_label, value) => {
+        const { details, stop } = captureEvents()
+        armRainCooldownFromSuccess(value)
+        stop()
+        expect(details).toEqual([])
+    })
+})

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -51,6 +51,9 @@ export type QrPayment = {
         amountSponsored?: number
         txHash?: string
     }
+    /** Set when the payment pulled from the card: Rain's withdrawal-signature
+     *  lock, in seconds, for the shared cooldown countdown. */
+    cooldownSec?: number
 }
 
 export type QrPaymentCharge = {

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -178,6 +178,8 @@ export interface SubmitRainWithdrawalInput {
 
 export interface SubmitRainWithdrawalResponse {
     txHash: string
+    /** Rain's post-consumption withdrawal-signature lock, in seconds. */
+    cooldownSec?: number
 }
 
 // ─── Funds-recovery types ────────────────────────────────────────────────────
@@ -290,6 +292,20 @@ export class RainCooldownError extends Error {
 export interface RainCooldownEventDetail {
     retryAfterSec: number
     message: string
+    /** Armed from a successful pull (server-confirmed lock), not from a 425:
+     *  show the countdown, skip the "please wait" intro modal. */
+    silent?: boolean
+}
+
+/** Arm the shared cooldown from a server-confirmed lock duration. */
+function armCooldownFromSuccess(cooldownSec: unknown) {
+    if (typeof window === 'undefined') return
+    if (typeof cooldownSec !== 'number' || !Number.isFinite(cooldownSec) || cooldownSec <= 0) return
+    window.dispatchEvent(
+        new CustomEvent<RainCooldownEventDetail>('rain:cooldown', {
+            detail: { retryAfterSec: cooldownSec, message: '', silent: true },
+        })
+    )
 }
 
 /**
@@ -555,12 +571,16 @@ export const rainApi = {
      * request payments through this path for the first time → the regression.)
      */
     submitWithdrawal: async (input: SubmitRainWithdrawalInput): Promise<SubmitRainWithdrawalResponse> => {
-        return rainRequest<SubmitRainWithdrawalResponse>({
+        const res = await rainRequest<SubmitRainWithdrawalResponse>({
             method: 'POST',
             path: '/rain/cards/withdraw/submit',
             body: input,
             timeoutMs: 120_000,
         })
+        // The pull just consumed a signature: the lock is running now, so the
+        // next review step can show its countdown before the passkey.
+        armCooldownFromSuccess(res.cooldownSec)
+        return res
     },
 
     /**
@@ -601,11 +621,13 @@ export const rainApi = {
      */
     stampWithdrawal: async (input: { preparationId: string; txHash: string }): Promise<void> => {
         try {
-            await rainRequest<{ ok: boolean }>({
+            const res = await rainRequest<{ ok: boolean; cooldownSec?: number }>({
                 method: 'POST',
                 path: '/rain/cards/withdraw/stamp',
                 body: input,
             })
+            // The mixed userOp consumed a signature too: same lock, same countdown.
+            armCooldownFromSuccess(res.cooldownSec)
         } catch (e) {
             // Non-fatal: intent stays PENDING until expiry, no history
             // categorization until then. Log loudly but don't block the user.

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -788,12 +788,12 @@ export const rainApi = {
      *  passkey). Waits for the on-chain receipt, so the timeout is generous. */
     moveToCard: async (
         cardId: string,
-        amountCents: number
+        input: { amountCents: number; idempotencyKey: string }
     ): Promise<{ ok: boolean; amountCents: number; userOpHash: string }> => {
         return rainRequest({
             method: 'POST',
             path: `/rain/cards/${cardId}/move-to-card`,
-            body: { amountCents },
+            body: input,
             timeoutMs: 90_000,
         })
     },

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -83,6 +83,9 @@ export interface RainCardCollateralPolicy {
 
 export interface UpdateCollateralSettingsInput {
     collateralTargetCents?: number
+    /** False lowers the target without pinning it (a move off the card, not a
+     *  number the user chose) so an auto-sized card stays auto-sized. */
+    pinTarget?: boolean
     walletFloorCents?: number
     loadAllToCard?: boolean
 }
@@ -297,8 +300,13 @@ export interface RainCooldownEventDetail {
     silent?: boolean
 }
 
-/** Arm the shared cooldown from a server-confirmed lock duration. */
-function armCooldownFromSuccess(cooldownSec: unknown) {
+/**
+ * Arm the shared cooldown from a server-confirmed lock duration. Every
+ * success path that consumed a Rain withdrawal signature feeds this — the
+ * direct submit and stamp below, and the coordinated Manteca QR / off-ramp
+ * completions, whose replies carry the same `cooldownSec`.
+ */
+export function armRainCooldownFromSuccess(cooldownSec: unknown) {
     if (typeof window === 'undefined') return
     if (typeof cooldownSec !== 'number' || !Number.isFinite(cooldownSec) || cooldownSec <= 0) return
     window.dispatchEvent(
@@ -579,7 +587,7 @@ export const rainApi = {
         })
         // The pull just consumed a signature: the lock is running now, so the
         // next review step can show its countdown before the passkey.
-        armCooldownFromSuccess(res.cooldownSec)
+        armRainCooldownFromSuccess(res.cooldownSec)
         return res
     },
 
@@ -627,7 +635,7 @@ export const rainApi = {
                 body: input,
             })
             // The mixed userOp consumed a signature too: same lock, same countdown.
-            armCooldownFromSuccess(res.cooldownSec)
+            armRainCooldownFromSuccess(res.cooldownSec)
         } catch (e) {
             // Non-fatal: intent stays PENDING until expiry, no history
             // categorization until then. Log loudly but don't block the user.

--- a/src/services/rain.ts
+++ b/src/services/rain.ts
@@ -58,6 +58,33 @@ export interface RainCardSummary {
     /** Whether the user has granted the one-time session-key permission
      *  used to submit collateral withdrawals with a single passkey tap. */
     hasWithdrawApproval: boolean
+    /** On-card / off-card policy the auto-balancer runs for this card.
+     *  Optional for backward-compat with a pre-deploy backend. */
+    collateral?: RainCardCollateralPolicy
+}
+
+/**
+ * How much stays on the card and how much stays off it (TASK-22293). The
+ * per-purchase limit is a separate Rain control and no longer drives this.
+ */
+export interface RainCardCollateralPolicy {
+    /** Cents the auto-balancer keeps on the card. */
+    targetCents: number
+    /** True when the user set the target; the nightly tuner leaves it alone. */
+    targetPinned: boolean
+    /** Cents the sweep leaves off the card. */
+    walletFloorCents: number
+    /** Sweep everything to the card — no target, no floor, no debounce. */
+    loadAllToCard: boolean
+    /** Per-authorization purchase limit mirrored from Rain, in cents. */
+    cardLimitCents: number | null
+    autoBalanceEnabled: boolean
+}
+
+export interface UpdateCollateralSettingsInput {
+    collateralTargetCents?: number
+    walletFloorCents?: number
+    loadAllToCard?: boolean
 }
 
 export interface RainCardOverview {
@@ -751,6 +778,26 @@ export const rainApi = {
     },
 
     /** Read the current spending limits (per-txn / 24h / 30d / all-time) from Rain. */
+    /** Change what stays on / off the card. Raising the target tops the card
+     *  up in the background; lowering it never withdraws (see useMoveOffCard). */
+    updateCollateralSettings: async (cardId: string, input: UpdateCollateralSettingsInput): Promise<void> => {
+        await rainRequest<{ ok: boolean }>({ method: 'PATCH', path: `/rain/cards/${cardId}`, body: input })
+    },
+
+    /** User-chosen wallet→card move through the stored session key (no
+     *  passkey). Waits for the on-chain receipt, so the timeout is generous. */
+    moveToCard: async (
+        cardId: string,
+        amountCents: number
+    ): Promise<{ ok: boolean; amountCents: number; userOpHash: string }> => {
+        return rainRequest({
+            method: 'POST',
+            path: `/rain/cards/${cardId}/move-to-card`,
+            body: { amountCents },
+            timeoutMs: 90_000,
+        })
+    },
+
     getCardLimits: async (cardId: string): Promise<RainCardLimit[]> => {
         const { limits } = await rainRequest<{ limits: RainCardLimit[] }>({
             method: 'GET',

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -420,7 +420,8 @@ export interface paths {
                         "application/json": {
                             claim: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -485,7 +486,8 @@ export interface paths {
                         "application/json": {
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -503,6 +505,45 @@ export interface paths {
                                 badgeCode?: string;
                                 outcome: "awarded" | "already_owned" | "inactive" | "expired" | "unknown" | "definition_missing";
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/badge/team": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            awarded: boolean;
                         };
                     };
                 };
@@ -1372,6 +1413,7 @@ export interface paths {
                             admittedTotal: number;
                             eligibilityReason?: string;
                             flowEarlyAccess: boolean;
+                            geoProhibited: boolean;
                             hasCardAccess: boolean;
                             isEligible: boolean;
                             isPublicLaunched: boolean;
@@ -5422,6 +5464,173 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/healthz/bridge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/manteca/{geo}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    geo: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/rain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/rhino": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/healthz/sumsub": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/history/{entryId}": {
         parameters: {
             query?: never;
@@ -5532,7 +5741,8 @@ export interface paths {
                             attributionResolved: true;
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5552,7 +5762,8 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5584,7 +5795,8 @@ export interface paths {
                             attributionResolved: false;
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5604,7 +5816,8 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5757,7 +5970,8 @@ export interface paths {
                             attributionResolved: true;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5790,7 +6004,8 @@ export interface paths {
                             attributionResolved: false;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -6010,53 +6225,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/manteca/initiate-onboarding": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Initiate Manteca onboarding
-         * @description Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    Authorization: string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        exchange?: string;
-                        failureUrl?: string;
-                        returnUrl: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/manteca/prices": {
         parameters: {
             query?: never;
@@ -6211,6 +6379,8 @@ export interface paths {
                     "application/json": {
                         /** @description Amount for static QR codes (optional for dynamic QR codes) */
                         amount?: string;
+                        /** @description Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour. */
+                        idempotencyKey?: unknown;
                         /** @description The QR code string to process for payment */
                         qrCode: string;
                         /** @description Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users. */
@@ -7097,7 +7267,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        actionType: "BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED";
+                        actionType: ("BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED") | "DIRECT_TRANSFER" | "P2P_SEND" | "P2P_REQUEST_FULFILL" | "SEND_LINK" | "QR_PAY" | "ONRAMP" | "OFFRAMP" | "CRYPTO_WITHDRAW" | "CARD_SPEND_AUTH" | "CARD_SPEND_CLEAR";
                         otherUserId?: string;
                         usdAmount?: number;
                     };
@@ -7348,6 +7518,14 @@ export interface paths {
                             };
                             balanceUnavailable: boolean;
                             cards: {
+                                collateral: {
+                                    autoBalanceEnabled: boolean;
+                                    cardLimitCents: null | number;
+                                    loadAllToCard: boolean;
+                                    targetCents: number;
+                                    targetPinned: boolean;
+                                    walletFloorCents: number;
+                                };
                                 expiryMonth: number;
                                 expiryYear: number;
                                 hasWithdrawApproval: boolean;
@@ -7911,7 +8089,6 @@ export interface paths {
                         amount: string;
                         chargeId?: string;
                         directTransfer: boolean;
-                        kind: "P2P_SEND" | "QR_PAY" | "LINK_CREATE" | "CRYPTO_WITHDRAW" | "FIAT_OFFRAMP" | "FIAT_ONRAMP" | "REQUEST_PAY" | "AUTO_REBALANCE" | "CARD_SPEND" | "DEPOSIT_EXTERNAL" | "OTHER";
                         recipientAddress: string;
                         totalAmountCents?: string;
                     };
@@ -8005,6 +8182,97 @@ export interface paths {
                 };
                 /** @description Default Response */
                 502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/rain/cards/withdraw/prepare/cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        preparationId: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8135,6 +8403,18 @@ export interface paths {
                     content: {
                         "application/json": {
                             ok: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
                         };
                     };
                 };
@@ -8310,10 +8590,13 @@ export interface paths {
                     "application/json": {
                         autoBalanceEnabled?: boolean;
                         cardLimit?: number;
+                        collateralTargetCents?: number;
                         limits?: {
                             amount: number;
                             frequency: "perAuthorization" | "per24HourPeriod" | "per30DayPeriod" | "perAllTime";
                         }[];
+                        loadAllToCard?: boolean;
+                        walletFloorCents?: number;
                     };
                 };
             };
@@ -8713,6 +8996,89 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/rain/cards/{cardId}/move-to-card": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    cardId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amountCents: number;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            amountCents: number;
+                            ok: boolean;
+                            userOpHash: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/rain/cards/{cardId}/physical-waitlist": {
         parameters: {
             query?: never;
@@ -8953,123 +9319,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/rain/cards/{cardId}/provisioning-data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    cardId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        wallet: "apple" | "google";
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            cardId: string;
-                            cardSecret: string;
-                            last4: string;
-                            network: string;
-                            cardholderName?: string;
-                            billingAddress: {
-                                line1: string;
-                                line2?: string;
-                                city: string;
-                                region: string;
-                                postalCode: string;
-                                countryCode: string;
-                            };
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rain/webhooks": {
         parameters: {
             query?: never;
@@ -9097,6 +9346,39 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/readyz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -9641,6 +9923,9 @@ export interface paths {
                         context: "withdraw" | "pay-request" | "claim-xchain";
                         contextId: string;
                         depositChain: string;
+                        depositChainId?: string;
+                        depositContractVersion?: string;
+                        depositIdx?: number;
                         destinationAddress: string;
                         destinationChain: string;
                         feeUsd?: number;
@@ -9784,7 +10069,24 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody: {
+                content: {
+                    "multipart/form-data": {
+                        amount?: string | number;
+                        attachment?: unknown;
+                        chainId?: string;
+                        contractVersion?: string;
+                        depositIdx?: string | number;
+                        filename?: string;
+                        mimetype?: string;
+                        preparationId?: string;
+                        pubKey: string;
+                        reference?: string;
+                        tokenAddress?: string;
+                        txHash?: string;
+                    };
+                };
+            };
             responses: {
                 /** @description Default Response */
                 200: {
@@ -9881,6 +10183,44 @@ export interface paths {
                 };
                 cookie?: never;
             };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amount: string | number;
+                        chainId: string;
+                        contractVersion: string;
+                        depositIdx: string | number;
+                        tokenAddress: string;
+                        txHash: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/status/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
             requestBody?: never;
             responses: {
                 /** @description Default Response */
@@ -9892,6 +10232,12 @@ export interface paths {
                 };
             };
         };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/sumsub/webhooks": {
@@ -10114,7 +10460,6 @@ export interface paths {
                         fullName?: string;
                         hasSeenEarlyUserModal?: boolean;
                         locale?: string;
-                        offrampHandle?: string;
                         pushSubscriptionId?: string;
                         residenceCountry?: string;
                         secondResidenceCountry?: string;
@@ -10131,7 +10476,61 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+                /** @description Invalid input — malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code. */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description The declared residence changed too recently. Only the residence keys were refused — every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`. */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "RESIDENCE_CHANGE_COOLDOWN";
+                            error: string;
+                            /** Format: date-time */
+                            retryAt: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                            success: boolean;
+                        };
+                    };
                 };
             };
         };
@@ -10347,7 +10746,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -10384,7 +10783,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -10638,6 +11037,112 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/identity/restart": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @description Level the token must target. The declared residence decides (AR/BR → LATAM, US/MX → NA, SEPA zone → EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs. */
+                        regionIntent?: "LATAM" | "ROW" | "EU" | "NA";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            applicantId: string;
+                            levelName: string;
+                            /** @description The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level). */
+                            regionIntent: string;
+                            token: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            /** Format: date-time */
+                            retryAt?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
                 };
             };
         };
@@ -10935,7 +11440,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -10972,7 +11477,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -11003,6 +11508,8 @@ export interface paths {
                             };
                             residence: {
                                 declared: string | null;
+                                declaredSecond: string | null;
+                                kycReported: string | null;
                                 nextChangeAllowedAt: string | null;
                                 verified: string | null;
                             };
@@ -11108,6 +11615,250 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/users/saved-addresses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddresses: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            }[];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        address: string;
+                        chainId: string;
+                        nickname: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddress: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/saved-addresses/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {boolean} */
+                            deleted: true;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        nickname: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            savedAddress: {
+                                address: string;
+                                chainId: string;
+                                createdAt: string;
+                                id: string;
+                                lastUsedAt: string;
+                                nickname: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/users/search": {
@@ -11375,7 +12126,24 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         put?: never;
         post: {
             parameters: {

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -8338,6 +8338,8 @@ export interface paths {
                             frequency: "perAuthorization" | "per24HourPeriod" | "per30DayPeriod" | "perAllTime";
                         }[];
                         loadAllToCard?: boolean;
+                        /** @description Default true. False lowers collateralTargetCents without pinning it (a move off the card), so the nightly tuner keeps sizing the card. */
+                        pinTarget?: boolean;
                         walletFloorCents?: number;
                     };
                 };

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -9018,6 +9018,7 @@ export interface paths {
                 content: {
                     "application/json": {
                         amountCents: number;
+                        idempotencyKey: string;
                     };
                 };
             };

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -420,8 +420,7 @@ export interface paths {
                         "application/json": {
                             claim: {
                                 acquisition?: {
-                                    /** @enum {string} */
-                                    destination: "normal_app";
+                                    destination: "offramp_migration" | "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -486,8 +485,7 @@ export interface paths {
                         "application/json": {
                             claims: {
                                 acquisition?: {
-                                    /** @enum {string} */
-                                    destination: "normal_app";
+                                    destination: "offramp_migration" | "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -505,45 +503,6 @@ export interface paths {
                                 badgeCode?: string;
                                 outcome: "awarded" | "already_owned" | "inactive" | "expired" | "unknown" | "definition_missing";
                             }[];
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/badge/team": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    Authorization: string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            awarded: boolean;
                         };
                     };
                 };
@@ -1413,7 +1372,6 @@ export interface paths {
                             admittedTotal: number;
                             eligibilityReason?: string;
                             flowEarlyAccess: boolean;
-                            geoProhibited: boolean;
                             hasCardAccess: boolean;
                             isEligible: boolean;
                             isPublicLaunched: boolean;
@@ -5464,173 +5422,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/healthz/bridge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/healthz/manteca/{geo}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    geo: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/healthz/rain": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/healthz/rhino": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/healthz/sumsub": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/history/{entryId}": {
         parameters: {
             query?: never;
@@ -5741,8 +5532,7 @@ export interface paths {
                             attributionResolved: true;
                             claims: {
                                 acquisition?: {
-                                    /** @enum {string} */
-                                    destination: "normal_app";
+                                    destination: "offramp_migration" | "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5762,8 +5552,7 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                /** @enum {string} */
-                                destination: "normal_app";
+                                destination: "offramp_migration" | "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5795,8 +5584,7 @@ export interface paths {
                             attributionResolved: false;
                             claims: {
                                 acquisition?: {
-                                    /** @enum {string} */
-                                    destination: "normal_app";
+                                    destination: "offramp_migration" | "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5816,8 +5604,7 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                /** @enum {string} */
-                                destination: "normal_app";
+                                destination: "offramp_migration" | "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5970,8 +5757,7 @@ export interface paths {
                             attributionResolved: true;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                /** @enum {string} */
-                                destination: "normal_app";
+                                destination: "offramp_migration" | "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -6004,8 +5790,7 @@ export interface paths {
                             attributionResolved: false;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                /** @enum {string} */
-                                destination: "normal_app";
+                                destination: "offramp_migration" | "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -6225,6 +6010,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/manteca/initiate-onboarding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Initiate Manteca onboarding
+         * @description Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        exchange?: string;
+                        failureUrl?: string;
+                        returnUrl: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/manteca/prices": {
         parameters: {
             query?: never;
@@ -6379,8 +6211,6 @@ export interface paths {
                     "application/json": {
                         /** @description Amount for static QR codes (optional for dynamic QR codes) */
                         amount?: string;
-                        /** @description Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour. */
-                        idempotencyKey?: unknown;
                         /** @description The QR code string to process for payment */
                         qrCode: string;
                         /** @description Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users. */
@@ -7267,7 +7097,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        actionType: ("BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED") | "DIRECT_TRANSFER" | "P2P_SEND" | "P2P_REQUEST_FULFILL" | "SEND_LINK" | "QR_PAY" | "ONRAMP" | "OFFRAMP" | "CRYPTO_WITHDRAW" | "CARD_SPEND_AUTH" | "CARD_SPEND_CLEAR";
+                        actionType: "BRIDGE_TRANSFER" | "MANTECA_TRANSFER" | "MANTECA_QR_PAYMENT" | "P2P_SEND_LINK" | "P2P_REQUEST_PAYMENT" | "KYC_VERIFIED";
                         otherUserId?: string;
                         usdAmount?: number;
                     };
@@ -8089,6 +7919,7 @@ export interface paths {
                         amount: string;
                         chargeId?: string;
                         directTransfer: boolean;
+                        kind: "P2P_SEND" | "QR_PAY" | "LINK_CREATE" | "CRYPTO_WITHDRAW" | "FIAT_OFFRAMP" | "FIAT_ONRAMP" | "REQUEST_PAY" | "AUTO_REBALANCE" | "CARD_SPEND" | "DEPOSIT_EXTERNAL" | "OTHER";
                         recipientAddress: string;
                         totalAmountCents?: string;
                     };
@@ -8182,97 +8013,6 @@ export interface paths {
                 };
                 /** @description Default Response */
                 502: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/rain/cards/withdraw/prepare/cancel": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        preparationId: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            ok: boolean;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                503: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -8402,6 +8142,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            cooldownSec: number;
                             ok: boolean;
                         };
                     };
@@ -8490,6 +8231,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            cooldownSec: number;
                             txHash: string;
                         };
                     };
@@ -8996,90 +8738,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/rain/cards/{cardId}/move-to-card": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    cardId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        amountCents: number;
-                        idempotencyKey: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            amountCents: number;
-                            ok: boolean;
-                            userOpHash: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                502: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            code?: string;
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rain/cards/{cardId}/physical-waitlist": {
         parameters: {
             query?: never;
@@ -9320,6 +8978,123 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/rain/cards/{cardId}/provisioning-data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    cardId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        wallet: "apple" | "google";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            cardId: string;
+                            cardSecret: string;
+                            last4: string;
+                            network: string;
+                            cardholderName?: string;
+                            billingAddress: {
+                                line1: string;
+                                line2?: string;
+                                city: string;
+                                region: string;
+                                postalCode: string;
+                                countryCode: string;
+                            };
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            code?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            code?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            code?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            code?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            code?: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/rain/webhooks": {
         parameters: {
             query?: never;
@@ -9347,39 +9122,6 @@ export interface paths {
                 };
             };
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/readyz": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -9924,9 +9666,6 @@ export interface paths {
                         context: "withdraw" | "pay-request" | "claim-xchain";
                         contextId: string;
                         depositChain: string;
-                        depositChainId?: string;
-                        depositContractVersion?: string;
-                        depositIdx?: number;
                         destinationAddress: string;
                         destinationChain: string;
                         feeUsd?: number;
@@ -10070,24 +9809,7 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody: {
-                content: {
-                    "multipart/form-data": {
-                        amount?: string | number;
-                        attachment?: unknown;
-                        chainId?: string;
-                        contractVersion?: string;
-                        depositIdx?: string | number;
-                        filename?: string;
-                        mimetype?: string;
-                        preparationId?: string;
-                        pubKey: string;
-                        reference?: string;
-                        tokenAddress?: string;
-                        txHash?: string;
-                    };
-                };
-            };
+            requestBody?: never;
             responses: {
                 /** @description Default Response */
                 200: {
@@ -10184,44 +9906,6 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        amount: string | number;
-                        chainId: string;
-                        contractVersion: string;
-                        depositIdx: string | number;
-                        tokenAddress: string;
-                        txHash: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        trace?: never;
-    };
-    "/status/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
             requestBody?: never;
             responses: {
                 /** @description Default Response */
@@ -10233,12 +9917,6 @@ export interface paths {
                 };
             };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/sumsub/webhooks": {
@@ -10461,6 +10139,7 @@ export interface paths {
                         fullName?: string;
                         hasSeenEarlyUserModal?: boolean;
                         locale?: string;
+                        offrampHandle?: string;
                         pushSubscriptionId?: string;
                         residenceCountry?: string;
                         secondResidenceCountry?: string;
@@ -10477,61 +10156,7 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-                /** @description Invalid input — malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            message: string;
-                            success: boolean;
-                        };
-                    };
-                };
-                /** @description The declared residence changed too recently. Only the residence keys were refused — every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`. */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {string} */
-                            code: "RESIDENCE_CHANGE_COOLDOWN";
-                            error: string;
-                            /** Format: date-time */
-                            retryAt: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            message: string;
-                            success: boolean;
-                        };
-                    };
+                    content?: never;
                 };
             };
         };
@@ -10747,7 +10372,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -10784,7 +10409,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -11038,112 +10663,6 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/users/identity/restart": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** @description Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one. */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": {
-                        /** @description Level the token must target. The declared residence decides (AR/BR → LATAM, US/MX → NA, SEPA zone → EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs. */
-                        regionIntent?: "LATAM" | "ROW" | "EU" | "NA";
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            applicantId: string;
-                            levelName: string;
-                            /** @description The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level). */
-                            regionIntent: string;
-                            token: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            /** Format: date-time */
-                            retryAt?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
                 };
             };
         };
@@ -11441,7 +10960,7 @@ export interface paths {
                                 nextActions: {
                                     effectiveDate?: string;
                                     key: string;
-                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
+                                    kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
                                     levelKey?: string;
                                     purpose: string;
                                     requirementKey?: string;
@@ -11478,7 +10997,7 @@ export interface paths {
                                         nextAction?: {
                                             effectiveDate?: string;
                                             key: string;
-                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted" | "rain-hosted";
+                                            kind: "sumsub" | "accept-tos" | "wait" | "contact-support" | "provide-email" | "bridge-hosted";
                                             levelKey?: string;
                                             purpose: string;
                                             requirementKey?: string;
@@ -11509,8 +11028,6 @@ export interface paths {
                             };
                             residence: {
                                 declared: string | null;
-                                declaredSecond: string | null;
-                                kycReported: string | null;
                                 nextChangeAllowedAt: string | null;
                                 verified: string | null;
                             };
@@ -11616,250 +11133,6 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
-        trace?: never;
-    };
-    "/users/saved-addresses": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            savedAddresses: {
-                                address: string;
-                                chainId: string;
-                                createdAt: string;
-                                id: string;
-                                lastUsedAt: string;
-                                nickname: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        address: string;
-                        chainId: string;
-                        nickname: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            savedAddress: {
-                                address: string;
-                                chainId: string;
-                                createdAt: string;
-                                id: string;
-                                lastUsedAt: string;
-                                nickname: string;
-                            };
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/users/saved-addresses/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            deleted: true;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        nickname: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            savedAddress: {
-                                address: string;
-                                chainId: string;
-                                createdAt: string;
-                                id: string;
-                                lastUsedAt: string;
-                                nickname: string;
-                            };
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
         trace?: never;
     };
     "/users/search": {
@@ -12127,24 +11400,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
+        get?: never;
         put?: never;
         post: {
             parameters: {
@@ -12199,6 +11455,90 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/rain/cards/{cardId}/move-to-card": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    cardId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        amountCents: number;
+                        idempotencyKey: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            amountCents: number;
+                            ok: boolean;
+                            userOpHash: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code?: string;
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -498,10 +498,20 @@
                                                 "acquisition": {
                                                     "properties": {
                                                         "destination": {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
+                                                            "anyOf": [
+                                                                {
+                                                                    "enum": [
+                                                                        "offramp_migration"
+                                                                    ],
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "enum": [
+                                                                        "normal_app"
+                                                                    ],
+                                                                    "type": "string"
+                                                                }
+                                                            ]
                                                         },
                                                         "fallback": {
                                                             "enum": [
@@ -676,10 +686,20 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "enum": [
-                                                                    "normal_app"
-                                                                ],
-                                                                "type": "string"
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "offramp_migration"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "normal_app"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -791,40 +811,6 @@
                                     },
                                     "required": [
                                         "claims"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/badge/team": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "Authorization",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "awarded": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "awarded"
                                     ],
                                     "type": "object"
                                 }
@@ -2464,9 +2450,6 @@
                                         "flowEarlyAccess": {
                                             "type": "boolean"
                                         },
-                                        "geoProhibited": {
-                                            "type": "boolean"
-                                        },
                                         "hasCardAccess": {
                                             "type": "boolean"
                                         },
@@ -2519,7 +2502,6 @@
                                     "required": [
                                         "hasCardAccess",
                                         "isEligible",
-                                        "geoProhibited",
                                         "flowEarlyAccess",
                                         "isPublicLaunched",
                                         "waitlistJoinedAt",
@@ -2748,7 +2730,7 @@
                         "description": "Default Response"
                     }
                 },
-                "summary": "Get the user\u2019s current waitlist state",
+                "summary": "Get the user’s current waitlist state",
                 "tags": [
                     "card"
                 ]
@@ -3349,7 +3331,6 @@
                                     },
                                     "claimParams": {
                                         "items": {},
-                                        "maxItems": 4,
                                         "minItems": 3,
                                         "type": "array"
                                     },
@@ -7300,7 +7281,7 @@
         },
         "/dev/poll": {
             "post": {
-                "description": "Triggers runPollingCycle() on demand \u2014 used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
+                "description": "Triggers runPollingCycle() on demand — used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
                 "responses": {
                     "200": {
                         "content": {
@@ -7965,7 +7946,7 @@
         },
         "/dev/submit-to-providers": {
             "post": {
-                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user \u2192 Manteca, US user \u2192 Bridge) end-to-end.",
+                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user → Manteca, US user → Bridge) end-to-end.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -8203,7 +8184,7 @@
         },
         "/dev/trigger-sumsub-webhook": {
             "post": {
-                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) \u2014 same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub \u2192 routing chain without real webhook delivery.",
+                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) — same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub → routing chain without real webhook delivery.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -9193,61 +9174,6 @@
                 }
             }
         },
-        "/healthz/bridge": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/healthz/manteca/{geo}": {
-            "get": {
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "geo",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/healthz/rain": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/healthz/rhino": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/healthz/sumsub": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
         "/history/{entryId}": {
             "get": {
                 "parameters": [
@@ -9378,10 +9304,20 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "enum": [
-                                                                    "normal_app"
-                                                                ],
-                                                                "type": "string"
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "offramp_migration"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "normal_app"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9496,10 +9432,20 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "enum": [
-                                                        "normal_app"
-                                                    ],
-                                                    "type": "string"
+                                                    "anyOf": [
+                                                        {
+                                                            "enum": [
+                                                                "offramp_migration"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9573,10 +9519,20 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "enum": [
-                                                                    "normal_app"
-                                                                ],
-                                                                "type": "string"
+                                                                "anyOf": [
+                                                                    {
+                                                                        "enum": [
+                                                                            "offramp_migration"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "normal_app"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    }
+                                                                ]
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9691,10 +9647,20 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "enum": [
-                                                        "normal_app"
-                                                    ],
-                                                    "type": "string"
+                                                    "anyOf": [
+                                                        {
+                                                            "enum": [
+                                                                "offramp_migration"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9825,10 +9791,20 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "enum": [
-                                                        "normal_app"
-                                                    ],
-                                                    "type": "string"
+                                                    "anyOf": [
+                                                        {
+                                                            "enum": [
+                                                                "offramp_migration"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9905,10 +9881,20 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "enum": [
-                                                        "normal_app"
-                                                    ],
-                                                    "type": "string"
+                                                    "anyOf": [
+                                                        {
+                                                            "enum": [
+                                                                "offramp_migration"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
+                                                        }
+                                                    ]
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -10131,7 +10117,7 @@
         },
         "/manteca/deposit/{depositId}/status": {
             "get": {
-                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only \u2014 the webhook/poller remain the authoritative completion trigger.",
+                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only — the webhook/poller remain the authoritative completion trigger.",
                 "parameters": [
                     {
                         "in": "path",
@@ -10156,6 +10142,54 @@
                     }
                 },
                 "summary": "Get deposit order status",
+                "tags": [
+                    "manteca"
+                ]
+            }
+        },
+        "/manteca/initiate-onboarding": {
+            "post": {
+                "description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "Authorization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "exchange": {
+                                        "type": "string"
+                                    },
+                                    "failureUrl": {
+                                        "type": "string"
+                                    },
+                                    "returnUrl": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "returnUrl"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                },
+                "summary": "Initiate Manteca onboarding",
                 "tags": [
                     "manteca"
                 ]
@@ -10514,9 +10548,6 @@
                                     "amount": {
                                         "description": "Amount for static QR codes (optional for dynamic QR codes)",
                                         "type": "string"
-                                    },
-                                    "idempotencyKey": {
-                                        "description": "Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour."
                                     },
                                     "qrCode": {
                                         "description": "The QR code string to process for payment",
@@ -12022,102 +12053,38 @@
                                     "actionType": {
                                         "anyOf": [
                                             {
-                                                "anyOf": [
-                                                    {
-                                                        "enum": [
-                                                            "BRIDGE_TRANSFER"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "enum": [
-                                                            "MANTECA_TRANSFER"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "enum": [
-                                                            "MANTECA_QR_PAYMENT"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "enum": [
-                                                            "P2P_SEND_LINK"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "enum": [
-                                                            "P2P_REQUEST_PAYMENT"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "enum": [
-                                                            "KYC_VERIFIED"
-                                                        ],
-                                                        "type": "string"
-                                                    }
-                                                ]
-                                            },
-                                            {
                                                 "enum": [
-                                                    "DIRECT_TRANSFER"
+                                                    "BRIDGE_TRANSFER"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_SEND"
+                                                    "MANTECA_TRANSFER"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_REQUEST_FULFILL"
+                                                    "MANTECA_QR_PAYMENT"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "SEND_LINK"
+                                                    "P2P_SEND_LINK"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "QR_PAY"
+                                                    "P2P_REQUEST_PAYMENT"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "ONRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "OFFRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CRYPTO_WITHDRAW"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CARD_SPEND_AUTH"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CARD_SPEND_CLEAR"
+                                                    "KYC_VERIFIED"
                                                 ],
                                                 "type": "string"
                                             }
@@ -13390,6 +13357,76 @@
                                     "directTransfer": {
                                         "type": "boolean"
                                     },
+                                    "kind": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "P2P_SEND"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "QR_PAY"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "LINK_CREATE"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CRYPTO_WITHDRAW"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "FIAT_OFFRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "FIAT_ONRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "REQUEST_PAY"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "AUTO_REBALANCE"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CARD_SPEND"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "DEPOSIT_EXTERNAL"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "OTHER"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
                                     "recipientAddress": {
                                         "pattern": "^0x[0-9a-fA-F]{40}$",
                                         "type": "string"
@@ -13402,7 +13439,8 @@
                                 "required": [
                                     "amount",
                                     "recipientAddress",
-                                    "directTransfer"
+                                    "directTransfer",
+                                    "kind"
                                 ],
                                 "type": "object"
                             }
@@ -13615,133 +13653,6 @@
                 }
             }
         },
-        "/rain/cards/withdraw/prepare/cancel": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "preparationId": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "preparationId"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "ok": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "ok"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "409": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
         "/rain/cards/withdraw/session-approve": {
             "post": {
                 "requestBody": {
@@ -13880,12 +13791,16 @@
                             "application/json": {
                                 "schema": {
                                     "properties": {
+                                        "cooldownSec": {
+                                            "type": "number"
+                                        },
                                         "ok": {
                                             "type": "boolean"
                                         }
                                     },
                                     "required": [
-                                        "ok"
+                                        "ok",
+                                        "cooldownSec"
                                     ],
                                     "type": "object"
                                 }
@@ -14029,12 +13944,16 @@
                             "application/json": {
                                 "schema": {
                                     "properties": {
+                                        "cooldownSec": {
+                                            "type": "number"
+                                        },
                                         "txHash": {
                                             "type": "string"
                                         }
                                     },
                                     "required": [
-                                        "txHash"
+                                        "txHash",
+                                        "cooldownSec"
                                     ],
                                     "type": "object"
                                 }
@@ -14836,138 +14755,6 @@
                 }
             }
         },
-        "/rain/cards/{cardId}/move-to-card": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "cardId",
-                        "required": true,
-                        "schema": {
-                            "format": "uuid",
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "amountCents": {
-                                        "maximum": 10000000,
-                                        "minimum": 100,
-                                        "type": "integer"
-                                    },
-                                    "idempotencyKey": {
-                                        "maxLength": 100,
-                                        "minLength": 8,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "amountCents",
-                                    "idempotencyKey"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "amountCents": {
-                                            "type": "number"
-                                        },
-                                        "ok": {
-                                            "type": "boolean"
-                                        },
-                                        "userOpHash": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "ok",
-                                        "amountCents",
-                                        "userOpHash"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "409": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "502": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
         "/rain/cards/{cardId}/physical-waitlist": {
             "get": {
                 "parameters": [
@@ -15342,17 +15129,225 @@
                 }
             }
         },
-        "/rain/webhooks": {
+        "/rain/cards/{cardId}/provisioning-data": {
             "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "wallet": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "apple"
+                                                ]
+                                            },
+                                            {
+                                                "type": "string",
+                                                "enum": [
+                                                    "google"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "wallet"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        },
+                        "in": "path",
+                        "name": "cardId",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Default Response"
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cardId": {
+                                            "type": "string"
+                                        },
+                                        "cardSecret": {
+                                            "type": "string"
+                                        },
+                                        "last4": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "cardholderName": {
+                                            "type": "string"
+                                        },
+                                        "billingAddress": {
+                                            "type": "object",
+                                            "properties": {
+                                                "line1": {
+                                                    "type": "string"
+                                                },
+                                                "line2": {
+                                                    "type": "string"
+                                                },
+                                                "city": {
+                                                    "type": "string"
+                                                },
+                                                "region": {
+                                                    "type": "string"
+                                                },
+                                                "postalCode": {
+                                                    "type": "string"
+                                                },
+                                                "countryCode": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "line1",
+                                                "city",
+                                                "region",
+                                                "postalCode",
+                                                "countryCode"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "cardId",
+                                        "cardSecret",
+                                        "last4",
+                                        "network",
+                                        "billingAddress"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "code": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ]
+                                }
+                            }
+                        }
                     }
                 }
             }
         },
-        "/readyz": {
-            "get": {
+        "/rain/webhooks": {
+            "post": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -15982,15 +15977,6 @@
                                     "depositChain": {
                                         "type": "string"
                                     },
-                                    "depositChainId": {
-                                        "type": "string"
-                                    },
-                                    "depositContractVersion": {
-                                        "type": "string"
-                                    },
-                                    "depositIdx": {
-                                        "type": "number"
-                                    },
                                     "destinationAddress": {
                                         "type": "string"
                                     },
@@ -16165,74 +16151,6 @@
                 }
             },
             "post": {
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "properties": {
-                                    "amount": {
-                                        "anyOf": [
-                                            {
-                                                "pattern": "^[0-9]+$",
-                                                "type": "string"
-                                            },
-                                            {
-                                                "minimum": 1,
-                                                "type": "integer"
-                                            }
-                                        ]
-                                    },
-                                    "attachment": {},
-                                    "chainId": {
-                                        "type": "string"
-                                    },
-                                    "contractVersion": {
-                                        "type": "string"
-                                    },
-                                    "depositIdx": {
-                                        "anyOf": [
-                                            {
-                                                "pattern": "^[0-9]+$",
-                                                "type": "string"
-                                            },
-                                            {
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        ]
-                                    },
-                                    "filename": {
-                                        "type": "string"
-                                    },
-                                    "mimetype": {
-                                        "type": "string"
-                                    },
-                                    "preparationId": {
-                                        "type": "string"
-                                    },
-                                    "pubKey": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "reference": {
-                                        "type": "string"
-                                    },
-                                    "tokenAddress": {
-                                        "type": "string"
-                                    },
-                                    "txHash": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "pubKey"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16312,75 +16230,6 @@
                         }
                     }
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "amount": {
-                                        "anyOf": [
-                                            {
-                                                "pattern": "^[0-9]+$",
-                                                "type": "string"
-                                            },
-                                            {
-                                                "minimum": 1,
-                                                "type": "integer"
-                                            }
-                                        ]
-                                    },
-                                    "chainId": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "contractVersion": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "depositIdx": {
-                                        "anyOf": [
-                                            {
-                                                "pattern": "^[0-9]+$",
-                                                "type": "string"
-                                            },
-                                            {
-                                                "minimum": 0,
-                                                "type": "integer"
-                                            }
-                                        ]
-                                    },
-                                    "tokenAddress": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "txHash": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "txHash",
-                                    "chainId",
-                                    "depositIdx",
-                                    "contractVersion",
-                                    "amount",
-                                    "tokenAddress"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/status/summary": {
-            "get": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16582,6 +16431,10 @@
                                         "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8}){0,2}$",
                                         "type": "string"
                                     },
+                                    "offrampHandle": {
+                                        "maxLength": 320,
+                                        "type": "string"
+                                    },
                                     "pushSubscriptionId": {
                                         "type": "string"
                                     },
@@ -16617,106 +16470,6 @@
                 },
                 "responses": {
                     "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "additionalProperties": true,
-                                    "properties": {},
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code.",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code."
-                    },
-                    "409": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "message": {
-                                            "type": "string"
-                                        },
-                                        "success": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "success",
-                                        "message"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "429": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`.",
-                                    "properties": {
-                                        "code": {
-                                            "enum": [
-                                                "RESIDENCE_CHANGE_COOLDOWN"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "retryAt": {
-                                            "format": "date-time",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error",
-                                        "code",
-                                        "retryAt"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`."
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "message": {
-                                            "type": "string"
-                                        },
-                                        "success": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "success",
-                                        "message"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
                         "description": "Default Response"
                     }
                 }
@@ -17021,12 +16774,6 @@
                                                                             "bridge-hosted"
                                                                         ],
                                                                         "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "rain-hosted"
-                                                                        ],
-                                                                        "type": "string"
                                                                     }
                                                                 ]
                                                             },
@@ -17326,12 +17073,6 @@
                                                                                     {
                                                                                         "enum": [
                                                                                             "bridge-hosted"
-                                                                                        ],
-                                                                                        "type": "string"
-                                                                                    },
-                                                                                    {
-                                                                                        "enum": [
-                                                                                            "rain-hosted"
                                                                                         ],
                                                                                         "type": "string"
                                                                                     }
@@ -17759,181 +17500,6 @@
                 }
             }
         },
-        "/users/identity/restart": {
-            "post": {
-                "description": "Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one.",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "regionIntent": {
-                                        "anyOf": [
-                                            {
-                                                "enum": [
-                                                    "LATAM"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "ROW"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "EU"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "NA"
-                                                ],
-                                                "type": "string"
-                                            }
-                                        ],
-                                        "description": "Level the token must target. The declared residence decides (AR/BR \u2192 LATAM, US/MX \u2192 NA, SEPA zone \u2192 EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs."
-                                    }
-                                },
-                                "type": "object"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "applicantId": {
-                                            "type": "string"
-                                        },
-                                        "levelName": {
-                                            "type": "string"
-                                        },
-                                        "regionIntent": {
-                                            "description": "The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level).",
-                                            "type": "string"
-                                        },
-                                        "token": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "token",
-                                        "levelName",
-                                        "applicantId",
-                                        "regionIntent"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "403": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "409": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "429": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "retryAt": {
-                                            "format": "date-time",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                },
-                "tags": [
-                    "users"
-                ]
-            }
-        },
         "/users/identity/resubmit": {
             "post": {
                 "responses": {
@@ -18170,12 +17736,6 @@
                                                                     {
                                                                         "enum": [
                                                                             "bridge-hosted"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "rain-hosted"
                                                                         ],
                                                                         "type": "string"
                                                                     }
@@ -18479,12 +18039,6 @@
                                                                                             "bridge-hosted"
                                                                                         ],
                                                                                         "type": "string"
-                                                                                    },
-                                                                                    {
-                                                                                        "enum": [
-                                                                                            "rain-hosted"
-                                                                                        ],
-                                                                                        "type": "string"
                                                                                     }
                                                                                 ]
                                                                             },
@@ -18707,26 +18261,6 @@
                                                         }
                                                     ]
                                                 },
-                                                "declaredSecond": {
-                                                    "anyOf": [
-                                                        {
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "type": "null"
-                                                        }
-                                                    ]
-                                                },
-                                                "kycReported": {
-                                                    "anyOf": [
-                                                        {
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "type": "null"
-                                                        }
-                                                    ]
-                                                },
                                                 "nextChangeAllowedAt": {
                                                     "anyOf": [
                                                         {
@@ -18750,9 +18284,7 @@
                                             },
                                             "required": [
                                                 "declared",
-                                                "declaredSecond",
                                                 "verified",
-                                                "kycReported",
                                                 "nextChangeAllowedAt"
                                             ],
                                             "type": "object"
@@ -18818,405 +18350,6 @@
             "post": {
                 "responses": {
                     "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/users/saved-addresses": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "savedAddresses": {
-                                            "items": {
-                                                "properties": {
-                                                    "address": {
-                                                        "type": "string"
-                                                    },
-                                                    "chainId": {
-                                                        "type": "string"
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string"
-                                                    },
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "lastUsedAt": {
-                                                        "type": "string"
-                                                    },
-                                                    "nickname": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "address",
-                                                    "chainId",
-                                                    "nickname",
-                                                    "lastUsedAt",
-                                                    "createdAt"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "required": [
-                                        "savedAddresses"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "address": {
-                                        "pattern": "^(0x[a-fA-F0-9]{40}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
-                                        "type": "string"
-                                    },
-                                    "chainId": {
-                                        "maxLength": 32,
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "nickname": {
-                                        "maxLength": 15,
-                                        "minLength": 1,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "address",
-                                    "chainId",
-                                    "nickname"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "savedAddress": {
-                                            "properties": {
-                                                "address": {
-                                                    "type": "string"
-                                                },
-                                                "chainId": {
-                                                    "type": "string"
-                                                },
-                                                "createdAt": {
-                                                    "type": "string"
-                                                },
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "lastUsedAt": {
-                                                    "type": "string"
-                                                },
-                                                "nickname": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "id",
-                                                "address",
-                                                "chainId",
-                                                "nickname",
-                                                "lastUsedAt",
-                                                "createdAt"
-                                            ],
-                                            "type": "object"
-                                        }
-                                    },
-                                    "required": [
-                                        "savedAddress"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/users/saved-addresses/{id}": {
-            "delete": {
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "format": "uuid",
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "deleted": {
-                                            "enum": [
-                                                true
-                                            ],
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "deleted"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                }
-            },
-            "patch": {
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "format": "uuid",
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "nickname": {
-                                        "maxLength": 15,
-                                        "minLength": 1,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "nickname"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "savedAddress": {
-                                            "properties": {
-                                                "address": {
-                                                    "type": "string"
-                                                },
-                                                "chainId": {
-                                                    "type": "string"
-                                                },
-                                                "createdAt": {
-                                                    "type": "string"
-                                                },
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "lastUsedAt": {
-                                                    "type": "string"
-                                                },
-                                                "nickname": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "id",
-                                                "address",
-                                                "chainId",
-                                                "nickname",
-                                                "lastUsedAt",
-                                                "createdAt"
-                                            ],
-                                            "type": "object"
-                                        }
-                                    },
-                                    "required": [
-                                        "savedAddress"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
                         "description": "Default Response"
                     }
                 }
@@ -19400,13 +18533,6 @@
             }
         },
         "/webhooks/onesignal": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            },
             "post": {
                 "responses": {
                     "200": {
@@ -19429,6 +18555,138 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/rain/cards/{cardId}/move-to-card": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "cardId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amountCents": {
+                                        "maximum": 10000000,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    },
+                                    "idempotencyKey": {
+                                        "maxLength": 100,
+                                        "minLength": 8,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "amountCents",
+                                    "idempotencyKey"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "amountCents": {
+                                            "type": "number"
+                                        },
+                                        "ok": {
+                                            "type": "boolean"
+                                        },
+                                        "userOpHash": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "ok",
+                                        "amountCents",
+                                        "userOpHash"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -14858,10 +14858,16 @@
                                         "maximum": 10000000,
                                         "minimum": 100,
                                         "type": "integer"
+                                    },
+                                    "idempotencyKey": {
+                                        "maxLength": 100,
+                                        "minLength": 8,
+                                        "type": "string"
                                     }
                                 },
                                 "required": [
-                                    "amountCents"
+                                    "amountCents",
+                                    "idempotencyKey"
                                 ],
                                 "type": "object"
                             }

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -14149,6 +14149,10 @@
                                     "loadAllToCard": {
                                         "type": "boolean"
                                     },
+                                    "pinTarget": {
+                                        "description": "Default true. False lowers collateralTargetCents without pinning it (a move off the card), so the nightly tuner keeps sizing the card.",
+                                        "type": "boolean"
+                                    },
                                     "walletFloorCents": {
                                         "maximum": 1000000,
                                         "minimum": 0,

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -498,20 +498,10 @@
                                                 "acquisition": {
                                                     "properties": {
                                                         "destination": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "enum": [
-                                                                        "offramp_migration"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                {
-                                                                    "enum": [
-                                                                        "normal_app"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            ]
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
                                                         },
                                                         "fallback": {
                                                             "enum": [
@@ -686,20 +676,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -811,6 +791,40 @@
                                     },
                                     "required": [
                                         "claims"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/badge/team": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "Authorization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "awarded": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "awarded"
                                     ],
                                     "type": "object"
                                 }
@@ -2450,6 +2464,9 @@
                                         "flowEarlyAccess": {
                                             "type": "boolean"
                                         },
+                                        "geoProhibited": {
+                                            "type": "boolean"
+                                        },
                                         "hasCardAccess": {
                                             "type": "boolean"
                                         },
@@ -2502,6 +2519,7 @@
                                     "required": [
                                         "hasCardAccess",
                                         "isEligible",
+                                        "geoProhibited",
                                         "flowEarlyAccess",
                                         "isPublicLaunched",
                                         "waitlistJoinedAt",
@@ -2730,7 +2748,7 @@
                         "description": "Default Response"
                     }
                 },
-                "summary": "Get the user’s current waitlist state",
+                "summary": "Get the user\u2019s current waitlist state",
                 "tags": [
                     "card"
                 ]
@@ -3331,6 +3349,7 @@
                                     },
                                     "claimParams": {
                                         "items": {},
+                                        "maxItems": 4,
                                         "minItems": 3,
                                         "type": "array"
                                     },
@@ -7281,7 +7300,7 @@
         },
         "/dev/poll": {
             "post": {
-                "description": "Triggers runPollingCycle() on demand — used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
+                "description": "Triggers runPollingCycle() on demand \u2014 used by the QA harness to observe provider state transitions without waiting for the 5-minute interval.",
                 "responses": {
                     "200": {
                         "content": {
@@ -7946,7 +7965,7 @@
         },
         "/dev/submit-to-providers": {
             "post": {
-                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user → Manteca, US user → Bridge) end-to-end.",
+                "description": "Drives Peanut's submitToProviders(userId, applicantId) synchronously, the same function the Sumsub status-processor calls after GREEN. Used by QA harness to test routing (AR user \u2192 Manteca, US user \u2192 Bridge) end-to-end.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -8184,7 +8203,7 @@
         },
         "/dev/trigger-sumsub-webhook": {
             "post": {
-                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) — same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub → routing chain without real webhook delivery.",
+                "description": "Invokes processSumsubKycUpdate({ applicantId, externalUserId, reviewAnswer, reviewStatus, source: 'webhook' }) \u2014 same entry point as the real /sumsub/webhooks route, minus HMAC. Used by the QA harness to exercise the full Sumsub \u2192 routing chain without real webhook delivery.",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -9174,6 +9193,61 @@
                 }
             }
         },
+        "/healthz/bridge": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/manteca/{geo}": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "geo",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/rain": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/rhino": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/healthz/sumsub": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/history/{entryId}": {
             "get": {
                 "parameters": [
@@ -9304,20 +9378,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9432,20 +9496,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9519,20 +9573,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9647,20 +9691,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9791,20 +9825,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9881,20 +9905,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -10117,7 +10131,7 @@
         },
         "/manteca/deposit/{depositId}/status": {
             "get": {
-                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only — the webhook/poller remain the authoritative completion trigger.",
+                "description": "Poll the status of a deposit order by its Manteca synthetic id. Used by the BRL PIX QR flow to detect completion (intent.status === COMPLETED) without leaving the user on a static QR. Read-only \u2014 the webhook/poller remain the authoritative completion trigger.",
                 "parameters": [
                     {
                         "in": "path",
@@ -10142,54 +10156,6 @@
                     }
                 },
                 "summary": "Get deposit order status",
-                "tags": [
-                    "manteca"
-                ]
-            }
-        },
-        "/manteca/initiate-onboarding": {
-            "post": {
-                "description": "Creates an onboarding widget URL for the current user using userId as userExternalId and returns the URL",
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "Authorization",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "exchange": {
-                                        "type": "string"
-                                    },
-                                    "failureUrl": {
-                                        "type": "string"
-                                    },
-                                    "returnUrl": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "returnUrl"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                },
-                "summary": "Initiate Manteca onboarding",
                 "tags": [
                     "manteca"
                 ]
@@ -10548,6 +10514,9 @@
                                     "amount": {
                                         "description": "Amount for static QR codes (optional for dynamic QR codes)",
                                         "type": "string"
+                                    },
+                                    "idempotencyKey": {
+                                        "description": "Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour."
                                     },
                                     "qrCode": {
                                         "description": "The QR code string to process for payment",
@@ -12053,38 +12022,102 @@
                                     "actionType": {
                                         "anyOf": [
                                             {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            "BRIDGE_TRANSFER"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "MANTECA_TRANSFER"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "MANTECA_QR_PAYMENT"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "P2P_SEND_LINK"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "P2P_REQUEST_PAYMENT"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "enum": [
+                                                            "KYC_VERIFIED"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            },
+                                            {
                                                 "enum": [
-                                                    "BRIDGE_TRANSFER"
+                                                    "DIRECT_TRANSFER"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "MANTECA_TRANSFER"
+                                                    "P2P_SEND"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "MANTECA_QR_PAYMENT"
+                                                    "P2P_REQUEST_FULFILL"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_SEND_LINK"
+                                                    "SEND_LINK"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "P2P_REQUEST_PAYMENT"
+                                                    "QR_PAY"
                                                 ],
                                                 "type": "string"
                                             },
                                             {
                                                 "enum": [
-                                                    "KYC_VERIFIED"
+                                                    "ONRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "OFFRAMP"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CRYPTO_WITHDRAW"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CARD_SPEND_AUTH"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "CARD_SPEND_CLEAR"
                                                 ],
                                                 "type": "string"
                                             }
@@ -12416,6 +12449,44 @@
                                         "cards": {
                                             "items": {
                                                 "properties": {
+                                                    "collateral": {
+                                                        "properties": {
+                                                            "autoBalanceEnabled": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "cardLimitCents": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "null"
+                                                                    },
+                                                                    {
+                                                                        "type": "number"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "loadAllToCard": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "targetCents": {
+                                                                "type": "number"
+                                                            },
+                                                            "targetPinned": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "walletFloorCents": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "targetCents",
+                                                            "targetPinned",
+                                                            "walletFloorCents",
+                                                            "loadAllToCard",
+                                                            "cardLimitCents",
+                                                            "autoBalanceEnabled"
+                                                        ],
+                                                        "type": "object"
+                                                    },
                                                     "expiryMonth": {
                                                         "type": "number"
                                                     },
@@ -12453,7 +12524,8 @@
                                                     "status",
                                                     "network",
                                                     "issuedAt",
-                                                    "hasWithdrawApproval"
+                                                    "hasWithdrawApproval",
+                                                    "collateral"
                                                 ],
                                                 "type": "object"
                                             },
@@ -13318,76 +13390,6 @@
                                     "directTransfer": {
                                         "type": "boolean"
                                     },
-                                    "kind": {
-                                        "anyOf": [
-                                            {
-                                                "enum": [
-                                                    "P2P_SEND"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "QR_PAY"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "LINK_CREATE"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CRYPTO_WITHDRAW"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "FIAT_OFFRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "FIAT_ONRAMP"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "REQUEST_PAY"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "AUTO_REBALANCE"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "CARD_SPEND"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "DEPOSIT_EXTERNAL"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "OTHER"
-                                                ],
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
                                     "recipientAddress": {
                                         "pattern": "^0x[0-9a-fA-F]{40}$",
                                         "type": "string"
@@ -13400,8 +13402,7 @@
                                 "required": [
                                     "amount",
                                     "recipientAddress",
-                                    "directTransfer",
-                                    "kind"
+                                    "directTransfer"
                                 ],
                                 "type": "object"
                             }
@@ -13614,6 +13615,133 @@
                 }
             }
         },
+        "/rain/cards/withdraw/prepare/cancel": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "preparationId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "preparationId"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "ok"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/rain/cards/withdraw/session-approve": {
             "post": {
                 "requestBody": {
@@ -13758,6 +13886,27 @@
                                     },
                                     "required": [
                                         "ok"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
                                     ],
                                     "type": "object"
                                 }
@@ -14029,6 +14178,11 @@
                                         "minimum": 0,
                                         "type": "number"
                                     },
+                                    "collateralTargetCents": {
+                                        "maximum": 10000000,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
                                     "limits": {
                                         "items": {
                                             "properties": {
@@ -14072,6 +14226,14 @@
                                             "type": "object"
                                         },
                                         "type": "array"
+                                    },
+                                    "loadAllToCard": {
+                                        "type": "boolean"
+                                    },
+                                    "walletFloorCents": {
+                                        "maximum": 1000000,
+                                        "minimum": 0,
+                                        "type": "integer"
                                     }
                                 },
                                 "type": "object"
@@ -14674,6 +14836,132 @@
                 }
             }
         },
+        "/rain/cards/{cardId}/move-to-card": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "cardId",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amountCents": {
+                                        "maximum": 10000000,
+                                        "minimum": 100,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "amountCents"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "amountCents": {
+                                            "type": "number"
+                                        },
+                                        "ok": {
+                                            "type": "boolean"
+                                        },
+                                        "userOpHash": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "ok",
+                                        "amountCents",
+                                        "userOpHash"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "502": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/rain/cards/{cardId}/physical-waitlist": {
             "get": {
                 "parameters": [
@@ -15048,225 +15336,17 @@
                 }
             }
         },
-        "/rain/cards/{cardId}/provisioning-data": {
+        "/rain/webhooks": {
             "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "wallet": {
-                                        "anyOf": [
-                                            {
-                                                "type": "string",
-                                                "enum": [
-                                                    "apple"
-                                                ]
-                                            },
-                                            {
-                                                "type": "string",
-                                                "enum": [
-                                                    "google"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                "required": [
-                                    "wallet"
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "schema": {
-                            "format": "uuid",
-                            "type": "string"
-                        },
-                        "in": "path",
-                        "name": "cardId",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cardId": {
-                                            "type": "string"
-                                        },
-                                        "cardSecret": {
-                                            "type": "string"
-                                        },
-                                        "last4": {
-                                            "type": "string"
-                                        },
-                                        "network": {
-                                            "type": "string"
-                                        },
-                                        "cardholderName": {
-                                            "type": "string"
-                                        },
-                                        "billingAddress": {
-                                            "type": "object",
-                                            "properties": {
-                                                "line1": {
-                                                    "type": "string"
-                                                },
-                                                "line2": {
-                                                    "type": "string"
-                                                },
-                                                "city": {
-                                                    "type": "string"
-                                                },
-                                                "region": {
-                                                    "type": "string"
-                                                },
-                                                "postalCode": {
-                                                    "type": "string"
-                                                },
-                                                "countryCode": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "line1",
-                                                "city",
-                                                "region",
-                                                "postalCode",
-                                                "countryCode"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "cardId",
-                                        "cardSecret",
-                                        "last4",
-                                        "network",
-                                        "billingAddress"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "503": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
+                        "description": "Default Response"
                     }
                 }
             }
         },
-        "/rain/webhooks": {
-            "post": {
+        "/readyz": {
+            "get": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -15896,6 +15976,15 @@
                                     "depositChain": {
                                         "type": "string"
                                     },
+                                    "depositChainId": {
+                                        "type": "string"
+                                    },
+                                    "depositContractVersion": {
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "type": "number"
+                                    },
                                     "destinationAddress": {
                                         "type": "string"
                                     },
@@ -16070,6 +16159,74 @@
                 }
             },
             "post": {
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "attachment": {},
+                                    "chainId": {
+                                        "type": "string"
+                                    },
+                                    "contractVersion": {
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "filename": {
+                                        "type": "string"
+                                    },
+                                    "mimetype": {
+                                        "type": "string"
+                                    },
+                                    "preparationId": {
+                                        "type": "string"
+                                    },
+                                    "pubKey": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "reference": {
+                                        "type": "string"
+                                    },
+                                    "tokenAddress": {
+                                        "type": "string"
+                                    },
+                                    "txHash": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "pubKey"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16149,6 +16306,75 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "chainId": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "contractVersion": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "anyOf": [
+                                            {
+                                                "pattern": "^[0-9]+$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "minimum": 0,
+                                                "type": "integer"
+                                            }
+                                        ]
+                                    },
+                                    "tokenAddress": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "txHash": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "txHash",
+                                    "chainId",
+                                    "depositIdx",
+                                    "contractVersion",
+                                    "amount",
+                                    "tokenAddress"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/status/summary": {
+            "get": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -16350,10 +16576,6 @@
                                         "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8}){0,2}$",
                                         "type": "string"
                                     },
-                                    "offrampHandle": {
-                                        "maxLength": 320,
-                                        "type": "string"
-                                    },
                                     "pushSubscriptionId": {
                                         "type": "string"
                                     },
@@ -16389,6 +16611,106 @@
                 },
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": true,
+                                    "properties": {},
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code.",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code."
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`.",
+                                    "properties": {
+                                        "code": {
+                                            "enum": [
+                                                "RESIDENCE_CHANGE_COOLDOWN"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "retryAt": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error",
+                                        "code",
+                                        "retryAt"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "message"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }
@@ -16693,6 +17015,12 @@
                                                                             "bridge-hosted"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "rain-hosted"
+                                                                        ],
+                                                                        "type": "string"
                                                                     }
                                                                 ]
                                                             },
@@ -16992,6 +17320,12 @@
                                                                                     {
                                                                                         "enum": [
                                                                                             "bridge-hosted"
+                                                                                        ],
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "enum": [
+                                                                                            "rain-hosted"
                                                                                         ],
                                                                                         "type": "string"
                                                                                     }
@@ -17419,6 +17753,181 @@
                 }
             }
         },
+        "/users/identity/restart": {
+            "post": {
+                "description": "Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "regionIntent": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "LATAM"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "ROW"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "EU"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "NA"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "description": "Level the token must target. The declared residence decides (AR/BR \u2192 LATAM, US/MX \u2192 NA, SEPA zone \u2192 EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs."
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "applicantId": {
+                                            "type": "string"
+                                        },
+                                        "levelName": {
+                                            "type": "string"
+                                        },
+                                        "regionIntent": {
+                                            "description": "The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level).",
+                                            "type": "string"
+                                        },
+                                        "token": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "token",
+                                        "levelName",
+                                        "applicantId",
+                                        "regionIntent"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "retryAt": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                },
+                "tags": [
+                    "users"
+                ]
+            }
+        },
         "/users/identity/resubmit": {
             "post": {
                 "responses": {
@@ -17655,6 +18164,12 @@
                                                                     {
                                                                         "enum": [
                                                                             "bridge-hosted"
+                                                                        ],
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "enum": [
+                                                                            "rain-hosted"
                                                                         ],
                                                                         "type": "string"
                                                                     }
@@ -17958,6 +18473,12 @@
                                                                                             "bridge-hosted"
                                                                                         ],
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    {
+                                                                                        "enum": [
+                                                                                            "rain-hosted"
+                                                                                        ],
+                                                                                        "type": "string"
                                                                                     }
                                                                                 ]
                                                                             },
@@ -18180,6 +18701,26 @@
                                                         }
                                                     ]
                                                 },
+                                                "declaredSecond": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "null"
+                                                        }
+                                                    ]
+                                                },
+                                                "kycReported": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "null"
+                                                        }
+                                                    ]
+                                                },
                                                 "nextChangeAllowedAt": {
                                                     "anyOf": [
                                                         {
@@ -18203,7 +18744,9 @@
                                             },
                                             "required": [
                                                 "declared",
+                                                "declaredSecond",
                                                 "verified",
+                                                "kycReported",
                                                 "nextChangeAllowedAt"
                                             ],
                                             "type": "object"
@@ -18269,6 +18812,405 @@
             "post": {
                 "responses": {
                     "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/users/saved-addresses": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddresses": {
+                                            "items": {
+                                                "properties": {
+                                                    "address": {
+                                                        "type": "string"
+                                                    },
+                                                    "chainId": {
+                                                        "type": "string"
+                                                    },
+                                                    "createdAt": {
+                                                        "type": "string"
+                                                    },
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "lastUsedAt": {
+                                                        "type": "string"
+                                                    },
+                                                    "nickname": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "address",
+                                                    "chainId",
+                                                    "nickname",
+                                                    "lastUsedAt",
+                                                    "createdAt"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddresses"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "address": {
+                                        "pattern": "^(0x[a-fA-F0-9]{40}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
+                                        "type": "string"
+                                    },
+                                    "chainId": {
+                                        "maxLength": 32,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "nickname": {
+                                        "maxLength": 15,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "address",
+                                    "chainId",
+                                    "nickname"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddress": {
+                                            "properties": {
+                                                "address": {
+                                                    "type": "string"
+                                                },
+                                                "chainId": {
+                                                    "type": "string"
+                                                },
+                                                "createdAt": {
+                                                    "type": "string"
+                                                },
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "lastUsedAt": {
+                                                    "type": "string"
+                                                },
+                                                "nickname": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "address",
+                                                "chainId",
+                                                "nickname",
+                                                "lastUsedAt",
+                                                "createdAt"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddress"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/users/saved-addresses/{id}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "deleted": {
+                                            "enum": [
+                                                true
+                                            ],
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "deleted"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            },
+            "patch": {
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "format": "uuid",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "nickname": {
+                                        "maxLength": 15,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "nickname"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "savedAddress": {
+                                            "properties": {
+                                                "address": {
+                                                    "type": "string"
+                                                },
+                                                "chainId": {
+                                                    "type": "string"
+                                                },
+                                                "createdAt": {
+                                                    "type": "string"
+                                                },
+                                                "id": {
+                                                    "type": "string"
+                                                },
+                                                "lastUsedAt": {
+                                                    "type": "string"
+                                                },
+                                                "nickname": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "id",
+                                                "address",
+                                                "chainId",
+                                                "nickname",
+                                                "lastUsedAt",
+                                                "createdAt"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "savedAddress"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }
@@ -18452,6 +19394,13 @@
             }
         },
         "/webhooks/onesignal": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            },
             "post": {
                 "responses": {
                     "200": {

--- a/src/types/manteca.types.ts
+++ b/src/types/manteca.types.ts
@@ -87,6 +87,9 @@ export type MantecaWithdrawData = {
 }
 
 export type MantecaWithdrawResponseData = {
+    /** Set when the off-ramp pulled from the card: Rain's withdrawal-signature
+     *  lock, in seconds, for the shared cooldown countdown. */
+    cooldownSec?: number
     id: string
     numberId: string
     userId: string

--- a/src/utils/__tests__/collateralPull.utils.test.ts
+++ b/src/utils/__tests__/collateralPull.utils.test.ts
@@ -1,0 +1,66 @@
+import { computeCollateralPull, formatLockRemaining } from '../collateralPull.utils'
+
+const usdc = (n: number) => BigInt(Math.round(n * 1_000_000))
+
+describe('computeCollateralPull', () => {
+    it('stays off card when the off-card balance covers the amount', () => {
+        expect(computeCollateralPull({ amountUsd: '20', offCardUnits: usdc(28.4), onCardCents: 10_000 })).toEqual({
+            pullsFromCard: false,
+            fromCardCents: 0,
+        })
+    })
+
+    it('pulls the whole amount from the card when the card alone covers it', () => {
+        // Mirrors the collateral-only preference: one Rain signature, not two taps.
+        expect(computeCollateralPull({ amountUsd: '50', offCardUnits: usdc(28.4), onCardCents: 10_000 })).toEqual({
+            pullsFromCard: true,
+            fromCardCents: 5_000,
+        })
+    })
+
+    it('pulls only the shortfall when neither side covers it alone', () => {
+        expect(computeCollateralPull({ amountUsd: '120', offCardUnits: usdc(28.4), onCardCents: 10_000 })).toEqual({
+            pullsFromCard: true,
+            fromCardCents: 9_160,
+        })
+    })
+
+    it('reports nothing for a true shortfall — the insufficient error owns that', () => {
+        expect(computeCollateralPull({ amountUsd: '200', offCardUnits: usdc(28.4), onCardCents: 10_000 })).toEqual({
+            pullsFromCard: false,
+            fromCardCents: 0,
+        })
+    })
+
+    it('reports nothing while either balance is unknown', () => {
+        expect(
+            computeCollateralPull({ amountUsd: '50', offCardUnits: undefined, onCardCents: 10_000 }).pullsFromCard
+        ).toBe(false)
+        expect(computeCollateralPull({ amountUsd: '50', offCardUnits: usdc(1), onCardCents: null }).pullsFromCard).toBe(
+            false
+        )
+    })
+
+    it('ignores empty, zero and junk amounts', () => {
+        for (const amountUsd of ['', '0', '0.00', 'abc', null, undefined]) {
+            expect(computeCollateralPull({ amountUsd, offCardUnits: usdc(0), onCardCents: 10_000 }).pullsFromCard).toBe(
+                false
+            )
+        }
+    })
+
+    it('an empty off-card balance sends the whole amount through the card', () => {
+        expect(computeCollateralPull({ amountUsd: '6.11', offCardUnits: 0n, onCardCents: 2_489 })).toEqual({
+            pullsFromCard: true,
+            fromCardCents: 611,
+        })
+    })
+})
+
+describe('formatLockRemaining', () => {
+    it('renders m:ss and never goes negative', () => {
+        expect(formatLockRemaining(95_000)).toBe('1:35')
+        expect(formatLockRemaining(500)).toBe('0:01')
+        expect(formatLockRemaining(-10)).toBe('0:00')
+    })
+})

--- a/src/utils/__tests__/collateralPull.utils.test.ts
+++ b/src/utils/__tests__/collateralPull.utils.test.ts
@@ -49,6 +49,30 @@ describe('computeCollateralPull', () => {
         }
     })
 
+    it('a multi-call flow (cross-chain) can only pull the shortfall, never the whole amount', () => {
+        // $28.40 off card, $100 on card, $50 cross-chain: execution goes mixed
+        // through sendTransactions, so $21.60 leaves the card — not $50.
+        expect(
+            computeCollateralPull({
+                amountUsd: '50',
+                offCardUnits: usdc(28.4),
+                onCardCents: 10_000,
+                collateralOnlyAllowed: false,
+            })
+        ).toEqual({ pullsFromCard: true, fromCardCents: 2_160 })
+    })
+
+    it('floors the off-card balance to the cent so a sub-cent dust never reads as a whole cent', () => {
+        // 1.000001 USDC off card is $1.00 for routing purposes, so a $1.00
+        // spend stays off card; $1.01 pulls the 1-cent shortfall.
+        expect(
+            computeCollateralPull({ amountUsd: '1.00', offCardUnits: 1_000_001n, onCardCents: 10_000 }).pullsFromCard
+        ).toBe(false)
+        expect(
+            computeCollateralPull({ amountUsd: '1.01', offCardUnits: 1_000_001n, onCardCents: 0 }).pullsFromCard
+        ).toBe(false)
+    })
+
     it('an empty off-card balance sends the whole amount through the card', () => {
         expect(computeCollateralPull({ amountUsd: '6.11', offCardUnits: 0n, onCardCents: 2_489 })).toEqual({
             pullsFromCard: true,

--- a/src/utils/collateralPull.utils.ts
+++ b/src/utils/collateralPull.utils.ts
@@ -1,0 +1,48 @@
+import { parseUsdAmountToUnits, usdcUnitsToRainCents } from './balance.utils'
+
+export interface CollateralPull {
+    /** The spend cannot be covered off card and will pull from the card balance. */
+    pullsFromCard: boolean
+    /** Cents that will leave the card: the whole amount when the card alone can
+     *  cover it (collateral-only, one signature), otherwise only the shortfall
+     *  (mixed). 0 when nothing is pulled. */
+    fromCardCents: number
+}
+
+const NONE: CollateralPull = { pullsFromCard: false, fromCardCents: 0 }
+
+/**
+ * Mirrors `computeSpendStrategy` (spendPreflight.ts) on displayed balances so
+ * the review step can say, BEFORE the passkey, that a spend is going to touch
+ * the card balance — and therefore Rain's per-user withdrawal lock. Off-card
+ * first; the card is the fallback; mixed only when neither covers it alone.
+ * Unknown balances, a zero amount and a true shortfall all report no pull —
+ * the insufficient-balance error owns that last case.
+ */
+export function computeCollateralPull(input: {
+    amountUsd: string | number | null | undefined
+    offCardUnits: bigint | undefined
+    onCardCents: number | null
+}): CollateralPull {
+    if (input.amountUsd == null || input.offCardUnits === undefined || input.onCardCents === null) return NONE
+    const units = parseUsdAmountToUnits(input.amountUsd)
+    if (units === null || units <= 0n) return NONE
+    if (units <= input.offCardUnits) return NONE
+
+    const amountCents = Number(usdcUnitsToRainCents(units))
+    const offCardCents = Number(usdcUnitsToRainCents(input.offCardUnits))
+    const onCardCents = Math.max(0, Math.floor(input.onCardCents))
+    if (onCardCents >= amountCents) return { pullsFromCard: true, fromCardCents: amountCents }
+
+    const shortfallCents = amountCents - offCardCents
+    if (shortfallCents <= 0 || offCardCents + onCardCents < amountCents) return NONE
+    return { pullsFromCard: true, fromCardCents: shortfallCents }
+}
+
+/** m:ss for a remaining lock, never negative. */
+export function formatLockRemaining(ms: number): string {
+    const totalSec = Math.max(0, Math.ceil(ms / 1000))
+    const m = Math.floor(totalSec / 60)
+    const s = totalSec % 60
+    return `${m}:${s.toString().padStart(2, '0')}`
+}

--- a/src/utils/collateralPull.utils.ts
+++ b/src/utils/collateralPull.utils.ts
@@ -1,4 +1,5 @@
 import { parseUsdAmountToUnits, usdcUnitsToRainCents } from './balance.utils'
+import { usdcUnitsToDisplayCents } from '@/hooks/wallet/useBalanceSplit'
 
 export interface CollateralPull {
     /** The spend cannot be covered off card and will pull from the card balance. */
@@ -22,7 +23,16 @@ const NONE: CollateralPull = { pullsFromCard: false, fromCardCents: 0 }
 export function computeCollateralPull(input: {
     amountUsd: string | number | null | undefined
     offCardUnits: bigint | undefined
+    /** Landed spending power only — in-transit top-ups cannot be pulled. */
     onCardCents: number | null
+    /**
+     * Whether the flow can execute collateral-only (a single direct transfer
+     * with no follow-up kernel calls). Multi-call flows — cross-chain
+     * withdrawals and cross-chain request payments through
+     * `sendTransactions` — can only go mixed, so only the shortfall leaves
+     * the card. Defaults to the single-recipient case.
+     */
+    collateralOnlyAllowed?: boolean
 }): CollateralPull {
     if (input.amountUsd == null || input.offCardUnits === undefined || input.onCardCents === null) return NONE
     const units = parseUsdAmountToUnits(input.amountUsd)
@@ -30,9 +40,10 @@ export function computeCollateralPull(input: {
     if (units <= input.offCardUnits) return NONE
 
     const amountCents = Number(usdcUnitsToRainCents(units))
-    const offCardCents = Number(usdcUnitsToRainCents(input.offCardUnits))
+    const offCardCents = usdcUnitsToDisplayCents(input.offCardUnits)
     const onCardCents = Math.max(0, Math.floor(input.onCardCents))
-    if (onCardCents >= amountCents) return { pullsFromCard: true, fromCardCents: amountCents }
+    const collateralOnlyAllowed = input.collateralOnlyAllowed ?? true
+    if (collateralOnlyAllowed && onCardCents >= amountCents) return { pullsFromCard: true, fromCardCents: amountCents }
 
     const shortfallCents = amountCents - offCardCents
     if (shortfallCents <= 0 || offCardCents + onCardCents < amountCents) return NONE


### PR DESCRIPTION
## Summary

Frontend half of the on card / off card change (TASK-22293). The app showed one balance while the money sat in two buckets with very different exit costs, and nothing on screen explained why a send waited for a "card cool-down" or why a tap declined with money in the account.

- **Home**: card holders get a quiet second line under the total — "$100.00 on card · $28.40 off card" — linking to the new screen. Hidden-balance mode masks both halves.
- **Card › On card** (`/card/on-card`): both halves, *Keep on card* (the balancer's target), *Keep off card* (the floor the sweep never crosses), *Load everything to card*, and manual moves. *Move to card* runs through the stored session key (no passkey, lands in about a minute). *Move off card* is one passkey and pins the target below the remaining amount first, so the balancer cannot sweep the money straight back. Lowering *Keep on card* offers the excess back the way the limit decrease used to.
- **Per-purchase limit** is only that now: the limit screen no longer moves collateral. `useReturnExcessCollateral` becomes `useMoveOffCard` (same contract, amount-driven).
- **CollateralPullNotice** on every amount / review step — direct send, payment link, request pay, QR pay, crypto / Manteca / bank withdraw. It mirrors `computeSpendStrategy` on the displayed balances and says, before the passkey, "$X of this comes off your card balance" and, when the card's withdrawal lock is armed, a live countdown (read from `RainCooldownContext`, which until now only spoke after the 425).
- `card_withdraw_attempted` now carries `amount_cents` (the data gap that stopped the floor from being sized against real send sizes).
- Copy in en, es-419, pt-BR and es-AR (voseo deltas). The cooldown intro modal no longer tells users to lower their card limit.

Full analysis, industry comparison and the vocabulary decision: https://claude.ai/code/artifact/cc606d64-993b-408b-ac2a-5604074fd53a

## Task

TASK-22293 — Card collateral: wallet floor + separate card-balance target so in-app transfers stop hitting the Rain cooldown

## Cross-repo

**Product truth and help copy** move in [mono #138](https://github.com/peanutprotocol/mono/pull/138) (card.md funding model and card-limit bullets, quick-ref, currencies, security, lessons-from-corrections, and the collateral / custody help articles in en, es-419, pt-br) — content ships separately from code per CONTRIBUTING.

Pairs with peanut-api-ts `feat/oncard-offcard-balances` (target, floor, debounce, deferred refill, move-to-card, tuner). **Backend first.** `RainCardSummary.collateral` is optional so an old backend still renders Home and the card screen; the On card screen shows a spinner until the backend ships. `src/types/api.openapi.json` + `api.generated.ts` regenerated from that branch's snapshot (the copy in this repo was also behind `dev` on unrelated routes, hence the larger diff).

## Risks

- **Every surface the notice sits on already gates on balance**; the notice renders only when the amount is affordable and will pull from the card, so it cannot appear alongside an insufficient-balance error. It reads the same displayed balances the gates read.
- **`useHomeFlow` now reads the Rain overview** — same query key the Home banners already poll, so no extra requests.
- **Analytics**: seven new client events, all amounts in cents, no counterparty data.
- OTA-shippable; no native change.

## QA

- `pnpm typecheck` clean, eslint clean on touched files, prettier applied.
- New: `collateralPull.utils.test.ts` (routing mirror: off-card covers / card covers whole / mixed shortfall / true shortfall / unknowns / junk), `useMoveOffCard.test.tsx` (threshold skip, forced collateral-only, cap at spending power, fail-closed on missing wallet, no submit on cancelled passkey). Updated: `useHomeFlow.test.ts` (split present only with an active card and both halves known), link-send view test (mocks the notice — the view test mounts no wallet providers). i18n parity suites green (es-AR stays a subset of es-419).
- Ran: `src/features/home`, `src/features/payments`, `src/app/(mobile-ui)/withdraw`, `src/app/(mobile-ui)/qr-pay`, `src/components/Withdraw`, `src/components/Send`, `src/components/Card`, `src/components/Home`, `src/i18n` — 504 tests green.

Screenshots: Home split line and On card screen require a card user against the paired backend; not captured in this environment.

## Rollout order

1. Merge [mono #138](https://github.com/peanutprotocol/mono/pull/138) first — product truth (funding model, floor, inflow hold, controls) and the help articles must describe the new policy before users see it.
2. Migrate and deploy [peanut-api-ts #1527](https://github.com/peanutprotocol/peanut-api-ts/pull/1527).
3. Deploy this PR.
