### PR TITLE
fix(qr-scanner): stop teaching native users to change a browser permission

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':capgo-capacitor-passkey')
     implementation project(':capgo-capacitor-updater')
     implementation project(':onesignal-capacitor-plugin')
+    implementation project(':capacitor-native-settings')
 
 }
 apply from: "../../node_modules/.pnpm/@sumsub+cordova-idensic-mobile-sdk-plugin@1.42.0/node_modules/@sumsub/cordova-idensic-mobile-sdk-plugin/src/android/build-extras.gradle"

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -46,3 +46,6 @@ project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.pnpm
 
 include ':onesignal-capacitor-plugin'
 project(':onesignal-capacitor-plugin').projectDir = new File('../node_modules/@onesignal/capacitor-plugin/android')
+
+include ':capacitor-native-settings'
+project(':capacitor-native-settings').projectDir = new File('../node_modules/.pnpm/capacitor-native-settings@8.2.0_@capacitor+core@8.2.0/node_modules/capacitor-native-settings/android')

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(name: "CapgoCapacitorPasskey", path: "../../../node_modules/@capgo/capacitor-passkey"),
         .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.pnpm/@capgo+capacitor-updater@8.51.14_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater"),
         .package(name: "OnesignalCapacitorPlugin", path: "../../../node_modules/@onesignal/capacitor-plugin"),
+        .package(name: "CapacitorNativeSettings", path: "../../../node_modules/.pnpm/capacitor-native-settings@8.2.0_@capacitor+core@8.2.0/node_modules/capacitor-native-settings"),
         .package(name: "SumsubCordovaIdensicMobileSdkPlugin", path: "../../capacitor-cordova-ios-plugins/sources/SumsubCordovaIdensicMobileSdkPlugin")
     ],
     targets: [
@@ -50,6 +51,7 @@ let package = Package(
                 .product(name: "CapgoCapacitorPasskey", package: "CapgoCapacitorPasskey"),
                 .product(name: "CapgoCapacitorUpdater", package: "CapgoCapacitorUpdater"),
                 .product(name: "OnesignalCapacitorPlugin", package: "OnesignalCapacitorPlugin"),
+                .product(name: "CapacitorNativeSettings", package: "CapacitorNativeSettings"),
                 .product(name: "SumsubCordovaIdensicMobileSdkPlugin", package: "SumsubCordovaIdensicMobileSdkPlugin")
             ]
         )

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "@zerodev/sdk": "5.5.7",
         "@zerodev/webauthn-key": "^5.5.0",
         "canvas-confetti": "^1.9.3",
+        "capacitor-native-settings": "8.2.0",
         "circle-flags": "^2.8.2",
         "classnames": "^2.5.1",
         "d3-force": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.4
+      capacitor-native-settings:
+        specifier: 8.2.0
+        version: 8.2.0(@capacitor/core@8.2.0)
       circle-flags:
         specifier: ^2.8.2
         version: 2.8.2
