### PR TITLE
feat(migration): QR payload hand-off through /app, store pair fixes, app-link coverage (TASK-21788)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,8 @@
 
                 <data android:scheme="https" android:host="peanut.me" />
 
+                <data android:path="/app" />
+                <data android:pathPrefix="/app/" />
                 <data android:path="/home" />
                 <data android:pathPrefix="/home/" />
                 <data android:path="/card" />

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,6 +5,7 @@
             {
                 "appID": "4K73GMPZP8.com.squirrellabs.peanut-app",
                 "paths": [
+                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",
@@ -26,6 +27,7 @@
             {
                 "appID": "web.app.peanut",
                 "paths": [
+                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",
@@ -47,6 +49,7 @@
             {
                 "appID": "PW388G893L.me.peanut.wallet",
                 "paths": [
+                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",

--- a/src/app/app/__tests__/smart-store-link.test.tsx
+++ b/src/app/app/__tests__/smart-store-link.test.tsx
@@ -1,0 +1,169 @@
+/** @jest-environment jsdom */
+/**
+ * /app — the smart store link a download QR encodes.
+ *
+ * The branching here is the whole deferred-deep-link hand-off: android may
+ * bounce automatically because the payload rides the Play install referrer,
+ * iOS may NOT, because the clipboard write only succeeds inside the tap. A
+ * regression that auto-redirects iOS loses the context for every scan without
+ * anything visibly breaking.
+ */
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { STORE_URL } from '@/constants/migration.consts'
+
+let mockDeviceType = 'web'
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: mockDeviceType }),
+}))
+
+const mockReplace = jest.fn()
+const mockNotFound = jest.fn()
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ replace: mockReplace }),
+    notFound: () => mockNotFound(),
+}))
+
+// flags land immediately: the page waits for this callback (or a 4s timeout)
+// before it is willing to 404
+jest.mock('posthog-js', () => ({
+    capture: jest.fn(),
+    onFeatureFlags: jest.fn((cb: () => void) => {
+        cb()
+        return jest.fn()
+    }),
+}))
+
+let mockNative = false
+jest.mock('@/utils/capacitor', () => ({
+    isNativeBridge: () => mockNative,
+    isCapacitor: () => mockNative,
+    isAndroidNative: () => false,
+    isIOSNative: () => false,
+    openExternalUrl: jest.fn(),
+}))
+
+let mockFlagOn = true
+jest.mock('@/utils/migration.utils', () => ({
+    isPwaSunsetOn: () => mockFlagOn,
+    trackStoreClick: jest.fn(),
+}))
+
+// the marker check is the real one (pinned in deferred-link.test.ts); only the
+// side-effecting ends are stubbed so the test can see what changed hands
+const mockCopyIOSHandoff = jest.fn().mockResolvedValue(undefined)
+const mockTrackHandoffCreated = jest.fn()
+const mockApplyDeferredPayload = jest.fn<{ dest: string | null; locale: null }, [unknown]>(() => ({
+    dest: null,
+    locale: null,
+}))
+jest.mock('@/utils/deferred-link', () => ({
+    ...jest.requireActual('@/utils/deferred-link'),
+    copyIOSHandoff: (...args: unknown[]) => mockCopyIOSHandoff(...args),
+    trackDeferredHandoffCreated: (...args: unknown[]) => mockTrackHandoffCreated(...args),
+    applyDeferredPayload: (payload: unknown) => mockApplyDeferredPayload(payload),
+}))
+
+jest.mock('@/components/Migration/MigrationHero', () => ({
+    __esModule: true,
+    default: () => <div data-testid="hero" />,
+}))
+
+import { trackStoreClick } from '@/utils/migration.utils'
+import SmartStoreRedirect from '../page'
+
+const PAYLOAD = 'pnutdl=1&lang=pt-br&invite=ABC123&dest=%2Fsend'
+const locationReplace = jest.fn()
+
+function visit(search: string) {
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+            origin: 'https://peanut.me',
+            pathname: '/app',
+            search,
+            href: `https://peanut.me/app${search}`,
+            replace: locationReplace,
+        },
+    })
+}
+
+const renderPage = () => render(<SmartStoreRedirect />, { wrapper: IntlWrapper })
+const link = (name: RegExp) => screen.getByRole('link', { name })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeviceType = 'web'
+    mockNative = false
+    mockFlagOn = true
+    visit('')
+})
+
+describe('/app smart store link', () => {
+    it('bounces a bare visit straight to the device store (today’s behaviour)', () => {
+        mockDeviceType = 'ios'
+        renderPage()
+        expect(locationReplace).toHaveBeenCalledWith(STORE_URL.ios)
+        expect(mockTrackHandoffCreated).not.toHaveBeenCalled()
+    })
+
+    it('bounces android with the payload on the install referrer', () => {
+        mockDeviceType = 'android'
+        visit(`?${PAYLOAD}&s=landing_hero`)
+        renderPage()
+        // the surface tag is ours, not the app's — it must not ride along
+        expect(locationReplace).toHaveBeenCalledWith(`${STORE_URL.android}&referrer=${encodeURIComponent(PAYLOAD)}`)
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('android')
+    })
+
+    it('never auto-redirects iOS with a payload — the clipboard needs the tap', () => {
+        mockDeviceType = 'ios'
+        visit(`?${PAYLOAD}`)
+        renderPage()
+        expect(locationReplace).not.toHaveBeenCalled()
+        expect(link(/app store/i)).toHaveAttribute('href', STORE_URL.ios)
+        expect(link(/google play/i)).toBeInTheDocument()
+
+        fireEvent.click(link(/app store/i))
+        expect(mockCopyIOSHandoff).toHaveBeenCalledWith(PAYLOAD)
+        expect(trackStoreClick).toHaveBeenCalledWith('ios', 'smart_link', true)
+    })
+
+    it('ignores a querystring without the marker', () => {
+        mockDeviceType = 'ios'
+        visit('?utm_source=newsletter')
+        renderPage()
+        expect(locationReplace).toHaveBeenCalledWith(STORE_URL.ios)
+    })
+
+    it('shows both stores on desktop and never redirects', () => {
+        renderPage()
+        expect(locationReplace).not.toHaveBeenCalled()
+        expect(screen.getAllByRole('link')).toHaveLength(2)
+    })
+
+    it('inside the app, applies the payload and routes to its destination', () => {
+        mockNative = true
+        mockApplyDeferredPayload.mockReturnValue({ dest: '/send', locale: null })
+        visit(`?${PAYLOAD}`)
+        renderPage()
+        expect(mockApplyDeferredPayload).toHaveBeenCalledWith(expect.objectContaining({ invite: 'ABC123' }))
+        expect(mockReplace).toHaveBeenCalledWith('/send')
+        expect(locationReplace).not.toHaveBeenCalled()
+    })
+
+    it('inside the app with no payload, still goes home', () => {
+        mockNative = true
+        renderPage()
+        expect(mockApplyDeferredPayload).not.toHaveBeenCalled()
+        expect(mockReplace).toHaveBeenCalledWith('/home')
+    })
+
+    it('404s while the flag is off', () => {
+        mockFlagOn = false
+        renderPage()
+        expect(mockNotFound).toHaveBeenCalled()
+    })
+})

