### PR TITLE
fix(qr-scanner): stop teaching native users to change a browser permission (design-system)

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':capgo-capacitor-passkey')
     implementation project(':capgo-capacitor-updater')
     implementation project(':onesignal-capacitor-plugin')
+    implementation project(':capacitor-native-settings')
 
 }
 apply from: "../../node_modules/.pnpm/@sumsub+cordova-idensic-mobile-sdk-plugin@1.42.0/node_modules/@sumsub/cordova-idensic-mobile-sdk-plugin/src/android/build-extras.gradle"

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -46,3 +46,6 @@ project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.pnpm
 
 include ':onesignal-capacitor-plugin'
 project(':onesignal-capacitor-plugin').projectDir = new File('../node_modules/@onesignal/capacitor-plugin/android')
+
+include ':capacitor-native-settings'
+project(':capacitor-native-settings').projectDir = new File('../node_modules/.pnpm/capacitor-native-settings@8.2.0_@capacitor+core@8.2.0/node_modules/capacitor-native-settings/android')

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(name: "CapgoCapacitorPasskey", path: "../../../node_modules/@capgo/capacitor-passkey"),
         .package(name: "CapgoCapacitorUpdater", path: "../../../node_modules/.pnpm/@capgo+capacitor-updater@8.45.9_@capacitor+core@8.2.0/node_modules/@capgo/capacitor-updater"),
         .package(name: "OnesignalCapacitorPlugin", path: "../../../node_modules/@onesignal/capacitor-plugin"),
+        .package(name: "CapacitorNativeSettings", path: "../../../node_modules/.pnpm/capacitor-native-settings@8.2.0_@capacitor+core@8.2.0/node_modules/capacitor-native-settings"),
         .package(name: "SumsubCordovaIdensicMobileSdkPlugin", path: "../../capacitor-cordova-ios-plugins/sources/SumsubCordovaIdensicMobileSdkPlugin")
     ],
     targets: [
@@ -50,6 +51,7 @@ let package = Package(
                 .product(name: "CapgoCapacitorPasskey", package: "CapgoCapacitorPasskey"),
                 .product(name: "CapgoCapacitorUpdater", package: "CapgoCapacitorUpdater"),
                 .product(name: "OnesignalCapacitorPlugin", package: "OnesignalCapacitorPlugin"),
+                .product(name: "CapacitorNativeSettings", package: "CapacitorNativeSettings"),
                 .product(name: "SumsubCordovaIdensicMobileSdkPlugin", package: "SumsubCordovaIdensicMobileSdkPlugin")
             ]
         )

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "@zerodev/sdk": "5.5.7",
         "@zerodev/webauthn-key": "^5.5.0",
         "canvas-confetti": "^1.9.3",
+        "capacitor-native-settings": "8.2.0",
         "circle-flags": "^2.8.2",
         "classnames": "^2.5.1",
         "d3-force": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.4
+      capacitor-native-settings:
+        specifier: 8.2.0
+        version: 8.2.0(@capacitor/core@8.2.0)
       circle-flags:
         specifier: ^2.8.2
         version: 2.8.2