@@ -4250,6 +4253,11 @@ packages:
 
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
+
+  capacitor-native-settings@8.2.0:
+    resolution: {integrity: sha512-jqklDll5YFvPpt2SI+wa+oMy0ykvWESSclDMhSI/t1TvJDnomATa7Iz0eE219DY/6pJxRhI7+8RYE0ePtAYxAw==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.2'
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -13838,6 +13846,10 @@ snapshots:
       tinycolor2: 1.6.0
 
   canvas-confetti@1.9.4: {}
+
+  capacitor-native-settings@8.2.0(@capacitor/core@8.2.0):
+    dependencies:
+      '@capacitor/core': 8.2.0
 
   ccount@2.0.1: {}
 

--- a/scripts/native-fingerprint.mjs
+++ b/scripts/native-fingerprint.mjs
@@ -101,6 +101,7 @@ export const NATIVE_DEPENDENCIES = [
     '@capgo/capacitor-updater',
     '@onesignal/capacitor-plugin',
     '@sumsub/cordova-idensic-mobile-sdk-plugin',
+    'capacitor-native-settings',
 ]
 
 // Backstop for anything not yet in the list above. Deliberately not a scope allowlist:

--- a/src/components/Global/QRScanner/CameraPermissionModal.tsx
+++ b/src/components/Global/QRScanner/CameraPermissionModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import { useTranslations } from 'next-intl'
@@ -8,6 +9,8 @@ import { Button } from '@/components/0_Bruddle/Button'
 import Carousel from '@/components/Global/Carousel'
 import { useDeviceType, DeviceType } from '@/hooks/useGetDeviceType'
 import { useGetBrowserType, BrowserType } from '@/hooks/useGetBrowserType'
+import { isAndroidNativeBridge, isNativeBridge } from '@/utils/capacitor'
+import { canOpenAppSettings, openAppSettings } from '@/utils/native-settings'
 import {
     ANDROID_CHROME_1,
     ANDROID_CHROME_2,
@@ -45,6 +48,21 @@ const INSTRUCTIONS = {
     ],
 } as const satisfies Record<string, readonly Step[]>
 
+/*
+ * Native has no browser chrome, so every screenshot above is wrong there: the
+ * camera grant is an OS permission on the app, reachable only through Settings.
+ * Text steps carry it instead — the deep link lands the user on the app's own
+ * settings page, so there is nothing left worth screenshotting.
+ */
+const NATIVE_STEPS = {
+    ios: ['qrScanner.cameraPermission.native.step1', 'qrScanner.cameraPermission.native.iosStep2'],
+    android: [
+        'qrScanner.cameraPermission.native.step1',
+        'qrScanner.cameraPermission.native.androidStep2',
+        'qrScanner.cameraPermission.native.androidStep3',
+    ],
+} as const satisfies Record<string, readonly string[]>
+
 function getInstructionKey(device: DeviceType, browser: BrowserType | null): keyof typeof INSTRUCTIONS | null {
     if (device === DeviceType.ANDROID) return 'android_chrome'
     if (device === DeviceType.IOS) {
@@ -71,8 +89,44 @@ export default function CameraPermissionModal({ visible, onRetry, onClose }: Cam
     const { deviceType } = useDeviceType()
     const { browserType } = useGetBrowserType()
 
-    const key = getInstructionKey(deviceType, browserType)
+    const isNative = isNativeBridge()
+    const canDeepLinkToSettings = isNative && canOpenAppSettings()
+
+    const key = isNative ? null : getInstructionKey(deviceType, browserType)
     const steps = key ? INSTRUCTIONS[key] : null
+    // the bridge names the platform outright, so native copy does not ride on
+    // the user-agent sniff the browser instructions have to fall back to
+    const nativeStepKeys = isNative ? (isAndroidNativeBridge() ? NATIVE_STEPS.android : NATIVE_STEPS.ios) : null
+
+    const onRetryRef = useRef(onRetry)
+    onRetryRef.current = onRetry
+
+    /*
+     * Changing a permission in Settings terminates the app on both OSes, so
+     * this only catches the user who came back having changed nothing — but
+     * without it that user is staring at a modal whose only button sends them
+     * back to Settings again.
+     */
+    useEffect(() => {
+        if (!visible || !canDeepLinkToSettings) return
+        let cancelled = false
+        let remove: (() => void) | undefined
+        import('@capacitor/app')
+            .then(({ App }) =>
+                App.addListener('appStateChange', ({ isActive }) => {
+                    if (isActive) onRetryRef.current()
+                })
+            )
+            .then((handle) => {
+                if (cancelled) handle.remove()
+                else remove = () => handle.remove()
+            })
+            .catch(() => {})
+        return () => {
+            cancelled = true
+            remove?.()
+        }
+    }, [visible, canDeepLinkToSettings])
 
     return (
         <ActionModal
@@ -89,12 +143,21 @@ export default function CameraPermissionModal({ visible, onRetry, onClose }: Cam
             // 2026-09-03, kush). trade-off accepted: a camera-denied native
             // user loses the paste entry on this screen
             ctas={[
-                {
-                    text: tCommon('tryAgain'),
-                    variant: 'purple',
-                    shadowSize: '4',
-                    onClick: onRetry,
-                },
+                canDeepLinkToSettings
+                    ? {
+                          text: t('qrScanner.cameraPermission.native.openSettings'),
+                          variant: 'purple' as const,
+                          shadowSize: '4' as const,
+                          onClick: () => {
+                              void openAppSettings()
+                          },
+                      }
+                    : {
+                          text: tCommon('tryAgain'),
+                          variant: 'purple' as const,
+                          shadowSize: '4' as const,
+                          onClick: onRetry,
+                      },
             ]}
             footer={
                 <Button variant="stroke" className="w-full" onClick={onClose}>
@@ -104,10 +167,23 @@ export default function CameraPermissionModal({ visible, onRetry, onClose }: Cam
             content={
                 <div className="flex w-full flex-col gap-4">
                     <p className="text-body-s text-foreground-secondary">
-                        {steps
-                            ? t('qrScanner.cameraPermission.withStepsHint')
-                            : t('qrScanner.cameraPermission.noStepsHint')}
+                        {nativeStepKeys
+                            ? t('qrScanner.cameraPermission.native.hint')
+                            : steps
+                              ? t('qrScanner.cameraPermission.withStepsHint')
+                              : t('qrScanner.cameraPermission.noStepsHint')}
                     </p>
+
+                    {nativeStepKeys && (
+                        <ol className="flex flex-col gap-2">
+                            {nativeStepKeys.map((stepKey, i) => (
+                                <li key={stepKey} className="flex gap-2 text-body-s text-foreground-secondary">
+                                    <span className="text-foreground-primary">{i + 1}.</span>
+                                    <span>{t(stepKey)}</span>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
 
                     {steps && (
                         <Carousel>

--- a/src/components/Global/QRScanner/__tests__/CameraPermissionModal.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/CameraPermissionModal.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+/**
+ * Native has no browser chrome, so the per-browser screenshot carousel — which
+ * teaches the user to change a *site* permission — is wrong there: the camera
+ * grant is an OS permission on the app. These pin the split.
+ */
+import React from 'react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { isAndroidNativeBridge, isNativeBridge } from '@/utils/capacitor'
+import { canOpenAppSettings, openAppSettings } from '@/utils/native-settings'
+import { DeviceType } from '@/hooks/useGetDeviceType'
+import { BrowserType } from '@/hooks/useGetBrowserType'
+import CameraPermissionModal from '../CameraPermissionModal'
+
+jest.mock('@/utils/capacitor', () => ({
+    ...jest.requireActual('@/utils/capacitor'),
+    isNativeBridge: jest.fn(),
+    isAndroidNativeBridge: jest.fn(),
+}))
+jest.mock('@/utils/native-settings', () => ({
+    canOpenAppSettings: jest.fn(),
+    openAppSettings: jest.fn().mockResolvedValue(true),
+}))
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: { alt?: string }) => <img alt={props.alt ?? ''} />,
+}))
+
+const deviceType = { current: DeviceType.IOS }
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: deviceType.current }),
+}))
+jest.mock('@/hooks/useGetBrowserType', () => ({
+    ...jest.requireActual('@/hooks/useGetBrowserType'),
+    useGetBrowserType: () => ({ browserType: BrowserType.SAFARI }),
+}))
+
+const appStateListener = { current: null as ((state: { isActive: boolean }) => void) | null }
+const removeListener = jest.fn()
+jest.mock('@capacitor/app', () => ({
+    App: {
+        addListener: (_event: string, fn: (state: { isActive: boolean }) => void) => {
+            appStateListener.current = fn
+            return Promise.resolve({ remove: removeListener })
+        },
+    },
+}))
+
+const mockedIsNativeBridge = isNativeBridge as jest.Mock
+const mockedIsAndroidNativeBridge = isAndroidNativeBridge as jest.Mock
+const mockedCanOpenAppSettings = canOpenAppSettings as jest.Mock
+
+function renderModal(onRetry = jest.fn()) {
+    const result = renderWithIntl(<CameraPermissionModal visible onRetry={onRetry} onClose={jest.fn()} />)
+    return { ...result, onRetry }
+}
+
+beforeEach(() => {
+    deviceType.current = DeviceType.IOS
+    appStateListener.current = null
+    jest.clearAllMocks()
+})
+
+describe('web', () => {
+    beforeEach(() => {
+        mockedIsNativeBridge.mockReturnValue(false)
+        mockedCanOpenAppSettings.mockReturnValue(false)
+    })
+
+    it('keeps the browser screenshot carousel and the Try again CTA', () => {
+        renderModal()
+        expect(screen.getByAltText('Step 1: tap “aA” in the address bar')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+        expect(screen.queryByText('Open Settings')).not.toBeInTheDocument()
+    })
+})
+
+describe('native', () => {
+    beforeEach(() => {
+        mockedIsNativeBridge.mockReturnValue(true)
+        mockedCanOpenAppSettings.mockReturnValue(true)
+    })
+
+    it('drops every browser screenshot for OS text steps', () => {
+        renderModal()
+        expect(screen.queryByAltText('Step 1: tap “aA” in the address bar')).not.toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Peanut needs the camera to scan a QR code. Turn on Camera for Peanut in your device settings.'
+            )
+        ).toBeInTheDocument()
+        expect(screen.getByText('Open Settings and find Peanut')).toBeInTheDocument()
+        expect(screen.getByText('Turn on Camera')).toBeInTheDocument()
+    })
+
+    it('gives android its own permissions steps', () => {
+        mockedIsAndroidNativeBridge.mockReturnValue(true)
+        renderModal()
+        expect(screen.getByText('Tap Permissions')).toBeInTheDocument()
+        expect(screen.getByText('Set Camera to Allow')).toBeInTheDocument()
+        expect(screen.queryByText('Turn on Camera')).not.toBeInTheDocument()
+    })
+
+    it('deep-links to the app settings page instead of retrying', () => {
+        const { onRetry } = renderModal()
+        fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }))
+        expect(openAppSettings).toHaveBeenCalled()
+        expect(onRetry).not.toHaveBeenCalled()
+    })
+
+    it('retries on its own when the app comes back to the foreground', async () => {
+        const { onRetry } = renderModal()
+        await waitFor(() => expect(appStateListener.current).not.toBeNull())
+        appStateListener.current?.({ isActive: false })
+        expect(onRetry).not.toHaveBeenCalled()
+        appStateListener.current?.({ isActive: true })
+        expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the native steps but falls back to Try again on a binary that cannot deep-link', () => {
+        mockedCanOpenAppSettings.mockReturnValue(false)
+        renderModal()
+        expect(screen.getByText('Open Settings and find Peanut')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Open Settings' })).not.toBeInTheDocument()
+    })
+})

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3140,7 +3140,15 @@
                 "iosChrome2": "Step 2: enable Camera",
                 "iosSafari1": "Step 1: tap “aA” in the address bar",
                 "iosSafari2": "Step 2: tap “Website Settings”",
-                "iosSafari3": "Step 3: set Camera to “Allow”"
+                "iosSafari3": "Step 3: set Camera to “Allow”",
+                "native": {
+                    "hint": "Peanut needs the camera to scan a QR code. Turn on Camera for Peanut in your device settings.",
+                    "openSettings": "Open Settings",
+                    "step1": "Open Settings and find Peanut",
+                    "iosStep2": "Turn on Camera",
+                    "androidStep2": "Tap Permissions",
+                    "androidStep3": "Set Camera to Allow"
+                }
             },
             "useCopiedCode": "Use copied code",
             "paymentMethods": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3140,7 +3140,15 @@
                 "iosChrome2": "Paso 2: activa la cámara",
                 "iosSafari1": "Paso 1: toca “aA” en la barra de direcciones",
                 "iosSafari2": "Paso 2: toca “Ajustes del sitio web”",
-                "iosSafari3": "Paso 3: configura la cámara en “Permitir”"
+                "iosSafari3": "Paso 3: configura la cámara en “Permitir”",
+                "native": {
+                    "hint": "Peanut necesita la cámara para escanear un código QR. Activa la cámara para Peanut en la configuración de tu dispositivo.",
+                    "openSettings": "Abre Configuración",
+                    "step1": "Abre Configuración y busca Peanut",
+                    "iosStep2": "Activa la cámara",
+                    "androidStep2": "Toca Permisos",
+                    "androidStep3": "Elige Permitir en Cámara"
+                }
             },
             "useCopiedCode": "Usar código copiado",
             "paymentMethods": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1381,7 +1381,15 @@
                 "iosChrome1": "Paso 1: abrí Ajustes → Chrome",
                 "iosChrome2": "Paso 2: activá la cámara",
                 "iosSafari1": "Paso 1: tocá “aA” en la barra de direcciones",
-                "iosSafari2": "Paso 2: tocá “Ajustes del sitio web”"
+                "iosSafari2": "Paso 2: tocá “Ajustes del sitio web”",
+                "native": {
+                    "hint": "Peanut necesita la cámara para escanear un código QR. Activá la cámara para Peanut en la configuración de tu dispositivo.",
+                    "openSettings": "Abrí Configuración",
+                    "step1": "Abrí Configuración y buscá Peanut",
+                    "iosStep2": "Activá la cámara",
+                    "androidStep2": "Tocá Permisos",
+                    "androidStep3": "Elegí Permitir en Cámara"
+                }
             }
         },
         "qrScannerOverlay": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3140,7 +3140,15 @@
                 "iosChrome2": "Passo 2: ative a câmera",
                 "iosSafari1": "Passo 1: toque em “aA” na barra de endereço",
                 "iosSafari2": "Passo 2: toque em “Ajustes do site”",
