### PR TITLE
Remove non-interactive info icons

### DIFF
--- a/src/app/(mobile-ui)/qr/[code]/page.tsx
+++ b/src/app/(mobile-ui)/qr/[code]/page.tsx
@@ -203,7 +203,6 @@ export default function RedirectQrClaimPage() {
                 {/* Important note */}
                 <Card className="border-2 border-action-secondary bg-action-secondary/10 p-4">
                     <div className="flex gap-3">
-                        <Icon name="info" size={20} className="flex-shrink-0 text-action-secondary" />
                         <p className="text-body-s">
                             {t.rich('claim.permanentNote', { strong: (chunks) => <strong>{chunks}</strong> })}
                         </p>

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -900,7 +900,6 @@ function MantecaBankWithdrawFlow() {
                             )}
 
                             <div className="flex items-center gap-2 text-body-s text-foreground-secondary">
-                                <Icon name="info" size={16} />
                                 <span>{t('manteca.ownAccountOnly')}</span>
                             </div>
                         </div>

--- a/src/components/AddMoney/components/InputAmountStep.tsx
+++ b/src/components/AddMoney/components/InputAmountStep.tsx
@@ -3,7 +3,6 @@
 import { Button } from '@/components/0_Bruddle/Button'
 import { FieldColumn } from '@/components/0_Bruddle/FieldColumn'
 import { Notification } from '@/components/0_Bruddle/Notification'
-import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import AmountInput from '@/components/Global/AmountInput'
 import RateUnavailable from '@/components/Global/RateUnavailable'