@@ -4118,6 +4121,11 @@ packages:
 
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
+
+  capacitor-native-settings@8.2.0:
+    resolution: {integrity: sha512-jqklDll5YFvPpt2SI+wa+oMy0ykvWESSclDMhSI/t1TvJDnomATa7Iz0eE219DY/6pJxRhI7+8RYE0ePtAYxAw==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.2'
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -13425,6 +13433,10 @@ snapshots:
       tinycolor2: 1.6.0
 
   canvas-confetti@1.9.4: {}
+
+  capacitor-native-settings@8.2.0(@capacitor/core@8.2.0):
+    dependencies:
+      '@capacitor/core': 8.2.0
 
   ccount@2.0.1: {}
 

--- a/src/components/Global/QRScanner/CameraPermissionModal.tsx
+++ b/src/components/Global/QRScanner/CameraPermissionModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import { useTranslations } from 'next-intl'
@@ -8,6 +9,8 @@ import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import Carousel from '@/components/Global/Carousel'
 import { useDeviceType, DeviceType } from '@/hooks/useGetDeviceType'
 import { useGetBrowserType, BrowserType } from '@/hooks/useGetBrowserType'
+import { isAndroidNativeBridge, isNativeBridge } from '@/utils/capacitor'
+import { canOpenAppSettings, openAppSettings } from '@/utils/native-settings'
 import {
     ANDROID_CHROME_1,
     ANDROID_CHROME_2,
@@ -45,6 +48,21 @@ const INSTRUCTIONS = {
     ],
 } as const satisfies Record<string, readonly Step[]>
 
+/*
+ * Native has no browser chrome, so every screenshot above is wrong there: the
+ * camera grant is an OS permission on the app, reachable only through Settings.
+ * Text steps carry it instead — the deep link lands the user on the app's own
+ * settings page, so there is nothing left worth screenshotting.
+ */
+const NATIVE_STEPS = {
+    ios: ['qrScanner.cameraPermission.native.step1', 'qrScanner.cameraPermission.native.iosStep2'],
+    android: [
+        'qrScanner.cameraPermission.native.step1',
+        'qrScanner.cameraPermission.native.androidStep2',
+        'qrScanner.cameraPermission.native.androidStep3',
+    ],
+} as const satisfies Record<string, readonly string[]>
+
 function getInstructionKey(device: DeviceType, browser: BrowserType | null): keyof typeof INSTRUCTIONS | null {
     if (device === DeviceType.ANDROID) return 'android_chrome'
     if (device === DeviceType.IOS) {
@@ -73,8 +91,44 @@ export default function CameraPermissionModal({ visible, onRetry, onClose, onPas
     const { deviceType } = useDeviceType()
     const { browserType } = useGetBrowserType()
 
-    const key = getInstructionKey(deviceType, browserType)
+    const isNative = isNativeBridge()
+    const canDeepLinkToSettings = isNative && canOpenAppSettings()
+
+    const key = isNative ? null : getInstructionKey(deviceType, browserType)
     const steps = key ? INSTRUCTIONS[key] : null
+    // the bridge names the platform outright, so native copy does not ride on
+    // the user-agent sniff the browser instructions have to fall back to
+    const nativeStepKeys = isNative ? (isAndroidNativeBridge() ? NATIVE_STEPS.android : NATIVE_STEPS.ios) : null
+
+    const onRetryRef = useRef(onRetry)
+    onRetryRef.current = onRetry
+
+    /*
+     * Changing a permission in Settings terminates the app on both OSes, so
+     * this only catches the user who came back having changed nothing — but
+     * without it that user is staring at a modal whose only button sends them
+     * back to Settings again.
+     */
+    useEffect(() => {
+        if (!visible || !canDeepLinkToSettings) return
+        let cancelled = false
+        let remove: (() => void) | undefined
+        import('@capacitor/app')
+            .then(({ App }) =>
+                App.addListener('appStateChange', ({ isActive }) => {
+                    if (isActive) onRetryRef.current()
+                })
+            )
+            .then((handle) => {
+                if (cancelled) handle.remove()
+                else remove = () => handle.remove()
+            })
+            .catch(() => {})
+        return () => {
+            cancelled = true
+            remove?.()
+        }
+    }, [visible, canDeepLinkToSettings])
 
     return (
         <ActionModal
@@ -87,12 +141,21 @@ export default function CameraPermissionModal({ visible, onRetry, onClose, onPas
             modalClassName="!z-[60]"
             modalPanelClassName="max-w-md mx-8"
             ctas={[
-                {
-                    text: tCommon('tryAgain'),
-                    variant: 'purple',
-                    shadowSize: '4',
-                    onClick: onRetry,
-                },
+                canDeepLinkToSettings
+                    ? {
+                          text: t('qrScanner.cameraPermission.native.openSettings'),
+                          variant: 'purple' as const,
+                          shadowSize: '4' as const,
+                          onClick: () => {
+                              void openAppSettings()
+                          },
+                      }
+                    : {
+                          text: tCommon('tryAgain'),
+                          variant: 'purple' as const,
+                          shadowSize: '4' as const,
+                          onClick: onRetry,
+                      },
                 ...(onPaste
                     ? [
                           {
@@ -108,10 +171,23 @@ export default function CameraPermissionModal({ visible, onRetry, onClose, onPas
             content={
                 <div className="flex w-full flex-col gap-4">
                     <p className="text-body-s text-foreground-secondary">
-                        {steps
-                            ? t('qrScanner.cameraPermission.withStepsHint')
-                            : t('qrScanner.cameraPermission.noStepsHint')}
+                        {nativeStepKeys
+                            ? t('qrScanner.cameraPermission.native.hint')
+                            : steps
+                              ? t('qrScanner.cameraPermission.withStepsHint')
+                              : t('qrScanner.cameraPermission.noStepsHint')}
                     </p>
+
+                    {nativeStepKeys && (
+                        <ol className="flex flex-col gap-2">
+                            {nativeStepKeys.map((stepKey, i) => (
+                                <li key={stepKey} className="flex gap-2 text-body-s text-foreground-secondary">
+                                    <span className="text-foreground-primary">{i + 1}.</span>
+                                    <span>{t(stepKey)}</span>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
 
                     {steps && (
                         <Carousel>

--- a/src/components/Global/QRScanner/__tests__/CameraPermissionModal.test.tsx
+++ b/src/components/Global/QRScanner/__tests__/CameraPermissionModal.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+/**
+ * Native has no browser chrome, so the per-browser screenshot carousel — which
+ * teaches the user to change a *site* permission — is wrong there: the camera
+ * grant is an OS permission on the app. These pin the split.
+ */
+import React from 'react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { isAndroidNativeBridge, isNativeBridge } from '@/utils/capacitor'
+import { canOpenAppSettings, openAppSettings } from '@/utils/native-settings'
+import { DeviceType } from '@/hooks/useGetDeviceType'
+import { BrowserType } from '@/hooks/useGetBrowserType'
+import CameraPermissionModal from '../CameraPermissionModal'
+
+jest.mock('@/utils/capacitor', () => ({
+    ...jest.requireActual('@/utils/capacitor'),
+    isNativeBridge: jest.fn(),
+    isAndroidNativeBridge: jest.fn(),
+}))
+jest.mock('@/utils/native-settings', () => ({
+    canOpenAppSettings: jest.fn(),
+    openAppSettings: jest.fn().mockResolvedValue(true),
+}))
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: { alt?: string }) => <img alt={props.alt ?? ''} />,
+}))
+
+const deviceType = { current: DeviceType.IOS }
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: deviceType.current }),
+}))
+jest.mock('@/hooks/useGetBrowserType', () => ({
+    ...jest.requireActual('@/hooks/useGetBrowserType'),
+    useGetBrowserType: () => ({ browserType: BrowserType.SAFARI }),
+}))
+
+const appStateListener = { current: null as ((state: { isActive: boolean }) => void) | null }
+const removeListener = jest.fn()
+jest.mock('@capacitor/app', () => ({
+    App: {
+        addListener: (_event: string, fn: (state: { isActive: boolean }) => void) => {
+            appStateListener.current = fn
+            return Promise.resolve({ remove: removeListener })
+        },
+    },
+}))
+
+const mockedIsNativeBridge = isNativeBridge as jest.Mock
+const mockedIsAndroidNativeBridge = isAndroidNativeBridge as jest.Mock
+const mockedCanOpenAppSettings = canOpenAppSettings as jest.Mock
+
+function renderModal(onRetry = jest.fn()) {
+    const result = renderWithIntl(<CameraPermissionModal visible onRetry={onRetry} onClose={jest.fn()} />)
+    return { ...result, onRetry }
+}
+
+beforeEach(() => {
+    deviceType.current = DeviceType.IOS
+    appStateListener.current = null
+    jest.clearAllMocks()
+})
+
+describe('web', () => {
+    beforeEach(() => {
+        mockedIsNativeBridge.mockReturnValue(false)
+        mockedCanOpenAppSettings.mockReturnValue(false)
+    })
+
+    it('keeps the browser screenshot carousel and the Try again CTA', () => {
+        renderModal()
+        expect(screen.getByAltText('Step 1: tap “aA” in the address bar')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+        expect(screen.queryByText('Open Settings')).not.toBeInTheDocument()
+    })
+})
+
+describe('native', () => {
+    beforeEach(() => {
+        mockedIsNativeBridge.mockReturnValue(true)
+        mockedCanOpenAppSettings.mockReturnValue(true)
+    })
+
+    it('drops every browser screenshot for OS text steps', () => {
+        renderModal()
+        expect(screen.queryByAltText('Step 1: tap “aA” in the address bar')).not.toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Peanut needs the camera to scan a QR code. Turn on Camera for Peanut in your device settings.'
+            )
+        ).toBeInTheDocument()
+        expect(screen.getByText('Open Settings and find Peanut')).toBeInTheDocument()
+        expect(screen.getByText('Turn on Camera')).toBeInTheDocument()
+    })
+
+    it('gives android its own permissions steps', () => {
+        mockedIsAndroidNativeBridge.mockReturnValue(true)
+        renderModal()
+        expect(screen.getByText('Tap Permissions')).toBeInTheDocument()
+        expect(screen.getByText('Set Camera to Allow')).toBeInTheDocument()
+        expect(screen.queryByText('Turn on Camera')).not.toBeInTheDocument()
+    })
+
+    it('deep-links to the app settings page instead of retrying', () => {
+        const { onRetry } = renderModal()
+        fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }))
+        expect(openAppSettings).toHaveBeenCalled()
+        expect(onRetry).not.toHaveBeenCalled()
+    })
+
+    it('retries on its own when the app comes back to the foreground', async () => {
+        const { onRetry } = renderModal()
+        await waitFor(() => expect(appStateListener.current).not.toBeNull())
+        appStateListener.current?.({ isActive: false })
+        expect(onRetry).not.toHaveBeenCalled()
+        appStateListener.current?.({ isActive: true })
+        expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the native steps but falls back to Try again on a binary that cannot deep-link', () => {
+        mockedCanOpenAppSettings.mockReturnValue(false)
+        renderModal()
+        expect(screen.getByText('Open Settings and find Peanut')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Open Settings' })).not.toBeInTheDocument()
+    })
+})

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2746,7 +2746,15 @@
                 "iosChrome2": "Step 2: enable Camera",
                 "iosSafari1": "Step 1: tap “aA” in the address bar",
                 "iosSafari2": "Step 2: tap “Website Settings”",
-                "iosSafari3": "Step 3: set Camera to “Allow”"
+                "iosSafari3": "Step 3: set Camera to “Allow”",
+                "native": {
+                    "hint": "Peanut needs the camera to scan a QR code. Turn on Camera for Peanut in your device settings.",
+                    "openSettings": "Open Settings",
+                    "step1": "Open Settings and find Peanut",
+                    "iosStep2": "Turn on Camera",
+                    "androidStep2": "Tap Permissions",
+                    "androidStep3": "Set Camera to Allow"
+                }
             },
             "useCopiedCode": "Use copied code",
             "paymentMethods": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2746,7 +2746,15 @@
                 "iosChrome2": "Paso 2: activa la cámara",
                 "iosSafari1": "Paso 1: toca “aA” en la barra de direcciones",
                 "iosSafari2": "Paso 2: toca “Ajustes del sitio web”",
-                "iosSafari3": "Paso 3: configura la cámara en “Permitir”"
+                "iosSafari3": "Paso 3: configura la cámara en “Permitir”",
+                "native": {
+                    "hint": "Peanut necesita la cámara para escanear un código QR. Activa la cámara para Peanut en la configuración de tu dispositivo.",
+                    "openSettings": "Abre Configuración",
+                    "step1": "Abre Configuración y busca Peanut",
+                    "iosStep2": "Activa la cámara",
+                    "androidStep2": "Toca Permisos",
+                    "androidStep3": "Elige Permitir en Cámara"
+                }
             },
             "useCopiedCode": "Usar código copiado",
             "paymentMethods": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1074,7 +1074,15 @@
                 "iosChrome1": "Paso 1: abrí Ajustes → Chrome",
                 "iosChrome2": "Paso 2: activá la cámara",
                 "iosSafari1": "Paso 1: tocá “aA” en la barra de direcciones",
-                "iosSafari2": "Paso 2: tocá “Ajustes del sitio web”"
+                "iosSafari2": "Paso 2: tocá “Ajustes del sitio web”",
+                "native": {
+                    "hint": "Peanut necesita la cámara para escanear un código QR. Activá la cámara para Peanut en la configuración de tu dispositivo.",
+                    "openSettings": "Abrí Configuración",
+                    "step1": "Abrí Configuración y buscá Peanut",
+                    "iosStep2": "Activá la cámara",
+                    "androidStep2": "Tocá Permisos",
+                    "androidStep3": "Elegí Permitir en Cámara"
+                }
             }
         },
         "qrScannerOverlay": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2746,7 +2746,15 @@
                 "iosChrome2": "Passo 2: ative a câmera",
                 "iosSafari1": "Passo 1: toque em “aA” na barra de endereço",
                 "iosSafari2": "Passo 2: toque em “Ajustes do site”",
-                "iosSafari3": "Passo 3: defina a câmera como “Permitir”"
+                "iosSafari3": "Passo 3: defina a câmera como “Permitir”",
+                "native": {
+                    "hint": "O Peanut precisa da câmera para ler um QR code. Ative a câmera para o Peanut nas configurações do aparelho.",
+                    "openSettings": "Abra as Configurações",
+                    "step1": "Abra as Configurações e encontre o Peanut",
+                    "iosStep2": "Ative a câmera",
+                    "androidStep2": "Toque em Permissões",
+                    "androidStep3": "Defina Câmera como Permitir"
+                }
             },
             "useCopiedCode": "Usar código copiado",
             "paymentMethods": {

--- a/src/utils/__tests__/native-settings.test.ts
+++ b/src/utils/__tests__/native-settings.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment jsdom */
+/**
+ * The QR scanner's "Open Settings" button. capacitor-native-settings is native
+ * code, so an OTA'd bundle can run on a binary that predates it — these pin the
+ * feature check and the iOS-only `app-settings:` route that covers that gap.
+ */
+import { canOpenAppSettings, openAppSettings } from '../native-settings'
+
+const mockOpen = jest.fn()
+jest.mock('capacitor-native-settings', () => ({
+    NativeSettings: { open: (...args: unknown[]) => mockOpen(...args) },
+    AndroidSettings: { ApplicationDetails: 'application_details' },
+    IOSSettings: { App: 'app' },
+}))
+
+function setBridge(options: { platform?: string; native?: boolean; plugin?: boolean } = {}) {
+    const { platform = 'ios', native = true, plugin = true } = options
+    window.Capacitor = {
+        getPlatform: () => platform,
+        isNativePlatform: () => native,
+        isPluginAvailable: (name: string) => plugin && name === 'NativeSettings',
+    }
+}
+
+describe('canOpenAppSettings', () => {
+    afterEach(() => {
+        delete window.Capacitor
+        jest.clearAllMocks()
+    })
+
+    it('is false on web', () => {
+        expect(canOpenAppSettings()).toBe(false)
+    })
+
+    it('is false on a capacitor-flavoured build with no live bridge', () => {
+        setBridge({ native: false })
+        expect(canOpenAppSettings()).toBe(false)
+    })
+
+    it('is true on either platform once the plugin is in the binary', () => {
+        setBridge({ platform: 'android' })
+        expect(canOpenAppSettings()).toBe(true)
+        setBridge({ platform: 'ios' })
+        expect(canOpenAppSettings()).toBe(true)
+    })
+
+    it('stays true on an iOS binary without the plugin, false on Android', () => {
+        setBridge({ platform: 'ios', plugin: false })
+        expect(canOpenAppSettings()).toBe(true)
+        setBridge({ platform: 'android', plugin: false })
+        expect(canOpenAppSettings()).toBe(false)
+    })
+})
+
+describe('openAppSettings', () => {
+    const assign = jest.fn()
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                get href() {
+                    return 'http://localhost/'
+                },
+                set href(value: string) {
+                    assign(value)
+                },
+            },
+        })
+    })
+
+    afterEach(() => {
+        delete window.Capacitor
+        jest.clearAllMocks()
+    })
+
+    it('asks the plugin for the app-details screen on android', async () => {
+        setBridge({ platform: 'android' })
+        mockOpen.mockResolvedValue({ status: true })
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(mockOpen).toHaveBeenCalledWith({ optionAndroid: 'application_details', optionIOS: 'app' })
+        expect(assign).not.toHaveBeenCalled()
+    })
+
+    it('navigates to app-settings: when the iOS binary predates the plugin', async () => {
+        setBridge({ platform: 'ios', plugin: false })
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(mockOpen).not.toHaveBeenCalled()
+        expect(assign).toHaveBeenCalledWith('app-settings:')
+    })
+
+    it('falls back to the iOS navigation when the plugin call fails', async () => {
+        setBridge({ platform: 'ios' })
+        mockOpen.mockRejectedValue(new Error('not implemented'))
+        await expect(openAppSettings()).resolves.toBe(true)
+        expect(assign).toHaveBeenCalledWith('app-settings:')
+    })
+
+    it('reports failure on android when the plugin refuses, rather than navigating', async () => {
+        setBridge({ platform: 'android' })
+        mockOpen.mockResolvedValue({ status: false })
+        await expect(openAppSettings()).resolves.toBe(false)
+        expect(assign).not.toHaveBeenCalled()
+    })
+
+    it('does nothing on web', async () => {
+        await expect(openAppSettings()).resolves.toBe(false)
+        expect(mockOpen).not.toHaveBeenCalled()
+        expect(assign).not.toHaveBeenCalled()
+    })
+})

--- a/src/utils/native-settings.ts
+++ b/src/utils/native-settings.ts
@@ -1,0 +1,51 @@
+import { isNativeBridge } from './capacitor'
+
+function platform(): string | undefined {
+    return window.Capacitor?.getPlatform?.()
+}
+
+function hasPlugin(): boolean {
+    return !!window.Capacitor?.isPluginAvailable?.('NativeSettings')
+}
+
+/**
+ * Whether this install can deep-link to the app's own OS settings page.
+ *
+ * capacitor-native-settings is native code, so an OTA'd bundle can land on a
+ * binary that predates it — hence the feature check rather than a bare
+ * isNativeBridge(). iOS still answers true without it: Capacitor hands any
+ * top-level navigation it doesn't own to UIApplication.open, which resolves
+ * `app-settings:` (WebViewDelegationHandler.decidePolicyFor). Android has no
+ * such escape — Bridge.launchIntent fires ACTION_VIEW on the raw URI and never
+ * parses an `intent://`, so there the plugin is the only route.
+ */
+export function canOpenAppSettings(): boolean {
+    if (!isNativeBridge()) return false
+    return hasPlugin() || platform() === 'ios'
+}
+
+export async function openAppSettings(): Promise<boolean> {
+    if (!isNativeBridge()) return false
+
+    if (hasPlugin()) {
+        try {
+            const { NativeSettings, AndroidSettings, IOSSettings } = await import('capacitor-native-settings')
+            // IOSSettings.App is the one app-settings URL Apple sanctions; the
+            // plugin's other options are private `App-prefs:` paths.
+            const { status } = await NativeSettings.open({
+                optionAndroid: AndroidSettings.ApplicationDetails,
+                optionIOS: IOSSettings.App,
+            })
+            if (status) return true
+        } catch (err) {
+            console.warn('NativeSettings.open failed:', err)
+        }
+    }
+
+    if (platform() === 'ios') {
+        window.location.href = 'app-settings:'
+        return true
+    }
+
+    return false
+}


### PR DESCRIPTION
Companion to #2997 (based on `dev`) — same change, applied to `feat/design-system`.

## What

The QR scanner's camera-permission modal shows per-browser screenshots — *tap the lock icon in the address bar*, *open Website Settings*, *set Camera to "Allow"*. In the Capacitor app there is no address bar and no site permission: the camera grant is an OS permission attached to the app, so every step points at a surface the user cannot reach. Native gets text steps naming the OS path plus a button that opens the app's own settings page; web and PWA are untouched.

Full rationale, the OTA-vs-binary split, the dependency review and the verification log are in **#2997** — please read that one first. This description covers only what differs here.

## What differs on this branch

**The paste CTA is kept.** `dev` deleted it in `60c56ef11` (2026-09-03) as a second secondary that broke the modal recipe; this branch still has it, along with the `LinkButton` footer. The cherry-pick conflicted exactly there, and I resolved it in this branch's favour rather than dragging `dev`'s ruling backwards: `onPaste` stays in the props and still renders its CTA. So on native here the modal reads Open Settings → Click to paste → Dismiss, whereas on `dev` it reads Open Settings → Dismiss.

That is the only intentional divergence between the two PRs. Everything else — the util, the copy, the four catalogs, both test files, and the `cap update` output — is identical.

## Ordering

These two are independent and can land in either order. Whichever merges second will conflict on the same CTA array when `dev` and `feat/design-system` next reconcile; the resolution is whatever the paste ruling is by then, not anything about this change.

## Verification (re-run on this base)

`tsc --noEmit` clean, `eslint` clean on all four changed source files, `prettier --check` clean, 250 tests green across `i18n` + `QRScanner` + `native-settings` (including the 6 new modal tests and 9 for the util). `npx cap update` on this branch produced byte-identical native registration to the cherry-picked hunks.

Not verified on a device — same caveat as #2997: the `app-settings:` fallback is read off Capacitor's source, and this machine has no Xcode.

## One thing #2997 needs and this does not

#2997 carries a second commit registering `capacitor-native-settings` in `NATIVE_DEPENDENCIES` (`scripts/native-fingerprint.mjs`) — the guard that stops a bundle calling the plugin being OTA'd onto a binary built before it. `feat/design-system` predates that script entirely, so there is nothing to register here.


## Screenshots (head `6f3fee3`, 375×667)

Captured from this branch running locally; native variants forced by stubbing the Capacitor bridge (`isNativePlatform` / `getPlatform` / `isPluginAvailable`), web variants by UA. Images live on the [`shots/pr-2999`](https://github.com/peanutprotocol/peanut-ui/tree/shots/pr-2999) branch.

### Native (new)

| iOS (plugin present) | Android (plugin present) | Old binary, no plugin (fallback) |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/1beec2a89b6e7a52c3fef65351798f482100a346/native-ios.png" width="250" alt="iOS native: text steps + Open Settings" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/1beec2a89b6e7a52c3fef65351798f482100a346/native-android.png" width="250" alt="Android native: 3 text steps + Open Settings" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/1beec2a89b6e7a52c3fef65351798f482100a346/native-old-binary-fallback.png" width="250" alt="Android native without NativeSettings plugin: same steps, Try again CTA" /> |
| 2 steps, `Open Settings` deep-links via plugin (or `app-settings:` fallback) | 3 steps (Permissions level exists on Android) | Same text steps; CTA falls back to `Try again` because no deep link is possible |

This branch keeps the `Click to paste` secondary CTA (see "What differs on this branch" above), so native reads Open Settings → Click to paste → Dismiss.

### Web / PWA (unchanged)

| iOS Safari | Android Chrome |
| --- | --- |
| <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/1beec2a89b6e7a52c3fef65351798f482100a346/web-ios-safari-unchanged.png" width="250" alt="Web iOS Safari: browser screenshot carousel, unchanged" /> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/1beec2a89b6e7a52c3fef65351798f482100a346/web-android-chrome-unchanged.png" width="250" alt="Web Android Chrome: browser screenshot carousel, unchanged" /> |

Browser-instruction carousel still renders exactly as before on web.