-                "iosSafari3": "Passo 3: defina a câmera como “Permitir”"
+                "iosSafari3": "Passo 3: defina a câmera como “Permitir”",
+                "native": {
+                    "hint": "O Peanut precisa da câmera para ler um QR code. Ative a câmera para o Peanut nas configurações do aparelho.",
+                    "openSettings": "Abra as Configurações",
+                    "step1": "Abra as Configurações e encontre o Peanut",
+                    "iosStep2": "Ative a câmera",
+                    "androidStep2": "Toque em Permissões",
+                    "androidStep3": "Defina Câmera como Permitir"
+                }
             },
             "useCopiedCode": "Usar código copiado",
             "paymentMethods": {

--- a/src/utils/__tests__/native-settings.test.ts
+++ b/src/utils/__tests__/native-settings.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+/**
+ * The QR scanner's "Open Settings" button. capacitor-native-settings is native
+ * code, so an OTA'd bundle can run on a binary that predates it — these pin the
+ * feature check and the iOS-only `app-settings:` route that covers that gap.
+ */
+import { canOpenAppSettings, openAppSettings } from '../native-settings'
+
+const mockOpen = jest.fn()
+jest.mock('capacitor-native-settings', () => ({
+    NativeSettings: { open: (...args: unknown[]) => mockOpen(...args) },
+    AndroidSettings: { ApplicationDetails: 'application_details' },
+    IOSSettings: { App: 'app' },
+}))
+
+function setBridge(options: { platform?: string; native?: boolean; plugin?: boolean } = {}) {
+    const { platform = 'ios', native = true, plugin = true } = options
+    window.Capacitor = {
+        getPlatform: () => platform,
+        isNativePlatform: () => native,
+        isPluginAvailable: (name: string) => plugin && name === 'NativeSettings',
+    }
+}
+
+describe('canOpenAppSettings', () => {
+    afterEach(() => {
+        delete window.Capacitor
+        jest.clearAllMocks()
+    })
+
+    it('is false on web', () => {
+        expect(canOpenAppSettings()).toBe(false)
+    })
+
+    it('is false on a capacitor-flavoured build with no live bridge', () => {
+        setBridge({ native: false })
+        expect(canOpenAppSettings()).toBe(false)
+    })
+
+    it('is true on either platform once the plugin is in the binary', () => {
+        setBridge({ platform: 'android' })
+        expect(canOpenAppSettings()).toBe(true)
+        setBridge({ platform: 'ios' })
+        expect(canOpenAppSettings()).toBe(true)
+    })
+
+    it('stays true on an iOS binary without the plugin, false on Android', () => {
+        setBridge({ platform: 'ios', plugin: false })
+        expect(canOpenAppSettings()).toBe(true)
+        setBridge({ platform: 'android', plugin: false })
+        expect(canOpenAppSettings()).toBe(false)
+    })
+})
+
+describe('openAppSettings', () => {
+    const assign = jest.fn()
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                get href() {
+                    return 'http://localhost/'
+                },
+                set href(value: string) {
+                    assign(value)
+                },
+            },
+        })
+    })
+
+    afterEach(() => {
+        delete window.Capacitor
+        jest.clearAllMocks()
+    })
+
+    it('asks the plugin for the app-details screen on android', async () => {
+        setBridge({ platform: 'android' })
+        mockOpen.mockResolvedValue({ status: true })
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(mockOpen).toHaveBeenCalledWith({ optionAndroid: 'application_details', optionIOS: 'app' })
+        expect(assign).not.toHaveBeenCalled()
+    })
+
+    it('navigates to app-settings: when the iOS binary predates the plugin', async () => {
+        setBridge({ platform: 'ios', plugin: false })
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(mockOpen).not.toHaveBeenCalled()
+        expect(assign).toHaveBeenCalledWith('app-settings:')
+    })
+
+    it('falls back to the iOS navigation when the plugin call fails', async () => {
+        setBridge({ platform: 'ios' })
+        mockOpen.mockRejectedValue(new Error('not implemented'))
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(assign).toHaveBeenCalledWith('app-settings:')
+    })
+
+    it('reports failure on android when the plugin refuses, rather than navigating', async () => {
+        setBridge({ platform: 'android' })
+        mockOpen.mockResolvedValue({ status: false })
+        await expect(openAppSettings()).resolves.toBe(false)
+        expect(assign).not.toHaveBeenCalled()
+    })
+
+    it('does nothing on web', async () => {
+        await expect(openAppSettings()).resolves.toBe(false)
+        expect(mockOpen).not.toHaveBeenCalled()
+        expect(assign).not.toHaveBeenCalled()
+    })
+})

