### PR TITLE
chore(landing): delete the Send-in-seconds scroll-jack (TASK-21788)

### DIFF
--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useFooterVisibility } from '@/context/footerVisibility'
-import { Suspense, useEffect, useMemo, useState, useRef, useCallback, type ReactNode } from 'react'
+import { Suspense, useEffect, useMemo, useState, type ReactNode } from 'react'
 // Imported directly, not through the barrel: `export *` pulls every sibling
 // into this chunk, including dropLink's nine repeat: Infinity animations,
 // which the landing page never renders.
@@ -102,25 +102,6 @@ export function LandingPageClient({
     }, [migrationOn, deviceType, isDesktop, heroConfig.primaryCta, tMigration])
 
     const [buttonVisible, setButtonVisible] = useState(true)
-    const [isScrollFrozen, setIsScrollFrozen] = useState(false)
-    const [buttonScale, setButtonScale] = useState(1)
-    const [animationComplete, setAnimationComplete] = useState(false)
-    const [shrinkingPhase, setShrinkingPhase] = useState(false)
-    const [hasGrown, setHasGrown] = useState(false)
-    const sendInSecondsRef = useRef<HTMLDivElement>(null)
-    const frozenScrollY = useRef(0)
-    const virtualScrollY = useRef(0)
-    const touchStartY = useRef(0)
-
-    // Use refs to avoid re-attaching listeners on every state change
-    const isScrollFrozenRef = useRef(isScrollFrozen)
-    const animationCompleteRef = useRef(animationComplete)
-    const shrinkingPhaseRef = useRef(shrinkingPhase)
-    const hasGrownRef = useRef(hasGrown)
-    isScrollFrozenRef.current = isScrollFrozen
-    animationCompleteRef.current = animationComplete
-    shrinkingPhaseRef.current = shrinkingPhase
-    hasGrownRef.current = hasGrown
 
     useEffect(() => {
         if (isFooterVisible) {
@@ -129,108 +110,6 @@ export function LandingPageClient({
             setButtonVisible(true)
         }
     }, [isFooterVisible])
-
-    // Shared logic: accumulate virtual scroll delta and animate the button scale
-    const handleScrollDelta = useCallback((deltaY: number) => {
-        if (!isScrollFrozenRef.current || animationCompleteRef.current) return
-        if (deltaY <= 0) return
-
-        virtualScrollY.current += deltaY
-
-        const maxVirtualScroll = 500
-        const newScale = Math.min(1.5, 1 + (virtualScrollY.current / maxVirtualScroll) * 0.5)
-        setButtonScale(newScale)
-
-        if (newScale >= 1.5) {
-            setAnimationComplete(true)
-            setHasGrown(true)
-            document.body.style.overflow = ''
-            setIsScrollFrozen(false)
-        }
-    }, [])
-
-    useEffect(() => {
-        const handleScroll = () => {
-            if (sendInSecondsRef.current) {
-                const targetElement = document.getElementById('sticky-button-target')
-                if (!targetElement) return
-
-                const targetRect = targetElement.getBoundingClientRect()
-                const currentScrollY = window.scrollY
-
-                const stickyButtonTop = window.innerHeight - 16 - 52
-                const stickyButtonBottom = window.innerHeight - 16
-
-                const shouldFreeze =
-                    targetRect.top <= stickyButtonBottom - 60 &&
-                    targetRect.bottom >= stickyButtonTop - 60 &&
-                    !animationCompleteRef.current &&
-                    !shrinkingPhaseRef.current &&
-                    !hasGrownRef.current
-
-                if (shouldFreeze && !isScrollFrozenRef.current) {
-                    setIsScrollFrozen(true)
-                    frozenScrollY.current = currentScrollY
-                    virtualScrollY.current = 0
-                    document.body.style.overflow = 'hidden'
-                    window.scrollTo(0, frozenScrollY.current)
-                } else if (isScrollFrozenRef.current && !animationCompleteRef.current) {
-                    window.scrollTo(0, frozenScrollY.current)
-                } else if (
-                    animationCompleteRef.current &&
-                    !shrinkingPhaseRef.current &&
-                    currentScrollY > frozenScrollY.current + 50
-                ) {
-                    setShrinkingPhase(true)
-                } else if (shrinkingPhaseRef.current) {
-                    const shrinkDistance = Math.max(0, currentScrollY - (frozenScrollY.current + 50))
-                    const maxShrinkDistance = 200
-                    const shrinkProgress = Math.min(1, shrinkDistance / maxShrinkDistance)
-                    const newScale = 1.5 - shrinkProgress * 0.5
-                    setButtonScale(Math.max(1, newScale))
-                } else if (animationCompleteRef.current && currentScrollY < frozenScrollY.current - 100) {
-                    setAnimationComplete(false)
-                    setShrinkingPhase(false)
-                    setButtonScale(1)
-                    setHasGrown(false)
-                }
-            }
-        }
-
-        const handleWheel = (event: WheelEvent) => {
-            if (isScrollFrozenRef.current && !animationCompleteRef.current) {
-                event.preventDefault()
-                handleScrollDelta(event.deltaY)
-            }
-        }
-
-        const handleTouchStart = (event: TouchEvent) => {
-            touchStartY.current = event.touches[0].clientY
-        }
-
-        const handleTouchMove = (event: TouchEvent) => {
-            if (isScrollFrozenRef.current && !animationCompleteRef.current) {
-                event.preventDefault()
-                const deltaY = touchStartY.current - event.touches[0].clientY
-                touchStartY.current = event.touches[0].clientY
-                handleScrollDelta(deltaY)
-            }
-        }
-
-        window.addEventListener('scroll', handleScroll)
-        window.addEventListener('wheel', handleWheel, { passive: false })
-        window.addEventListener('touchstart', handleTouchStart, { passive: true })
-        window.addEventListener('touchmove', handleTouchMove, { passive: false })
-        handleScroll()
-
-        return () => {
-            window.removeEventListener('scroll', handleScroll)
-            window.removeEventListener('wheel', handleWheel)
-            window.removeEventListener('touchstart', handleTouchStart)
-            window.removeEventListener('touchmove', handleTouchMove)
-            document.body.style.overflow = ''
-        }
-    }, [handleScrollDelta])
 
     // Only the words with a real article behind them become links; the rest
     // stay plain text. Words come from the content system's marquee list, so an
@@ -253,8 +132,6 @@ export function LandingPageClient({
         }
     }, [contentHrefs, marqueeMessages])
 
-    // Memoized because this component re-renders per scroll frame while the
-    // send button grows.
     const doorMarqueeProps = useMemo(
         () => ({
             visible: true,
@@ -275,7 +152,6 @@ export function LandingPageClient({
             <Hero
                 primaryCta={primaryCta}
                 buttonVisible={buttonVisible}
-                buttonScale={buttonScale}
                 strings={strings}
                 locale={locale}
                 customCta={
@@ -317,7 +193,7 @@ export function LandingPageClient({
             <Marquee {...marqueeProps} />
             {securitySlot}
             <Marquee {...marqueeProps} />
-            <div ref={sendInSecondsRef}>{sendInSecondsSlot}</div>
+            {sendInSecondsSlot}
             <Marquee {...marqueeProps} />
             {faqSlot}
             <Marquee {...marqueeProps} />

--- a/src/components/LandingPage/__tests__/LandingPageClient.scrollJack.test.tsx
+++ b/src/components/LandingPage/__tests__/LandingPageClient.scrollJack.test.tsx
@@ -3,7 +3,7 @@
  * page used to freeze `document.body` and swallow wheel/touch events while it
  * grew the CTA. Nothing may bring that back.
  */
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { act, type ReactNode } from 'react'
 import type { LandingStrings } from '../landingStrings'
 import type { LandingContentHrefs } from '../landingContentHrefs'
@@ -149,10 +149,13 @@ describe('LandingPageClient — no scroll-jack', () => {
         }
     })
 
-    it('renders the send-in-seconds slot without a scroll-jack target wrapper', () => {
-        const { container } = renderLanding()
+    it('renders the send-in-seconds slot with no wrapper element around it', () => {
+        const { container } = renderLanding(<section id="send-in-seconds" data-testid="send-in-seconds" />)
 
-        expect(container.querySelector('#send-in-seconds')).toBeInTheDocument()
-        expect(container.querySelector('#sticky-button-target')).toBeNull()
+        // The deleted wrapper was `<div ref={sendInSecondsRef}>{sendInSecondsSlot}</div>`, which
+        // carried no id or class — the only thing that catches it coming back is the slot's
+        // parent. LandingPageClient returns a fragment, so the slot must be a direct child of
+        // the render container; pre-deletion it was a child of that anonymous div.
+        expect(screen.getByTestId('send-in-seconds').parentElement).toBe(container)
     })
 })

--- a/src/components/LandingPage/__tests__/LandingPageClient.scrollJack.test.tsx
+++ b/src/components/LandingPage/__tests__/LandingPageClient.scrollJack.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Regression guard for the deleted "Send in seconds" scroll-jack: the landing
+ * page used to freeze `document.body` and swallow wheel/touch events while it
+ * grew the CTA. Nothing may bring that back.
+ */
+import { render } from '@testing-library/react'
+import { act, type ReactNode } from 'react'
+import type { LandingStrings } from '../landingStrings'
+import type { LandingContentHrefs } from '../landingContentHrefs'
+
+const heroProps: Record<string, unknown>[] = []
+
+jest.mock('next/dynamic', () => ({
+    __esModule: true,
+    default: () => () => null,
+}))
+
+jest.mock('@/context/footerVisibility', () => ({
+    useFooterVisibility: () => ({ isFooterVisible: false }),
+}))
+
+jest.mock('next-intl', () => ({
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}))
+
+jest.mock('@/hooks/useMigrationFlag', () => ({
+    useMigrationFlag: () => false,
+}))
+
+jest.mock('@/hooks/useGetDeviceType', () => ({
+    ...jest.requireActual('@/hooks/useGetDeviceType'),
+    useDeviceType: () => ({ deviceType: 'web' }),
+}))
+
+jest.mock('@/utils/migration.utils', () => ({
+    storeAnchorHref: () => 'https://example.test/store',
+    onStoreAnchorClick: jest.fn(),
+}))
+
+jest.mock('@/components/Migration/StoreBadges', () => ({
+    __esModule: true,
+    default: () => <div data-testid="store-badges" />,
+}))
+
+jest.mock('../hero', () => ({
+    Hero: (props: Record<string, unknown>) => {
+        heroProps.push(props)
+        return <section id="hero" />
+    },
+}))
+
+jest.mock('../marquee', () => ({ Marquee: () => <div data-testid="marquee" /> }))
+jest.mock('../noFees', () => ({ NoFees: () => <div data-testid="no-fees" /> }))
+jest.mock('../ShhhhhFold', () => ({ ShhhhhFold: () => <div data-testid="door" /> }))
+jest.mock('../StickyMobileCTA', () => ({ StickyMobileCTA: () => <div data-testid="sticky" /> }))
+
+// imported after the mocks so the component picks them up
+import { LandingPageClient } from '../LandingPageClient'
+
+// window.innerHeight is 768 in jsdom: the old handler froze the page while the
+// target's top was <= 692 and its bottom >= 640.
+const armFreezeWindow = (node: HTMLDivElement | null) => {
+    if (!node) return
+    node.getBoundingClientRect = () => ({ top: 600, bottom: 660, height: 60 }) as DOMRect
+}
+
+/**
+ * jsdom gives every element a zero rect, so the deleted freeze window could
+ * never open by accident. This puts a `#sticky-button-target` back on screen,
+ * parked exactly where the old handler used to freeze the page — the fixture
+ * that makes this suite fail against the pre-deletion component.
+ */
+const legacyTarget = () => (
+    <section id="send-in-seconds">
+        <div id="sticky-button-target" ref={armFreezeWindow}>
+            cta
+        </div>
+    </section>
+)
+
+const renderLanding = (sendInSecondsSlot: ReactNode = <section id="send-in-seconds" />) =>
+    render(
+        <LandingPageClient
+            heroConfig={{ primaryCta: { label: 'Sign up', href: '/setup' } }}
+            marqueeMessages={['GLOBAL']}
+            locale="en"
+            strings={{} as LandingStrings}
+            contentHrefs={{} as LandingContentHrefs}
+            problemSlot={<div />}
+            mantecaSlot={<div />}
+            regulatedRailsSlot={<div />}
+            yourMoneySlot={<div />}
+            securitySlot={<div />}
+            sendInSecondsSlot={sendInSecondsSlot}
+            footerSlot={<div />}
+            faqSlot={<div />}
+        />
+    )
+
+describe('LandingPageClient — no scroll-jack', () => {
+    beforeEach(() => {
+        heroProps.length = 0
+        document.body.style.overflow = ''
+    })
+
+    it('never freezes body scroll, however far the page is scrolled', () => {
+        renderLanding(legacyTarget())
+
+        for (const y of [0, 400, 1200, 4000]) {
+            act(() => {
+                window.scrollY = y
+                window.dispatchEvent(new Event('scroll'))
+            })
+            expect(document.body.style.overflow).toBe('')
+        }
+    })
+
+    it('does not preventDefault wheel or touchmove events', () => {
+        renderLanding(legacyTarget())
+
+        act(() => {
+            window.scrollY = 1200
+            window.dispatchEvent(new Event('scroll'))
+        })
+
+        const wheel = Object.assign(new Event('wheel', { bubbles: true, cancelable: true }), { deltaY: 400 })
+        const touchStart = Object.assign(new Event('touchstart', { bubbles: true, cancelable: true }), {
+            touches: [{ clientY: 500 }],
+        })
+        const touchMove = Object.assign(new Event('touchmove', { bubbles: true, cancelable: true }), {
+            touches: [{ clientY: 100 }],
+        })
+        act(() => {
+            window.dispatchEvent(wheel)
+            window.dispatchEvent(touchStart)
+            window.dispatchEvent(touchMove)
+        })
+
+        expect(wheel.defaultPrevented).toBe(false)
+        expect(touchMove.defaultPrevented).toBe(false)
+    })
+
+    it('does not hand the hero a buttonScale', () => {
+        renderLanding()
+
+        expect(heroProps.length).toBeGreaterThan(0)
+        for (const props of heroProps) {
+            expect(props).not.toHaveProperty('buttonScale')
+        }
+    })
+
+    it('renders the send-in-seconds slot without a scroll-jack target wrapper', () => {
+        const { container } = renderLanding()
+
+        expect(container.querySelector('#send-in-seconds')).toBeInTheDocument()
+        expect(container.querySelector('#sticky-button-target')).toBeNull()
+    })
+})

--- a/src/components/LandingPage/__tests__/ctaScrollJackRemnants.test.tsx
+++ b/src/components/LandingPage/__tests__/ctaScrollJackRemnants.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * The scroll-jack drove the hero CTA through a `--cta-scale` custom property
+ * and anchored itself on `#sticky-button-target` in the send-in-seconds fold.
+ * Both are gone; the `.cta-motion` / `.cta-enter` entrance stays.
+ */
+import { render } from '@testing-library/react'
+import { Hero } from '../hero'
+import { SendInSeconds } from '../sendInSeconds'
+import { landingStrings } from '../landingStrings'
+import { getTranslations } from '@/i18n'
+
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: ({ alt }: { alt?: string }) => <img alt={alt ?? ''} />,
+}))
+
+const strings = landingStrings(getTranslations('en'))
+
+describe('Hero CTA', () => {
+    it('renders the CTA without a scale custom property', () => {
+        const { container } = render(
+            <Hero strings={strings} locale="en" buttonVisible primaryCta={{ label: 'Sign up', href: '/setup' }} />
+        )
+
+        const cta = container.querySelector('.cta-motion') as HTMLElement | null
+        expect(cta).not.toBeNull()
+        expect(cta!.getAttribute('style')).not.toContain('--cta-scale')
+        // the translate/rotate entrance stays
+        expect(cta!.getAttribute('style')).toContain('--cta-x')
+    })
+
+    it('keeps rendering a custom CTA without a scale custom property', () => {
+        const { container } = render(
+            <Hero strings={strings} locale="en" buttonVisible customCta={<span>store pair</span>} />
+        )
+
+        const cta = container.querySelector('.cta-motion') as HTMLElement | null
+        expect(cta).not.toBeNull()
+        expect(cta!.getAttribute('style')).not.toContain('--cta-scale')
+    })
+})
+
+describe('SendInSeconds fold', () => {
+    it('drops the scroll-jack target but keeps the section anchor and CTA entrance', () => {
+        const { container } = render(<SendInSeconds locale="en" />)
+
+        expect(container.querySelector('#send-in-seconds')).toBeInTheDocument()
+        expect(container.querySelector('#sticky-button-target')).toBeNull()
+
+        const cta = container.querySelector('.cta-motion.cta-enter')
+        expect(cta).not.toBeNull()
+        expect(container.querySelector('a[href="/send"]')).toBeInTheDocument()
+    })
+})

--- a/src/components/LandingPage/__tests__/ctaScrollJackRemnants.test.tsx
+++ b/src/components/LandingPage/__tests__/ctaScrollJackRemnants.test.tsx
@@ -41,14 +41,22 @@ describe('Hero CTA', () => {
 })
 
 describe('SendInSeconds fold', () => {
-    it('drops the scroll-jack target but keeps the section anchor and CTA entrance', () => {
+    // The scroll-jack regression guard. Keep it free of fold-10 content assertions.
+    it('drops the scroll-jack target but keeps the section anchor and the CTA motion class', () => {
         const { container } = render(<SendInSeconds locale="en" />)
 
         expect(container.querySelector('#send-in-seconds')).toBeInTheDocument()
         expect(container.querySelector('#sticky-button-target')).toBeNull()
+        expect(container.querySelector('.cta-motion')).not.toBeNull()
+    })
 
-        const cta = container.querySelector('.cta-motion.cta-enter')
-        expect(cta).not.toBeNull()
+    // Fold 10's content as it ships today. PR 2 of TASK-21788 rewrites this fold into
+    // "GET THE APP" and re-points the CTA away from /send, so this is the test to
+    // retarget or delete there — the regression guard above stays untouched.
+    it('links the CTA to /send with the entrance animation (fold-10 content, superseded by PR 2)', () => {
+        const { container } = render(<SendInSeconds locale="en" />)
+
+        expect(container.querySelector('.cta-motion.cta-enter')).not.toBeNull()
         expect(container.querySelector('a[href="/send"]')).toBeInTheDocument()
     })
 })

--- a/src/components/LandingPage/hero.tsx
+++ b/src/components/LandingPage/hero.tsx
@@ -107,7 +107,6 @@ type HeroProps = {
     primaryCta?: CTAButton
     secondaryCta?: CTAButton
     buttonVisible?: boolean
-    buttonScale?: number
     /** replaces the primary button entirely (store-button pair on desktop during the migration window) */
     customCta?: React.ReactNode
 }
@@ -117,12 +116,11 @@ type HeroProps = {
  * framer-motion animate/whileHover pair. Same values, but the transform runs on
  * the compositor instead of a main-thread rAF loop.
  */
-const getCtaStyle = (variant: 'primary' | 'secondary', buttonVisible?: boolean, buttonScale?: number): CSSProperties =>
+const getCtaStyle = (variant: 'primary' | 'secondary', buttonVisible?: boolean): CSSProperties =>
     ({
         '--cta-x': buttonVisible ? '0px' : '20px',
         '--cta-y': buttonVisible ? '0px' : '20px',
         '--cta-r': buttonVisible ? '0deg' : '1deg',
-        '--cta-scale': buttonScale || 1,
         '--cta-hover-x': variant === 'primary' ? '0px' : '3px',
         opacity: buttonVisible ? 1 : 0,
         pointerEvents: buttonVisible ? 'auto' : 'none',
@@ -131,20 +129,12 @@ const getCtaStyle = (variant: 'primary' | 'secondary', buttonVisible?: boolean, 
 const getButtonContainerClasses = (variant: 'primary' | 'secondary') =>
     `relative z-20 mt-8 flex flex-col items-center justify-center ${variant === 'primary' ? 'mx-auto w-fit' : 'right-[calc(50%-120px)]'}`
 
-export function Hero({
-    primaryCta,
-    secondaryCta,
-    buttonVisible,
-    buttonScale = 1,
-    customCta,
-    strings,
-    locale,
-}: HeroProps) {
+export function Hero({ primaryCta, secondaryCta, buttonVisible, customCta, strings, locale }: HeroProps) {
     const renderCTAButton = (cta: CTAButton, variant: 'primary' | 'secondary') => {
         return (
             <div
                 className={`${getButtonContainerClasses(variant)} cta-motion`}
-                style={getCtaStyle(variant, buttonVisible, buttonScale)}
+                style={getCtaStyle(variant, buttonVisible)}
             >
                 <a
                     href={cta.href}
@@ -170,7 +160,7 @@ export function Hero({
     const renderCustomCta = () => (
         <div
             className={`${getButtonContainerClasses('primary')} cta-motion`}
-            style={getCtaStyle('primary', buttonVisible, buttonScale)}
+            style={getCtaStyle('primary', buttonVisible)}
         >
             {customCta}
         </div>

--- a/src/components/LandingPage/sendInSeconds.tsx
+++ b/src/components/LandingPage/sendInSeconds.tsx
@@ -96,9 +96,7 @@ export function SendInSeconds({ locale = DEFAULT_LOCALE }: { locale?: Locale }) 
                     {i18n.landingSendTagline2}
                 </p>
 
-                <div id="sticky-button-target">
-                    <SendInSecondsCTA strings={landingStrings(i18n)} />
-                </div>
+                <SendInSecondsCTA strings={landingStrings(i18n)} />
             </div>
         </section>
     )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1862,7 +1862,7 @@ input::placeholder {
    Hover is gated on (hover: hover) to match tailwind's hoverOnlyWhenSupported,
    so a tap on iOS can't latch the button into its hover transform. */
 .cta-motion {
-    transform: translate(var(--cta-x, 0px), var(--cta-y, 0px)) rotate(var(--cta-r, 0deg)) scale(var(--cta-scale, 1));
+    transform: translate(var(--cta-x, 0px), var(--cta-y, 0px)) rotate(var(--cta-r, 0deg));
     transition:
         transform 0.45s cubic-bezier(0.34, 1.36, 0.64, 1),
         opacity 0.45s ease;
@@ -1885,7 +1885,7 @@ input::placeholder {
 @keyframes cta-enter {
     from {
         opacity: 0;
-        transform: translate(0, 4px) rotate(0.75deg) scale(var(--cta-scale, 1));
+        transform: translate(0, 4px) rotate(0.75deg);
     }
 }
 


### PR DESCRIPTION
## Summary

The "Send in seconds" fold froze the page. On the way down, once the CTA reached the sticky-bar band, `LandingPageClient` set `document.body.style.overflow = 'hidden'`, pinned `window.scrollY`, and swallowed `wheel` and `touchmove` with `preventDefault` until the reader had pushed 500px of virtual delta into growing the button to 1.5x. This deletes that machinery. Scrolling is now ordinary scrolling everywhere on the landing page.

Part of the PWA-sunset landing work (TASK-21788), split out as its own PR because it is a straight deletion and touches no migration surface.

## What changed

- `LandingPageClient.tsx`: removed `isScrollFrozen`, `buttonScale`, `animationComplete`, `shrinkingPhase`, `hasGrown`, their mirror refs, `frozenScrollY` / `virtualScrollY` / `touchStartY`, `handleScrollDelta`, and the `scroll` / `wheel` / `touchstart` / `touchmove` effect with its `document.body.style.overflow` writes. `buttonVisible` and its footer-visibility effect stay — that is the separate fade-out on the footer.
- `hero.tsx`: dropped the `buttonScale` prop, its default, and `--cta-scale` from `getCtaStyle`. The `--cta-x` / `--cta-y` / `--cta-r` entrance and the hover transform are untouched.
- `sendInSeconds.tsx`: removed the `<div id="sticky-button-target">` wrapper — the only thing that read it was the deleted handler. `id="send-in-seconds"` on the section stays, and fold 10 keeps its `.cta-motion .cta-enter` entrance.
- `globals.css`: dropped the now-unsettable `scale(var(--cta-scale, 1))` from `.cta-motion` and the `cta-enter` keyframe (no-op; see Divergences).
- New tests: `__tests__/LandingPageClient.scrollJack.test.tsx` and `__tests__/ctaScrollJackRemnants.test.tsx`.

## How verified

- `pnpm test -- src/components/LandingPage` → 7 suites, 27 tests, all green (includes the two new suites and the pre-existing Footer / SEOFooter / CurrencySelect ones).
- The new suite is a real guard, not a vacuous one. jsdom gives every element a zero rect, so the old freeze window could never open by accident; the test re-inserts a `#sticky-button-target` with `getBoundingClientRect` stubbed to `{top: 600, bottom: 660}`, which is inside the band the old handler froze on at jsdom's 768px viewport. Run against the pre-deletion component (copied out of `HEAD` into a scratch file), its tests fail: body overflow becomes `hidden`, `wheel` and `touchmove` come back `defaultPrevented`, and the hero receives a `buttonScale`. Against this branch all four pass.
- Round-1 review fix: the fourth test used to assert `#sticky-button-target` was absent from a slot that never contained it, so it could not fail either way. It now asserts the thing this PR actually removed — the anonymous `<div ref={sendInSecondsRef}>` around `sendInSecondsSlot` — by checking the slot's `parentElement` is the render container (`LandingPageClient` returns a fragment). Re-adding `<div>{sendInSecondsSlot}</div>` to the component makes exactly that test fail, and reverting makes it pass again.
- Round-1 review fix: `ctaScrollJackRemnants.test.tsx` split the fold-10 block in two. One `it` holds only the scroll-jack regression assertions (`#send-in-seconds` present, `#sticky-button-target` null, `.cta-motion` present); a second, separately named `it` holds the `/send` href and the `.cta-enter` entrance, so PR 2's "GET THE APP" rewrite of fold 10 can retarget or delete that one without touching the regression guard or reading as a scroll-jack regression.
- `pnpm exec eslint --quiet` on the six touched files → clean, exit 0.
- `pnpm exec tsc --noEmit` → 6 errors, all pre-existing `TS2307` in untouched files, none in this diff (see Divergences #3).
- `pnpm exec prettier --write` on the touched files, then re-run clean.
- **Browser pass, flag off** (round-1 review fix — this is the one change in the set that ships to 100% of landing traffic, so it is verified in a real engine, not only jsdom). `next dev --webpack -p 3053` in the worktree + Playwright 1.58.2 chromium, on `/` and `/pt-br` at 1440x900 and 390x844 — four combinations, all clean:
  - `getComputedStyle(document.body).overflow` is `visible` and `document.body.style.overflow` is empty both while fold 10 is centred in the viewport and after scrolling past it; same for `<html>`.
  - a dispatched cancelable `wheel` (deltaY 400) and `touchmove` at fold 10 both come back `defaultPrevented === false`.
  - a real `mouse.wheel` sequence at fold 10 moves the page 1472 / 1860 / 1499 / 2021 px on the four combinations — the page never pins.
  - `#sticky-button-target` is absent from the live DOM; `scrollWidth - clientWidth` is 0 (no horizontal overflow).
  - the `.cta-enter` entrance still fires after the keyframe edit: replaying the class gives a running `CSSAnimation` named `cta-enter`, duration 450ms, computed transform `matrix(0.999914, 0.0130896, -0.0130896, 0.999914, 0, 4)` — the 0.75deg rotation and 4px lift of the `from` frame, resolving correctly now that `scale(var(--cta-scale, 1))` is gone.
  - fold-10 centring survived the wrapper removal: the `.cta-motion` element's centre X equals `#send-in-seconds`'s centre X to **0.00px** on all four combinations (720.00 vs 720.00 at 1440, 195.00 vs 195.00 at 390).
  - console: no React `#418` / `#423`, no `pageerror` from application code. The only console errors are dev-server infrastructure (`webpack-hmr` websocket handshake failures, and `ERR_CONNECTION_REFUSED` on the run where earlyoom killed the server mid-pass — that combination was re-run clean afterwards).
  - screenshots: `run/shots-scrolljack/fold10-{en,pt-br}-{1440x900,390x844}.png`, raw measurements in `run/shots-scrolljack/report.json` and `report-ptbr-390.json`.

## Divergences

1. **Also removed the dead `--cta-scale` from `globals.css`.** The brief scoped the deletion to the components. Once `hero.tsx` stops writing the property, nothing in `src`, `e2e`, `public`, `scripts` or `docs` sets it, so `.cta-motion`'s `scale(var(--cta-scale, 1))` and the identical call in the `cta-enter` keyframe were permanently `scale(1)`. Both removed — a no-op at runtime that stops the CSS from carrying a variable no component can set.
2. **Removed the `#sticky-button-target` wrapper and the ref wrapper around the send-in-seconds slot.** The brief made the first conditional on a clean grep; the grep is clean, and the `<div ref={sendInSecondsRef}>` in `LandingPageClient` existed only to feed the freeze handler. Both were plain class-less block elements around block / inline-block children, so the layout is unchanged.
3. **`pnpm typecheck` is not clean on this worktree, for reasons this PR cannot fix.** It reports exactly 6 `TS2307` "Cannot find module" errors and nothing else: `web-vitals` (`src/utils/web-vitals-shim.ts` x2, its test), `@capacitor/app-launcher` and `@capgo/capacitor-in-app-review` (`src/utils/app-review.ts`), `capacitor-native-settings` (`src/utils/native-settings.ts`). None are in a file this PR touches, and none are of any other error class. This is the documented symlinked-`node_modules` worktree artifact — the native-only packages are absent from the shared store the worktree links to. CI installs properly and should be clean.

4. **Browser verification proved fold-10 centring geometrically instead of by screenshot diff against `origin/dev`.** The review asked for a pixel diff of the send-in-seconds fold against `origin/dev`; everything else on that list was run as asked. The diff was replaced by a direct measurement in the same run — section centre X vs `.cta-motion` centre X, equal to 0.00px on all four route x width combinations — which answers the question exactly rather than by proxy and does not need a second `next dev` on `origin/dev`. This box cannot afford one: three sibling TASK-21788 sessions compile in parallel and earlyoom SIGTERM'd the single dev server four times during the pass (`next-server` badness ~1100 at VmRSS 2.1-2.5 GiB). Two host-level tweaks, neither a repo change, were needed to keep one server alive: `fs.inotify.max_user_watches` 92678 -> 524288 (the ENOSPC watcher errors were putting `next dev` into an endless config-changed restart loop) and a temporary 3 GB swapfile at `/swap-verify.img`, which should be removed once the parallel runs finish.

## Flag-off impact

The scroll-jack ran in both flag states, so this is the one landing change in the set that is visible with `pwa-sunset` off: the page no longer freezes at fold 10 and the CTA no longer grows. That is the intent of the ticket. Nothing else about the flag-off page changes — same DOM, same copy, same entrance animations, same sticky mobile bar.

