### PR TITLE
fix(native): honour telemetry-safe segments only in the sub-view position

### DIFF
--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -856,6 +856,17 @@ describe('redactNativePath (deep-link telemetry)', () => {
         expect(redactNativePath('/not-a-declared-route/secret-value')).toBe('/:id/:id')
     })
 
+    // The API allows usernames such as `bank` or `crypto`, and `/<username>` is
+    // a profile link — a safe sub-view token must not leak one from the
+    // identifier position.
+    it('keeps safe sub-view tokens only in the sub-view position', () => {
+        expect(redactNativePath('https://peanut.me/bank')).toBe('https://peanut.me/:id')
+        expect(redactNativePath('/profile/crypto')).toBe('/profile/:id')
+        expect(redactNativePath('/manteca/success')).toBe('/:id/:id')
+        expect(redactNativePath('/add-money/us/bank')).toBe('/add-money/:id/bank')
+        expect(redactNativePath('/withdraw/manteca')).toBe('/withdraw/:id')
+    })
+
     // The authority can carry userinfo, which is attacker-controlled on a link
     // and would otherwise survive into `raw` next to the redacted path.
     it('drops userinfo from the authority', () => {

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -333,6 +333,10 @@ function baseOrigin(): string | null {
 /**
  * Static sub-view segments that carry diagnostic value and no identifier.
  * Everything NOT here and not a route root is treated as an identifier.
+ *
+ * Honoured only in the sub-view position — `/<root>/<id>/<sub-view>` — so a
+ * user whose username collides with one of these (`/bank` is a valid profile
+ * link) is still redacted at the identifier position.
  */
 const TELEMETRY_SAFE_SEGMENTS = new Set(['success', 'bank', 'manteca', 'crypto', 'us'])
 
@@ -376,11 +380,14 @@ export function redactNativePath(value: string): string {
     const authority = beforeQuery.match(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i)?.[0] ?? ''
     const prefix = authority.replace(/\/\/[^/]*@/, '//')
     const path = beforeQuery.slice(authority.length)
-    const redacted = path
-        .split('/')
-        .map((segment) => {
+    const segments = path.split('/')
+    const redacted = segments
+        .map((segment, i) => {
             if (segment === '') return segment
-            if (NATIVE_EXPORT_ROOTS.has(segment) || TELEMETRY_SAFE_SEGMENTS.has(segment)) return segment
+            if (NATIVE_EXPORT_ROOTS.has(segment)) return segment
+            // sub-view position only: two after a root, `/qr/<code>/success`
+            const underRoot = i >= 2 && NATIVE_EXPORT_ROOTS.has(segments[i - 2])
+            if (underRoot && TELEMETRY_SAFE_SEGMENTS.has(segment)) return segment
             return ':id'
         })
         .join('/')


### PR DESCRIPTION
Follow-up to #2990, which merged at `f4d2b02e6` a few minutes before this commit was pushed to its branch — so the fix never reached `dev`. Cherry-pick of `d9a4ca9e6`, unchanged.

## What

`redactNativePath` kept the telemetry-safe sub-view tokens (`success`, `bank`, `manteca`, `crypto`, `us`) at **every** path position. The API allows usernames like `bank`, and `/<username>` is a profile link, so `https://peanut.me/bank` survived redaction and sent the username in `native_link_received.raw`. Raised by Chip (MINOR) and CodeRabbit (MAJOR, CWE-200) on the since-closed #2991.

A safe token is now honoured only two segments after a route root — `/qr/<code>/success`, `/add-money/<country>/bank` — and is an identifier anywhere else. Collision tests: `/bank`, `/profile/crypto`, `/manteca/success` all redact; the two legitimate sub-view shapes keep their token.

## Verification

- `native-routes.test`: green on this branch (`useNativeAppLinks.test` unchanged and green on #2990's head).
- `src/content` gitlink is `dev`'s (`f5990317`) — no submodule drift.
