### PR TITLE
fix(limits): render the Manteca cap-nudge, which never reached a screen

### DIFF
--- a/src/features/limits/components/CapNudgeCard.tsx
+++ b/src/features/limits/components/CapNudgeCard.tsx
@@ -9,7 +9,20 @@ import { startKycAction } from '@/app/actions/sumsub'
 import { useAuth } from '@/context/authContext'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { useLimits } from '@/hooks/useLimits'
+import { markSubmitted } from '@/hooks/useSubmissionWindow'
+import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
 import { selectMantecaCapNudge } from '@/utils/capability-gate'
+
+/**
+ * How long a local submission suppresses the CTA on its own.
+ *
+ * The backend only flips the hint from `raise` to `wait` when the RFI webhook
+ * lands, which is asynchronous and can be lost. Long enough to cover the
+ * ordinary webhook, short enough that a lost one re-offers the upload instead
+ * of hiding it forever — and short enough that it can never be the reason a
+ * genuinely NEW cap block goes unanswered.
+ */
+const CAP_NUDGE_SUBMITTED_TTL_MS = 10 * 60 * 1000
 
 /**
  * The Manteca cap-nudge — the surface for "you hit your monthly cap, verify your
@@ -27,35 +40,52 @@ import { selectMantecaCapNudge } from '@/utils/capability-gate'
  *
  * Deliberately tiny, for the same reason the card's PoA self-heal is: the
  * multi-phase KYC machinery is bank-onboarding shaped and completes on rail
- * semantics this lifecycle never reaches. Here we need only mint → open → refetch.
+ * semantics this lifecycle never reaches. Here we need only mint → open →
+ * arm the poller → let the backend take over.
  */
 export default function CapNudgeCard() {
     const t = useTranslations('limits.capNudge')
     const tKyc = useTranslations('kyc')
     const { rails, nextActions } = useCapabilities()
-    const { fetchUser } = useAuth()
+    const { user, fetchUser } = useAuth()
     const { refetch: refetchLimits } = useLimits()
 
     const [token, setToken] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [isStarting, setIsStarting] = useState(false)
-    // Optimistic "we got it" between the SDK submit and the backend stamping
-    // `submittedAt` on the marker (a webhook round-trip later). Without it the
-    // actionable CTA lingers and invites a second upload of the same document.
-    const [submitted, setSubmitted] = useState(false)
     // Two concurrent taps race the backend's create-action idempotency into
     // minting two Sumsub actions — the same guard the card PoA self-heal uses.
     const startingRef = useRef(false)
 
+    const userId = user?.user?.userId
     const nudge = selectMantecaCapNudge(rails, nextActions)
     const actionKey = nudge?.state === 'raise' ? nudge.actionKey : null
 
-    // Once the backend's own state takes over — the marker gains `submittedAt`
-    // and the hint flips to `wait`, or a NEW cap block re-seeds the actionable
-    // CTA — drop the optimistic flag so the re-offered upload isn't suppressed.
+    // Optimistic "we got it", persisted per user rather than held in component
+    // state. The webhook that stamps `submittedAt` on the marker is a
+    // round-trip away, and a flag that dies with this component let the user
+    // navigate away, come back, and be offered the same upload again — which
+    // is how a second Sumsub action gets minted for a document already in.
+    // localStorage is unreadable during SSR, hence the post-render read.
+    const [submittedAt, setSubmittedAt] = useState<number | null>(null)
     useEffect(() => {
-        if (submitted && nudge?.state !== 'raise') setSubmitted(false)
-    }, [submitted, nudge?.state])
+        if (!userId) return
+        const stored = getUserPreferences(userId)?.capNudgeSubmittedAt
+        const parsed = stored ? Date.parse(stored) : NaN
+        setSubmittedAt(Number.isNaN(parsed) ? null : parsed)
+    }, [userId])
+
+    const recentlySubmitted = submittedAt !== null && Date.now() - submittedAt < CAP_NUDGE_SUBMITTED_TTL_MS
+
+    // Once the backend's own state takes over, drop the local flag: the marker
+    // it wrote outlives this device, and leaving ours behind would suppress a
+    // later, genuinely new cap block.
+    useEffect(() => {
+        if (!userId || submittedAt === null) return
+        if (nudge?.state === 'raise' && recentlySubmitted) return
+        updateUserPreferences(userId, { capNudgeSubmittedAt: undefined })
+        setSubmittedAt(null)
+    }, [userId, submittedAt, nudge?.state, recentlySubmitted])
 
     const start = useCallback(async () => {
         if (!actionKey || startingRef.current) return
@@ -84,14 +114,29 @@ export default function CapNudgeCard() {
         return response.data.token
     }, [actionKey])
 
-    const refresh = useCallback(() => {
+    const onSubmit = useCallback(() => {
+        setToken(null)
+        // Arm the shared post-write poller BEFORE refetching. This rail is
+        // ENABLED, so the auto-refresh predicate's pending-rail arm never fires
+        // for it — without the window a single refetch races the webhook, and
+        // losing that race leaves the actionable hint sitting in the user cache
+        // for its full staleTime with nothing scheduled to correct it.
+        markSubmitted()
+        if (userId) updateUserPreferences(userId, { capNudgeSubmittedAt: new Date().toISOString() })
+        setSubmittedAt(Date.now())
+        void fetchUser()
+        void refetchLimits()
+    }, [userId, fetchUser, refetchLimits])
+
+    const onClose = useCallback(() => {
+        setToken(null)
         void fetchUser()
         void refetchLimits()
     }, [fetchUser, refetchLimits])
 
     if (!nudge) return null
 
-    if (nudge.state === 'under-review' || submitted) {
+    if (nudge.state === 'under-review' || recentlySubmitted) {
         return (
             <Card position="single" className="p-4">
                 <p className="text-body-s text-foreground-secondary">{t('underReview')}</p>
@@ -118,15 +163,8 @@ export default function CapNudgeCard() {
             <SumsubKycWrapper
                 visible={token !== null}
                 accessToken={token}
-                onClose={() => {
-                    setToken(null)
-                    refresh()
-                }}
-                onComplete={() => {
-                    setToken(null)
-                    setSubmitted(true)
-                    refresh()
-                }}
+                onClose={onClose}
+                onComplete={onSubmit}
                 onRefreshToken={refreshToken}
             />
         </>

--- a/src/features/limits/components/CapNudgeCard.tsx
+++ b/src/features/limits/components/CapNudgeCard.tsx
@@ -88,7 +88,26 @@ export default function CapNudgeCard() {
         setSubmittedAt(Number.isNaN(parsed) ? null : parsed)
     }, [userId])
 
-    const recentlySubmitted = submittedAt !== null && Date.now() - submittedAt < CAP_NUDGE_SUBMITTED_TTL_MS
+    // Recomputed only on render — and with a lost webhook the backend keeps
+    // returning the same `raise` hint, so React Query's structural sharing hands
+    // back an identical object and nothing re-renders. Without a timer at the
+    // boundary the card stayed in the review state forever and the 20s re-arm
+    // kept the 4s user poll alive indefinitely. Schedule the expiry so it
+    // actually arrives.
+    const [now, setNow] = useState(() => Date.now())
+    const expiresAt = submittedAt === null ? null : submittedAt + CAP_NUDGE_SUBMITTED_TTL_MS
+    useEffect(() => {
+        if (expiresAt === null) return
+        const remaining = expiresAt - Date.now()
+        if (remaining <= 0) {
+            setNow(Date.now())
+            return
+        }
+        const id = setTimeout(() => setNow(Date.now()), remaining)
+        return () => clearTimeout(id)
+    }, [expiresAt])
+
+    const recentlySubmitted = expiresAt !== null && now < expiresAt
 
     // Once the backend's own state takes over, drop the local flag: the marker
     // it wrote outlives this device, and leaving ours behind would suppress a

--- a/src/features/limits/components/CapNudgeCard.tsx
+++ b/src/features/limits/components/CapNudgeCard.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/0_Bruddle/Button'
+import Card from '@/components/Global/Card'
+import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
+import { startKycAction } from '@/app/actions/sumsub'
+import { useAuth } from '@/context/authContext'
+import { useCapabilities } from '@/hooks/useCapabilities'
+import { useLimits } from '@/hooks/useLimits'
+import { selectMantecaCapNudge } from '@/utils/capability-gate'
+
+/**
+ * The Manteca cap-nudge — the surface for "you hit your monthly cap, verify your
+ * income to raise it". Lives on the limits page, next to the (different)
+ * {@link IncreaseLimitsButton} flow, so a capped user is never interrupted
+ * mid-payment to be sold a limit raise.
+ *
+ * Two states, both non-blocking — the rail stays usable under the cap:
+ *   - `raise`        — a fresh cap block: description + a CTA that mints a
+ *                      source-of-funds token and opens the Sumsub SDK.
+ *   - `under-review` — the document is already in. Sumsub accepting it does NOT
+ *                      raise the Manteca cap (still a manual support step), so
+ *                      this state neither re-asks for the document nor claims
+ *                      the limit changed. It renders as copy with no control.
+ *
+ * Deliberately tiny, for the same reason the card's PoA self-heal is: the
+ * multi-phase KYC machinery is bank-onboarding shaped and completes on rail
+ * semantics this lifecycle never reaches. Here we need only mint → open → refetch.
+ */
+export default function CapNudgeCard() {
+    const t = useTranslations('limits.capNudge')
+    const tKyc = useTranslations('kyc')
+    const { rails, nextActions } = useCapabilities()
+    const { fetchUser } = useAuth()
+    const { refetch: refetchLimits } = useLimits()
+
+    const [token, setToken] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    const [isStarting, setIsStarting] = useState(false)
+    // Optimistic "we got it" between the SDK submit and the backend stamping
+    // `submittedAt` on the marker (a webhook round-trip later). Without it the
+    // actionable CTA lingers and invites a second upload of the same document.
+    const [submitted, setSubmitted] = useState(false)
+    // Two concurrent taps race the backend's create-action idempotency into
+    // minting two Sumsub actions — the same guard the card PoA self-heal uses.
+    const startingRef = useRef(false)
+
+    const nudge = selectMantecaCapNudge(rails, nextActions)
+    const actionKey = nudge?.state === 'raise' ? nudge.actionKey : null
+
+    // Once the backend's own state takes over — the marker gains `submittedAt`
+    // and the hint flips to `wait`, or a NEW cap block re-seeds the actionable
+    // CTA — drop the optimistic flag so the re-offered upload isn't suppressed.
+    useEffect(() => {
+        if (submitted && nudge?.state !== 'raise') setSubmitted(false)
+    }, [submitted, nudge?.state])
+
+    const start = useCallback(async () => {
+        if (!actionKey || startingRef.current) return
+        startingRef.current = true
+        setIsStarting(true)
+        setError(null)
+        try {
+            const response = await startKycAction(actionKey)
+            if (response.error || !response.data?.token) {
+                // Inline, not silent: a dead primary CTA on a limits screen reads
+                // as "the raise isn't available to me".
+                setError(response.error ?? tKyc('errorStartDocVerification'))
+                return
+            }
+            setToken(response.data.token)
+        } finally {
+            startingRef.current = false
+            setIsStarting(false)
+        }
+    }, [actionKey, tKyc])
+
+    const refreshToken = useCallback(async (): Promise<string> => {
+        if (!actionKey) throw new Error('No cap-nudge action to refresh')
+        const response = await startKycAction(actionKey)
+        if (!response.data?.token) throw new Error(response.error ?? 'Failed to refresh token')
+        return response.data.token
+    }, [actionKey])
+
+    const refresh = useCallback(() => {
+        void fetchUser()
+        void refetchLimits()
+    }, [fetchUser, refetchLimits])
+
+    if (!nudge) return null
+
+    if (nudge.state === 'under-review' || submitted) {
+        return (
+            <Card position="single" className="p-4">
+                <p className="text-body-s text-foreground-secondary">{t('underReview')}</p>
+            </Card>
+        )
+    }
+
+    return (
+        <>
+            <Card position="single" className="space-y-3 p-4">
+                <p className="text-body-s text-foreground-secondary">{t('description')}</p>
+                <Button
+                    className="w-full"
+                    shadowSize="4"
+                    onClick={() => void start()}
+                    loading={isStarting}
+                    disabled={isStarting}
+                >
+                    {t('cta')}
+                </Button>
+                {error && <p className="text-center text-body-xs text-foreground-error">{error}</p>}
+            </Card>
+
+            <SumsubKycWrapper
+                visible={token !== null}
+                accessToken={token}
+                onClose={() => {
+                    setToken(null)
+                    refresh()
+                }}
+                onComplete={() => {
+                    setToken(null)
+                    setSubmitted(true)
+                    refresh()
+                }}
+                onRefreshToken={refreshToken}
+            />
+        </>
+    )
+}

--- a/src/features/limits/components/CapNudgeCard.tsx
+++ b/src/features/limits/components/CapNudgeCard.tsx
@@ -25,6 +25,19 @@ import { selectMantecaCapNudge } from '@/utils/capability-gate'
 const CAP_NUDGE_SUBMITTED_TTL_MS = 10 * 60 * 1000
 
 /**
+ * Re-arm cadence for the post-write poller, comfortably under the submission
+ * window's 30s so it never lapses. Same device as {@link useWaitingOnProviderModal},
+ * and for the same reason: one `markSubmitted()` buys 30 seconds, and this rail
+ * is ENABLED so the poller has no other predicate to keep it alive. A GREEN
+ * review webhook can land well after that, and when it does there is nothing
+ * scheduled to go and fetch the `wait` state it produced.
+ *
+ * Bounded by the card being mounted — leave the page and the interval clears —
+ * and by the backend answering, whichever comes first.
+ */
+const REARM_INTERVAL_MS = 20_000
+
+/**
  * The Manteca cap-nudge — the surface for "you hit your monthly cap, verify your
  * income to raise it". Lives on the limits page, next to the (different)
  * {@link IncreaseLimitsButton} flow, so a capped user is never interrupted
@@ -86,6 +99,15 @@ export default function CapNudgeCard() {
         updateUserPreferences(userId, { capNudgeSubmittedAt: undefined })
         setSubmittedAt(null)
     }, [userId, submittedAt, nudge?.state, recentlySubmitted])
+
+    // Keep the poller alive for as long as we are still waiting on the webhook.
+    // Stops the moment the backend's own state takes over (the hint flips to
+    // `wait`), or the local marker ages out, or the user leaves the page.
+    useEffect(() => {
+        if (!recentlySubmitted || nudge?.state !== 'raise') return
+        const id = setInterval(() => markSubmitted(), REARM_INTERVAL_MS)
+        return () => clearInterval(id)
+    }, [recentlySubmitted, nudge?.state])
 
     const start = useCallback(async () => {
         if (!actionKey || startingRef.current) return

--- a/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
+++ b/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * CapNudgeCard — the limits-page surface for the Manteca cap-nudge.
+ *
+ * The nudge travelled from the backend to `railVerdict` and stopped there: no
+ * component read it, so a capped AR user had no in-app route to a limit raise
+ * at all. These pin the two states the backend emits and, above all, that the
+ * `wait` state is not tappable — Sumsub accepting the document does not mean
+ * Manteca raised the cap, so the review state must neither re-ask for the
+ * document nor claim the limit changed.
+ */
+import React from 'react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithIntl as render } from '@/test-utils/intl'
+import type { NextAction, RailCapability } from '@/types/capabilities'
+import CapNudgeCard from '../CapNudgeCard'
+
+let mockRails: RailCapability[] = []
+let mockNextActions: NextAction[] = []
+const mockFetchUser = jest.fn(() => Promise.resolve(null))
+const mockRefetchLimits = jest.fn()
+const mockStartKycAction = jest.fn()
+
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ rails: mockRails, nextActions: mockNextActions }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ fetchUser: mockFetchUser }),
+}))
+jest.mock('@/hooks/useLimits', () => ({
+    useLimits: () => ({ refetch: mockRefetchLimits }),
+}))
+jest.mock('@/app/actions/sumsub', () => ({
+    startKycAction: (key: string) => mockStartKycAction(key),
+}))
+jest.mock('@/components/Kyc/SumsubKycWrapper', () => ({
+    SumsubKycWrapper: (props: { visible: boolean; accessToken: string | null; onComplete: () => void }) =>
+        props.visible ? (
+            <div data-testid="sumsub-sdk">
+                <span>{props.accessToken}</span>
+                <button onClick={props.onComplete}>submit-document</button>
+            </div>
+        ) : null,
+}))
+jest.mock('@/utils/capacitor', () => ({
+    isNativeBridge: () => false,
+    isAndroidNative: () => false,
+    isCapacitor: () => false,
+}))
+
+const mantecaRail = (overrides: Partial<RailCapability> = {}): RailCapability => ({
+    id: 'manteca.bank_transfer_ar',
+    provider: 'manteca',
+    method: 'BANK_TRANSFER_AR',
+    channel: 'bank',
+    country: 'AR',
+    currency: 'ARS',
+    status: 'enabled',
+    ...overrides,
+})
+
+const raiseAction: NextAction = {
+    key: 'sumsub:source_of_funds',
+    kind: 'sumsub',
+    purpose: 'raise-manteca-limit',
+    levelKey: 'source_of_funds',
+}
+const reviewAction: NextAction = {
+    key: 'manteca:limit-review',
+    kind: 'wait',
+    purpose: 'manteca-limit-under-review',
+}
+
+describe('CapNudgeCard', () => {
+    beforeEach(() => {
+        mockRails = []
+        mockNextActions = []
+        mockFetchUser.mockReset()
+        mockFetchUser.mockResolvedValue(null)
+        mockRefetchLimits.mockReset()
+        mockStartKycAction.mockReset()
+        mockStartKycAction.mockResolvedValue({ data: { token: 'tok-1', levelName: 'source-of-funds' } })
+    })
+
+    test('renders nothing when the user carries no cap-nudge', () => {
+        mockRails = [mantecaRail()]
+        const { container } = render(<CapNudgeCard />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    describe('fresh cap block → actionable CTA', () => {
+        beforeEach(() => {
+            mockRails = [mantecaRail({ hintActions: ['sumsub:source_of_funds'] })]
+            mockNextActions = [raiseAction]
+        })
+
+        test('shows the raise copy and a tappable CTA', () => {
+            render(<CapNudgeCard />)
+            expect(screen.getByText(/hit your monthly limit/i)).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: /verify income/i })).toBeEnabled()
+        })
+
+        test('tapping the CTA starts the source-of-funds flow and opens the SDK', async () => {
+            render(<CapNudgeCard />)
+            fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+
+            await waitFor(() => expect(screen.getByTestId('sumsub-sdk')).toBeInTheDocument())
+            expect(mockStartKycAction).toHaveBeenCalledWith('sumsub:source_of_funds')
+            expect(screen.getByText('tok-1')).toBeInTheDocument()
+        })
+
+        test('a failed start surfaces inline instead of a dead CTA', async () => {
+            mockStartKycAction.mockResolvedValue({ error: 'Sumsub is down' })
+            render(<CapNudgeCard />)
+            fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+
+            expect(await screen.findByText('Sumsub is down')).toBeInTheDocument()
+            expect(screen.queryByTestId('sumsub-sdk')).not.toBeInTheDocument()
+        })
+
+        test('submitting flips to the review state without waiting for the webhook', async () => {
+            render(<CapNudgeCard />)
+            fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+            fireEvent.click(await screen.findByText('submit-document'))
+
+            expect(await screen.findByText(/reviewing your limit/i)).toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /verify income/i })).not.toBeInTheDocument()
+            expect(mockFetchUser).toHaveBeenCalled()
+            expect(mockRefetchLimits).toHaveBeenCalled()
+        })
+    })
+
+    describe('completed RFI → non-actionable review state', () => {
+        beforeEach(() => {
+            mockRails = [mantecaRail({ hintActions: ['manteca:limit-review'] })]
+            mockNextActions = [reviewAction]
+        })
+
+        test('shows the review copy with no control at all', () => {
+            render(<CapNudgeCard />)
+            expect(screen.getByText(/reviewing your limit/i)).toBeInTheDocument()
+            expect(screen.queryByRole('button')).not.toBeInTheDocument()
+        })
+
+        test('does not re-ask for the document, and claims no raise', () => {
+            render(<CapNudgeCard />)
+            expect(screen.queryByText(/hit your monthly limit/i)).not.toBeInTheDocument()
+            expect(screen.queryByText(/verify income/i)).not.toBeInTheDocument()
+            expect(screen.queryByTestId('sumsub-sdk')).not.toBeInTheDocument()
+        })
+    })
+
+    test('a new cap block after a review flips the CTA back on', () => {
+        mockRails = [
+            mantecaRail({ hintActions: ['manteca:limit-review'] }),
+            mantecaRail({ id: 'manteca.pix_br', method: 'PIX_BR', hintActions: ['sumsub:source_of_funds'] }),
+        ]
+        mockNextActions = [reviewAction, raiseAction]
+        render(<CapNudgeCard />)
+        expect(screen.getByRole('button', { name: /verify income/i })).toBeInTheDocument()
+    })
+})