--- a/src/utils/native-settings.ts
+++ b/src/utils/native-settings.ts
@@ -1,0 +1,51 @@
+import { isNativeBridge } from './capacitor'
+
+function platform(): string | undefined {
+    return window.Capacitor?.getPlatform?.()
+}
+
+function hasPlugin(): boolean {
+    return !!window.Capacitor?.isPluginAvailable?.('NativeSettings')
+}
+
+/**
+ * Whether this install can deep-link to the app's own OS settings page.
+ *
+ * capacitor-native-settings is native code, so an OTA'd bundle can land on a
+ * binary that predates it — hence the feature check rather than a bare
+ * isNativeBridge(). iOS still answers true without it: Capacitor hands any
+ * top-level navigation it doesn't own to UIApplication.open, which resolves
+ * `app-settings:` (WebViewDelegationHandler.decidePolicyFor). Android has no
+ * such escape — Bridge.launchIntent fires ACTION_VIEW on the raw URI and never
+ * parses an `intent://`, so there the plugin is the only route.
+ */
+export function canOpenAppSettings(): boolean {
+    if (!isNativeBridge()) return false
+    return hasPlugin() || platform() === 'ios'
+}
+
+export async function openAppSettings(): Promise<boolean> {
+    if (!isNativeBridge()) return false
+
+    if (hasPlugin()) {
+        try {
+            const { NativeSettings, AndroidSettings, IOSSettings } = await import('capacitor-native-settings')
+            // IOSSettings.App is the one app-settings URL Apple sanctions; the
+            // plugin's other options are private `App-prefs:` paths.
+            const { status } = await NativeSettings.open({
+                optionAndroid: AndroidSettings.ApplicationDetails,
+                optionIOS: IOSSettings.App,
+            })
+            if (status) return true
+        } catch (err) {
+            console.warn('NativeSettings.open failed:', err)
+        }
+    }
+
+    if (platform() === 'ios') {
+        window.location.href = 'app-settings:'
+        return true
+    }
+
+    return false
+}


