### PR TITLE
fix(passkey): one signup tap, one ceremony — and keep the Android error name

### DIFF
--- a/src/components/Setup/Views/SetupPasskey.tsx
+++ b/src/components/Setup/Views/SetupPasskey.tsx
@@ -53,6 +53,21 @@ const SetupPasskey = () => {
     // hydrates asynchronously from a stale web-authn-key cookie (native cookie
     // jar) can never be mistaken for a fresh registration and skip the step.
     const registrationInitiatedRef = useRef(false)
+    /*
+     * Synchronous latch around the WHOLE handler. `isRegistering` only flips
+     * once handleRegister runs, and two awaits precede it — the live support
+     * re-check and the username-availability request — so on a phone the button
+     * stayed enabled for a second or more after the first tap. Every extra tap
+     * in that window started its own registration, and the losers surfaced
+     * CeremonyConflictError ("Something interrupted the passkey prompt") while
+     * the real ceremony was still coming up (PEANUT-UI-T09). A ref, not state:
+     * the latch also has to hold for callers that aren't the button — the help
+     * modal's retry action re-enters the handler directly.
+     */
+    const setupInFlightRef = useRef(false)
+    // Covers those same two awaits in the UI, so the button reads as busy
+    // instead of dead while the username check is in flight.
+    const [isPreparing, setIsPreparing] = useState(false)
 
     // preflight check for common passkey issues
     useEffect(() => {
@@ -68,6 +83,18 @@ const SetupPasskey = () => {
 
     // handle passkey registration with retry logic
     const handlePasskeySetup = async () => {
+        if (setupInFlightRef.current) return
+        setupInFlightRef.current = true
+        setIsPreparing(true)
+        try {
+            await runPasskeySetup()
+        } finally {
+            setupInFlightRef.current = false
+            setIsPreparing(false)
+        }
+    }
+
+    const runPasskeySetup = async () => {
         // clear any previous inline errors
         setInlineError(null)
         setErrorName(null)
@@ -227,8 +254,8 @@ const SetupPasskey = () => {
                         re-checks support and surfaces an actionable message, so a tap is
                         never a silent no-op. Only disabled while actually working. */}
                     <Button
-                        loading={isRegistering || isLoading}
-                        disabled={isRegistering || isLoading}
+                        loading={isPreparing || isRegistering || isLoading}
+                        disabled={isPreparing || isRegistering || isLoading}
                         onClick={handlePasskeySetup}
                         className="text-nowrap"
                         shadowSize="4"

--- a/src/components/Setup/Views/__tests__/SetupPasskey.test.tsx
+++ b/src/components/Setup/Views/__tests__/SetupPasskey.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import SetupPasskey from '../SetupPasskey'
+
+const mockHandleRegister = jest.fn()
+const mockApiFetch = jest.fn()
+
+jest.mock('@/hooks/useZeroDev', () => ({
+    useZeroDev: () => ({ handleRegister: mockHandleRegister, address: undefined, isRegistering: false }),
+}))
+jest.mock('@/hooks/useLogin', () => ({ useLogin: () => ({ handleLoginClick: jest.fn(), isLoggingIn: false }) }))
+jest.mock('@/hooks/useSetupFlow', () => ({ useSetupFlow: () => ({ isLoading: false, handleNext: jest.fn() }) }))
+jest.mock('@/hooks/useGetDeviceType', () => ({ useDeviceType: () => ({ deviceType: 'Android' }) }))
+jest.mock('@/redux/hooks', () => ({ useSetupStore: () => ({ username: 'kim' }) }))
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: (...args: unknown[]) => mockApiFetch(...args) }))
+jest.mock('@/utils/passkeyPreflight', () => ({ checkPasskeySupport: async () => ({ isSupported: true }) }))
+jest.mock('@/utils/passkeyDebug', () => ({ capturePasskeyDebugInfo: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+
+describe('SetupPasskey — one tap, one ceremony', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        // 404 = username free, so the handler proceeds to registration
+        mockApiFetch.mockResolvedValue({ status: 404 })
+        mockHandleRegister.mockImplementation(() => new Promise(() => {}))
+    })
+
+    /*
+     * PEANUT-UI-T09: `isRegistering` only goes true once handleRegister runs,
+     * and two awaits precede it (support re-check + username lookup). On a
+     * phone that left the button live for a second or more, so every extra tap
+     * started its own registration; the losers hit the ceremony guard and
+     * showed "Something interrupted the passkey prompt" while the real sheet
+     * was still coming up.
+     */
+    it('ignores taps that land while the pre-ceremony checks are still running', async () => {
+        mockApiFetch.mockImplementation(() => new Promise<{ status: number }>(() => {}))
+
+        renderWithIntl(<SetupPasskey />)
+        const button = screen.getByRole('button')
+
+        fireEvent.click(button)
+        fireEvent.click(button)
+        fireEvent.click(button)
+
+        await waitFor(() => expect(mockApiFetch).toHaveBeenCalledTimes(1))
+        expect(mockApiFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the button for the whole handler, not just the ceremony', async () => {
+        renderWithIntl(<SetupPasskey />)
+        const button = screen.getByRole('button')
+
+        fireEvent.click(button)
+
+        await waitFor(() => expect(button).toBeDisabled())
+    })
+})

--- a/src/hooks/__tests__/useZeroDev-ceremony-conflict.test.tsx
+++ b/src/hooks/__tests__/useZeroDev-ceremony-conflict.test.tsx
@@ -1,0 +1,159 @@
+import { act, renderHook } from '@testing-library/react'
+import { useZeroDev } from '../useZeroDev'
+import { removeFromCookie } from '@/utils/general.utils'
+import { CeremonyConflictError } from '@/utils/passkeyCeremony.utils'
+
+const mockDispatch = jest.fn()
+const mockCaptureException = jest.fn()
+const mockToWebAuthnKey = jest.fn()
+let mockActiveCeremonyId: number | null = null
+
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { userId: 'u1', username: 'alice' } }, logoutUser: jest.fn() }),
+}))
+jest.mock('@/context/kernelClient.context', () => ({
+    useKernelClient: () => ({
+        setWebAuthnKey: jest.fn(),
+        getClientForChain: jest.fn(),
+        ensureClientForChain: jest.fn(),
+    }),
+}))
+jest.mock('@/context/loadingStates.context', () => {
+    const React = jest.requireActual<typeof import('react')>('react')
+    return { loadingStateContext: React.createContext({ setLoadingState: jest.fn() }) }
+})
+jest.mock('@/redux/hooks', () => ({
+    useAppDispatch: () => mockDispatch,
+    useSetupStore: () => ({ inviteCode: '', inviteType: undefined }),
+    useZerodevStore: () => ({
+        isKernelClientReady: true,
+        isRegistering: false,
+        isLoggingIn: false,
+        isSendingUserOp: false,
+        address: undefined,
+    }),
+}))
+jest.mock('@/redux/slices/zerodev-slice', () => ({
+    zerodevActions: {
+        resetZeroDevState: () => ({ type: 'zerodev/reset' }),
+        setIsRegistering: (payload: boolean) => ({ type: 'zerodev/registering', payload }),
+        setIsLoggingIn: (payload: boolean) => ({ type: 'zerodev/logging-in', payload }),
+        setIsSendingUserOp: (payload: boolean) => ({ type: 'zerodev/sending', payload }),
+        setAddress: (payload: string) => ({ type: 'zerodev/address', payload }),
+    },
+}))
+jest.mock('@/redux/slices/setup-slice', () => ({
+    setupActions: { setInviteCode: (payload: string) => ({ type: 'setup/invite-code', payload }) },
+}))
+jest.mock('@/utils/general.utils', () => ({
+    getFromCookie: () => null,
+    removeFromCookie: jest.fn(),
+    saveToCookie: jest.fn(),
+    saveToLocalStorage: jest.fn(),
+}))
+jest.mock('@zerodev/passkey-validator', () => ({
+    toWebAuthnKey: (...args: unknown[]) => mockToWebAuthnKey(...args),
+    WebAuthnMode: { Register: 'Register', Login: 'Login' },
+}))
+jest.mock('@/services/invites', () => ({ invitesApi: { acceptInvite: jest.fn() } }))
+jest.mock('@/services/invite-acquisition', () => ({ settleAcceptedInviteAcquisition: jest.fn() }))
+jest.mock('@/app/shhhhh/shhhhh-acquisition', () => ({ settleShhhhhCampaignContinuation: jest.fn() }))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({ getPendingBadgeCampaigns: () => [] }))
+jest.mock('@/services/badge-campaigns', () => ({
+    claimAndSettlePendingBadgeCampaigns: jest.fn(),
+    isConfirmedBadgeCampaignClaim: jest.fn(),
+    isUnavailableBadgeCampaignClaim: jest.fn(),
+}))
+jest.mock('@/services/consent', () => ({ signupConsentDocuments: () => [] }))
+jest.mock('@/utils/auth.utils', () => ({ clearAuthState: jest.fn() }))
+// Only `currentCeremonyId` is stubbed: the guard's own module-level window
+// stays real, so a test that does NOT claim a ceremony still runs one for real.
+jest.mock('@/utils/passkeyCeremony.utils', () => ({
+    ...jest.requireActual('@/utils/passkeyCeremony.utils'),
+    currentCeremonyId: () => mockActiveCeremonyId,
+}))
+jest.mock('@/utils/walletCredential.utils', () => ({
+    isStaleKeyError: () => false,
+    createStaleSessionError: () => new Error('stale'),
+}))
+jest.mock('@sentry/nextjs', () => ({
+    captureException: (...args: unknown[]) => mockCaptureException(...args),
+    captureMessage: jest.fn(),
+}))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, getNativeRpId: () => 'localhost' }))
+jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
+
+/*
+ * PEANUT-UI-T09. The component latch (SetupPasskey.test.tsx) is not the
+ * backstop: the help modal's retry re-enters the hook, and a losing tap used to
+ * run handleRegister's prologue in full — wiping the passkey cookie and the
+ * redux address that the ceremony already on screen was about to fill, then
+ * releasing that ceremony's isRegistering flag. Both rules live in useZeroDev,
+ * so both are pinned here.
+ */
+describe('useZeroDev — a losing ceremony touches nothing the winner owns', () => {
+    let errorSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockActiveCeremonyId = null
+        errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => errorSpy.mockRestore())
+
+    const runCatching = async (call: (hook: ReturnType<typeof useZeroDev>) => Promise<unknown>) => {
+        const { result } = renderHook(() => useZeroDev())
+        let thrown: unknown
+        await act(async () => {
+            try {
+                await call(result.current)
+            } catch (e) {
+                thrown = e
+            }
+        })
+        return thrown as Error & { code?: string }
+    }
+
+    it('rejects a registration that races an active ceremony before destroying any state', async () => {
+        mockActiveCeremonyId = 7
+
+        const thrown = await runCatching((hook) => hook.handleRegister('alice'))
+
+        expect(thrown.name).toBe('CeremonyConflictError')
+        // the ordering IS the fix — the bail must precede the prologue
+        expect(removeFromCookie).not.toHaveBeenCalled()
+        expect(mockDispatch).not.toHaveBeenCalledWith({ type: 'zerodev/reset' })
+        expect(mockToWebAuthnKey).not.toHaveBeenCalled()
+        // the flag belongs to the ceremony already on screen
+        expect(mockDispatch).not.toHaveBeenCalledWith({ type: 'zerodev/registering', payload: false })
+    })
+
+    it('still clears isRegistering when the registration itself fails', async () => {
+        mockToWebAuthnKey.mockRejectedValue(Object.assign(new Error('nope'), { name: 'NotAllowedError' }))
+
+        const thrown = await runCatching((hook) => hook.handleRegister('alice'))
+
+        expect(thrown.name).toBe('NotAllowedError')
+        expect(mockDispatch).toHaveBeenCalledWith({ type: 'zerodev/registering', payload: false })
+    })
+
+    it('leaves isLoggingIn alone when a login loses the ceremony window', async () => {
+        mockToWebAuthnKey.mockRejectedValue(new CeremonyConflictError())
+
+        const thrown = await runCatching((hook) => hook.handleLogin())
+
+        expect(thrown.name).toBe('PasskeyError')
+        expect(thrown.code).toBe('PASSKEY_INTERRUPTED')
+        expect(mockDispatch).not.toHaveBeenCalledWith({ type: 'zerodev/logging-in', payload: false })
+    })
+
+    it('still clears isLoggingIn for an ordinary login failure', async () => {
+        mockToWebAuthnKey.mockRejectedValue(Object.assign(new Error('cancelled'), { name: 'NotAllowedError' }))
+
+        await runCatching((hook) => hook.handleLogin())
+
+        expect(mockDispatch).toHaveBeenCalledWith({ type: 'zerodev/logging-in', payload: false })
+    })
+})

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -11,10 +11,17 @@ import { zerodevActions } from '@/redux/slices/zerodev-slice'
 import { getFromCookie, removeFromCookie, saveToCookie, saveToLocalStorage } from '@/utils/general.utils'
 import { clearAuthState } from '@/utils/auth.utils'
 import { isStaleKeyError, createStaleSessionError } from '@/utils/walletCredential.utils'
