### PR TITLE
design(setup): residence step polish and onboarding safe-area cover

### DIFF
--- a/src/components/Common/CountryCombobox.tsx
+++ b/src/components/Common/CountryCombobox.tsx
@@ -15,6 +15,9 @@ interface CountryComboboxProps {
     placeholder?: string
     className?: string
     'aria-label'?: string
+    /** When set (and a country is picked), the trailing chevron becomes a clear
+     *  affordance for that pick. */
+    onClear?: () => void
 }
 
 const normalize = (text: string) =>
@@ -37,6 +40,7 @@ export const CountryCombobox = ({
     placeholder,
     className,
     'aria-label': ariaLabel,
+    onClear,
 }: CountryComboboxProps) => {
     const t = useTranslations('global.countryCombobox')
     const id = useId()
@@ -164,6 +168,18 @@ export const CountryCombobox = ({
                     >
                         <div className="flex size-6 items-center justify-center">
                             <Icon name="cancel" size={16} className="text-foreground-secondary" />
+                        </div>
+                    </Button>
+                ) : onClear && selected ? (
+                    <Button
+                        variant="transparent"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={onClear}
+                        className="absolute top-1/2 right-2 w-fit -translate-y-1/2 p-0"
+                        aria-label={t('removeCountry', { country: selected.label })}
+                    >
+                        <div className="flex size-6 items-center justify-center">
+                            <Icon name="cancel" size={16} className="text-foreground-primary" />
                         </div>
                     </Button>
                 ) : (

--- a/src/components/Global/AppShell/index.tsx
+++ b/src/components/Global/AppShell/index.tsx
@@ -49,6 +49,13 @@ export const AppShell = ({
                     on non-edge-to-edge Android — no-op there. On Android 15+ Capacitor
                     overwrites it with the natively measured inset. */}
                 <div className="bg-blue-300 pt-safe-top">{banner}</div>
+                {/* The strip above only RESERVES the inset — it scrolls away with the
+                    document on steps taller than the viewport (the dual-residence
+                    compare cards), and the illustration then rides up under the status
+                    bar. This cover paints the inset wherever the page is scrolled to,
+                    the same way the app variant does. Height is exactly the inset, so
+                    it stops short of the back button at top-8. */}
+                <div aria-hidden className="pointer-events-none fixed inset-x-0 top-0 z-40 h-safe-top bg-blue-300" />
                 {children}
                 {/* Bottom safe-area fill. Mirrors the strip above so the bottom
                     matches on edge-to-edge Android; iOS fills white (the panel

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -204,7 +204,11 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                             className="flex w-1/2 items-center justify-center gap-2 rounded-full py-3"
                         >
                             <Icon name="arrow-down-left" size={20} fill="black" />
-                            <span className="font-bold">{tNav('request')}</span>
+                            {/* Not navigation.request: that labels the user's OWN
+                                Request flow, and es-419 renders it "Recibir" —
+                                receiving, which is not what this button does to
+                                someone else's profile. */}
+                            <span className="font-bold">{t('requestAction')}</span>
                         </Button>
                     </div>
                 )}

--- a/src/components/Setup/Views/Residence.tsx
+++ b/src/components/Setup/Views/Residence.tsx
@@ -2,7 +2,10 @@ import { Notification } from '@/components/0_Bruddle/Notification'
 import BaseInput from '@/components/0_Bruddle/BaseInput'
 import { FieldError } from '@/components/0_Bruddle/FieldError'
 import { Button } from '@/components/0_Bruddle/Button'
+import { MiniHeader } from '@/components/0_Bruddle/MiniHeader'
 import { CountryCombobox } from '@/components/Common/CountryCombobox'
+import { useSetupImageOverride } from '@/components/Setup/components/SetupWrapper'
+import { PeanutCheering } from '@/assets/mascot'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { deriveResidenceRestrictionsFrom } from '@/hooks/useResidenceRestrictions'
 import { useResidenceRestrictionSetsWithStatus } from '@/hooks/useResidenceRestrictionSets'
@@ -26,6 +29,11 @@ type PartialRestriction = 'card' | 'banking'
 const UNDERLINED_LINK =
     'relative text-body-s underline underline-offset-2 after:absolute after:inset-x-0 after:-inset-y-3.5 focus-visible:outline-[3px] focus-visible:outline-action-focus'
 const CHANGE_COUNTRY_LINK = `mt-1 self-center text-center disabled:opacity-50 ${UNDERLINED_LINK}`
+const BULLET_ROW = 'flex items-start gap-2'
+// h-4 is the Body/XS line box, so the dot centres on the first line (and stays
+// put when the row wraps) without an off-scale margin nudge
+const BULLET_MARKER = 'flex h-4 shrink-0 items-center'
+const BULLET_DOT = 'size-1 rounded-round bg-action-primary'
 
 const ResidenceStep = () => {
     const t = useTranslations('setup')
@@ -51,6 +59,13 @@ const ResidenceStep = () => {
 
     const countryOptions = useMemo(() => buildResidenceCountryOptions(locale), [locale])
 
+    // a declared pair: two distinct countries, both on screen
+    const hasPair =
+        showSecondCountry &&
+        !!residenceCountry &&
+        !!secondResidenceCountry &&
+        residenceCountry !== secondResidenceCountry
+
     // The geo guess, only if it is actually offered in the list.
     const geoSuggestion = useMemo(() => {
         if (!geoCountryCode) return undefined
@@ -71,29 +86,32 @@ const ResidenceStep = () => {
         dispatch(setupActions.setResidenceCountry(value))
     }
 
-    const onContinue = () => {
-        if (!residenceCountry) return
+    // The picked primary is passed in, not read off the store: the dual-residence
+    // "Select <country>" buttons dispatch the promotion and continue in the same
+    // handler, so the store value this render closed over is a step behind.
+    const continueWith = (primary: string, second: string) => {
+        if (!primary) return
         posthog.capture(ANALYTICS_EVENTS.SIGNUP_RESIDENCE_SELECTED, {
-            residence_country: residenceCountry,
-            second_residence_country: secondResidenceCountry || undefined,
+            residence_country: primary,
+            second_residence_country: second || undefined,
             was_prefilled: wasPrefilledRef.current,
             geo_country: geoCountryCode?.toUpperCase() || undefined,
         })
-        if (restrictionSets.full.has(residenceCountry)) {
+        if (restrictionSets.full.has(primary)) {
             posthog.capture(ANALYTICS_EVENTS.SIGNUP_RESIDENCE_RESTRICTED_SHOWN, {
-                residence_country: residenceCountry,
+                residence_country: primary,
             })
             setView('restricted')
             return
         }
-        const partial: PartialRestriction | null = restrictionSets.cardOnly.has(residenceCountry)
+        const partial: PartialRestriction | null = restrictionSets.cardOnly.has(primary)
             ? 'card'
-            : restrictionSets.bankingOnly.has(residenceCountry)
+            : restrictionSets.bankingOnly.has(primary)
               ? 'banking'
               : null
         if (partial) {
             posthog.capture(ANALYTICS_EVENTS.SIGNUP_RESIDENCE_PARTIAL_SHOWN, {
-                residence_country: residenceCountry,
+                residence_country: primary,
                 restriction_type: partial,
             })
             setPartialRestriction(partial)
@@ -114,18 +132,40 @@ const ResidenceStep = () => {
         // limits on the compare cards, so the congrats claim would contradict
         // them. Advance silently instead — the heads-ups stay primary-driven.
         if (
-            secondResidenceCountry &&
-            (restrictionSets.full.has(secondResidenceCountry) ||
-                restrictionSets.cardOnly.has(secondResidenceCountry) ||
-                restrictionSets.bankingOnly.has(secondResidenceCountry))
+            second &&
+            (restrictionSets.full.has(second) ||
+                restrictionSets.cardOnly.has(second) ||
+                restrictionSets.bankingOnly.has(second))
         ) {
             void handleNext()
             return
         }
         posthog.capture(ANALYTICS_EVENTS.SIGNUP_RESIDENCE_CONGRATS_SHOWN, {
-            residence_country: residenceCountry,
+            residence_country: primary,
         })
         setView('congrats')
+    }
+
+    const onContinue = () => continueWith(residenceCountry, secondResidenceCountry)
+
+    // Picking a main residence from the compare cards promotes it and demotes
+    // the other; the pair itself is unchanged, only its order.
+    const onSelectPrimary = (primary: string) => {
+        const second = primary === residenceCountry ? secondResidenceCountry : residenceCountry
+        if (primary !== residenceCountry) {
+            wasPrefilledRef.current = false
+            dispatch(setupActions.setResidenceCountry(primary))
+            dispatch(setupActions.setSecondResidenceCountry(second))
+        }
+        continueWith(primary, second)
+    }
+
+    // Clearing one half of a declared pair leaves the other as the sole
+    // residence, back on the single-country selector.
+    const onRemoveCountry = (removed: 'primary' | 'second') => {
+        if (removed === 'primary') dispatch(setupActions.setResidenceCountry(secondResidenceCountry))
+        dispatch(setupActions.setSecondResidenceCountry(''))
+        setShowSecondCountry(false)
     }
 
     const onRestrictedContinue = () => {
@@ -152,6 +192,10 @@ const ResidenceStep = () => {
         })
         setView('notify-done')
     }
+
+    // celebration illustration for the "Good news" outcome only — the selector
+    // it shares a step with keeps the step's neutral greeting
+    useSetupImageOverride(view === 'congrats' ? PeanutCheering.src : null)
 
     /* The tier sets render from the bundled mirror and are replaced by the
        server-authoritative lists asynchronously. A congrats view reached
@@ -347,6 +391,7 @@ const ResidenceStep = () => {
                     // opens already filled instead of visibly changing itself.
                     value={residenceCountry || geoSuggestion}
                     onValueChange={onResidenceChange}
+                    onClear={hasPair ? () => onRemoveCountry('primary') : undefined}
                 />
                 <button
                     type="button"
@@ -371,6 +416,7 @@ const ResidenceStep = () => {
                         placeholder={t('residenceStep.secondCountryPlaceholder')}
                         value={secondResidenceCountry || undefined}
                         onValueChange={(value) => dispatch(setupActions.setSecondResidenceCountry(value))}
+                        onClear={hasPair ? () => onRemoveCountry('second') : undefined}
                     />
                 )}
                 {/* Dual-residence comparison: facts about each residence, not a
@@ -379,57 +425,98 @@ const ResidenceStep = () => {
                     verification, so there is nothing to win by answering
                     untruthfully. Entirely client-derived (restriction tiers +
                     the same static rail map Unlock payments renders). */}
-                {showSecondCountry &&
-                    residenceCountry &&
-                    secondResidenceCountry &&
-                    residenceCountry !== secondResidenceCountry && (
-                        <div className="mt-2 flex flex-col gap-3">
-                            <div className="grid grid-cols-2 gap-2">
-                                {[residenceCountry, secondResidenceCountry].map((iso2) => {
-                                    const summary = residenceAvailability(restrictionSets, iso2)
-                                    const label = countryOptions.find((option) => option.value === iso2)?.label ?? iso2
-                                    return (
-                                        <div
-                                            key={iso2}
-                                            className="rounded-sm border border-border-default bg-background-default p-3"
-                                        >
-                                            <p className="mb-1 text-label-m">
-                                                {t('residenceStep.compare.cardTitle', { country: label })}
-                                            </p>
-                                            <ul className="space-y-2 text-body-xs text-foreground-secondary">
-                                                {summary.available.map((item) => (
-                                                    <li key={item}>{t(`residenceStep.compare.items.${item}`)}</li>
-                                                ))}
-                                                {summary.unavailable.map((item) => (
-                                                    <li key={item} className="text-foreground-secondary line-through">
+                {hasPair && (
+                    <div className="mt-2 flex flex-col gap-3">
+                        <div className="grid grid-cols-2 gap-2">
+                            {[residenceCountry, secondResidenceCountry].map((iso2) => {
+                                const summary = residenceAvailability(restrictionSets, iso2)
+                                const label = countryOptions.find((option) => option.value === iso2)?.label ?? iso2
+                                return (
+                                    <div
+                                        key={iso2}
+                                        className="rounded-sm border border-border-default bg-background-default p-3"
+                                    >
+                                        <p className="mb-1 text-label-m">
+                                            {t('residenceStep.compare.cardTitle', { country: label })}
+                                        </p>
+                                        {/* Drawn rather than list-disc: an outside marker hangs
+                                                left of the text column and an inside one re-indents
+                                                wrapped lines, and neither puts the dot on the card
+                                                title's own left edge. */}
+                                        <ul className="space-y-2 text-body-xs text-foreground-secondary">
+                                            {summary.available.map((item) => (
+                                                <li key={item} className={BULLET_ROW}>
+                                                    <span aria-hidden className={BULLET_MARKER}>
+                                                        <span className={BULLET_DOT} />
+                                                    </span>
+                                                    <span>{t(`residenceStep.compare.items.${item}`)}</span>
+                                                </li>
+                                            ))}
+                                            {summary.unavailable.map((item) => (
+                                                <li key={item} className={BULLET_ROW}>
+                                                    <span aria-hidden className={BULLET_MARKER}>
+                                                        <span className={BULLET_DOT} />
+                                                    </span>
+                                                    <span className="line-through">
                                                         {t(`residenceStep.compare.missing.${item}`)}
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                            {/* One verification enrols every rail in the region's
+                                                    </span>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                        {/* One verification enrols every rail in the region's
                                                 set, but a rail in another currency only pays out
                                                 into an account on that network — so it is stated
                                                 as a condition, not as a benefit of living here. */}
-                                            {summary.multiCurrency && (
-                                                <p className="mt-2 text-body-xs text-foreground-secondary">
-                                                    {t('residenceStep.compare.multiCurrencyNote')}
-                                                </p>
-                                            )}
-                                        </div>
-                                    )
-                                })}
-                            </div>
-                            <Notification priority="info" hideIcon title={t('residenceStep.compare.guideTitle')}>
-                                <p>{t('residenceStep.compare.guideDeclaration')}</p>
-                                <p className="mt-1">{t('residenceStep.compare.guideOrder')}</p>
-                                <p className="mt-1">{t('residenceStep.compare.guideSecond')}</p>
-                            </Notification>
+                                        {summary.multiCurrency && (
+                                            <p className="mt-2 text-body-xs text-foreground-secondary">
+                                                {t('residenceStep.compare.multiCurrencyNote')}
+                                            </p>
+                                        )}
+                                    </div>
+                                )
+                            })}
                         </div>
-                    )}
+                        {/* The title slot is a sentence-case Body/S line; this guidance
+                                labels a block of prose, so it takes the mini-header step. */}
+                        <Notification priority="info" hideIcon>
+                            <MiniHeader className="mb-1 text-inherit">
+                                {t('residenceStep.compare.guideTitle')}
+                            </MiniHeader>
+                            <p>{t('residenceStep.compare.guideDeclaration')}</p>
+                            <p className="mt-1">{t('residenceStep.compare.guideOrder')}</p>
+                        </Notification>
+                    </div>
+                )}
             </div>
-            <Button shadowSize="4" onClick={onContinue} disabled={!residenceCountry || isLoading} loading={isLoading}>
-                {t('next')}
-            </Button>
+            {/* One button per declared country: the tap IS the main-residence
+                declaration, so there is no separate order control to get wrong. */}
+            {hasPair ? (
+                <div className="flex w-full flex-col gap-3">
+                    {[residenceCountry, secondResidenceCountry].map((iso2) => (
+                        <Button
+                            key={iso2}
+                            shadowSize="4"
+                            variant={iso2 === residenceCountry ? 'purple' : 'stroke'}
+                            onClick={() => onSelectPrimary(iso2)}
+                            disabled={isLoading}
+                            loading={isLoading}
+                        >
+                            {t('residenceStep.compare.selectCountry', {
+                                country: countryOptions.find((option) => option.value === iso2)?.label ?? iso2,
+                            })}
+                        </Button>
+                    ))}
+                </div>
+            ) : (
+                <Button
+                    shadowSize="4"
+                    onClick={onContinue}
+                    disabled={!residenceCountry || isLoading}
+                    loading={isLoading}
+                >
+                    {t('next')}
+                </Button>
+            )}
         </div>
     )
 }

--- a/src/components/Setup/Views/Residence.tsx
+++ b/src/components/Setup/Views/Residence.tsx
@@ -163,7 +163,12 @@ const ResidenceStep = () => {
     // Clearing one half of a declared pair leaves the other as the sole
     // residence, back on the single-country selector.
     const onRemoveCountry = (removed: 'primary' | 'second') => {
-        if (removed === 'primary') dispatch(setupActions.setResidenceCountry(secondResidenceCountry))
+        if (removed === 'primary') {
+            // the promoted country was typed, not suggested — leaving the flag set
+            // would attribute it to the geo guess for the rest of the step
+            wasPrefilledRef.current = false
+            dispatch(setupActions.setResidenceCountry(secondResidenceCountry))
+        }
         dispatch(setupActions.setSecondResidenceCountry(''))
         setShowSecondCountry(false)
     }

--- a/src/components/Setup/Views/__tests__/Residence.test.tsx
+++ b/src/components/Setup/Views/__tests__/Residence.test.tsx
@@ -129,6 +129,47 @@ describe('ResidenceStep', () => {
         expect(screen.getByText(/genuinely hold legal residence/)).toBeInTheDocument()
     })
 
+    it('replaces Next with one main-residence button per declared country', () => {
+        mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
+        render(<ResidenceStep />)
+        expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Select Brazil' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Select Germany' })).toBeInTheDocument()
+    })
+
+    it('promotes the picked country to main residence before continuing', () => {
+        // The tap IS the declaration: picking the second entry swaps the pair's
+        // order, and the outcome must be evaluated against the picked country —
+        // not the store value this render closed over.
+        mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
+        render(<ResidenceStep />)
+        fireEvent.click(screen.getByRole('button', { name: 'Select Germany' }))
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setResidenceCountry('DE'))
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setSecondResidenceCountry('BR'))
+        expect(mockedCapture).toHaveBeenCalledWith(
+            ANALYTICS_EVENTS.SIGNUP_RESIDENCE_SELECTED,
+            expect.objectContaining({ residence_country: 'DE', second_residence_country: 'BR' })
+        )
+    })
+
+    it('clearing the first country leaves the second as the only residence', () => {
+        mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
+        render(<ResidenceStep />)
+        fireEvent.click(screen.getByRole('button', { name: 'Remove Brazil' }))
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setResidenceCountry('DE'))
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setSecondResidenceCountry(''))
+        expect(screen.queryByText('Available with Brazil')).not.toBeInTheDocument()
+    })
+
+    it('clearing the second country keeps the first and collapses the pair', () => {
+        mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
+        render(<ResidenceStep />)
+        fireEvent.click(screen.getByRole('button', { name: 'Remove Germany' }))
+        expect(mockDispatch).not.toHaveBeenCalledWith(setupActions.setResidenceCountry('DE'))
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setSecondResidenceCountry(''))
+        expect(screen.queryByText('Available with Germany')).not.toBeInTheDocument()
+    })
+
     it('shows the congrats screen for an unrestricted residence and continues on demand', () => {
         mockSetupState.residenceCountry = 'BR'
         render(<ResidenceStep />)
@@ -218,7 +259,7 @@ describe('ResidenceStep', () => {
         // silently, like the flow did before the congrats screen existed.
         mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'GB' }
         render(<ResidenceStep />)
-        fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Select Brazil' }))
         expect(mockHandleNext).toHaveBeenCalled()
         expect(screen.queryByText('Good news')).not.toBeInTheDocument()
         expect(mockedCapture).not.toHaveBeenCalledWith(

--- a/src/components/Setup/Views/__tests__/Residence.test.tsx
+++ b/src/components/Setup/Views/__tests__/Residence.test.tsx
@@ -161,6 +161,26 @@ describe('ResidenceStep', () => {
         expect(screen.queryByText('Available with Brazil')).not.toBeInTheDocument()
     })
 
+    it('stops attributing a promoted country to the geo suggestion', () => {
+        // BR was suggested by geo; the user added DE and then cleared BR. DE was
+        // typed, so continuing must not report it as a prefilled geo match.
+        mockGeoCountry = 'br'
+        const view = render(<ResidenceStep />)
+        // the geo effect prefilled BR and latched the flag
+        expect(mockDispatch).toHaveBeenCalledWith(setupActions.setResidenceCountry('BR'))
+        mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
+        view.rerender(<ResidenceStep />)
+        fireEvent.click(screen.getByText('Have documents from more than one country?'))
+        fireEvent.click(screen.getByRole('button', { name: 'Remove Brazil' }))
+        mockSetupState = { residenceCountry: 'DE', secondResidenceCountry: '' }
+        view.rerender(<ResidenceStep />)
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+        expect(mockedCapture).toHaveBeenCalledWith(
+            ANALYTICS_EVENTS.SIGNUP_RESIDENCE_SELECTED,
+            expect.objectContaining({ residence_country: 'DE', was_prefilled: false })
+        )
+    })
+
     it('clearing the second country keeps the first and collapses the pair', () => {
         mockSetupState = { residenceCountry: 'BR', secondResidenceCountry: 'DE' }
         render(<ResidenceStep />)

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -19,8 +19,34 @@ import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import posthog from 'posthog-js'
-import { Children, type ReactNode, cloneElement, memo, type ReactElement, useState } from 'react'
+import {
+    Children,
+    type ReactNode,
+    cloneElement,
+    createContext,
+    memo,
+    type ReactElement,
+    useContext,
+    useEffect,
+    useState,
+} from 'react'
 import { twMerge } from '@/utils/tw'
+
+const SetupImageContext = createContext<(src: string | null) => void>(() => {})
+
+/**
+ * Lets a step's sub-view swap the wrapper's illustration for as long as it is
+ * mounted — the residence step's "Good news" outcome celebrates, while the
+ * selector it shares a step with keeps the neutral greeting. Sub-views are not
+ * steps, so they have no step config of their own to carry an image.
+ */
+export const useSetupImageOverride = (src: string | null) => {
+    const setImage = useContext(SetupImageContext)
+    useEffect(() => {
+        setImage(src)
+        return () => setImage(null)
+    }, [src, setImage])
+}
 
 /**
  * props interface for the SetupWrapper component
@@ -282,6 +308,7 @@ export const SetupWrapper = memo(function SetupWrapper({
     titleClassName,
 }: SetupWrapperProps) {
     const t = useTranslations('setup.braveInstall')
+    const [imageOverride, setImageOverride] = useState<string | null>(null)
     const { isBrave } = useBravePWAInstallState()
     const [showBraveSuccessMessage, setShowBraveSuccessMessage] = useState(false)
     const prefersReducedMotion = useReducedMotion()
@@ -328,7 +355,7 @@ export const SetupWrapper = memo(function SetupWrapper({
                     imageClassName={imageClassName}
                     screenId={screenId}
                     layoutType={layoutType}
-                    image={image}
+                    image={imageOverride ?? image}
                 />
 
                 {/* content section */}
@@ -382,18 +409,20 @@ export const SetupWrapper = memo(function SetupWrapper({
                     )}
                     {/* main content area */}
                     <div className="mx-auto w-full md:max-w-xs">
-                        {Children.map(children, (child) => {
-                            if ((child as ReactElement).type === InstallPWA) {
-                                return cloneElement(child as ReactElement, {
-                                    deferredPrompt,
-                                    canInstall,
-                                    deviceType,
-                                    screenId,
-                                    setShowBraveSuccessMessage,
-                                })
-                            }
-                            return child
-                        })}
+                        <SetupImageContext.Provider value={setImageOverride}>
+                            {Children.map(children, (child) => {
+                                if ((child as ReactElement).type === InstallPWA) {
+                                    return cloneElement(child as ReactElement, {
+                                        deferredPrompt,
+                                        canInstall,
+                                        deviceType,
+                                        screenId,
+                                        setShowBraveSuccessMessage,
+                                    })
+                                }
+                                return child
+                            })}
+                        </SetupImageContext.Provider>
                     </div>
                 </motion.div>
             </div>

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -165,8 +165,12 @@ const Navigation = memo(function Navigation({
 
     // Icons inherit currentColor: the stroke button inverts on hover/active, and
     // a hard-coded fill vanished into the black background.
+    // The row's containing block is the initial one (no positioned ancestor), so a
+    // bare top-8 is 32px from the VIEWPORT — under the status bar on any device
+    // whose inset is deeper than that, and under the shell's inset cover with it.
+    // Same max() shape the QR scanner header uses.
     return (
-        <div className="absolute top-8 z-20 flex w-full items-center justify-between px-6">
+        <div className="absolute top-[max(2rem,calc(var(--safe-top)_+_0.5rem))] z-20 flex w-full items-center justify-between px-6">
             <div>
                 {showBackButton && (
                     <Button

--- a/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
+++ b/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
@@ -71,6 +71,15 @@ describe('SetupWrapper navigation', () => {
         expect(svg).toHaveAttribute('stroke', 'currentColor')
     })
 
+    it('offsets the navigation row by the measured safe-area inset', () => {
+        // The row's containing block is the initial one, so a bare top-8 is 32px
+        // from the viewport — under the status bar (and under the shell's inset
+        // cover) on any device whose inset runs deeper than that.
+        renderWrapper({ showBackButton: true, onBack: jest.fn() })
+        const row = screen.getByRole('button', { name: 'Go back' }).closest('div.absolute')
+        expect(row?.className).toContain('top-[max(2rem,calc(var(--safe-top)_+_0.5rem))]')
+    })
+
     it('fires onBack from the back button', () => {
         const onBack = jest.fn()
         renderWrapper({ showBackButton: true, onBack })

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -849,7 +849,7 @@
                 "multiCurrencyNote": "Transfers in another currency need a bank account in that currency.",
                 "guideTitle": "Which country goes first?",
                 "guideDeclaration": "Both entries must be countries where you genuinely hold legal residence. This is a declaration, and providers verify it during the ID check, including proof of address.",
-                "guideOrder": "If both countries are truly home, pick the one to record as your main residence. Eligibility is decided by the documents you provide at verification.",
+                "guideOrder": "If both countries are truly home, pick the one to record as your main residence. Eligibility follows the residence you verify — the address you prove at the ID check.",
                 "selectCountry": "Select {country}"
             }
         },

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -526,7 +526,8 @@
             "begShareText": "Bro… I'm on my knees. Peanut is invite-only and I'm locked outside. Save my life and send me your invite",
             "begForInvite": "Beg for an invite",
             "activityPrivateNote": "Activity is only visible for you, it is not public.",
-            "noInviteTitle": "No invite, no Peanut"
+            "noInviteTitle": "No invite, no Peanut",
+            "requestAction": "Request"
         },
         "iosCopy": {
             "menu": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -814,7 +814,7 @@
                     "arQr": "QR payments and transfers",
                     "spei": "SPEI transfers",
                     "usdAch": "USD transfers (ACH and wire)",
-                    "eurSepa": "SEPA bank transfers",
+                    "eurSepa": "bank transfers",
                     "gbpFps": "GBP bank transfers (Faster Payments)"
                 },
                 "continue": "Continue"
@@ -849,8 +849,8 @@
                 "multiCurrencyNote": "Transfers in another currency need a bank account in that currency.",
                 "guideTitle": "Which country goes first?",
                 "guideDeclaration": "Both entries must be countries where you genuinely hold legal residence. This is a declaration, and providers verify it during the ID check, including proof of address.",
-                "guideOrder": "If both countries are truly home, either order is honest. The order only changes what the app shows you first, never what you are eligible for. Eligibility is decided by the verification itself.",
-                "guideSecond": "Your second country stays on record. You can verify its payment rails anytime from Unlock payments, and change the order later."
+                "guideOrder": "If both countries are truly home, pick the one to record as your main residence. Eligibility is decided by the documents you provide at verification.",
+                "selectCountry": "Select {country}"
             }
         },
         "passkey": {
@@ -3499,7 +3499,8 @@
         },
         "countryCombobox": {
             "noResults": "No countries match",
-            "clear": "Clear search"
+            "clear": "Clear search",
+            "removeCountry": "Remove {country}"
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -814,7 +814,7 @@
                     "arQr": "pagos y transferencias con QR",
                     "spei": "transferencias SPEI",
                     "usdAch": "transferencias en USD (ACH y wire)",
-                    "eurSepa": "transferencias bancarias SEPA",
+                    "eurSepa": "transferencias bancarias",
                     "gbpFps": "transferencias bancarias en GBP (Faster Payments)"
                 },
                 "continue": "Continuar"
@@ -849,8 +849,8 @@
                 "multiCurrencyNote": "Las transferencias en otra moneda requieren una cuenta bancaria en esa moneda.",
                 "guideTitle": "¿Qué país va primero?",
                 "guideDeclaration": "Ambos deben ser países donde realmente tienes residencia legal. Es una declaración, y los proveedores la verifican durante la verificación de identidad, incluido el comprobante de domicilio.",
-                "guideOrder": "Si ambos países son realmente tu hogar, cualquier orden es honesto. El orden solo cambia lo que la app te muestra primero, nunca aquello a lo que eres elegible. La elegibilidad la decide la verificación misma.",
-                "guideSecond": "Tu segundo país queda registrado. Puedes verificar sus métodos de pago en cualquier momento desde Desbloquear pagos, y cambiar el orden más adelante."
+                "guideOrder": "Si ambos países son realmente tu hogar, elige cuál quedará registrado como tu residencia principal. La elegibilidad la deciden los documentos que presentes en la verificación.",
+                "selectCountry": "Elegir {country}"
             }
         },
         "passkey": {
@@ -3499,7 +3499,8 @@
         },
         "countryCombobox": {
             "noResults": "Ningún país coincide",
-            "clear": "Borrar búsqueda"
+            "clear": "Borrar búsqueda",
+            "removeCountry": "Quitar {country}"
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -849,7 +849,7 @@
                 "multiCurrencyNote": "Las transferencias en otra moneda requieren una cuenta bancaria en esa moneda.",
                 "guideTitle": "¿Qué país va primero?",
                 "guideDeclaration": "Ambos deben ser países donde realmente tienes residencia legal. Es una declaración, y los proveedores la verifican durante la verificación de identidad, incluido el comprobante de domicilio.",
-                "guideOrder": "Si ambos países son realmente tu hogar, elige cuál quedará registrado como tu residencia principal. La elegibilidad la deciden los documentos que presentes en la verificación.",
+                "guideOrder": "Si ambos países son realmente tu hogar, elige cuál quedará registrado como tu residencia principal. La elegibilidad depende de la residencia que verifiques: el domicilio que compruebas en la verificación de identidad.",
                 "selectCountry": "Elegir {country}"
             }
         },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -526,7 +526,8 @@
             "begShareText": "Bro… estoy de rodillas. Peanut es solo por invitación y me quedé afuera. Sálvame la vida y mándame tu invitación",
             "begForInvite": "Rogar por una invitación",
             "activityPrivateNote": "La actividad solo es visible para ti, no es pública.",
-            "noInviteTitle": "Sin invitación no hay Peanut"
+            "noInviteTitle": "Sin invitación no hay Peanut",
+            "requestAction": "Solicitar"
         },
         "iosCopy": {
             "menu": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -506,8 +506,8 @@
                 },
                 "guideTitle": "¿Qué país va primero?",
                 "guideDeclaration": "Ambos deben ser países donde realmente tenés residencia legal. Es una declaración, y los proveedores la verifican durante la verificación de identidad, incluido el comprobante de domicilio.",
-                "guideOrder": "Si ambos países son realmente tu hogar, cualquier orden es honesto. El orden solo cambia lo que la app te muestra primero, nunca aquello a lo que sos elegible. La elegibilidad la decide la verificación misma.",
-                "guideSecond": "Tu segundo país queda registrado. Podés verificar sus métodos de pago en cualquier momento desde Desbloquear pagos, y cambiar el orden más adelante."
+                "guideOrder": "Si ambos países son realmente tu hogar, elegí cuál quedará registrado como tu residencia principal. La elegibilidad la deciden los documentos que presentes en la verificación.",
+                "selectCountry": "Elegir {country}"
             }
         },
         "passkey": {
@@ -1512,7 +1512,8 @@
         },
         "countryCombobox": {
             "noResults": "Ningún país coincide",
-            "clear": "Borrar búsqueda"
+            "clear": "Borrar búsqueda",
+            "removeCountry": "Quitar {country}"
         }
     },
     "errors": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -506,7 +506,7 @@
                 },
                 "guideTitle": "¿Qué país va primero?",
                 "guideDeclaration": "Ambos deben ser países donde realmente tenés residencia legal. Es una declaración, y los proveedores la verifican durante la verificación de identidad, incluido el comprobante de domicilio.",
-                "guideOrder": "Si ambos países son realmente tu hogar, elegí cuál quedará registrado como tu residencia principal. La elegibilidad la deciden los documentos que presentes en la verificación.",
+                "guideOrder": "Si ambos países son realmente tu hogar, elegí cuál quedará registrado como tu residencia principal. La elegibilidad depende de la residencia que verifiques: el domicilio que comprobás en la verificación de identidad.",
                 "selectCountry": "Elegir {country}"
             }
         },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -814,7 +814,7 @@
                     "arQr": "pagamentos e transferências por QR",
                     "spei": "transferências SPEI",
                     "usdAch": "transferências em USD (ACH e wire)",
-                    "eurSepa": "transferências bancárias SEPA",
+                    "eurSepa": "transferências bancárias",
                     "gbpFps": "transferências bancárias em GBP (Faster Payments)"
                 },
                 "continue": "Continuar"
@@ -849,8 +849,8 @@
                 "multiCurrencyNote": "Transferências em outra moeda exigem uma conta bancária nessa moeda.",
                 "guideTitle": "Qual país vem primeiro?",
                 "guideDeclaration": "Os dois devem ser países onde você realmente tem residência legal. Isso é uma declaração, e os provedores a verificam durante a verificação de identidade, incluindo o comprovante de residência.",
-                "guideOrder": "Se os dois países são realmente seu lar, qualquer ordem é honesta. A ordem só muda o que o app mostra primeiro, nunca aquilo a que você é elegível. A elegibilidade é decidida pela própria verificação.",
-                "guideSecond": "Seu segundo país fica registrado. Você pode verificar os métodos de pagamento dele a qualquer momento em Desbloquear pagamentos, e mudar a ordem depois."
+                "guideOrder": "Se os dois países são realmente seu lar, escolha qual ficará registrado como sua residência principal. A elegibilidade é decidida pelos documentos que você apresentar na verificação.",
+                "selectCountry": "Escolher {country}"
             }
         },
         "passkey": {
@@ -3499,7 +3499,8 @@
         },
         "countryCombobox": {
             "noResults": "Nenhum país encontrado",
-            "clear": "Limpar busca"
+            "clear": "Limpar busca",
+            "removeCountry": "Remover {country}"
         }
     },
     "errors": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -849,7 +849,7 @@
                 "multiCurrencyNote": "Transferências em outra moeda exigem uma conta bancária nessa moeda.",
                 "guideTitle": "Qual país vem primeiro?",
                 "guideDeclaration": "Os dois devem ser países onde você realmente tem residência legal. Isso é uma declaração, e os provedores a verificam durante a verificação de identidade, incluindo o comprovante de residência.",