### PR DESCRIPTION
## What

The QR scanner's camera-permission modal shows per-browser screenshots — *tap the lock icon in the address bar*, *open Website Settings*, *set Camera to "Allow"* — chosen by a device + browser sniff. In the Capacitor app there is no address bar and no site permission: the camera grant is an OS permission attached to the app, so every step and every screenshot points at a surface the user cannot reach.

Native now gets short text steps naming the OS path, plus a button that opens the app's own settings page. Web and PWA are untouched.

| | before (native) | after (native) |
|---|---|---|
| body | "Follow these steps to enable camera access" | "Peanut needs the camera to scan a QR code. Turn on Camera for Peanut in your device settings." |
| steps | 2–3 browser screenshots | iOS: Open Settings and find Peanut → Turn on Camera. Android: … → Tap Permissions → Set Camera to Allow |
| primary CTA | Try again | Open Settings |

The permission *request* is untouched — `ensureNativeCameraPermission()` already settles it through `@capacitor/camera` and `useQRScanner` already raises this modal on denial. Only what the user is told afterwards changes.

## Three things the original write-up got wrong or didn't know

**This is not a design-system component.** It landed 2026-04-02 in `2f622d68c` ("feat: cam perm modal comp"), months before the DS work; the DS only restyled it (seven commits, most recently the one-primary-CTA ruling on 09-03 and the content taxonomy on 09-04). The browser framing is original April code the DS inherited.