--- a/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
+++ b/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
@@ -19,12 +19,24 @@ let mockNextActions: NextAction[] = []
 const mockFetchUser = jest.fn(() => Promise.resolve(null))
 const mockRefetchLimits = jest.fn()
 const mockStartKycAction = jest.fn()
+const mockMarkSubmitted = jest.fn()
+let mockPrefs: Record<string, unknown> = {}
+const mockUpdatePrefs = jest.fn((_userId: string, prefs: Record<string, unknown>) => {
+    mockPrefs = { ...mockPrefs, ...prefs }
+})
 
 jest.mock('@/hooks/useCapabilities', () => ({
     useCapabilities: () => ({ rails: mockRails, nextActions: mockNextActions }),
 }))
 jest.mock('@/context/authContext', () => ({
-    useAuth: () => ({ fetchUser: mockFetchUser }),
+    useAuth: () => ({ user: { user: { userId: 'user-1' } }, fetchUser: mockFetchUser }),
+}))
+jest.mock('@/hooks/useSubmissionWindow', () => ({
+    markSubmitted: () => mockMarkSubmitted(),
+}))
+jest.mock('@/utils/general.utils', () => ({
+    getUserPreferences: () => mockPrefs,
+    updateUserPreferences: (userId: string, prefs: Record<string, unknown>) => mockUpdatePrefs(userId, prefs),
 }))
 jest.mock('@/hooks/useLimits', () => ({
     useLimits: () => ({ refetch: mockRefetchLimits }),
@@ -79,6 +91,11 @@ describe('CapNudgeCard', () => {
         mockRefetchLimits.mockReset()
         mockStartKycAction.mockReset()
         mockStartKycAction.mockResolvedValue({ data: { token: 'tok-1', levelName: 'source-of-funds' } })
+        mockMarkSubmitted.mockReset()
+        // mockClear, NOT mockReset: reset strips the implementation that
+        // writes through to mockPrefs, and the remount cases depend on it.
+        mockUpdatePrefs.mockClear()
+        mockPrefs = {}
     })
 
     test('renders nothing when the user carries no cap-nudge', () => {
@@ -127,12 +144,57 @@ describe('CapNudgeCard', () => {
             expect(mockFetchUser).toHaveBeenCalled()
             expect(mockRefetchLimits).toHaveBeenCalled()
         })
+
+        test('submitting arms the post-write poller, not just one refetch', async () => {
+            // This rail is ENABLED, so the auto-refresh predicate's pending-rail
+            // arm never fires for it. Without the window a single refetch races
+            // the webhook, and losing that race parks the actionable hint in the
+            // user cache for its full staleTime with nothing to correct it.
+            render(<CapNudgeCard />)
+            fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+            fireEvent.click(await screen.findByText('submit-document'))
+
+            expect(mockMarkSubmitted).toHaveBeenCalled()
+        })
+
+        test('the suppression survives a remount, so the same upload is not re-offered', async () => {
+            const { unmount } = render(<CapNudgeCard />)
+            fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+            fireEvent.click(await screen.findByText('submit-document'))
+            await screen.findByText(/reviewing your limit/i)
+            unmount()
+
+            // The backend still says `raise` — the webhook has not landed yet.
+            render(<CapNudgeCard />)
+            expect(await screen.findByText(/reviewing your limit/i)).toBeInTheDocument()
+            expect(screen.queryByRole('button', { name: /verify income/i })).not.toBeInTheDocument()
+        })
+
+        test('a stale local submission ages out and the upload is offered again', async () => {
+            // A lost webhook must re-offer the upload rather than hide it
+            // forever — and must never be the reason a NEW cap block goes
+            // unanswered.
+            mockPrefs = { capNudgeSubmittedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString() }
+
+            render(<CapNudgeCard />)
+            expect(await screen.findByRole('button', { name: /verify income/i })).toBeInTheDocument()
+            // and the dead marker is cleared, not left to shadow a later block
+            expect(mockUpdatePrefs).toHaveBeenCalledWith('user-1', { capNudgeSubmittedAt: undefined })
+        })
     })
 
     describe('completed RFI → non-actionable review state', () => {
         beforeEach(() => {
             mockRails = [mantecaRail({ hintActions: ['manteca:limit-review'] })]
             mockNextActions = [reviewAction]
+        })
+
+        test('clears a local submission marker once the backend confirms', async () => {
+            mockPrefs = { capNudgeSubmittedAt: new Date().toISOString() }
+            render(<CapNudgeCard />)
+            await waitFor(() =>
+                expect(mockUpdatePrefs).toHaveBeenCalledWith('user-1', { capNudgeSubmittedAt: undefined })
+            )
         })
 
         test('shows the review copy with no control at all', () => {

--- a/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
+++ b/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
@@ -9,7 +9,7 @@
  * document nor claim the limit changed.
  */
 import React from 'react'
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithIntl as render } from '@/test-utils/intl'
 import type { NextAction, RailCapability } from '@/types/capabilities'
 import CapNudgeCard from '../CapNudgeCard'
@@ -155,6 +155,54 @@ describe('CapNudgeCard', () => {
             fireEvent.click(await screen.findByText('submit-document'))
 
             expect(mockMarkSubmitted).toHaveBeenCalled()
+        })
+
+        test('keeps the poller armed past the 30s window while the webhook is outstanding', async () => {
+            // One markSubmitted() buys 30 seconds. This rail is ENABLED, so the
+            // auto-refresh poller has no other predicate keeping it alive — and a
+            // GREEN review webhook can land well after that, with nothing
+            // scheduled to fetch the `wait` state it produced.
+            jest.useFakeTimers()
+            try {
+                render(<CapNudgeCard />)
+                fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+                await act(async () => {})
+                fireEvent.click(screen.getByText('submit-document'))
+
+                const armedOnSubmit = mockMarkSubmitted.mock.calls.length
+                expect(armedOnSubmit).toBeGreaterThan(0)
+
+                act(() => {
+                    jest.advanceTimersByTime(60_000)
+                })
+                expect(mockMarkSubmitted.mock.calls.length).toBeGreaterThan(armedOnSubmit)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        test('stops re-arming once the backend answers', async () => {
+            jest.useFakeTimers()
+            try {
+                const { unmount } = render(<CapNudgeCard />)
+                fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+                await act(async () => {})
+                fireEvent.click(screen.getByText('submit-document'))
+                unmount()
+
+                // The backend's `wait` state has landed — nothing left to poll for.
+                mockRails = [mantecaRail({ hintActions: ['manteca:limit-review'] })]
+                mockNextActions = [reviewAction]
+                render(<CapNudgeCard />)
+                const settled = mockMarkSubmitted.mock.calls.length
+
+                act(() => {
+                    jest.advanceTimersByTime(120_000)
+                })
+                expect(mockMarkSubmitted.mock.calls.length).toBe(settled)
+            } finally {
+                jest.useRealTimers()
+            }
         })
 
         test('the suppression survives a remount, so the same upload is not re-offered', async () => {

--- a/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
+++ b/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
@@ -205,6 +205,54 @@ describe('CapNudgeCard', () => {
             }
         })
 
+        test('the TTL expires on its own, with no help from a re-render', async () => {
+            // With a lost webhook the backend keeps returning the same `raise`
+            // hint, React Query's structural sharing hands back an identical
+            // object, and nothing re-renders — so a TTL read only at render time
+            // never elapsed. The card stayed in the review state and the 20s
+            // re-arm kept the 4s user poll alive indefinitely.
+            jest.useFakeTimers()
+            try {
+                render(<CapNudgeCard />)
+                fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+                await act(async () => {})
+                fireEvent.click(screen.getByText('submit-document'))
+                expect(screen.getByText(/reviewing your limit/i)).toBeInTheDocument()
+
+                // Past the 10-minute marker TTL, with no other state change.
+                act(() => {
+                    jest.advanceTimersByTime(11 * 60 * 1000)
+                })
+
+                expect(screen.getByRole('button', { name: /verify income/i })).toBeInTheDocument()
+                expect(screen.queryByText(/reviewing your limit/i)).not.toBeInTheDocument()
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        test('and the poller stops being re-armed once the TTL is gone', async () => {
+            jest.useFakeTimers()
+            try {
+                render(<CapNudgeCard />)
+                fireEvent.click(screen.getByRole('button', { name: /verify income/i }))
+                await act(async () => {})
+                fireEvent.click(screen.getByText('submit-document'))
+
+                act(() => {
+                    jest.advanceTimersByTime(11 * 60 * 1000)
+                })
+                const afterExpiry = mockMarkSubmitted.mock.calls.length
+
+                act(() => {
+                    jest.advanceTimersByTime(5 * 60 * 1000)
+                })
+                expect(mockMarkSubmitted.mock.calls.length).toBe(afterExpiry)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
         test('the suppression survives a remount, so the same upload is not re-offered', async () => {
             const { unmount } = render(<CapNudgeCard />)
             fireEvent.click(screen.getByRole('button', { name: /verify income/i }))

--- a/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
+++ b/src/features/limits/components/__tests__/CapNudgeCard.test.tsx
@@ -125,6 +125,40 @@ describe('CapNudgeCard', () => {
             expect(screen.getByText('tok-1')).toBeInTheDocument()
         })
 
+        test('two taps in one tick mint exactly one Sumsub action', async () => {
+            // `startingRef` is the ONLY synchronous guard: the disabled prop does
+            // not apply until React renders again, so without a test that clicks
+            // twice while the first promise is still pending, removing the guard
+            // leaves the suite green and regresses into duplicate actions — which
+            // the backend's create-action idempotency answers by minting a
+            // suffixed second one.
+            let release: (value: unknown) => void = () => {}
+            mockStartKycAction.mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        release = resolve
+                    })
+            )
+
+            render(<CapNudgeCard />)
+            const cta = screen.getByRole('button', { name: /verify income/i })
+            // BOTH dispatches inside ONE act, so React has not re-rendered
+            // between them. Two `fireEvent.click` calls flush in between, the
+            // disabled prop lands, and the second click is swallowed by the
+            // button — which makes the guard look tested when it is not.
+            act(() => {
+                cta.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+                cta.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+            })
+
+            expect(mockStartKycAction).toHaveBeenCalledTimes(1)
+
+            await act(async () => {
+                release({ data: { token: 'tok-1', levelName: 'source-of-funds' } })
+            })
+            expect(mockStartKycAction).toHaveBeenCalledTimes(1)
+        })
+
         test('a failed start surfaces inline instead of a dead CTA', async () => {
             mockStartKycAction.mockResolvedValue({ error: 'Sumsub is down' })
             render(<CapNudgeCard />)

--- a/src/features/limits/views/MantecaLimitsView.tsx
+++ b/src/features/limits/views/MantecaLimitsView.tsx
@@ -17,6 +17,7 @@ import {
     getFlagUrlForCurrency,
     type LimitsPeriod,
 } from '../utils'
+import CapNudgeCard from '../components/CapNudgeCard'
 import IncreaseLimitsButton from '../components/IncreaseLimitsButton'
 import LimitsError from '../components/LimitsError'
 import LimitsDocsLink from '../components/LimitsDocsLink'
@@ -105,6 +106,8 @@ const MantecaLimitsView = () => {
                             <p>{t('appliesTo')}</p>
                         </div>
                     </div>
+
+                    <CapNudgeCard />
 
                     <IncreaseLimitsButton />
 

--- a/src/utils/capability-gate.test.ts
+++ b/src/utils/capability-gate.test.ts
@@ -970,6 +970,51 @@ describe('selectMantecaCapNudge', () => {
         expect(selectMantecaCapNudge([mantecaRail()], [])).toBeUndefined()
     })
 
+    test('survives the Bridge action-key collision', () => {
+        // The BE key is not provider-namespaced: Bridge emits the same
+        // `sumsub:source_of_funds` for its own requirement, and `upsertAction`
+        // keeps whichever rail emits FIRST. A user carrying both ends up with the
+        // Manteca rail pointing at a descriptor whose purpose reads `unlock-bridge`
+        // — and a purpose-only check dropped the real nudge, leaving exactly that
+        // cohort with no limit-raise route at all.
+        const bridgeWon: NextAction = {
+            key: 'sumsub:source_of_funds',
+            kind: 'sumsub',
+            purpose: 'unlock-bridge',
+            levelKey: 'source_of_funds',
+        }
+        const bridgeRail = bankRail({
+            id: 'bridge.sepa_eu',
+            method: 'SEPA_EU',
+            country: 'EU',
+            status: 'requires-info',
+            blockingActions: ['sumsub:source_of_funds'],
+        })
+        const rail = mantecaRail({ hintActions: ['sumsub:source_of_funds'] })
+
+        expect(selectMantecaCapNudge([bridgeRail, rail], [bridgeWon])).toEqual({
+            state: 'raise',
+            actionKey: 'sumsub:source_of_funds',
+        })
+    })
+
+    test('a Bridge requirement on a BRIDGE rail is still not a cap-nudge', () => {
+        // The rail-local read must not become a global one: the same descriptor
+        // reached from a Bridge rail is a Bridge requirement.
+        const bridgeSof: NextAction = {
+            key: 'sumsub:source_of_funds',
+            kind: 'sumsub',
+            purpose: 'unlock-bridge',
+            levelKey: 'source_of_funds',
+        }
+        const bridgeRail = bankRail({
+            id: 'bridge.sepa_eu',
+            status: 'requires-info',
+            blockingActions: ['sumsub:source_of_funds'],
+        })
+        expect(selectMantecaCapNudge([bridgeRail], [bridgeSof])).toBeUndefined()
+    })
+
     test('a Bridge advisory hint is not a cap-nudge', () => {
         const advisory: NextAction = {
             key: 'sumsub:eea_uplift',

--- a/src/utils/capability-gate.test.ts
+++ b/src/utils/capability-gate.test.ts
@@ -1,6 +1,7 @@
 import {
     deriveGate,
     getGateAdvisory,
+    selectMantecaCapNudge,
     getGateUserMessage,
     getKycModalVariant,
     type CapabilityState,
@@ -899,5 +900,97 @@ describe('deriveGate — legacy fallback fidelity (code-review regression pins)'
             'deposit'
         )
         expect(gate.kind).toBe('fixable-rejection')
+    })
+})
+
+describe('selectMantecaCapNudge', () => {
+    const raiseAction: NextAction = {
+        key: 'sumsub:source_of_funds',
+        kind: 'sumsub',
+        purpose: 'raise-manteca-limit',
+        levelKey: 'source_of_funds',
+    }
+    const reviewAction: NextAction = {
+        key: 'manteca:limit-review',
+        kind: 'wait',
+        purpose: 'manteca-limit-under-review',
+    }
+
+    function mantecaRail(overrides: Partial<RailCapability> = {}): RailCapability {
+        return bankRail({
+            id: 'manteca.pix_br',
+            provider: 'manteca',
+            method: 'PIX_BR',
+            country: 'BR',
+            currency: 'BRL',
+            status: 'enabled',
+            ...overrides,
+        })
+    }
+
+    test('a fresh cap block surfaces the actionable CTA — no effectiveDate needed', () => {
+        // The gap this closes: the hint carries no effectiveDate, so firstAdvisory
+        // drops it and nothing downstream ever saw it.
+        const rail = mantecaRail({ hintActions: ['sumsub:source_of_funds'] })
+        expect(selectMantecaCapNudge([rail], [raiseAction])).toEqual({
+            state: 'raise',
+            actionKey: 'sumsub:source_of_funds',
+        })
+    })
+
+    test('a completed RFI surfaces the non-actionable review state', () => {
+        const rail = mantecaRail({ hintActions: ['manteca:limit-review'] })
+        expect(selectMantecaCapNudge([rail], [reviewAction])).toEqual({ state: 'under-review' })
+    })
+
+    test('a NEW cap block outranks an in-review sibling — the CTA comes back', () => {
+        const reviewing = mantecaRail({ hintActions: ['manteca:limit-review'] })
+        const reBlocked = mantecaRail({
+            id: 'manteca.bank_transfer_ar',
+            method: 'BANK_TRANSFER_AR',
+            country: 'AR',
+            currency: 'ARS',
+            hintActions: ['sumsub:source_of_funds'],
+        })
+        expect(selectMantecaCapNudge([reviewing, reBlocked], [reviewAction, raiseAction])).toEqual({
+            state: 'raise',
+            actionKey: 'sumsub:source_of_funds',
+        })
+    })
+
+    test('reads the BE verdict too, not only the legacy hintActions list', () => {
+        const rail = mantecaRail({ resolved: { status: 'enabled', nextAction: raiseAction } })
+        expect(selectMantecaCapNudge([rail], [])).toEqual({
+            state: 'raise',
+            actionKey: 'sumsub:source_of_funds',
+        })
+    })
+
+    test('no nudge → undefined', () => {
+        expect(selectMantecaCapNudge([mantecaRail()], [])).toBeUndefined()
+    })
+
+    test('a Bridge advisory hint is not a cap-nudge', () => {
+        const advisory: NextAction = {
+            key: 'sumsub:eea_uplift',
+            kind: 'sumsub',
+            purpose: 'unlock-bridge',
+            effectiveDate: '2099-06-29',
+        }
+        const rail = bankRail({ status: 'enabled', hintActions: ['sumsub:eea_uplift'] })
+        expect(selectMantecaCapNudge([rail], [advisory])).toBeUndefined()
+    })
+
+    test('the review state can never be made tappable by a re-purposed kind', () => {
+        // Both branches are pinned to the kind the FE can honour: a `wait` action
+        // under the raise purpose must not yield an actionKey.
+        const miskinded: NextAction = { key: 'manteca:limit-review', kind: 'wait', purpose: 'raise-manteca-limit' }
+        const rail = mantecaRail({ hintActions: ['manteca:limit-review'] })
+        expect(selectMantecaCapNudge([rail], [miskinded])).toBeUndefined()
+    })
+
+    test('a hint key with no matching descriptor is ignored', () => {
+        const rail = mantecaRail({ hintActions: ['sumsub:source_of_funds'] })
+        expect(selectMantecaCapNudge([rail], [])).toBeUndefined()
     })
 })

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -237,6 +237,66 @@ function firstAdvisory(candidates: RailWithVerdict[]): GateAdvisory | undefined 
 }
 
 /**
+ * Purposes the Manteca cap-nudge is emitted under (peanut-api-ts
+ * `kyc/capabilities/resolver.ts`). A full-tier Manteca rail that recently hit
+ * its monthly cap carries the marker as a `hintAction`; once the user submits
+ * the source-of-funds document the marker gains `submittedAt` and the hint
+ * becomes a `wait`.
+ */
+const CAP_NUDGE_RAISE_PURPOSE = 'raise-manteca-limit'
+const CAP_NUDGE_REVIEW_PURPOSE = 'manteca-limit-under-review'
+
+/**
+ * The Manteca cap-nudge, if the user is carrying one.
+ *
+ *   - `raise`        — a fresh cap block. `actionKey` starts the source-of-funds
+ *                      Sumsub flow (POST /users/kyc/start-action).
+ *   - `under-review` — the document is in, but Sumsub accepting it does NOT mean
+ *                      Manteca raised the cap (that is still a manual support
+ *                      step). Non-actionable by construction: no key to start.
+ */
+export type MantecaCapNudge = { state: 'raise'; actionKey: string } | { state: 'under-review' }
+
+/**
+ * Select the Manteca cap-nudge from the capability block.
+ *
+ * Deliberately NOT routed through {@link firstAdvisory}: that selector ranks
+ * Bridge's future-dated requirements by `effectiveDate`, and the cap-nudge has
+ * no date to rank by — it is already due. Loosening the date requirement there
+ * would push the nudge into the add-money/withdraw pre-empt modal, interrupting
+ * a payment to advertise a limit raise. This is its own read, consumed by the
+ * limits page.
+ *
+ * A fresh block outranks an in-review sibling: re-seeding the marker (a NEW cap
+ * block after a completed RFI) must restore the actionable CTA rather than leave
+ * the user staring at a stale "under review".
+ *
+ * Both branches are pinned to the action `kind` the FE can actually honour, so a
+ * future BE that re-purposes either key cannot make the review state tappable.
+ */
+export function selectMantecaCapNudge(rails: RailCapability[], nextActions: NextAction[]): MantecaCapNudge | undefined {
+    const byKey = new Map(nextActions.map((action) => [action.key, action]))
+    let underReview = false
+
+    for (const rail of rails) {
+        if (rail.provider !== 'manteca') continue
+        // The verdict's nextAction is the BE-derived carrier on an enabled rail;
+        // `hintActions` is the legacy one. Read both — same dual-source rule as
+        // railVerdict — so neither an older nor a newer BE drops the nudge.
+        const candidates = [...railHintActions(rail, byKey), rail.resolved?.nextAction]
+        for (const action of candidates) {
+            if (!action) continue
+            if (action.kind === 'sumsub' && action.purpose === CAP_NUDGE_RAISE_PURPOSE) {
+                return { state: 'raise', actionKey: action.key }
+            }
+            if (action.kind === 'wait' && action.purpose === CAP_NUDGE_REVIEW_PURPOSE) underReview = true
+        }
+    }
+
+    return underReview ? { state: 'under-review' } : undefined
+}
+
+/**
  * Input state for the pure derive. Held separately from the React hook so the
  * gate is independently testable (and re-usable from non-React callers).
  */

--- a/src/utils/capability-gate.ts
+++ b/src/utils/capability-gate.ts
@@ -247,6 +247,20 @@ const CAP_NUDGE_RAISE_PURPOSE = 'raise-manteca-limit'
 const CAP_NUDGE_REVIEW_PURPOSE = 'manteca-limit-under-review'
 
 /**
+ * The source-of-funds RFI the cap-nudge starts. Identified by key/level as well
+ * as purpose because the BE's action key is NOT provider-namespaced: Bridge
+ * emits the same `sumsub:source_of_funds` for its own source-of-funds
+ * requirement, and the resolver's `upsertAction` keeps whichever rail emits
+ * FIRST. A user carrying both a Bridge SoF requirement and a Manteca cap-nudge
+ * can therefore end up with the Manteca rail pointing at a descriptor whose
+ * purpose reads `unlock-bridge` — and a purpose-only check would drop the real
+ * nudge and leave exactly that cohort with no limit-raise route, which is the
+ * hole this whole selector exists to close.
+ */
+const CAP_NUDGE_RAISE_KEY = 'sumsub:source_of_funds'
+const CAP_NUDGE_RAISE_LEVEL = 'source_of_funds'
+
+/**
  * The Manteca cap-nudge, if the user is carrying one.
  *
  *   - `raise`        — a fresh cap block. `actionKey` starts the source-of-funds
@@ -286,7 +300,15 @@ export function selectMantecaCapNudge(rails: RailCapability[], nextActions: Next
         const candidates = [...railHintActions(rail, byKey), rail.resolved?.nextAction]
         for (const action of candidates) {
             if (!action) continue
-            if (action.kind === 'sumsub' && action.purpose === CAP_NUDGE_RAISE_PURPOSE) {
+            // Rail-LOCAL identification. These come from a Manteca rail's own
+            // hint list, and Bridge requirements ride Bridge rails' blocking
+            // actions — so a source-of-funds RFI reached from here is the cap
+            // nudge whatever purpose the deduped descriptor ended up carrying.
+            const isSourceOfFunds =
+                action.purpose === CAP_NUDGE_RAISE_PURPOSE ||
+                action.key === CAP_NUDGE_RAISE_KEY ||
+                action.levelKey === CAP_NUDGE_RAISE_LEVEL
+            if (action.kind === 'sumsub' && isSourceOfFunds) {
                 return { state: 'raise', actionKey: action.key }
             }
             if (action.kind === 'wait' && action.purpose === CAP_NUDGE_REVIEW_PURPOSE) underReview = true

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -429,6 +429,14 @@ export type UserPreferences = {
      *  gets a new fingerprint and re-surfaces; the tasks always stay
      *  reachable under Profile → Unlocked regions. */
     pendingVerificationTasksDismissed?: string[]
+    /** ISO timestamp of a Manteca cap-nudge source-of-funds submission this
+     *  device made. Optimistic only: the backend stamps `submittedAt` on the
+     *  marker a webhook later, and until it does this is the only thing that
+     *  knows the document is already in. Deliberately SHORT-LIVED — see
+     *  CAP_NUDGE_SUBMITTED_TTL_MS — so a lost webhook re-offers the upload
+     *  rather than hiding it forever, and a genuinely new cap block is never
+     *  suppressed by a stale local flag. */
+    capNudgeSubmittedAt?: string
 }
 
 export const updateUserPreferences = (


### PR DESCRIPTION
## What

The Manteca cap-nudge has never appeared on a screen. The backend has been emitting `mantecaCapNudge` on capped rails for a while and `railVerdict` correctly attaches it to the enabled rail's `verdict.nextAction` — but the only downstream consumer of a hint, `firstAdvisory`, skips any action without an `effectiveDate`, and that field is only ever set on Bridge future-dated requirements. The nudge was dropped there, silently.

Consequence: a capped user had no in-app route to raising their limit. The one limit-raising CTA we ship (`IncreaseLimitsButton`) drives a different endpoint (`POST /users/increase-limits`) and is scoped to BR legacy users, so an AR user who hit the cap saw nothing at all.

## Surface: the limits page

Of the two candidates, this one. The limits page already owns limit raising and sits next to the existing button; the payment-time route would interrupt a transfer to advertise a limit raise.

That choice also decided the plumbing. `firstAdvisory` keeps its `effectiveDate` requirement — loosening it is precisely what would have pushed the nudge into the add-money/withdraw pre-empt modal — so the cap-nudge gets its own selector, `selectMantecaCapNudge`, and Bridge advisory behaviour is byte-identical (the pre-existing test pinning "a hint WITHOUT effectiveDate is not an advisory pre-empt" still passes untouched).

## Both states render

| marker | hint | card |
| --- | --- | --- |
| fresh cap block | `sumsub:source_of_funds`, `raise-manteca-limit` | description + CTA → source-of-funds Sumsub flow |
| RFI completed | `manteca:limit-review`, kind `wait` | review copy, **no control on it** |

The `wait` state matters: Sumsub accepting the document does not mean Manteca raised the cap (still a manual support step), so it must neither re-ask for a document already submitted nor claim a raise that hasn't happened. A genuinely new cap block re-seeds the marker and the actionable CTA comes back on its own — and a fresh block outranks an in-review sibling, so the CTA wins.

Both branches are pinned to the action `kind` the FE can actually honour, so a future backend that re-purposes either key cannot make the review state tappable.

Between the SDK submit and the backend stamping `submittedAt` there is a webhook round-trip, so the card flips to the review copy optimistically and drops the flag once the backend's own state takes over — otherwise the CTA lingers and invites a second upload of the same document.

The component is deliberately tiny, for the reason the card's PoA self-heal gives: the multi-phase KYC machinery is bank-onboarding shaped and completes on rail semantics this lifecycle never reaches.

## Verification

- `capability-gate.test.ts` — 8 new selector cases (hint with no `effectiveDate` surviving; review state; re-block precedence; verdict-vs-`hintActions` sourcing; Bridge advisory not matching; miskinded action not tappable). All 53 in the file pass.
- `CapNudgeCard.test.tsx` — 8 cases, one per state plus the start/failure/submit transitions.
- `tsc --noEmit` clean; prettier clean; ds-lint ratchet green (no metric increased).

## Not in this PR

The open question on peanut-api-ts#1423 — whether Manteca documents `POST /v2/documentations/uploadUrl` with `docType: FUNDS` and an async `OPERATION_LIMIT_UPDATED` confirmation — is unresolved and needs someone with Manteca dashboard access. Worth noting the asserted path *moved between review rounds* (`/v2/…` in the first two, `/crypto/v2/…` in the third); a documented vendor endpoint doesn't move, so the exact path needs confirming rather than copying. If it is real, the raise could be automated end-to-end and the `wait` state would clear on a *confirmed* raise rather than on Sumsub GREEN. Nothing here blocks that: it would change what clears the review state, not the states themselves.

Copy (`limits.capNudge`, en / es-419 / pt-BR) landed separately in #2852 and is already on `dev`.