-import { capturePasskeySignFailure, classifyPasskeyError, normalizePasskeyServerError } from '@/utils/webauthn.utils'
+import {
+    capturePasskeySignFailure,
+    classifyPasskeyError,
+    normalizeNativePasskeyError,
+    normalizePasskeyServerError,
+} from '@/utils/webauthn.utils'
 import { withCeremonyPurpose } from '@/utils/webauthn-ceremony-telemetry'
 import {
     captureCeremonyGuardError,
+    CeremonyConflictError,
+    currentCeremonyId,
     guardPasskeyCeremony,
     isCeremonyGuardError,
     isPasskeyShimInstalled,
@@ -73,6 +80,21 @@ export const useZeroDev = () => {
 
     // register function
     const handleRegister = async (username: string): Promise<void> => {
+        /*
+         * Bail BEFORE the reset below when a ceremony already owns the window.
+         * A second tap used to run the whole prologue anyway: it wiped the
+         * address and passkey cookie the in-flight registration was about to
+         * fill, then its catch dispatched setIsRegistering(false) — releasing
+         * the *winner's* flag and re-enabling the button mid-ceremony, which is
+         * how one impatient double-tap turned into a run of
+         * CeremonyConflictErrors (PEANUT-UI-T09).
+         */
+        if (currentCeremonyId() !== null) {
+            const conflict = new CeremonyConflictError()
+            captureCeremonyGuardError(conflict, 'register')
+            throw conflict
+        }
+
         // CRITICAL: clear any stale state from previous user before registering new passkey
         // this is the SINGLE place where cleanup happens for new signups
         // handles cases where: old cookies persist, session expired, user didn't logout properly
@@ -250,15 +272,19 @@ export const useZeroDev = () => {
                 dispatch(zerodevActions.setIsRegistering(false))
                 return
             }
-            const err = e as Error
+            const err = normalizeNativePasskeyError(e) as Error
             console.error('[useZeroDev] registration failed:', err.name, err.message, err, {
                 shimInstalled: isPasskeyShimInstalled(),
             })
             if (isCeremonyGuardError(err)) {
                 captureCeremonyGuardError(err, 'register')
             }
-            dispatch(zerodevActions.setIsRegistering(false))
-            throw e
+            // A conflict means another ceremony owns isRegistering — clearing it
+            // here would unlock the button while that one is still on screen.
+            if (err.name !== 'CeremonyConflictError') {
+                dispatch(zerodevActions.setIsRegistering(false))
+            }
+            throw err
         }
     }
 
@@ -298,7 +324,11 @@ export const useZeroDev = () => {
         } catch (e) {
             const err = normalizePasskeyServerError(e)
             const { code, message } = classifyPasskeyError(err)
-            dispatch(zerodevActions.setIsLoggingIn(false))
+            // Same ownership rule as registration: the losing ceremony must not
+            // release the flag the running one set.
+            if (!(err instanceof Error && err.name === 'CeremonyConflictError')) {
+                dispatch(zerodevActions.setIsLoggingIn(false))
+            }
             // Ceremony guards and server/network failures: nothing was
             // authenticated, so keep any existing state (no clearAuthState) and
             // report with a discriminating tag — this is the telemetry that

--- a/src/utils/__tests__/webauthn.utils.test.ts
+++ b/src/utils/__tests__/webauthn.utils.test.ts
@@ -3,6 +3,7 @@ import {
     capturePasskeySignFailure,
     classifyPasskeyError,
     getPasskeyErrorSetupKey,
+    normalizeNativePasskeyError,
     normalizePasskeyServerError,
 } from '../webauthn.utils'
 
@@ -141,5 +142,44 @@ describe('getPasskeyErrorSetupKey', () => {
         expect(getPasskeyErrorSetupKey(new Error('boom'))).toBeUndefined()
         expect(getPasskeyErrorSetupKey(passkeyError('SOME_FUTURE_CODE'))).toBeUndefined()
         expect(getPasskeyErrorSetupKey(undefined)).toBeUndefined()
+    })
+})
+
+describe('normalizeNativePasskeyError', () => {
+    // @capgo/capacitor-passkey rejects with a bare CapacitorException: the
+    // Android plugin flattens every non-DOM CreateCredentialException to
+    // code "UnknownError", and the JS shim passes the Error through without
+    // ever setting `name`. Callers switch on `err.name`, so without this the
+    // whole native failure surface collapses into "unexpected error".
+    const capacitorRejection = (message: string, code?: string, dataName?: string) =>
+        Object.assign(new Error(message), { code, data: dataName ? { name: dataName } : undefined })
+
+    test('maps an Android Credential Manager cancellation to NotAllowedError', () => {
+        const err = normalizeNativePasskeyError(
+            capacitorRejection('User cancelled the selector', 'UnknownError', 'UnknownError')
+        )
+        expect((err as Error).name).toBe('NotAllowedError')
+        expect(classifyPasskeyError(err).code).toBe('LOGIN_CANCELED')
+    })
+
+    test('recovers a DOM name the plugin did preserve', () => {
+        const err = normalizeNativePasskeyError(
+            capacitorRejection('The device does not support passkeys.', 'NotSupportedError', 'NotSupportedError')
+        )
+        expect((err as Error).name).toBe('NotSupportedError')
+        expect(classifyPasskeyError(err).code).toBe('PASSKEY_UNSUPPORTED')
+    })
+
+    test('leaves an unattributable native failure alone rather than guessing', () => {
+        const err = normalizeNativePasskeyError(capacitorRejection('Passkey registration failed.', 'UnknownError'))
+        expect((err as Error).name).toBe('Error')
+        expect(classifyPasskeyError(err).code).toBe('LOGIN_ERROR')
+    })
+
+    test('never renames an error that already carries a real name', () => {
+        const guardError = Object.assign(new Error('another passkey ceremony is already in progress'), {
+            name: 'CeremonyConflictError',
+        })
+        expect((normalizeNativePasskeyError(guardError) as Error).name).toBe('CeremonyConflictError')
     })
 })