**The framing predates the modal too.** Before it, denial surfaced the flat string still in the catalog as `qrScanner.cameraPermissionDenied` — *"Please allow camera access in your browser settings."* The April modal just gave that sentence screenshots.

**iOS needs no plugin.** `@capacitor/ios`'s `WebViewDelegationHandler.decidePolicyFor` hands any top-level navigation that isn't the app URL to `UIApplication.shared.open` with no scheme filter, so `app-settings:` resolves there today — OTA-shippable. Android's `Bridge.launchIntent` fires `Intent.ACTION_VIEW` on the raw URI and never calls `Intent.parseUri`, so `intent://` is dead and the plugin is the only route.

## OTA vs binary

The **copy fix ships OTA on both platforms** — Android users get correct instructions in the next Capgo bundle, they just walk to Settings themselves. Only the one-tap button splits: iOS via the `app-settings:` fallback now, Android when a store build carries `capacitor-native-settings`.

`canOpenAppSettings()` feature-detects with `Capacitor.isPluginAvailable('NativeSettings')` rather than assuming, because an OTA'd bundle can always land on a binary older than itself. Without the plugin and off iOS, the modal keeps the native text steps and falls back to the `Try again` CTA.

## Dependency

`capacitor-native-settings@8.2.0` — published 2026-08-04, past the 14-day supply-chain floor. Peers `@capacitor/core >=8.0.2`; ships `Package.swift` (required — `ios/App/CapApp-SPM/Package.swift` is committed and SPM-based), a podspec, and an `android/build.gradle` that inherits our root SDK levels and declares no permissions. The native registration files are `npx cap update` output, not hand-edits.