-                "guideOrder": "Se os dois países são realmente seu lar, escolha qual ficará registrado como sua residência principal. A elegibilidade é decidida pelos documentos que você apresentar na verificação.",
+                "guideOrder": "Se os dois países são realmente seu lar, escolha qual ficará registrado como sua residência principal. A elegibilidade depende da residência que você verificar: o endereço que você comprova na verificação de identidade.",
                 "selectCountry": "Escolher {country}"
             }
         },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -526,7 +526,8 @@
             "begShareText": "Mano… estou de joelhos. O Peanut é só por convite e fiquei de fora. Salva minha vida e me manda seu convite",
             "begForInvite": "Implorar por um convite",
             "activityPrivateNote": "A atividade é visível só para você, não é pública.",
-            "noInviteTitle": "Sem convite, sem Peanut"
+            "noInviteTitle": "Sem convite, sem Peanut",
+            "requestAction": "Cobrar"
         },
         "iosCopy": {
             "menu": {


### PR DESCRIPTION
Design pass on the two residence screens, plus one real bug found while reproducing it.

## Onboarding safe area (bug)

`AppShell` variant `onboarding` only **reserved** the status-bar inset — a static padded div at the document top. On any setup step taller than the viewport it scrolled away with the document and the illustration rode up under the status bar. The dual-residence compare cards are what make this step tall enough to hit it.

The `app` variant already paints a fixed cover for exactly this; the onboarding variant now does too (`bg-blue-300`, `h-safe-top`, `z-40` — exactly the inset height, so it stops short of the back button at `top-8`). No-op on web and on non-edge-to-edge Android, where the inset is 0.

## "Good news"

- Celebrates with its own illustration (`PeanutCheering`) instead of inheriting the step's neutral greeting. Sub-views are not steps and have no step config to carry an image, so `SetupWrapper` now exposes `useSetupImageOverride` — claimed while the view is mounted, released on unmount.
- The SEPA-zone rail phrase now reads **"bank transfers"**: *"…a quick ID check unlocks bank transfers."*

  Per `mono/product/countries.md`, one Bridge verification opens **all four** rails — SEPA (EUR), ACH/wire (USD), Faster Payments (GBP), SPEI (MXN) — to the user whatever their residence (UK residents excepted, blocked from Bridge entirely). Naming one scheme understated what the ID check actually unlocks, and the same file warns that SEPA membership and Bridge's coverage list disagree (Monaco / San Marino / Vatican are members but see "coming soon"), so promising the scheme by name is the copy shape it tells us to avoid. Only the congrats phrase changed — the compare cards still say "SEPA transfers (EUR)", where the label is a per-country fact, and PIX / SPEI / ACH / Faster Payments are untouched per the same file's "marketing should still lead with the local one".

## "Where do you legally live?"

- **Clear affordance.** Once a pair is declared, each combobox swaps its chevron for an X. Clearing the first promotes the second to sole residence; clearing the second just drops it. Either lands back on the single-country selector.
- **The pair's `Next` becomes one button per country.** The tap **is** the main-residence declaration — it promotes the picked country and demotes the other. That needed the continue path to take the picked country as an argument instead of reading the store, which is a render behind the dispatch.
- **Guidance rewritten to match.** It used to say either order is honest and only changes what the app shows first; that is no longer true now that the tap records the choice. It now reads: *"If both countries are truly home, pick the one to record as your main residence. Eligibility is decided by the documents you provide at verification."* The "second country stays on record / change the order later" paragraph is gone.
- **Guidance title** takes the DS `MiniHeader` step (uppercase label) instead of the Notification's sentence-case title slot.
- **Comparison lists get pink bullets**, drawn rather than `list-disc`: an outside marker hangs left of the text column and an inside one re-indents wrapped lines, and neither puts the dot on the card title's own left edge. Wrapped rows hang correctly.

All copy changes are in en / es-419 / es-AR / pt-BR.

## Verification

- `tsc --noEmit` clean; `ds-lint --check` no ratchet increase; prettier clean.
- Residence suite 48/48, including four new cases: the two Select buttons replacing `Next`, the promotion-before-continue path, and both clear directions.
- i18n + AppShell + SetupWrapper + CountryCombobox suites green (332 tests).
- Every state screenshotted against the dev server (selector, declared pair, after-clear, Good news, and the safe area before/after at the same scroll position with a 40px inset simulated).

## Open question

Struck-through unavailable rows currently carry the same pink dot as available ones, so the strike is the only differentiator. Happy to mute those to grey if that reads better.