@@ -124,7 +123,6 @@ const InputAmountStep = ({
                 {limitsCardProps && <LimitsWarningCard {...limitsCardProps} />}
 
                 <div className="flex items-center gap-2 text-body-xs text-foreground-secondary">
-                    <Icon name="info" width={16} height={16} />
                     <span>{t('mustMatchBankTransfer')}</span>
                 </div>
                 <Button

--- a/src/components/AddMoney/views/RhinoDeposit.view.tsx
+++ b/src/components/AddMoney/views/RhinoDeposit.view.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/0_Bruddle/Button'
 import { IconBubble } from '@/components/0_Bruddle/IconBubble'
 import Card from '@/components/Global/Card'
 import CopyToClipboard, { type CopyToClipboardRef } from '@/components/Global/CopyToClipboard'
-import { Icon } from '@/components/Global/Icons/Icon'
 import NavHeader from '@/components/Global/NavHeader'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import ChainChip from '../components/ChainChip'
@@ -191,7 +190,6 @@ const RhinoDepositView = ({
                             <div className="flex w-full flex-col gap-1">
                                 <div className="flex w-full items-center justify-between">
                                     <div className="flex items-center gap-2">
-                                        <Icon name="info" size={16} className="text-foreground-secondary" />
                                         <p className="text-body-s text-foreground-secondary">
                                             {t('minDepositForLabel', { network: amountLimitsTitle })}
                                         </p>
@@ -204,7 +202,6 @@ const RhinoDepositView = ({
 
                                 <div className="flex w-full items-center justify-between">
                                     <div className="flex items-center gap-2">
-                                        <Icon name="info" size={16} className="text-foreground-secondary" />
                                         <p className="text-body-s text-foreground-secondary">
                                             {t('maxDepositForLabel', { network: amountLimitsTitle })}
                                         </p>

--- a/src/components/Badges/index.tsx
+++ b/src/components/Badges/index.tsx
@@ -7,7 +7,6 @@ import { getBadgeIcon } from './badge.utils'
 import { useBadgeCopy } from './useBadgeCopy'
 import { getCardPosition } from '../Global/Card/card.utils'
 import EmptyState from '../Global/EmptyStates/EmptyState'
-import { Icon } from '../Global/Icons/Icon'
 import { BadgeDetailModal } from './BadgeDetailModal'
 import { useMemo, useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
@@ -96,7 +95,6 @@ export const Badges = () => {
                 </div>
 
                 <div className="flex items-center justify-center gap-2 text-body-xs text-foreground-secondary">
-                    <Icon name="info" width={16} height={16} />
                     <span>{t('publicProfileNote')}</span>
                 </div>
             </div>

--- a/src/components/Claim/Link/views/MantecaDetailsStep.view.tsx
+++ b/src/components/Claim/Link/views/MantecaDetailsStep.view.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@/components/0_Bruddle/Button'
 import { FieldError } from '@/components/0_Bruddle/FieldError'
-import { Icon } from '@/components/Global/Icons/Icon'
 import { MercadoPagoStep } from '@/types/manteca.types'
 import { type Dispatch, type FC, type SetStateAction, useState } from 'react'
 import ValidatedInput from '@/components/Global/ValidatedInput'
@@ -66,7 +65,6 @@ const MantecaDetailsStep: FC<MantecaDetailsStepProps> = ({
                 {errorMessage && <FieldError>{errorMessage}</FieldError>}
             </div>
             <div className="flex items-center gap-2 text-body-xs text-foreground-secondary">
-                <Icon name="info" width={16} height={16} />
                 <span>{t('manteca.ownAccountOnly')}</span>
             </div>
             <Button

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -495,7 +495,6 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                                 {/* Info banner when cross-chain is disabled */}
                                 {isCrossChainDisabled && (
                                     <div className="flex items-center gap-2 rounded-sm bg-background-badge-attention p-3 text-body-s text-foreground-primary">
-                                        <Icon name="info" size={16} className="flex-shrink-0" />
                                         <span>{t('tokenSelector.crossChainUnavailable')}</span>
                                     </div>
                                 )}
@@ -543,7 +542,6 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
                                             placeholder={t('tokenSelector.searchTokenPlaceholder')}
                                         />
                                         <div className="flex items-center justify-center gap-2">
-                                            <Icon name="info" size={10} className="text-foreground-secondary" />
                                             <span className="text-body-xs text-foreground-secondary">
                                                 {t('tokenSelector.sponsoredHint')}
                                             </span>

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -270,7 +270,6 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                         <HomeHistory username={username} />
                         {isSelfProfile && (
                             <div className="mt-3 mb-1 flex w-full items-center justify-center gap-2 rounded-sm bg-background-disabled/25 px-3 py-2">
-                                <Icon name="info" size={16} className="text-foreground-secondary" />
                                 <p className="text-center text-body-s text-foreground-secondary">
                                     {t('activityPrivateNote')}
                                 </p>

--- a/src/components/TransactionDetails/ReceiptActions.tsx
+++ b/src/components/TransactionDetails/ReceiptActions.tsx
@@ -175,7 +175,6 @@ export function ReceiptActions({
 
             {isPendingSentLink && !shouldShowQrShare && (
                 <div className="flex items-center justify-center gap-1 text-center text-label-m text-foreground-secondary">
-                    <Icon name="info" size={20} />
                     {t('pendingLinkDeviceNote')}
                 </div>
             )}

--- a/src/components/Withdraw/views/PixKeySend.view.tsx
+++ b/src/components/Withdraw/views/PixKeySend.view.tsx
@@ -8,7 +8,6 @@ import { useSafeBack } from '@/hooks/useSafeBack'
 import { Button } from '@/components/0_Bruddle/Button'
 import NavHeader from '@/components/Global/NavHeader'
 import ValidatedInput from '@/components/Global/ValidatedInput'
-import { Icon } from '@/components/Global/Icons/Icon'
 import { isPixEmvcoQr, normalizePixInput, validatePixKey } from '@/utils/withdraw.utils'
 import { pixKeyToQrPayUrl } from '@/utils/pix.utils'
 import { useTranslations } from 'next-intl'
@@ -76,7 +75,6 @@ export default function PixKeySendView({ destinationParam }: { destinationParam?
                             {errorMessage && <FieldError>{errorMessage}</FieldError>}
                         </div>
                         <div className="flex items-center gap-2 text-body-s text-foreground-secondary">
-                            <Icon name="info" size={16} />
                             <span>{t('pixKey.info')}</span>
                         </div>
                     </div>

--- a/src/features/limits/views/MantecaLimitsView.tsx
+++ b/src/features/limits/views/MantecaLimitsView.tsx
@@ -2,7 +2,6 @@
 
 import NavHeader from '@/components/Global/NavHeader'
 import Card from '@/components/Global/Card'
-import { Icon } from '@/components/Global/Icons/Icon'
 import { useLimits } from '@/hooks/useLimits'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useTranslations } from 'next-intl'
@@ -103,7 +102,6 @@ const MantecaLimitsView = () => {
                         })}
                         {/* info text */}
                         <div className="flex items-center justify-center gap-2 text-body-xs text-foreground-secondary">
-                            <Icon name="info" size={16} />
                             <p>{t('appliesTo')}</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Removes the `(i)` info icon from 13 spots across the app where it sits next to static helper text with no link, tooltip, or press handler — it visually implies "tap for more info" but does nothing.
- Genuinely interactive info icons (real `Tooltip`/`Menu.Button`/`Link`/`Button` triggers) are untouched.

## Screens affected
- Badges list ("Your Badges" — public profile note)
- QR invite claim page (permanent note)
- Manteca withdraw page + limits view + Pix send + claim/link Manteca step (own-account-only / applies-to notes)
- Pending sent link receipt actions (device note)
- Public profile activity-private note
- Add money: bank transfer match note, Rhino min/max deposit labels
- Token selector: cross-chain-unavailable banner, sponsored-network hint

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm prettier --check` on changed files (already formatted)
- [ ] Spot-check a couple of the affected screens in the running app
