### PR TITLE
fix(tokens): send the session with wallet-portfolio requests

### DIFF
--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -1,17 +1,18 @@
 'use client'
 
 /**
- * Token price + wallet portfolio — public endpoints, no auth required.
- * CORS + the per-IP rate limiter on /tokens/* are the gate.
+ * Token prices are public (CORS + the per-IP rate limiter on /tokens/* are the
+ * gate). The wallet portfolio is owner-only: the API checks the address against
+ * the caller's own accounts, so that call carries the session token.
  */
 
 import { apiFetch } from '@/utils/api-fetch'
 import { type ITokenPriceData, type IUserBalance } from '@/interfaces/interfaces'
 
-async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
-    // includeAuth: false — public endpoints; a rate lookup must not queue
-    // behind auth hydration and sends no token either way.
-    const response = await apiFetch(path, { method: 'GET', includeAuth: false })
+async function getJson<T>(path: string, errorLabel: string, includeAuth: boolean): Promise<T | null> {
+    // includeAuth: false keeps a public rate lookup from queueing behind auth
+    // hydration; it sends no token either way.
+    const response = await apiFetch(path, { method: 'GET', includeAuth })
     if (response.status === 404) return null
     if (!response.ok) {
         const text = await response.text().catch(() => '')
@@ -22,7 +23,7 @@ async function getJson<T>(path: string, errorLabel: string): Promise<T | null> {
 
 export async function fetchTokenPrice(tokenAddress: string, chainId: string): Promise<ITokenPriceData | undefined> {
     const qs = `address=${encodeURIComponent(tokenAddress)}&chainId=${encodeURIComponent(chainId)}`
-    const result = await getJson<ITokenPriceData>(`/tokens/price?${qs}`, 'Failed to fetch token price')
+    const result = await getJson<ITokenPriceData>(`/tokens/price?${qs}`, 'Failed to fetch token price', false)
     return result ?? undefined
 }
 
@@ -32,7 +33,8 @@ export async function fetchWalletBalances(
     const qs = `address=${encodeURIComponent(address)}`
     const result = await getJson<{ balances: IUserBalance[]; totalBalance: number }>(
         `/tokens/wallet-portfolio?${qs}`,
-        'Failed to fetch wallet balances'
+        'Failed to fetch wallet balances',
+        true
     )
     return result ?? { balances: [], totalBalance: 0 }
 }

--- a/src/utils/__tests__/demo-api.test.ts
+++ b/src/utils/__tests__/demo-api.test.ts
@@ -22,6 +22,19 @@ const body = async (path: string, options?: RequestInit) => {
 }
 
 describe('demoRespond — routing', () => {
+    it('answers wallet-portfolio synthetically instead of hitting the owner-only endpoint', async () => {
+        const originalFetch = global.fetch
+        global.fetch = jest.fn()
+        try {
+            const { res, data } = await body('/tokens/wallet-portfolio?address=0xdemo')
+            expect(res.status).toBe(200)
+            expect(data).toEqual({ balances: [], totalBalance: 0 })
+            expect(global.fetch).not.toHaveBeenCalled()
+        } finally {
+            global.fetch = originalFetch
+        }
+    })
+
     it('bounds and forwards the shared FX passthrough', async () => {
         const originalFetch = global.fetch
         global.fetch = jest.fn().mockResolvedValue(

--- a/src/utils/demo-api.ts
+++ b/src/utils/demo-api.ts
@@ -18,15 +18,10 @@ const PASSTHROUGH_TIMEOUT_MS = 10_000
 
 // Public read-only rate endpoints proxied to the real backend so demo shows live
 // FX rates. Best-effort: any failure falls through to the canned handler below.
-// /tokens/* are public too — the canned {} fallback is NOT a valid shape for
-// them (fetchWalletBalances crashed on `{}.balances.filter` in recover-funds).
-const PASSTHROUGH_GET = new Set([
-    '/bridge/exchange-rate',
-    '/manteca/prices',
-    '/fx/rate',
-    '/tokens/price',
-    '/tokens/wallet-portfolio',
-])
+// /tokens/price is public too — the canned {} fallback is NOT a valid shape
+// for it. /tokens/wallet-portfolio is owner-only (session required), so it
+// gets a synthetic handler instead of a passthrough that would 401.
+const PASSTHROUGH_GET = new Set(['/bridge/exchange-rate', '/manteca/prices', '/fx/rate', '/tokens/price'])
 
 const EMPTY_GRAPH = {
     nodes: [] as unknown[],
@@ -501,6 +496,10 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
         pattern: '/fx/rate',
         handler: () => json({ error: 'FX_UNAVAILABLE', message: 'Exchange rates are unavailable.' }, 503),
     },
+
+    // The demo wallet holds nothing to recover; the shape is what
+    // fetchWalletBalances reads.
+    { method: 'GET', pattern: '/tokens/wallet-portfolio', handler: () => ({ balances: [], totalBalance: 0 }) },
 
     // bridge on/off-ramp
     {


### PR DESCRIPTION
## Summary

Companion to peanutprotocol/peanut-api-ts#1528 (external security report, 2026-09-05). The API is making `GET /tokens/wallet-portfolio` owner-only — an unauthenticated live USD balance for any address turned the public username → wallet lookup into a balance lookup for any user.

- `fetchWalletBalances` now sends the session token. Its only caller is recover-funds, which queries the user's own wallet.
- `fetchTokenPrice` is unchanged: token prices stay public and still skip auth hydration.

## Rollout
Merge this first — it works against both the current and the hardened API. Merging the API PR first would give recover-funds a 401 until this ships.

## Tests
No behaviour to unit test beyond the flag; prettier + eslint clean on the file.