We use only `IOSSettings.App` → `UIApplication.openSettingsURLString`, the one app-settings URL Apple sanctions; the plugin's other options are private `App-prefs:` paths and are an App Store review risk.

## Two judgement calls to flag

**The paste fallback is gone, and I did not bring it back.** The write-up asks to keep it, but it predates `60c56ef11` (2026-09-03, kush), which deleted the paste CTA because it made a second secondary and broke the modal recipe. Re-adding it would revert an explicit ruling, so I left it out. If the ruling should be revisited for the camera-denied case specifically, that's a separate call.

**No `Try again` next to `Open Settings`,** for the same one-primary reason. An `appStateChange` listener retries on return instead. It only matters for the user who went to Settings and came back having changed nothing — changing a permission terminates the app on both OSes, so the normal path is a fresh launch.

Also: native copy picks iOS vs Android from `isAndroidNativeBridge()` rather than `useDeviceType()` as the write-up suggested. The bridge names the platform outright; the UA sniff is only needed for the browser branch.

## Verification

- `tsc --noEmit` clean; `eslint` clean on all changed files; `prettier --check` clean.
- 76 tests across `QRScanner` + `native-settings`; 318 across `i18n` + `QRScanner` + `native-settings`. New: 6 modal tests (web keeps the carousel, native drops it, per-OS steps, deep-link instead of retry, resume-retry, plugin-less fallback) and 9 for the util.
- Catalog parity, duplicate-value drift and ICU compilation pass for all four locales. `native.openSettings` deliberately shares its string with `profile.backup.steps.android.step1.title`, including the es-AR voseo override, so the drift check stays green.

**Not verified on a device.** The `app-settings:` claim is read off Capacitor's source, and this Mac has CommandLineTools only — no Xcode, no simulator. Worth a real check on the next TestFlight build. If it doesn't fire, iOS degrades to the same text-steps state as Android rather than breaking.

## Second commit

`fix(native): record capacitor-native-settings in the OTA fingerprint` — `scripts/native-fingerprint.mjs`'s `NATIVE_DEPENDENCIES` is what makes the OTA guard's fingerprint move on a lockfile-only plugin bump, and its suite asserts every synced plugin appears there. Registering the plugin is what stops a bundle that calls it being OTA'd onto a binary built before it. `feat/design-system` predates that script, so the companion PR (#2999) does not carry this commit.