--- a/src/utils/webauthn.utils.ts
+++ b/src/utils/webauthn.utils.ts
@@ -119,6 +119,48 @@ export function normalizePasskeyServerError(error: unknown): unknown {
     return error
 }
 
+/**
+ * @capgo/capacitor-passkey (8.2.2, still true on 8.5.1) drops the DOM error
+ * name on the native path twice over: the Android plugin maps every
+ * non-`CreatePublicKeyCredentialDomException` to `"UnknownError"`, and the JS
+ * shim's `normalizePluginError` returns Capacitor's rejection unchanged
+ * whenever it is already an `Error` — which `CapacitorException` always is, and
+ * it never sets `name`. So a user dismissing the Android Credential Manager
+ * sheet arrives here as `Error("User cancelled the selector")` instead of
+ * `NotAllowedError`, and every caller that switches on `err.name` falls through
+ * to its unknown-failure branch (generic help modal + a `passkey_setup_error`
+ * Sentry report for something the user did on purpose).
+ *
+ * Recovering the name from the plugin's `code`/`data.name` is not enough on its
+ * own — the cancellation exceptions are the ones flattened to `UnknownError` —
+ * so androidx's cancellation and no-provider messages are mapped explicitly.
+ */
+const ANDROID_CANCELLATION_MESSAGE =
+    /user cancelled the selector|activity is cancelled by the user|cancelled by the user/i
+const ANDROID_NO_CREATE_OPTION_MESSAGE = /no create options|no credential available to create/i
+
+type PluginRejection = Error & { code?: unknown; data?: { name?: unknown } }
+
+function pluginErrorName(error: PluginRejection): string | undefined {
+    if (typeof error.code === 'string' && error.code.endsWith('Error')) return error.code
+    const dataName = error.data?.name
+    return typeof dataName === 'string' && dataName.endsWith('Error') ? dataName : undefined
+}
+
+export function normalizeNativePasskeyError(error: unknown): unknown {
+    if (!(error instanceof Error) || error.name !== 'Error') return error
+    const rejection = error as PluginRejection
+    const message = rejection.message ?? ''
+    const recovered =
+        ANDROID_CANCELLATION_MESSAGE.test(message) || ANDROID_NO_CREATE_OPTION_MESSAGE.test(message)
+            ? WebAuthnErrorName.NotAllowed
+            : pluginErrorName(rejection)
+    if (!recovered || recovered === 'UnknownError') return error
+    // Renaming in place keeps the original stack and the plugin's own fields.
+    rejection.name = recovered
+    return rejection
+}
+
 function isNetworkError(error: Error): boolean {
     if (error.name === 'TypeError' && /fetch|network/i.test(error.message)) return true
     // "Load failed" is WebKit's message for a failed fetch (common when the
@@ -131,7 +173,8 @@ function isNetworkError(error: Error): boolean {
  * Classification order: known DOMException name → network heuristic → fallback.
  */
 export function classifyPasskeyError(error: unknown): PasskeyErrorClassification {
-    const err = error instanceof Error ? error : new Error(String(error))
+    const normalized = normalizeNativePasskeyError(error)
+    const err = normalized instanceof Error ? normalized : new Error(String(normalized))
     let code: PasskeyErrorCode = 'LOGIN_ERROR'
     // iOS surfaces ceremony failures as a bare Error whose message carries the
     // ASAuthorizationError code, not a DOMException name: 1001 = user canceled,


### PR DESCRIPTION
Investigating [PEANUT-UI-T09](https://peanut-c34d84c05.sentry.io/issues/7709110627/) — a signup that could not be completed on Android native (binary 1.3.0, OTA `d5f8d49`, Motorola g86, Android 16).

## What the session actually looked like

From the breadcrumbs, on `/setup/?screen=passkey-permission`:

| time (UTC) | what happened |
|---|---|
| 16:21:57, 16:21:59 | two taps on **Set it up**, 2.4s apart |
| 16:22:01.194 | tap A reaches `handleRegister` → resets ZeroDev state, clears the passkey cookie |
| 16:22:02.534 | tap B reaches `handleRegister` → resets state **again**, then `CeremonyConflictError` |
| 16:22:03–16:22:12 | four more taps, six more resets, six more `CeremonyConflictError` |
| 16:22:23.448 | tap A's ceremony finally POSTs `/passkeys/register/options` |
| 16:22:32.868 | ceremony #3 ends: `Error: User cancelled the selector` after 9.4s |
| 16:23:14.883 | retry → ceremony #4 ends the same way after 2.0s |

## Two defects, both fixed here

**1. The button is live during the pre-ceremony awaits.** `isRegistering` only flips once `handleRegister` runs, and `handlePasskeySetup` awaits twice before that — the live `checkPasskeySupport()` re-check and the username-availability request. On a phone that is a second or more of a fully enabled button.

That alone would be cosmetic, except each losing tap did real damage:

- it ran `resetZeroDevState()` + `removeFromCookie(WEB_AUTHN_COOKIE_KEY)` **before** the conflict guard, wiping the address and cookie the in-flight registration was about to fill;
- its catch dispatched `setIsRegistering(false)` — releasing the *winner's* flag and re-enabling the button mid-ceremony, which is what turned one double-tap into a self-sustaining run of conflicts.

Fixed by latching the whole handler in `SetupPasskey` (and surfacing the busy state for the awaits), bailing out of `handleRegister` before the destructive reset when a ceremony already owns the window, and never clearing a flag this call did not set — in login as well as registration.

**2. Android passkey errors arrive nameless.** `@capgo/capacitor-passkey` loses the DOM error name twice over:

- `CapacitorPasskeyPlugin.rejectCreateException` maps every non-`CreatePublicKeyCredentialDomException` to `"UnknownError"` — which is exactly the bucket `CreateCredentialCancellationException` lands in;
- the JS shim's `normalizePluginError` short-circuits on `error instanceof Error` and returns Capacitor's rejection unchanged, and `CapacitorException` never sets `name`.

So dismissing the Credential Manager sheet reaches us as `Error("User cancelled the selector")`, `err.name === 'Error'`, and every `switch (err.name)` falls through to its unknown-failure branch: the generic troubleshooting modal, plus a `passkey_setup_error` Sentry event for something the user did deliberately. That is also why the ceremony telemetry on this issue reads `errorName: "Error", errorCode: "LOGIN_ERROR"`.

`normalizeNativePasskeyError` recovers the name from the plugin's `code`/`data.name` and maps androidx's cancellation and no-create-option messages to `NotAllowedError`. Verified still broken on the latest published plugin (8.5.1), so this stays a client-side normalization — no plugin bump, no binary.

## What this does *not* explain

The terminal failure on both attempts was a genuine `CreateCredentialCancellationException` from Android. After this change it is reported and worded correctly ("cancelled") instead of as an unknown crash, but if the sheet was never actually dismissed by hand, there is a third bug underneath that needs a device to pin down. The `assetlinks.json` side checks out: `me.peanut.wallet` is listed with `delegate_permission/common.get_login_creds` and three fingerprints, and `capacitor-passkey.xml` points at the right statement list.

## Scope

OTA-shippable — JS only, no native dependency change.

Tests: `SetupPasskey.test.tsx` (new) locks down one-tap-one-ceremony and the busy state; both cases fail against the pre-fix component. `webauthn.utils.test.ts` covers the four normalization outcomes.