--- a/src/app/app/__tests__/smart-store-link.test.tsx
+++ b/src/app/app/__tests__/smart-store-link.test.tsx
@@ -115,7 +115,34 @@ describe('/app smart store link', () => {
         renderPage()
         // the surface tag is ours, not the app's — it must not ride along
         expect(locationReplace).toHaveBeenCalledWith(`${STORE_URL.android}&referrer=${encodeURIComponent(PAYLOAD)}`)
-        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('android')
+        // the tag never reaches the app, but it does reach our own analytics:
+        // otherwise every smart_link event looks the same and the hero, app
+        // fold, footer and rates QRs are indistinguishable in the funnel
+        expect(mockTrackHandoffCreated).toHaveBeenCalledWith('android', { qr_surface: 'landing_hero' })
+    })
+
+    /*
+     * DEFERRED_LINK_HANDOFF_CREATED is the denominator for
+     * DEFERRED_LINK_RESTORED. The auto-redirect counts one; when the store
+     * intent does not take over the buttons come back clickable, and a tap
+     * used to count a second for the same visit — deflating the match rate on
+     * exactly the devices where the bounce is flaky.
+     */
+    it('counts the android hand-off once per visit, redirect plus tap', () => {
+        mockDeviceType = 'android'
+        visit(`?${PAYLOAD}&s=landing_footer`)
+        renderPage()
+        expect(mockTrackHandoffCreated).toHaveBeenCalledTimes(1)
+        fireEvent.click(link(/google play/i))
+        expect(mockTrackHandoffCreated).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores a surface tag that is not a known surface', () => {
+        mockDeviceType = 'ios'
+        visit(`?${PAYLOAD}&s=not_a_surface`)
+        renderPage()
+        fireEvent.click(link(/app store/i))
+        expect(trackStoreClick).toHaveBeenCalledWith('ios', 'smart_link', true, null)
     })
 
     it('never auto-redirects iOS with a payload — the clipboard needs the tap', () => {
@@ -128,7 +155,15 @@ describe('/app smart store link', () => {
 
         fireEvent.click(link(/app store/i))
         expect(mockCopyIOSHandoff).toHaveBeenCalledWith(PAYLOAD)
-        expect(trackStoreClick).toHaveBeenCalledWith('ios', 'smart_link', true)
+        expect(trackStoreClick).toHaveBeenCalledWith('ios', 'smart_link', true, null)
+    })
+
+    it('attributes the tap to the QR that produced the scan', () => {
+        mockDeviceType = 'ios'
+        visit(`?${PAYLOAD}&s=landing_app_fold`)
+        renderPage()
+        fireEvent.click(link(/app store/i))
+        expect(trackStoreClick).toHaveBeenCalledWith('ios', 'smart_link', true, 'landing_app_fold')
     })
 
     it('ignores a querystring without the marker', () => {

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -29,7 +29,7 @@
 // state (mounted guard) — deriving the redirect state from useDeviceType at
 // first render tripped React #418 on phones (device is WEB on the server).
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { notFound, useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
@@ -37,10 +37,12 @@ import { Button } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
 import {
+    isMigrationSurface,
     MIGRATION_SURFACES,
     MIGRATION_SURFACE_PARAM,
     STORE_NAME,
     STORE_URL,
+    type MigrationSurface,
     type StoreKind,
 } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -79,10 +81,18 @@ export default function SmartStoreRedirect() {
     // read after mount, never during render: window.location.search does not
     // exist on the server and a payload-derived first render would not match
     const [payload, setPayload] = useState<string | null>(null)
+    // the landing surface whose QR produced this scan (?s=). Reported as
+    // `qr_surface` on this page's events — without it every smart_link click
+    // looks the same and the hero / app fold / footer / rates QRs cannot be
+    // told apart in the funnel. Validated against the known surfaces so a
+    // hand-edited url can't inject a property value.
+    const [qrSurface, setQrSurface] = useState<MigrationSurface | null>(null)
     useEffect(() => {
         setMounted(true)
         const search = window.location.search
         const parsed = parseDeferredPayload(search)
+        const tag = new URLSearchParams(search).get(MIGRATION_SURFACE_PARAM)
+        if (isMigrationSurface(tag)) setQrSurface(tag)
         if (parsed) setPayload(readHandoffPayload(search))
         if (!isNativeBridge()) return
         // already installed: no install to defer to, so apply the context now
@@ -123,18 +133,30 @@ export default function SmartStoreRedirect() {
         [payload]
     )
 
+    // DEFERRED_LINK_HANDOFF_CREATED is the denominator for
+    // DEFERRED_LINK_RESTORED, so one visit must contribute at most one: the
+    // auto-redirect fires it, and if the store intent never takes over
+    // (blocked, offline, Play missing) the 4s fallback hands the visitor
+    // clickable buttons that would fire it a second time.
+    const handoffCounted = useRef(false)
+    const countHandoff = (platform: 'ios' | 'android') => {
+        if (handoffCounted.current) return
+        handoffCounted.current = true
+        trackDeferredHandoffCreated(platform, qrSurface ? { qr_surface: qrSurface } : undefined)
+    }
+
     // must stay synchronous up to the clipboard call: a web clipboard write
     // only succeeds inside the user gesture that triggered it
     const onStoreTap = (store: StoreKind) => {
-        trackStoreClick(store, MIGRATION_SURFACES.SMART_LINK, !!payload)
+        trackStoreClick(store, MIGRATION_SURFACES.SMART_LINK, !!payload, qrSurface)
         if (!payload) return
         if (store === 'android') {
             // the referrer is already in the href — count the hand-off at the tap
-            trackDeferredHandoffCreated('android')
+            countHandoff('android')
             return
         }
         void copyIOSHandoff(payload)
-            .then(() => trackDeferredHandoffCreated('ios'))
+            .then(() => countHandoff('ios'))
             .catch(() => {})
     }
 
@@ -145,12 +167,16 @@ export default function SmartStoreRedirect() {
         // picks the store themselves. android's referrer rides the url, so it
         // can still bounce; so can any device with nothing to hand off.
         if (payload && targetStore === 'ios') return
+        // counted before the navigation, and only once per visit
+        if (payload && targetStore === 'android') countHandoff('android')
         setRedirecting(true)
-        if (payload && targetStore === 'android') trackDeferredHandoffCreated('android')
         window.location.replace(storeHref(targetStore))
         // if the store didn't take over (blocked, offline), settle to buttons
         const fallback = setTimeout(() => setRedirecting(false), 4000)
         return () => clearTimeout(fallback)
+        // countHandoff is a stable ref-guarded closure over qrSurface; re-running
+        // this effect on a qrSurface change would re-trigger the redirect
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inNativeApp, settled, migrationOn, targetStore, payload, storeHref])
 
     if (inNativeApp) return <Loading variant="mascot" coverFullScreen />

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -8,6 +8,17 @@
 // the capacitor static export builds unchanged. same visual language as the
 // sunset screen (MigrationHero + 50/50 split).
 //
+// deferred context: the QR that produced the scan can carry a payload
+// (`?pnutdl=1&lang=…&invite=…&dest=…`, built by buildDeferredPayload on the
+// desktop that rendered the QR). This page is where it changes hands:
+//   android — rides the Play install referrer, so the auto-redirect can carry it
+//   iOS     — rides the clipboard, which needs a user gesture, so there is NO
+//             auto-redirect: the visitor taps App Store and the write happens
+//             inside that tap handler
+//   native  — the app itself opened this url (App Links claim /app), so there
+//             is no store to bounce to: apply the payload and route to `dest`
+// A bare /app (no marker) keeps today's behaviour exactly.
+//
 // flag-gated like every migration surface: until the pwa-sunset flag resolves
 // ON this page 404s — otherwise merging would put a live public page with
 // dead store links on peanut.me. posthog flags arrive async for first-time
@@ -18,35 +29,65 @@
 // state (mounted guard) — deriving the redirect state from useDeviceType at
 // first render tripped React #418 on phones (device is WEB on the server).
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { notFound, useRouter } from 'next/navigation'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/0_Bruddle/Button'
 import Loading from '@/components/Global/Loading'
 import MigrationHero from '@/components/Migration/MigrationHero'
-import { STORE_NAME, STORE_URL, type StoreKind } from '@/constants/migration.consts'
+import {
+    MIGRATION_SURFACES,
+    MIGRATION_SURFACE_PARAM,
+    STORE_NAME,
+    STORE_URL,
+    type StoreKind,
+} from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { isNativeBridge } from '@/utils/capacitor'
-import { isPwaSunsetOn } from '@/utils/migration.utils'
+import {
+    applyDeferredPayload,
+    copyIOSHandoff,
+    parseDeferredPayload,
+    playStoreUrlWithReferrer,
+    trackDeferredHandoffCreated,
+} from '@/utils/deferred-link'
+import { isPwaSunsetOn, trackStoreClick } from '@/utils/migration.utils'
 
 const FLAG_WAIT_MS = 4000
+
+/** the payload as it must be re-emitted, minus our own analytics tag */
+function readHandoffPayload(search: string): string | null {
+    if (!parseDeferredPayload(search)) return null
+    const params = new URLSearchParams(search)
+    params.delete(MIGRATION_SURFACE_PARAM)
+    return params.toString()
+}
 
 export default function SmartStoreRedirect() {
     const t = useTranslations('migration')
     const { deviceType } = useDeviceType()
     const router = useRouter()
 
-    // universal links (paths: ["*"]) open this page inside the native app when
-    // an installed user scans a download qr — there's no store to bounce to,
-    // so send them home instead of redirecting them out to the store.
+    // universal links (App Links claim /app) open this page inside the native
+    // app when an installed user scans a download qr — there's no store to
+    // bounce to, so apply whatever context the qr carried and route on.
     // isNativeBridge, not isCapacitor: capacitor-flavored web builds bake
     // NEXT_PUBLIC_CAPACITOR_BUILD=true with no bridge, and those visitors
     // still need the store page.
     const [mounted, setMounted] = useState(false)
+    // read after mount, never during render: window.location.search does not
+    // exist on the server and a payload-derived first render would not match
+    const [payload, setPayload] = useState<string | null>(null)
     useEffect(() => {
         setMounted(true)
-        if (isNativeBridge()) router.replace('/home')
+        const search = window.location.search
+        const parsed = parseDeferredPayload(search)
+        if (parsed) setPayload(readHandoffPayload(search))
+        if (!isNativeBridge()) return
+        // already installed: no install to defer to, so apply the context now
+        const dest = parsed ? applyDeferredPayload(parsed).dest : null
+        router.replace(dest ?? '/home')
     }, [router])
     const inNativeApp = mounted && isNativeBridge()
 
@@ -77,15 +118,40 @@ export default function SmartStoreRedirect() {
             ? 'android'
             : null
 
+    const storeHref = useCallback(
+        (store: StoreKind) => (payload && store === 'android' ? playStoreUrlWithReferrer(payload) : STORE_URL[store]),
+        [payload]
+    )
+
+    // must stay synchronous up to the clipboard call: a web clipboard write
+    // only succeeds inside the user gesture that triggered it
+    const onStoreTap = (store: StoreKind) => {
+        trackStoreClick(store, MIGRATION_SURFACES.SMART_LINK, !!payload)
+        if (!payload) return
+        if (store === 'android') {
+            // the referrer is already in the href — count the hand-off at the tap
+            trackDeferredHandoffCreated('android')
+            return
+        }
+        void copyIOSHandoff(payload)
+            .then(() => trackDeferredHandoffCreated('ios'))
+            .catch(() => {})
+    }
+
     const [redirecting, setRedirecting] = useState(false)
     useEffect(() => {
         if (inNativeApp || !settled || !migrationOn || !targetStore) return
+        // iOS + payload: the clipboard hand-off needs the tap, so the visitor
+        // picks the store themselves. android's referrer rides the url, so it
+        // can still bounce; so can any device with nothing to hand off.
+        if (payload && targetStore === 'ios') return
         setRedirecting(true)
-        window.location.replace(STORE_URL[targetStore])
+        if (payload && targetStore === 'android') trackDeferredHandoffCreated('android')
+        window.location.replace(storeHref(targetStore))
         // if the store didn't take over (blocked, offline), settle to buttons
         const fallback = setTimeout(() => setRedirecting(false), 4000)
         return () => clearTimeout(fallback)
-    }, [inNativeApp, settled, migrationOn, targetStore])
+    }, [inNativeApp, settled, migrationOn, targetStore, payload, storeHref])
 
     if (inNativeApp) return <Loading variant="mascot" coverFullScreen />
 
@@ -110,7 +176,12 @@ export default function SmartStoreRedirect() {
                 <div className="mx-auto flex w-full max-w-md flex-col gap-4">
                     {settled && migrationOn ? (
                         stores.map((s, i) => (
-                            <a key={s} href={STORE_URL[s]} className={redirecting && i > 0 ? 'hidden' : 'block'}>
+                            <a
+                                key={s}
+                                href={storeHref(s)}
+                                onClick={() => onStoreTap(s)}
+                                className={redirecting && i > 0 ? 'hidden' : 'block'}
+                            >
                                 <Button
                                     variant={i === 0 ? 'purple' : 'stroke'}
                                     shadowSize="4"

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -14,7 +14,7 @@ import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
-import StoreBadges from '@/components/Migration/StoreBadges'
+import StorePair from '@/components/Migration/StorePair'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -281,7 +281,7 @@ export function LandingPageClient({
                 customCta={
                     migrationOn && isDesktop ? (
                         <div className="flex flex-col items-center">
-                            <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
+                            <StorePair surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
                             {heroConfig.primaryCta.subtext && (
                                 <span className="mt-2 block text-center text-sm text-n-1 italic md:text-base">
                                     {heroConfig.primaryCta.subtext}

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
 import Link from 'next/link'
 import { Button } from '@/components/0_Bruddle/Button'
+import StorePair from '@/components/Migration/StorePair'
 import type { LandingStrings } from './landingStrings'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -22,6 +23,10 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
     const migrationOn = useMigrationFlag()
     const tMigration = useTranslations('migration')
     const { deviceType } = useDeviceType()
+    // WEB on a bar that only exists below `md` means desktop-mode-on-a-phone
+    // (or a UA we don't recognise): guessing iOS there sent Android users to
+    // the App Store, so show both stores and let them pick.
+    const storeUnknown = deviceType === DeviceType.WEB
     const store = deviceType === DeviceType.ANDROID ? 'android' : 'ios'
     // memoized: this bar re-renders through scroll-driven animation frames,
     // and the android href builds the hand-off payload (cookie reads)
@@ -74,24 +79,30 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
                     }`}
                 >
                     {migrationOn ? (
-                        // this bar is md:hidden so the visitor is on a phone —
-                        // deep-link their store during the migration window
-                        <a
-                            href={storeHref}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="pointer-events-auto block"
-                            onClick={() => onStoreAnchorClick(store, MIGRATION_SURFACES.LANDING_HERO)}
-                        >
-                            <Button
-                                variant="purple"
-                                shadowSize="4"
-                                icon={store === 'ios' ? 'apple-logo' : 'google-play'}
-                                className="w-full py-3 text-base font-extrabold uppercase"
+                        storeUnknown ? (
+                            <div className="pointer-events-auto">
+                                <StorePair surface={MIGRATION_SURFACES.LANDING_HERO} appearance="compact" />
+                            </div>
+                        ) : (
+                            // this bar is md:hidden so the visitor is on a phone —
+                            // deep-link their store during the migration window
+                            <a
+                                href={storeHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="pointer-events-auto block"
+                                onClick={() => onStoreAnchorClick(store, MIGRATION_SURFACES.LANDING_HERO)}
                             >
-                                {tMigration('downloadNow')}
-                            </Button>
-                        </a>
+                                <Button
+                                    variant="purple"
+                                    shadowSize="4"
+                                    icon={store === 'ios' ? 'apple-logo' : 'google-play'}
+                                    className="w-full py-3 text-base font-extrabold uppercase"
+                                >
+                                    {tMigration('downloadNow')}
+                                </Button>
+                            </a>
+                        )
                     ) : (
                         <div className="pointer-events-auto flex items-center gap-4">
                             <Link prefetch={false} href="/setup" className="block flex-1">

--- a/src/components/LandingPage/__tests__/StickyMobileCTA.test.tsx
+++ b/src/components/LandingPage/__tests__/StickyMobileCTA.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+/**
+ * StickyMobileCTA — the bar that slides in 300px down the landing page.
+ *
+ * It is `md:hidden`, so it only ever shows on a narrow viewport. That used to
+ * be read as "the visitor is on a phone, and if the UA isn't Android it's an
+ * iPhone" — which sent every desktop-mode Android browser to the App Store.
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import type { LandingStrings } from '../landingStrings'
+import { STORE_URL } from '@/constants/migration.consts'
+
+let mockDeviceType = 'ios'
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: mockDeviceType }),
+}))
+
+let mockFlagOn = true
+jest.mock('@/hooks/useMigrationFlag', () => ({ useMigrationFlag: () => mockFlagOn }))
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => false,
+    isAndroidNative: () => false,
+    isIOSNative: () => false,
+    openExternalUrl: jest.fn(),
+}))
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+jest.mock('@/utils/deferred-link', () => ({
+    buildDeferredPayload: () => 'pnutdl=1',
+    playStoreUrlWithReferrer: (payload: string) => `play://listing?referrer=${encodeURIComponent(payload)}`,
+    copyIOSHandoff: jest.fn().mockResolvedValue(undefined),
+    trackDeferredHandoffCreated: jest.fn(),
+}))
+
+import { StickyMobileCTA } from '../StickyMobileCTA'
+
+const strings = { signUpNow: 'SIGN UP NOW', logIn: 'Log in' } as LandingStrings
+
+const renderBar = () => render(<StickyMobileCTA strings={strings} />, { wrapper: IntlWrapper })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeviceType = 'ios'
+    mockFlagOn = true
+    // the bar only mounts past 300px of scroll
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 500 })
+})
+
+describe('StickyMobileCTA during the migration', () => {
+    it('deep-links the one store it can identify', () => {
+        mockDeviceType = 'android'
+        renderBar()
+        const links = screen.getAllByRole('link')
+        expect(links).toHaveLength(1)
+        expect(links[0]).toHaveAttribute('href', `play://listing?referrer=${encodeURIComponent('pnutdl=1')}`)
+    })
+
+    it('offers both stores when the device is unknown (desktop-mode phone)', () => {
+        mockDeviceType = 'web'
+        renderBar()
+        expect(screen.getByRole('link', { name: /app store/i })).toHaveAttribute('href', STORE_URL.ios)
+        expect(screen.getByRole('link', { name: /google play/i })).toBeInTheDocument()
+    })
+
+    it('keeps the sign-up bar while the flag is off', () => {
+        mockFlagOn = false
+        mockDeviceType = 'web'
+        renderBar()
+        expect(screen.getByText('SIGN UP NOW')).toBeInTheDocument()
+        expect(screen.queryByRole('link', { name: /app store/i })).not.toBeInTheDocument()
+    })
+})

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -1,33 +1,90 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
-import StoreBadges from '@/components/Migration/StoreBadges'
+import StorePair from '@/components/Migration/StorePair'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { SELF_URL } from '@/constants/general.consts'
 import { type MigrationSurface } from '@/constants/migration.consts'
+import type { StoreHandoff } from '@/utils/migration.utils'
+
+/** QR frame width in px — the value QRCodeWrapper's `max-w-*` resolves to.
+ *  Static class strings: a template literal would not survive Tailwind's scan. */
+const FRAME_WIDTH = {
+    160: 'max-w-[160px]',
+    192: 'max-w-[192px]',
+} as const
+
+export type QRSize = keyof typeof FRAME_WIDTH
 
 // one smart QR instead of a per-store toggle: it encodes /app, which
 // redirects to the store of whichever phone scans it.
-export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
+export default function DownloadQR({
+    surface,
+    payload,
+    size = 160,
+    handoff,
+}: {
+    surface: MigrationSurface
+    /** deferred-link querystring from `buildDeferredPayload()` — built by the
+     *  caller because it reads `window` (cookies, path) and this component
+     *  also renders on the server. */
+    payload?: string
+    size?: QRSize
+    handoff?: StoreHandoff
+}) {
     const t = useTranslations('migration')
+    const frameRef = useRef<HTMLDivElement>(null)
 
+    // impressions, not mounts: several surfaces render a QR far below the fold
+    // (the app fold, the footer), and counting those as shown would make the
+    // scan rate look broken. fires once, at 50% visible; in a modal the QR is
+    // already fully in view when it mounts, so that is the open event.
+    const hasContext = !!payload
+    const shown = useRef(false)
     useEffect(() => {
-        posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface })
-    }, [surface])
+        if (shown.current) return
+        const capture = () => {
+            if (shown.current) return
+            shown.current = true
+            posthog.capture(ANALYTICS_EVENTS.MIGRATION_QR_SHOWN, { surface, hasContext })
+        }
+        const node = frameRef.current
+        // no IntersectionObserver (jsdom, ancient webviews): count the mount
+        if (!node || typeof IntersectionObserver === 'undefined') {
+            capture()
+            return
+        }
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((e) => e.isIntersecting && e.intersectionRatio >= 0.5)) {
+                    capture()
+                    observer.disconnect()
+                }
+            },
+            { threshold: 0.5 }
+        )
+        observer.observe(node)
+        return () => observer.disconnect()
+    }, [surface, hasContext])
 
     // the serving origin, not SELF_URL: a preview's QR must point at the
     // preview (SELF_URL would send scanners to prod) and a LAN-served dev
     // build must encode the LAN address so a real phone can scan it
     const origin = typeof window !== 'undefined' ? window.location.origin : SELF_URL
+    // /app is the smart link: it reads the payload back off its own querystring
+    // and hands it to the store bounce, so context survives the install
+    const qrUrl = `${origin}/app?${payload ? `${payload}&` : ''}s=${encodeURIComponent(surface)}`
 
     return (
         <div className="flex w-full flex-col items-center gap-3 py-2">
-            <QRCodeWrapper url={`${origin}/app`} />
+            <div ref={frameRef} className="w-full">
+                <QRCodeWrapper url={qrUrl} className={FRAME_WIDTH[size]} />
+            </div>
             <span className="text-body-xs text-foreground-secondary">{t('qr.scanHint')}</span>
             {/* desktop can install directly too (e.g. Google Play from the browser) */}
-            <StoreBadges surface={surface} appearance="stacked" />
+            <StorePair surface={surface} appearance="stacked" handoff={handoff} />
         </div>
     )
 }

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import posthog from 'posthog-js'
 import { useTranslations } from 'next-intl'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
@@ -7,44 +7,85 @@ import StorePair from '@/components/Migration/StorePair'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { SELF_URL } from '@/constants/general.consts'
 import { type MigrationSurface } from '@/constants/migration.consts'
+import { buildDeferredPayload } from '@/utils/deferred-link'
 import type { StoreHandoff } from '@/utils/migration.utils'
 
 /** QR frame width in px — the value QRCodeWrapper's `max-w-*` resolves to.
- *  Static class strings: a template literal would not survive Tailwind's scan. */
+ *  Static class strings: a template literal would not survive Tailwind's scan.
+ *
+ *  The MODULE area is 36px narrower than the frame (2×16px `p-4` + 2×2px
+ *  `border-2`), so pick by the module area the surface needs:
+ *    160 → 124px modules (today's default everywhere)
+ *    192 → 156px modules — the landing hero
+ *    224 → 188px modules — the app fold and the footer, where the brief asks
+ *          for ~192px of modules and the code sits far from the reader.
+ */
 const FRAME_WIDTH = {
     160: 'max-w-[160px]',
     192: 'max-w-[192px]',
+    224: 'max-w-[224px]',
 } as const
 
 export type QRSize = keyof typeof FRAME_WIDTH
 
+type DownloadQRProps = {
+    surface: MigrationSurface
+    size?: QRSize
+} & (
+    | {
+          /** deferred-link querystring from `buildDeferredPayload()`, for a caller
+           *  that already holds one. */
+          payload?: string
+          handoff?: never
+      }
+    | {
+          payload?: never
+          /** where this surface was sending the user before the sunset (a fold CTA
+           *  that used to link /send). The payload is derived from it after mount
+           *  and handed to BOTH the QR and the store buttons underneath, so the two
+           *  can never carry different context. */
+          handoff?: StoreHandoff
+      }
+)
+
 // one smart QR instead of a per-store toggle: it encodes /app, which
 // redirects to the store of whichever phone scans it.
-export default function DownloadQR({
-    surface,
-    payload,
-    size = 160,
-    handoff,
-}: {
-    surface: MigrationSurface
-    /** deferred-link querystring from `buildDeferredPayload()` — built by the
-     *  caller because it reads `window` (cookies, path) and this component
-     *  also renders on the server. */
-    payload?: string
-    size?: QRSize
-    handoff?: StoreHandoff
-}) {
+export default function DownloadQR({ surface, payload, size = 160, handoff }: DownloadQRProps) {
     const t = useTranslations('migration')
     const frameRef = useRef<HTMLDivElement>(null)
+
+    // one context channel, two consumers. `handoff` is the input; the querystring
+    // the QR encodes is derived from it here rather than by the caller, so a
+    // surface cannot hand the buttons a destination and the QR nothing (they are
+    // mutually exclusive in the props type for the same reason). Derived after
+    // mount because buildDeferredPayload reads window (cookies, path) and this
+    // component also renders on the server.
+    const derivesPayload = !!handoff
+    const [derivedPayload, setDerivedPayload] = useState<string | null>(null)
+    // gates the impression event: capturing before the payload exists would
+    // report hasContext:false for every contextful QR
+    const [contextReady, setContextReady] = useState(!derivesPayload)
+    const dest = handoff?.dest
+    const invite = handoff?.invite
+    useEffect(() => {
+        if (!derivesPayload) return
+        try {
+            setDerivedPayload(buildDeferredPayload(dest, invite))
+        } catch {
+            // a payload failure must never cost the QR itself
+        }
+        setContextReady(true)
+    }, [derivesPayload, dest, invite])
+    const effectivePayload = payload ?? derivedPayload ?? undefined
 
     // impressions, not mounts: several surfaces render a QR far below the fold
     // (the app fold, the footer), and counting those as shown would make the
     // scan rate look broken. fires once, at 50% visible; in a modal the QR is
     // already fully in view when it mounts, so that is the open event.
-    const hasContext = !!payload
+    const hasContext = !!effectivePayload
     const shown = useRef(false)
     useEffect(() => {
-        if (shown.current) return
+        if (!contextReady || shown.current) return
         const capture = () => {
             if (shown.current) return
             shown.current = true
@@ -67,7 +108,7 @@ export default function DownloadQR({
         )
         observer.observe(node)
         return () => observer.disconnect()
-    }, [surface, hasContext])
+    }, [surface, hasContext, contextReady])
 
     // the serving origin, not SELF_URL: a preview's QR must point at the
     // preview (SELF_URL would send scanners to prod) and a LAN-served dev
@@ -75,7 +116,7 @@ export default function DownloadQR({
     const origin = typeof window !== 'undefined' ? window.location.origin : SELF_URL
     // /app is the smart link: it reads the payload back off its own querystring
     // and hands it to the store bounce, so context survives the install
-    const qrUrl = `${origin}/app?${payload ? `${payload}&` : ''}s=${encodeURIComponent(surface)}`
+    const qrUrl = `${origin}/app?${effectivePayload ? `${effectivePayload}&` : ''}s=${encodeURIComponent(surface)}`
 
     return (
         <div className="flex w-full flex-col items-center gap-3 py-2">

--- a/src/components/Migration/StorePair.tsx
+++ b/src/components/Migration/StorePair.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Button } from '@/components/0_Bruddle/Button'
-import { STORE_NAME, STORE_URL, type MigrationSurface } from '@/constants/migration.consts'
-import { trackStoreClick } from '@/utils/migration.utils'
+import { STORE_NAME, type MigrationSurface } from '@/constants/migration.consts'
+import { onStoreAnchorClick, storeAnchorHref, type StoreHandoff } from '@/utils/migration.utils'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 
 // store-button pair. compact: under download CTAs and QRs, same design
@@ -10,12 +10,20 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 // inside a modal, where the platform is usually known — one full-width white
 // button for the device you are on, falling back to both, one under the other,
 // when it is not.
-export default function StoreBadges({
+//
+// the buttons are real anchors carrying `storeAnchorHref` (android's install
+// referrer rides the url) with `onStoreAnchorClick` for tracking + the iOS
+// clipboard hand-off, so a suppressed window.open never costs the bounce.
+// pass `handoff` from a surface that knows where the user was heading (a fold
+// CTA that used to link /send) so that context survives the install.
+export default function StorePair({
     surface,
     appearance = 'compact',
+    handoff,
 }: {
     surface: MigrationSurface
     appearance?: 'compact' | 'hero' | 'stacked'
+    handoff?: StoreHandoff
 }) {
     const isHero = appearance === 'hero'
     const isStacked = appearance === 'stacked'
@@ -23,15 +31,23 @@ export default function StoreBadges({
     const thisPlatform = deviceType === DeviceType.IOS ? 'ios' : deviceType === DeviceType.ANDROID ? 'android' : null
     const stores = isStacked && thisPlatform ? ([thisPlatform] as const) : (['ios', 'android'] as const)
     return (
-        <div className={isStacked ? 'flex w-full flex-col gap-3' : 'flex items-center justify-center gap-3'}>
+        <div
+            className={
+                isStacked
+                    ? 'flex w-full flex-col gap-3'
+                    : // wraps rather than overflows: two 208px hero buttons plus the gap
+                      // need 428px, more than a 390px phone has, so they stack there
+                      'mx-auto flex w-full max-w-[26rem] flex-wrap items-center justify-center gap-3'
+            }
+        >
             {stores.map((s) => (
                 <a
                     key={s}
-                    href={STORE_URL[s]}
+                    href={storeAnchorHref(s, handoff)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={() => trackStoreClick(s, surface)}
-                    className={isStacked ? 'w-full' : undefined}
+                    onClick={() => onStoreAnchorClick(s, surface, handoff)}
+                    className={isStacked ? 'w-full' : isHero ? 'w-full sm:w-52' : undefined}
                 >
                     <Button
                         variant={isHero || isStacked ? 'stroke' : s === 'ios' ? 'purple' : 'stroke'}
@@ -40,7 +56,7 @@ export default function StoreBadges({
                         icon={s === 'ios' ? 'apple-logo' : 'google-play'}
                         className={
                             isHero
-                                ? 'w-52 bg-white px-6 py-3 text-button-m hover:bg-white/90 md:py-7 md:text-button-l'
+                                ? 'w-full bg-white px-6 py-3 text-button-m hover:bg-white/90 md:py-7 md:text-button-l'
                                 : isStacked
                                   ? 'w-full justify-center bg-white hover:bg-white/90'
                                   : 'w-auto px-4'

--- a/src/components/Migration/StorePair.tsx
+++ b/src/components/Migration/StorePair.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useMemo } from 'react'
 import { Button } from '@/components/0_Bruddle/Button'
 import { STORE_NAME, type MigrationSurface } from '@/constants/migration.consts'
 import { onStoreAnchorClick, storeAnchorHref, type StoreHandoff } from '@/utils/migration.utils'
@@ -30,20 +31,32 @@ export default function StorePair({
     const { deviceType } = useDeviceType()
     const thisPlatform = deviceType === DeviceType.IOS ? 'ios' : deviceType === DeviceType.ANDROID ? 'android' : null
     const stores = isStacked && thisPlatform ? ([thisPlatform] as const) : (['ios', 'android'] as const)
+    // built once per handoff, not per render: the android href runs
+    // buildDeferredPayload (cookie + badge-campaign + location reads) and the
+    // hero pair lives inside LandingPageClient, which re-renders on every
+    // scroll-driven animation frame. Same reason StickyMobileCTA memoizes it.
+    const hrefs = useMemo(
+        () => ({ ios: storeAnchorHref('ios', handoff), android: storeAnchorHref('android', handoff) }),
+        [handoff?.dest, handoff?.invite] // eslint-disable-line react-hooks/exhaustive-deps
+    )
     return (
         <div
             className={
                 isStacked
                     ? 'flex w-full flex-col gap-3'
-                    : // wraps rather than overflows: two 208px hero buttons plus the gap
-                      // need 428px, more than a 390px phone has, so they stack there
-                      'mx-auto flex w-full max-w-[26rem] flex-wrap items-center justify-center gap-3'
+                    : isHero
+                      ? // 27.5rem = 440px, the width two 208px (sm:w-52) hero buttons
+                        // plus the 12px gap need to sit on one line. A 26rem cap here
+                        // would wrap them at EVERY viewport >= sm, including 1440.
+                        // Below sm the anchors are w-full and stack by design.
+                        'mx-auto flex w-full max-w-[27.5rem] flex-wrap items-center justify-center gap-3'
+                      : 'mx-auto flex w-full max-w-[26rem] flex-wrap items-center justify-center gap-3'
             }
         >
             {stores.map((s) => (
                 <a
                     key={s}
-                    href={storeAnchorHref(s, handoff)}
+                    href={hrefs[s]}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={() => onStoreAnchorClick(s, surface, handoff)}

--- a/src/components/Migration/__tests__/DownloadQR.test.tsx
+++ b/src/components/Migration/__tests__/DownloadQR.test.tsx
@@ -1,0 +1,121 @@
+/** @jest-environment jsdom */
+/**
+ * DownloadQR — the one smart QR every desktop download surface renders.
+ *
+ * Two things are load-bearing and invisible to a screenshot: the encoded URL
+ * (a dropped payload silently breaks deferred deep linking for every scan) and
+ * the impression event, which only counts once the code is actually on screen —
+ * the app fold and the footer render theirs far below the fold.
+ */
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+jest.mock('@/components/Global/QRCodeWrapper', () => ({
+    __esModule: true,
+    default: ({ url, className }: { url: string; className?: string }) => (
+        <div data-testid="qr" data-url={url} data-class={className} />
+    ),
+}))
+
+jest.mock('@/components/Migration/StorePair', () => ({
+    __esModule: true,
+    default: ({ surface }: { surface: string }) => <div data-testid="store-pair" data-surface={surface} />,
+}))
+
+import posthog from 'posthog-js'
+import DownloadQR from '../DownloadQR'
+
+const render_ = (ui: React.ReactElement) => render(ui, { wrapper: IntlWrapper })
+const qrUrl = () => screen.getByTestId('qr').getAttribute('data-url')
+
+// hand-driven IntersectionObserver so the impression threshold is assertable
+let observerCallbacks: IntersectionObserverCallback[] = []
+class FakeObserver {
+    constructor(private cb: IntersectionObserverCallback) {
+        observerCallbacks.push(cb)
+    }
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+    takeRecords() {
+        return []
+    }
+}
+const intersect = (ratio: number) =>
+    act(() => {
+        observerCallbacks.forEach((cb) =>
+            cb(
+                [{ isIntersecting: ratio > 0, intersectionRatio: ratio }] as unknown as IntersectionObserverEntry[],
+                {
+                    disconnect() {},
+                } as unknown as IntersectionObserver
+            )
+        )
+    })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    observerCallbacks = []
+    ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = FakeObserver
+})
+afterEach(() => {
+    delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver
+})
+
+describe('DownloadQR', () => {
+    it('encodes /app with only the surface when there is no payload', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.LANDING_FOOTER} />)
+        expect(qrUrl()).toBe(`${window.location.origin}/app?s=landing_footer`)
+    })
+
+    it('encodes the deferred payload ahead of the surface', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.LANDING_HERO} payload="pnutdl=1&lang=pt-br&dest=%2Fsend" />)
+        expect(qrUrl()).toBe(`${window.location.origin}/app?pnutdl=1&lang=pt-br&dest=%2Fsend&s=landing_hero`)
+    })
+
+    it('renders at 160px by default and 192px when asked', () => {
+        const { rerender } = render_(<DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} />)
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-class', 'max-w-[160px]')
+        rerender(<DownloadQR surface={MIGRATION_SURFACES.LANDING_APP_FOLD} size={192} />)
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-class', 'max-w-[192px]')
+    })
+
+    it('counts an impression once the code is half visible, and only once', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.LANDING_APP_FOLD} payload="pnutdl=1" />)
+        expect(posthog.capture).not.toHaveBeenCalled()
+
+        intersect(0.2)
+        expect(posthog.capture).not.toHaveBeenCalled()
+
+        intersect(0.5)
+        expect(posthog.capture).toHaveBeenCalledWith('migration_qr_shown', {
+            surface: 'landing_app_fold',
+            hasContext: true,
+        })
+
+        intersect(1)
+        expect(posthog.capture).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports hasContext false for a context-free QR', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.SMART_LINK} />)
+        intersect(1)
+        expect(posthog.capture).toHaveBeenCalledWith('migration_qr_shown', {
+            surface: 'smart_link',
+            hasContext: false,
+        })
+    })
+
+    it('falls back to counting the mount where IntersectionObserver is missing', () => {
+        delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver
+        render_(<DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} />)
+        expect(posthog.capture).toHaveBeenCalledWith('migration_qr_shown', {
+            surface: 'download_modal',
+            hasContext: false,
+        })
+    })
+})

--- a/src/components/Migration/__tests__/DownloadQR.test.tsx
+++ b/src/components/Migration/__tests__/DownloadQR.test.tsx
@@ -23,7 +23,9 @@ jest.mock('@/components/Global/QRCodeWrapper', () => ({
 
 jest.mock('@/components/Migration/StorePair', () => ({
     __esModule: true,
-    default: ({ surface }: { surface: string }) => <div data-testid="store-pair" data-surface={surface} />,
+    default: ({ surface, handoff }: { surface: string; handoff?: { dest?: string } }) => (
+        <div data-testid="store-pair" data-surface={surface} data-dest={handoff?.dest ?? ''} />
+    ),
 }))
 
 import posthog from 'posthog-js'
@@ -77,11 +79,26 @@ describe('DownloadQR', () => {
         expect(qrUrl()).toBe(`${window.location.origin}/app?pnutdl=1&lang=pt-br&dest=%2Fsend&s=landing_hero`)
     })
 
-    it('renders at 160px by default and 192px when asked', () => {
+    /*
+     * One context channel: a surface hands DownloadQR a `handoff` and the QR
+     * derives its own payload from it, so the code and the buttons under it can
+     * never disagree about where the scanner was heading (they used to be two
+     * independent props, and passing one without the other silently dropped the
+     * context from whichever channel was left out).
+     */
+    it('derives the QR payload from handoff and gives the buttons the same context', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.LANDING_RATES} handoff={{ dest: '/send' }} />)
+        expect(qrUrl()).toBe(`${window.location.origin}/app?pnutdl=1&dest=%2Fsend&s=landing_rates`)
+        expect(screen.getByTestId('store-pair')).toHaveAttribute('data-dest', '/send')
+    })
+
+    it('renders at 160px by default, and at the larger frames when asked', () => {
         const { rerender } = render_(<DownloadQR surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} />)
         expect(screen.getByTestId('qr')).toHaveAttribute('data-class', 'max-w-[160px]')
-        rerender(<DownloadQR surface={MIGRATION_SURFACES.LANDING_APP_FOLD} size={192} />)
+        rerender(<DownloadQR surface={MIGRATION_SURFACES.LANDING_HERO} size={192} />)
         expect(screen.getByTestId('qr')).toHaveAttribute('data-class', 'max-w-[192px]')
+        rerender(<DownloadQR surface={MIGRATION_SURFACES.LANDING_APP_FOLD} size={224} />)
+        expect(screen.getByTestId('qr')).toHaveAttribute('data-class', 'max-w-[224px]')
     })
 
     it('counts an impression once the code is half visible, and only once', () => {
@@ -99,6 +116,15 @@ describe('DownloadQR', () => {
 
         intersect(1)
         expect(posthog.capture).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports hasContext true for a handoff-derived payload', () => {
+        render_(<DownloadQR surface={MIGRATION_SURFACES.LANDING_RATES} handoff={{ dest: '/send' }} />)
+        intersect(1)
+        expect(posthog.capture).toHaveBeenCalledWith('migration_qr_shown', {
+            surface: 'landing_rates',
+            hasContext: true,
+        })
     })
 
     it('reports hasContext false for a context-free QR', () => {

--- a/src/components/Migration/__tests__/StorePair.test.tsx
+++ b/src/components/Migration/__tests__/StorePair.test.tsx
@@ -96,8 +96,26 @@ describe('StorePair', () => {
         expect(screen.getAllByRole('link')).toHaveLength(2)
     })
 
+    /*
+     * Geometry, not just classes: the hero pair is a ROW at >= sm and the row's
+     * own max-width is the thing that decides it. Two sm:w-52 anchors (208px)
+     * plus gap-3 (12px) need 428px; a 26rem/416px cap wrapped them onto two
+     * lines at every desktop width, including 1440. jsdom has no layout, so the
+     * arithmetic is asserted directly.
+     */
     it('hero anchors go full-width before they would overflow a phone', () => {
         render(<StorePair surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />)
         expect(link(/app store/i)).toHaveClass('w-full', 'sm:w-52')
+    })
+
+    it('gives the hero row room for both buttons on one line', () => {
+        const { container } = render(<StorePair surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />)
+        const row = container.firstElementChild as HTMLElement
+        const cap = row.className.match(/max-w-\[([\d.]+)rem\]/)
+        expect(cap).not.toBeNull()
+        const capPx = parseFloat(cap![1]) * 16
+        const ANCHOR_PX = 208 // sm:w-52
+        const GAP_PX = 12 // gap-3
+        expect(capPx).toBeGreaterThanOrEqual(ANCHOR_PX * 2 + GAP_PX)
     })
 })

--- a/src/components/Migration/__tests__/StorePair.test.tsx
+++ b/src/components/Migration/__tests__/StorePair.test.tsx
@@ -1,0 +1,103 @@
+/** @jest-environment jsdom */
+/**
+ * StorePair — the two-store button row every migration surface reuses.
+ *
+ * The contract that matters is the anchor: a real href (so a suppressed
+ * window.open still bounces) carrying android's install referrer, plus a click
+ * handler that writes the iOS clipboard hand-off inside the tap. A regression
+ * here silently drops the deferred context on every download CTA at once.
+ */
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MIGRATION_SURFACES, STORE_URL } from '@/constants/migration.consts'
+
+let mockDeviceType = 'web'
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: mockDeviceType }),
+}))
+
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => false,
+    isAndroidNative: () => false,
+    isIOSNative: () => false,
+    openExternalUrl: jest.fn(),
+}))
+
+jest.mock('posthog-js', () => ({ capture: jest.fn() }))
+
+const mockBuildPayload = jest.fn()
+const mockCopyIOSHandoff = jest.fn().mockResolvedValue(undefined)
+const mockTrackHandoffCreated = jest.fn()
+jest.mock('@/utils/deferred-link', () => ({
+    buildDeferredPayload: (...args: unknown[]) => mockBuildPayload(...args),
+    playStoreUrlWithReferrer: (payload: string) => `play://listing?referrer=${encodeURIComponent(payload)}`,
+    copyIOSHandoff: (...args: unknown[]) => mockCopyIOSHandoff(...args),
+    trackDeferredHandoffCreated: (...args: unknown[]) => mockTrackHandoffCreated(...args),
+}))
+
+import posthog from 'posthog-js'
+import StorePair from '../StorePair'
+
+const link = (name: RegExp) => screen.getByRole('link', { name })
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeviceType = 'web'
+    mockBuildPayload.mockReturnValue('pnutdl=1&lang=pt-br')
+})
+
+describe('StorePair', () => {
+    it('carries the install referrer on the Play href and the bare url on iOS', () => {
+        render(<StorePair surface={MIGRATION_SURFACES.LANDING_HERO} />)
+        expect(link(/google play/i)).toHaveAttribute(
+            'href',
+            `play://listing?referrer=${encodeURIComponent('pnutdl=1&lang=pt-br')}`
+        )
+        // iOS can't ride the url — the clipboard hand-off needs the tap
+        expect(link(/app store/i)).toHaveAttribute('href', STORE_URL.ios)
+    })
+
+    it('passes the handoff context into both channels', () => {
+        render(<StorePair surface={MIGRATION_SURFACES.LANDING_RATES} handoff={{ dest: '/send' }} />)
+        expect(mockBuildPayload).toHaveBeenCalledWith('/send', undefined)
+
+        mockBuildPayload.mockClear()
+        fireEvent.click(link(/app store/i))
+        expect(mockBuildPayload).toHaveBeenCalledWith('/send', undefined)
+        expect(mockCopyIOSHandoff).toHaveBeenCalledWith('pnutdl=1&lang=pt-br')
+    })
+
+    it('reports the surface on a store tap', () => {
+        render(<StorePair surface={MIGRATION_SURFACES.LANDING_FOOTER} />)
+        fireEvent.click(link(/google play/i))
+        expect(posthog.capture).toHaveBeenCalledWith(
+            'migration_store_cta_clicked',
+            expect.objectContaining({ surface: 'landing_footer', store: 'android', handoff: true })
+        )
+    })
+
+    it('still bounces when the payload build throws', () => {
+        mockBuildPayload.mockImplementation(() => {
+            throw new Error('no cookies')
+        })
+        render(<StorePair surface={MIGRATION_SURFACES.SMART_LINK} />)
+        expect(link(/google play/i)).toHaveAttribute('href', STORE_URL.android)
+    })
+
+    it('stacked shows only the device store, and both when it is unknown', () => {
+        mockDeviceType = 'ios'
+        const { rerender } = render(<StorePair surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} appearance="stacked" />)
+        expect(screen.getAllByRole('link')).toHaveLength(1)
+        expect(link(/app store/i)).toBeInTheDocument()
+
+        mockDeviceType = 'web'
+        rerender(<StorePair surface={MIGRATION_SURFACES.DOWNLOAD_MODAL} appearance="stacked" />)
+        expect(screen.getAllByRole('link')).toHaveLength(2)
+    })
+
+    it('hero anchors go full-width before they would overflow a phone', () => {
+        render(<StorePair surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />)
+        expect(link(/app store/i)).toHaveClass('w-full', 'sm:w-52')
+    })
+})

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -59,6 +59,13 @@ export const STORE_NAME = {
     android: 'Google Play',
 } as const
 
+/**
+ * Query param the /app smart link carries its calling surface in, so a scan
+ * that lands on the store page is attributable to the QR that produced it.
+ * Short on purpose: it rides inside a QR, where every character costs modules.
+ */
+export const MIGRATION_SURFACE_PARAM = 's'
+
 /** `surface` property for migration analytics events. */
 export const MIGRATION_SURFACES = {
     DOWNLOAD_MODAL: 'download_modal',
@@ -68,6 +75,14 @@ export const MIGRATION_SURFACES = {
     SETUP: 'setup',
     GUEST_FLOW: 'guest_flow',
     PROFILE_UPDATE: 'profile_update',
+    // the /app smart link itself: the store buttons a scanner lands on
+    SMART_LINK: 'smart_link',
+    // landing folds that get their own download CTA once the flag is on
+    LANDING_APP_FOLD: 'landing_app_fold',
+    LANDING_FOOTER: 'landing_footer',
+    LANDING_RATES: 'landing_rates',
+    LANDING_COUNTRIES: 'landing_countries',
+    LANDING_DOOR: 'landing_door',
 } as const
 
 export type MigrationSurface = (typeof MIGRATION_SURFACES)[keyof typeof MIGRATION_SURFACES]

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -61,7 +61,12 @@ export const STORE_NAME = {
 
 /**
  * Query param the /app smart link carries its calling surface in, so a scan
- * that lands on the store page is attributable to the QR that produced it.
+ * that lands on the store page is attributable to the QR that produced it:
+ * /app reads it back (isMigrationSurface below) and reports it as `qr_surface`
+ * on its own store-click and hand-off events, which is what joins a smart_link
+ * click to the landing surface — hero vs app fold vs footer vs rates — whose QR
+ * produced the scan. Stripped before the payload is re-emitted into the Play
+ * install referrer, so it never reaches the app.
  * Short on purpose: it rides inside a QR, where every character costs modules.
  */
 export const MIGRATION_SURFACE_PARAM = 's'
@@ -86,4 +91,9 @@ export const MIGRATION_SURFACES = {
 } as const
 
 export type MigrationSurface = (typeof MIGRATION_SURFACES)[keyof typeof MIGRATION_SURFACES]
+
+/** guard for a surface arriving off a URL (the /app smart link's `?s=`). */
+export function isMigrationSurface(value: string | null | undefined): value is MigrationSurface {
+    return !!value && (Object.values(MIGRATION_SURFACES) as string[]).includes(value)
+}
 export type StoreKind = keyof typeof STORE_URL

--- a/src/utils/__tests__/app-links.test.ts
+++ b/src/utils/__tests__/app-links.test.ts
@@ -1,0 +1,52 @@
+/**
+ * App Links coverage: the iOS AASA and the Android intent-filter are two
+ * hand-maintained copies of one list. They drifted once already (a route
+ * claimed on one platform only opens the app on that platform, and the bug
+ * looks like "deep links are flaky on Android"), so parity is pinned here.
+ *
+ * /app gets its own case: it is the smart download link every QR encodes, and
+ * an installed user who scans one must land in the app — that is the whole
+ * point of claiming it (TASK-21788).
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const ROOT = process.cwd()
+// extension-less JSON — require() won't parse it
+const aasa = JSON.parse(readFileSync(join(ROOT, 'public/.well-known/apple-app-site-association'), 'utf8')) as {
+    applinks: { details: { appID: string; paths: string[] }[] }
+}
+const manifest = readFileSync(join(ROOT, 'android/app/src/main/AndroidManifest.xml'), 'utf8')
+
+const details = aasa.applinks.details
+const androidPaths = [...manifest.matchAll(/android:path="([^"]+)"/g)].map((m) => m[1])
+const androidPrefixes = [...manifest.matchAll(/android:pathPrefix="([^"]+)"/g)].map((m) => m[1])
+
+describe('App Links', () => {
+    it('claims /app and /app/* for every iOS appID', () => {
+        expect(details.length).toBeGreaterThan(0)
+        for (const detail of details) {
+            expect(detail.paths).toContain('/app')
+            expect(detail.paths).toContain('/app/*')
+        }
+    })
+
+    it('claims /app on Android with the same exact-plus-prefix shape', () => {
+        expect(androidPaths).toContain('/app')
+        expect(androidPrefixes).toContain('/app/')
+    })
+
+    it('lists the same paths for every iOS appID', () => {
+        const [first, ...rest] = details
+        for (const detail of rest) {
+            expect(detail.paths).toEqual(first.paths)
+        }
+    })
+
+    it('keeps the iOS and Android lists in parity', () => {
+        const iosExact = details[0].paths.filter((p) => !p.endsWith('/*'))
+        const iosWildcard = details[0].paths.filter((p) => p.endsWith('/*')).map((p) => p.replace(/\*$/, ''))
+        expect([...androidPaths].sort()).toEqual([...iosExact].sort())
+        expect([...androidPrefixes].sort()).toEqual([...iosWildcard].sort())
+    })
+})

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -686,6 +686,23 @@ describe('native-routes', () => {
             const sample = SAMPLE_BY_ROOT[root] ?? `/${root}`
             expect(deepLinkToNativePath(`https://peanut.me${sample}`)).not.toBeNull()
         })
+
+        /*
+         * The claim is `/app` + `/app/*`, but only `/app` is a real page — on
+         * the web app and in the static export alike. The wildcard therefore has
+         * to collapse rather than pass through, or an installed user opening
+         * peanut.me/app/anything gets the SPA's missing-route → home bounce,
+         * which reads as a dropped tap.
+         */
+        it('collapses the /app wildcard onto the one real page', () => {
+            expect(deepLinkToNativePath('https://peanut.me/app')).toBe('/app')
+            expect(deepLinkToNativePath('https://peanut.me/app/anything')).toBe('/app')
+            expect(deepLinkToNativePath('https://peanut.me/app/x?pnutdl=1&dest=%2Fsend')).toBe(
+                '/app?pnutdl=1&dest=%2Fsend'
+            )
+            mockIsCapacitor.mockReturnValue(false)
+            expect(deepLinkToNativePath('https://peanut.me/app/anything')).toBe('/app')
+        })
     })
 })
 

--- a/src/utils/__tests__/native-routes.test.ts
+++ b/src/utils/__tests__/native-routes.test.ts
@@ -706,11 +706,12 @@ describe('NATIVE_EXPORT_ROOTS matches the pages the native export ships', () => 
     const PAGE_FILE = /^page\.(tsx|ts|jsx|js)$/
 
     // Exported, deliberately not in NATIVE_EXPORT_ROOTS:
-    // - `app`: the smart store link. It must open externally, never be pushed
-    //   in-app, so isNativeExportPath must keep saying no.
     // - `dev`: pruneExportedAssets() strips every /dev page but /dev/deferred,
     //   which is reached through the AASA, not from in-app anchors.
-    const WEB_ONLY_EXPORTED = ['app', 'dev']
+    // (`app` used to sit here: the smart store link was web-only. It is now
+    // claimed by App Links so a scan by an installed user opens the app, which
+    // means the deep-link mapper has to resolve it — see NATIVE_EXPORT_ROOTS.)
+    const WEB_ONLY_EXPORTED = ['dev']
 
     // A directory counts once it has a page file anywhere below it that the
     // native build does not disable — a disabled page/dir contributes nothing.

--- a/src/utils/deferred-link.ts
+++ b/src/utils/deferred-link.ts
@@ -204,9 +204,9 @@ function captureRestore(
  * Consumers: the store-bounce handlers in migration.utils (openStore /
  * onStoreAnchorClick); the download modal (TASK-20769) joins them when built.
  */
-export function trackDeferredHandoffCreated(platform: 'ios' | 'android'): void {
+export function trackDeferredHandoffCreated(platform: 'ios' | 'android', props?: Record<string, unknown>): void {
     try {
-        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_HANDOFF_CREATED, { platform })
+        posthog.capture(ANALYTICS_EVENTS.DEFERRED_LINK_HANDOFF_CREATED, { platform, ...props })
     } catch {}
 }
 

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -66,9 +66,24 @@ export function getMigrationCutoverTime(): number {
     return MIGRATION_CUTOVER_DATE.getTime()
 }
 
-/** track a store CTA click without navigating (for anchors that navigate themselves). */
-export function trackStoreClick(store: StoreKind, surface: MigrationSurface, handoff = false) {
-    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, { surface, store, handoff })
+/**
+ * track a store CTA click without navigating (for anchors that navigate themselves).
+ * `qrSurface` is only ever set on the /app smart link, where `surface` is
+ * always `smart_link`: it carries the landing surface whose QR produced the
+ * scan, so smart-link clicks join back to hero / app fold / footer / rates.
+ */
+export function trackStoreClick(
+    store: StoreKind,
+    surface: MigrationSurface,
+    handoff = false,
+    qrSurface?: MigrationSurface | null
+) {
+    posthog.capture(ANALYTICS_EVENTS.MIGRATION_STORE_CTA_CLICKED, {
+        surface,
+        store,
+        handoff,
+        ...(qrSurface ? { qr_surface: qrSurface } : {}),
+    })
 }
 
 /** context a bounce surface knows before any cookie is written (claim page invite CTA). */

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -116,14 +116,15 @@ export function openStore(store: StoreKind, surface: MigrationSurface, handoff?:
 /**
  * href for a store CTA that is a real anchor and navigates itself: android
  * carries the hand-off in the url; iOS can't (the clipboard needs the tap) —
- * pair with onStoreAnchorClick. never preventDefault such an anchor: its own
+ * pair with onStoreAnchorClick, passing it the SAME handoff so both channels
+ * carry the same context. never preventDefault such an anchor: its own
  * navigation is the fallback that still works where window.open is suppressed
  * (in-app browsers, strict popup blockers).
  */
-export function storeAnchorHref(store: StoreKind): string {
+export function storeAnchorHref(store: StoreKind, handoff?: StoreHandoff): string {
     if (!isCapacitor() && store === 'android') {
         try {
-            return playStoreUrlWithReferrer(buildDeferredPayload())
+            return playStoreUrlWithReferrer(buildDeferredPayload(handoff?.dest, handoff?.invite))
         } catch {
             // fall through to the bare url — the bounce itself never breaks
         }
@@ -132,14 +133,14 @@ export function storeAnchorHref(store: StoreKind): string {
 }
 
 /** tracking + iOS clipboard hand-off for a self-navigating store anchor. */
-export function onStoreAnchorClick(store: StoreKind, surface: MigrationSurface) {
+export function onStoreAnchorClick(store: StoreKind, surface: MigrationSurface, handoff?: StoreHandoff) {
     if (isCapacitor()) {
         trackStoreClick(store, surface)
         return
     }
     let payload = ''
     try {
-        payload = buildDeferredPayload()
+        payload = buildDeferredPayload(handoff?.dest, handoff?.invite)
     } catch {}
     trackStoreClick(store, surface, !!payload)
     if (store === 'ios' && payload)

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -129,6 +129,19 @@ function mapDeepLinkPath(parsed: URL): string | null {
         return isCapacitor() ? null : appendParams(path, extraParams)
     }
 
+    /*
+     * The smart download link. App Links claim `/app` AND `/app/*` (a wildcard
+     * the AASA and the intent-filter give every claimed root), but there is no
+     * `/app/<anything>` route on either the web app or the native export — so a
+     * sub-path would open the app and land on a missing route, i.e. exactly the
+     * cold-boot-to-home dropped tap the null returns below exist to prevent.
+     * Collapse the whole claim onto the one real page instead of dropping it:
+     * /app's own native branch applies the deferred payload and routes on.
+     */
+    if (segments[0] === 'app') {
+        return appendParams('/app', extraParams)
+    }
+
     if (segments[0] === 'send' && segments[1]) {
         return appendParams(sendUrl(decodeURIComponent(segments.slice(1).join('/'))), extraParams)
     }

--- a/src/utils/native-routes.ts
+++ b/src/utils/native-routes.ts
@@ -255,6 +255,10 @@ function mapDeepLinkPath(parsed: URL): string | null {
  */
 export const NATIVE_EXPORT_ROOTS: ReadonlySet<string> = new Set([
     'add-money',
+    // the /app smart link. App Links claim it (TASK-21788) so an installed
+    // user who scans a download QR opens the app instead of the store page —
+    // and /app's own native branch applies the deferred payload and routes on.
+    'app',
     'badges',
     'card',
     'card-payment',


### PR DESCRIPTION
## Summary

PR 1 of the peanut.me landing → app-store migration (TASK-21788): the *mechanism* only, no page layout. It makes the download QR carry deferred context, teaches `/app` to hand that context to the right store on the right platform, fixes the store-button pair so it lays out correctly on desktop and can't overflow a phone, and claims `/app` for App Links on both platforms so an already-installed user who scans a QR lands in the app instead of the store page.

Everything here is inert until the `pwa-sunset` PostHog flag is on, except the App Links files (which are additive) and the `StoreBadges` → `StorePair` rename.

## What changed

- **`DownloadQR`** takes `size?: 160 | 192 | 224` and **one** context input: either `payload` (a querystring the caller already holds) or `handoff` (`{dest, invite}`), mutually exclusive in the props type. Given `handoff` it derives the payload itself after mount and passes the same `handoff` to the `StorePair` beneath it, so the code and the buttons can never carry different context. The encoded URL is `${origin}/app?${payload}&s=<surface>` (or `?s=<surface>` alone), so every scan is attributable to the QR that produced it and carries locale / invite / badge campaigns / destination through the install.
- **`size` is the QR frame width; the module area is 36px narrower** (`p-4` + `border-2`): 160 → 124px modules, 192 → 156px, 224 → 188px. Documented on the constant. **PR 2 should pass `size={192}` for the hero and `size={224}` for the app fold and the footer** to hit the brief's stated module areas.
- **`MIGRATION_QR_SHOWN`** moved from mount to a real impression: an `IntersectionObserver` at 50% visibility, once per mount, with `{ surface, hasContext }`. The app fold and the footer render their QR far below the fold, so counting mounts would have made the scan rate look broken. Falls back to counting the mount where `IntersectionObserver` is missing (jsdom, old WebViews); in a modal the QR is already in view on open, so that is the open event. The capture waits for the derived payload, so a contextful QR never reports `hasContext:false`.
- **`/app` (`src/app/app/page.tsx`)** reads `window.location.search` after mount and validates it with `parseDeferredPayload` (marker check):
  - *Android + payload* → auto-redirects to `playStoreUrlWithReferrer(payload)` and fires `trackDeferredHandoffCreated('android')`.
  - *iOS + payload* → **no** auto-redirect. The clipboard hand-off only succeeds inside a user gesture, so the visitor gets the pink App Store button + stroke Google Play button, and the App Store tap calls `copyIOSHandoff(payload)` inside the click handler before the anchor navigates.
  - *No payload* → today's behaviour, unchanged.
  - *Inside the native app* → `applyDeferredPayload(parsed)` then `router.replace(dest ?? '/home')`.
  - **`DEFERRED_LINK_HANDOFF_CREATED` is counted once per visit** (ref guard shared by the auto-redirect and the tap). Without it, a bounce that never took over — blocked, offline, Play missing — re-enabled the buttons after 4s and a tap counted a second hand-off, deflating the restore match rate on exactly the flaky devices.
  - Store taps report `trackStoreClick(store, 'smart_link', hasPayload, qrSurface)`. The `s=` tag is **read** here (validated against `MIGRATION_SURFACES`) and reported as `qr_surface` on the click and hand-off events, which is what joins a smart-link click back to the hero / app fold / footer / rates QR that produced the scan. It is still stripped before the payload is re-emitted, so it never rides into the Play install referrer.
- **`StoreBadges` → `StorePair`** (rename, imports updated). Anchors use `storeAnchorHref(store, handoff)` + `onStoreAnchorClick(store, surface, handoff)`. Container widths are per-appearance: `hero` is `max-w-[27.5rem]` (440px) so two `sm:w-52` anchors (208px each) plus `gap-3` (12px) = 428px sit on **one line** at every width ≥ `sm`, including 1366 and 1440; the compact row keeps `max-w-[26rem]`. Below `sm` the hero anchors are `w-full` and stack by design. The two hrefs are memoized per handoff identity — the android one runs `buildDeferredPayload` (cookie + badge-campaign + `window.location` reads) and the hero pair lives inside `LandingPageClient`, which re-renders every scroll-driven animation frame until PR 3 lands.
- **`storeAnchorHref` / `onStoreAnchorClick`** take an optional `StoreHandoff`, matching what `openStore` already accepted.
- **`StickyMobileCTA`**: `deviceType === WEB` (desktop-mode phone, or a UA we don't recognise) now renders the compact store pair instead of guessing iOS. Everything else is unchanged.
- **App links**: `/app` + `/app/*` added to all three appIDs in `public/.well-known/apple-app-site-association`, and `android:path="/app"` + `android:pathPrefix="/app/"` to the verified intent filter. `app` added to `NATIVE_EXPORT_ROOTS`, and `mapDeepLinkPath` collapses the whole `/app/*` claim onto `/app` — the wildcard has no route behind it on either the web app or the static export, so a passthrough would open the app onto a missing route (see Divergences).
- **`MIGRATION_SURFACES`** gains `SMART_LINK`, `LANDING_APP_FOLD`, `LANDING_FOOTER`, `LANDING_RATES`, `LANDING_COUNTRIES`, `LANDING_DOOR`; new `MIGRATION_SURFACE_PARAM = 's'` and `isMigrationSurface()` are shared by the QR builder and `/app`.
- **New tests**: `DownloadQR` URL building, handoff-derived payload reaching both channels, sizes, impression threshold and `hasContext`; `StorePair` hrefs, handoff, tap tracking and the hero row's one-line arithmetic; `/app` payload branching (android bounce, iOS no-bounce + clipboard-on-tap, bare visit, native apply-and-route, flag-off 404), `qr_surface` attribution, an unknown surface tag, and the once-per-visit hand-off count; `StickyMobileCTA` WEB case; `/app/*` collapsing in the deep-link mapper; an App Links parity guard (iOS AASA ↔ Android intent filter).

No new user-facing copy — no i18n keys added.

## How verified

- `pnpm typecheck` → clean on every touched file. 6 errors remain, all `TS2307` in files this PR does not touch (`src/utils/web-vitals-shim.ts`, `src/utils/app-review.ts`, `src/utils/native-settings.ts` and the web-vitals test): `web-vitals`, `@capacitor/app-launcher`, `@capgo/capacitor-in-app-review` and `capacitor-native-settings` are absent from this sandbox's shared `node_modules`. Same 6 before and after the change.
- `pnpm test -- src/components/Migration/__tests__/DownloadQR.test.tsx src/components/Migration/__tests__/StorePair.test.tsx src/app/app/__tests__/smart-store-link.test.tsx src/utils/__tests__/app-links.test.ts src/utils/__tests__/native-routes.test.ts src/components/LandingPage/__tests__/StickyMobileCTA.test.tsx src/components/Migration/__tests__/MigrationDownloadModal.test.tsx` → **7 suites, 246 tests, green**. `pnpm test -- src/utils/__tests__/deferred-link.test.ts src/utils/__tests__/migration.utils.test.ts` → **2 suites, 63 tests, green**.
- `pnpm lint --quiet <touched files>` → clean. `prettier --check <touched files>` → clean.
- Hero row geometry: asserted in `StorePair.test.tsx` against the resolved values rather than the class string (jsdom has no layout). Tailwind v4 with no `--spacing` or `--breakpoint-sm` override in `src/styles/globals.css`, so `w-52` = 13rem = 208px, `gap-3` = 0.75rem = 12px, `sm` = 640px, and the `max-w-[27.5rem]` = 440px cap clears the 428px the row needs. The previous `max-w-[26rem]` (416px) wrapped the pair at every width ≥ `sm`.
- No dev-server/browser check in this PR by design — the runtime pass (screenshots, QR decode, flag-off pixel diff) runs on the page PR, which is where the hero lockup actually renders.

## Divergences

1. **`/app` also had to become a mappable native route.** The brief asked only for the AASA + manifest entries. Adding them immediately failed the existing AASA drift guard, which asserts every claimed root resolves through `deepLinkToNativePath`. That is not a test technicality: an App Link the mapper drops cold-boots the app to `/home`, so the brief's own native branch (`applyDeferredPayload` → `router.replace(dest)`) could never run. `/app` is already built by the native static export, so nothing new ships — only the mapper's verdict changed. `app` was therefore added to `NATIVE_EXPORT_ROOTS` and removed from `WEB_ONLY_EXPORTED` in the export-drift test, with both comments updated. Side effect, accepted: an in-app anchor to `/app` would now push in-app rather than open the browser; there are none in the codebase.
2. **`handoff` threaded through the store helpers, and it is now the *only* context channel on `DownloadQR`** (a caller passes `payload` **or** `handoff`, never both; `handoff` derives the payload internally). PR 2 opens the hoisted modal with `dest=/send` on fold 4 and destination context on fold 5, and that modal's content is `DownloadQR` → `StorePair`. As first written the two props were independent: `handoff` alone left the QR context-free (and reported `hasContext:false`) while the buttons beneath it carried the destination, and `payload` alone did the reverse, with nothing catching it. One input, one derivation. The brief's reason for the caller building the payload — it reads `window` — is met by deriving it in a mount effect.
3. **`size` is the QR frame width, not the module area.** 160 is exactly the frame width `QRCodeWrapper` ships today (`max-w-[160px]`); the modules inside it are 124px. Reading "160 default" as the module area would silently resize every existing QR on merge, so the reading that keeps the stated default a no-op is the frame width. The frame→module mapping is now documented on the constant and a `224` option added, so PR 2 can hit the brief's module areas: `192` for the hero (156px modules), `224` for the app fold and footer (188px).
4. **The `/app/*` App Links wildcard is collapsed in the deep-link mapper.** The claim itself is exactly what the brief asked for on both platforms, but `/app/<anything>` is not a route on the web app or the static export. `mapDeepLinkPath` now returns `/app` for any `/app/*` deep link, so an installed user opening `peanut.me/app/anything` lands on the real page instead of the SPA's missing-route → home bounce. Neither the AASA drift guard nor the app-links parity test can see this class of bug — both only compare the two hand-maintained lists to each other.
5. **`/app` reads the `s=` surface tag instead of only stripping it.** The brief had the QR write the tag and `/app` strip it before re-emitting the payload. It still strips it (the tag must never ride into the Play install referrer), but it is now also validated against `MIGRATION_SURFACES` and reported as `qr_surface` on this page's click and hand-off events. Without that read the tag was costing QR modules for nothing and the landing surfaces were indistinguishable in the smart-link funnel — the one attribution question the param exists to answer.

## Flag-off impact

None on the page: every behaviour change is inside a `pwa-sunset` branch (`/app` still 404s with the flag off, `StickyMobileCTA`'s flag-off arm is untouched, `StorePair`/`DownloadQR` only render on migration surfaces). Three changes are live regardless and are additive by design: the `/app` App Links claim on both platforms, `app` joining `NATIVE_EXPORT_ROOTS`, and the mapper's `/app/*` collapse.

**Release gate — the two halves of the `/app` claim ship on different vehicles.** The AASA is a static file served by the web deploy, so iOS picks up the `/app` claim for already-installed apps within days of merge. The Android intent-filter lives in the APK and only takes effect in the next Play release. `app-links.test.ts` asserts the two *files* agree and stays green through the entire window in which the two *platforms* do not. So: **do not flip `pwa-sunset` on for Android traffic until an Android build containing this manifest is live in Play**, and run the runtime checklist's "Android UA" item against that binary, not against the web deploy. Until then an installed Android user who scans a download QR still lands on web `/app` (404 with the flag off; store buttons for an app they already have once it is on).
