### PR TITLE
feat(shhhhh): store hand-off instead of web signup when pwa-sunset is on (TASK-21788)

### DIFF
--- a/src/app/shhhhh/ShhhhhLandingPage.test.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps, ReactNode } from 'react'
 import { renderWithIntl } from '@/test-utils/intl'
 import en from '@/i18n/app/messages/en.json'
@@ -10,8 +10,11 @@ const mockUseGuestStoreHandoff = jest.fn()
 const mockGetInfo = jest.fn()
 const mockJoinWaitlist = jest.fn()
 
-let mockAuth: { user: null | { user: { userId: string } }; fetchUser: jest.Mock }
+let mockAuth: { user: null | { user: { userId: string } }; isFetchingUser?: boolean; fetchUser: jest.Mock }
 let mockSearch = ''
+let mockStoreHandoffModal: ReactNode = <div data-testid="store-handoff" />
+const mockQueuePendingBadgeCampaigns = jest.fn((campaigns: readonly string[], _expiryDays?: number) => [...campaigns])
+const callOrder: string[] = []
 
 jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
 jest.mock('@/context/authContext', () => ({ useAuth: () => mockAuth }))
@@ -22,11 +25,24 @@ jest.mock('@/hooks/useGuestStoreHandoff', () => ({
     useGuestStoreHandoff: (opts?: { surface?: string }) => {
         mockUseGuestStoreHandoff(opts)
         return {
-            interceptGuestCta: (handoff?: { dest?: string }) => mockInterceptGuestCta(handoff),
-            storeHandoffModal: <div data-testid="store-handoff" />,
+            interceptGuestCta: (handoff?: { dest?: string }) => {
+                callOrder.push('intercept')
+                return mockInterceptGuestCta(handoff)
+            },
+            storeHandoffModal: mockStoreHandoffModal,
         }
     },
 }))
+jest.mock('@/components/Invites/badge-campaign-context', () => {
+    const actual = jest.requireActual('@/components/Invites/badge-campaign-context')
+    return {
+        ...actual,
+        queuePendingBadgeCampaigns: (...args: [readonly string[], number?]) => {
+            callOrder.push('queue')
+            return mockQueuePendingBadgeCampaigns(...args)
+        },
+    }
+})
 jest.mock('@/services/badge-campaigns', () => ({
     claimAndSettlePendingBadgeCampaigns: jest.fn(async (campaigns: readonly string[]) => ({
         claims: campaigns.map((badgeCampaign) => ({ badgeCampaign, badgeCode: 'OTHER', outcome: 'awarded' })),
@@ -80,9 +96,21 @@ const SETUP_ROUTE = `/setup?redirect_uri=${encodeURIComponent('/card')}`
 
 const clickDoor = () => fireEvent.click(screen.getAllByText(DOOR)[0])
 
+// the sticky bar only mounts past 300px and short of the page bottom; jsdom
+// reports a zero-height body, so fake a long scrolled page.
+const scrollPastStickyThreshold = () => {
+    Object.defineProperty(document.body, 'scrollHeight', { value: 5000, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true })
+    Object.defineProperty(window, 'scrollY', { value: 900, configurable: true })
+    fireEvent.scroll(window)
+}
+
 beforeEach(() => {
     jest.clearAllMocks()
-    mockAuth = { user: null, fetchUser: jest.fn().mockResolvedValue(null) }
+    callOrder.length = 0
+    mockStoreHandoffModal = <div data-testid="store-handoff" />
+    mockQueuePendingBadgeCampaigns.mockImplementation((campaigns: readonly string[]) => [...campaigns])
+    mockAuth = { user: null, isFetchingUser: false, fetchUser: jest.fn().mockResolvedValue(null) }
     mockSearch = ''
     mockInterceptGuestCta.mockReturnValue(false)
     mockGetInfo.mockResolvedValue({ hasCardAccess: false, isPublicLaunched: false })
@@ -96,9 +124,67 @@ const render = () => {
 }
 
 describe('ShhhhhLandingPage door — pwa-sunset store hand-off', () => {
-    it('asks for the landing-door surface', () => {
+    it('asks for the landing-door surface and counts the settled guest impression', () => {
         render()
-        expect(mockUseGuestStoreHandoff).toHaveBeenCalledWith({ surface: 'landing_door' })
+        expect(mockUseGuestStoreHandoff).toHaveBeenCalledWith({
+            surface: 'landing_door',
+            trackImpressionWhenGuest: true,
+        })
+    })
+
+    it('does not count the impression while auth is still resolving', () => {
+        mockAuth = { user: null, isFetchingUser: true, fetchUser: jest.fn().mockResolvedValue(null) }
+        render()
+        expect(mockUseGuestStoreHandoff).toHaveBeenCalledWith({
+            surface: 'landing_door',
+            trackImpressionWhenGuest: false,
+        })
+    })
+
+    it('does nothing on a tap taken during the pre-auth flash', async () => {
+        mockAuth = { user: null, isFetchingUser: true, fetchUser: jest.fn().mockResolvedValue(null) }
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockGetInfo).not.toHaveBeenCalled())
+        expect(mockInterceptGuestCta).not.toHaveBeenCalled()
+        expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('queues the campaign tag before handing off, so it rides the deferred link', async () => {
+        mockSearch = 'campaign=acai'
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockInterceptGuestCta).toHaveBeenCalled())
+        expect(mockQueuePendingBadgeCampaigns).toHaveBeenCalledTimes(1)
+        expect(mockQueuePendingBadgeCampaigns.mock.calls[0][1]).toBe(30)
+        expect(callOrder).toEqual(['queue', 'intercept'])
+    })
+
+    it('hides the sticky mobile bar while the hand-off modal is open', async () => {
+        // the sticky bar is fixed z-50 and would cover the QR sheet's own
+        // close / store buttons on a narrow desktop-mode phone
+        mockStoreHandoffModal = null
+        render()
+        scrollPastStickyThreshold()
+        const withoutModal = await waitFor(() => {
+            const count = screen.getAllByText(DOOR).length
+            expect(count).toBeGreaterThan(2)
+            return count
+        })
+
+        mockStoreHandoffModal = <div data-testid="store-handoff" />
+        cleanup()
+        render()
+        scrollPastStickyThreshold()
+
+        await waitFor(() => expect(screen.getByTestId('store-handoff')).toBeInTheDocument())
+        expect(screen.getAllByText(DOOR).length).toBe(withoutModal - 1)
     })
 
     it('hands a signed-out visitor to the store with /card instead of web signup', async () => {
@@ -142,7 +228,11 @@ describe('ShhhhhLandingPage door — pwa-sunset store hand-off', () => {
     })
 
     it('never intercepts a signed-in visitor — they still join the waitlist', async () => {
-        mockAuth = { user: { user: { userId: 'u1' } }, fetchUser: jest.fn().mockResolvedValue(null) }
+        mockAuth = {
+            user: { user: { userId: 'u1' } },
+            isFetchingUser: false,
+            fetchUser: jest.fn().mockResolvedValue(null),
+        }
         mockInterceptGuestCta.mockReturnValue(true)
         render()
 

--- a/src/app/shhhhh/ShhhhhLandingPage.test.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { renderWithIntl } from '@/test-utils/intl'
+import en from '@/i18n/app/messages/en.json'
+import ShhhhhLandingPage from './ShhhhhLandingPage'
+
+const mockPush = jest.fn()
+const mockInterceptGuestCta = jest.fn<boolean, [handoff?: { dest?: string; invite?: string }]>(() => false)
+const mockUseGuestStoreHandoff = jest.fn()
+const mockGetInfo = jest.fn()
+const mockJoinWaitlist = jest.fn()
+
+let mockAuth: { user: null | { user: { userId: string } }; fetchUser: jest.Mock }
+let mockSearch = ''
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
+jest.mock('@/context/authContext', () => ({ useAuth: () => mockAuth }))
+jest.mock('@/services/card', () => ({
+    cardApi: { getInfo: () => mockGetInfo(), joinWaitlist: () => mockJoinWaitlist() },
+}))
+jest.mock('@/hooks/useGuestStoreHandoff', () => ({
+    useGuestStoreHandoff: (opts?: { surface?: string }) => {
+        mockUseGuestStoreHandoff(opts)
+        return {
+            interceptGuestCta: (handoff?: { dest?: string }) => mockInterceptGuestCta(handoff),
+            storeHandoffModal: <div data-testid="store-handoff" />,
+        }
+    },
+}))
+jest.mock('@/services/badge-campaigns', () => ({
+    claimAndSettlePendingBadgeCampaigns: jest.fn(async (campaigns: readonly string[]) => ({
+        claims: campaigns.map((badgeCampaign) => ({ badgeCampaign, badgeCode: 'OTHER', outcome: 'awarded' })),
+        pending: [],
+    })),
+    isConfirmedBadgeCampaignClaim: (claim: { outcome: string }) => claim.outcome === 'awarded',
+}))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+
+// Page furniture — this suite is about the door's routing branch, nothing else.
+jest.mock('@/components/LandingPage', () => ({ Marquee: () => null }))
+jest.mock('@/components/LandingPage/ScarcityCounter', () => ({ ScarcityCounter: () => null }))
+jest.mock('@/components/Marketing/HeroBackNav', () => ({ HeroBackNav: () => null }))
+jest.mock('@/components/Card/share-asset/PixelatedCardFace', () => ({ PixelatedCardFace: () => null }))
+jest.mock('@/components/Badges/badge.utils', () => ({ getBadgeIcon: () => '/badge.svg' }))
+jest.mock('next/image', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: ({ children, onClick, disabled }: ComponentProps<'button'>) => (
+        <button onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    ),
+}))
+jest.mock('framer-motion', () => ({
+    AnimatePresence: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    motion: new Proxy(
+        {},
+        {
+            get:
+                (_target, tag: string) =>
+                ({ children, ...props }: { children?: ReactNode }) => {
+                    const Tag = tag as 'div'
+                    const {
+                        initial: _i,
+                        animate: _a,
+                        exit: _e,
+                        transition: _t,
+                        whileInView: _w,
+                        ...rest
+                    } = props as Record<string, unknown>
+                    return <Tag {...rest}>{children}</Tag>
+                },
+        }
+    ),
+}))
+
+const DOOR = en.shhhhh.hero.tryTheDoor
+const WAITLIST_LINK = en.shhhhh.hero.orJoinWaitlist
+const SETUP_ROUTE = `/setup?redirect_uri=${encodeURIComponent('/card')}`
+
+const clickDoor = () => fireEvent.click(screen.getAllByText(DOOR)[0])
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockAuth = { user: null, fetchUser: jest.fn().mockResolvedValue(null) }
+    mockSearch = ''
+    mockInterceptGuestCta.mockReturnValue(false)
+    mockGetInfo.mockResolvedValue({ hasCardAccess: false, isPublicLaunched: false })
+    mockJoinWaitlist.mockResolvedValue({ position: 42 })
+    window.history.replaceState({}, '', '/shhhhh')
+})
+
+const render = () => {
+    if (mockSearch) window.history.replaceState({}, '', `/shhhhh?${mockSearch}`)
+    return renderWithIntl(<ShhhhhLandingPage />)
+}
+
+describe('ShhhhhLandingPage door — pwa-sunset store hand-off', () => {
+    it('asks for the landing-door surface', () => {
+        render()
+        expect(mockUseGuestStoreHandoff).toHaveBeenCalledWith({ surface: 'landing_door' })
+    })
+
+    it('hands a signed-out visitor to the store with /card instead of web signup', async () => {
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockInterceptGuestCta).toHaveBeenCalledWith({ dest: '/card' }))
+        expect(mockPush).not.toHaveBeenCalled()
+        expect(screen.getByTestId('store-handoff')).toBeInTheDocument()
+    })
+
+    it('hands off from the "or join the waitlist" link too', async () => {
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        fireEvent.click(screen.getByText(WAITLIST_LINK))
+
+        await waitFor(() => expect(mockInterceptGuestCta).toHaveBeenCalledWith({ dest: '/card' }))
+        expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('hands off before the campaign signup route when the link carries campaign tags', async () => {
+        mockSearch = 'campaign=acai'
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockInterceptGuestCta).toHaveBeenCalledWith({ dest: '/card' }))
+        expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('keeps the web signup route when the flag is off', async () => {
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockPush).toHaveBeenCalledWith(SETUP_ROUTE))
+    })
+
+    it('never intercepts a signed-in visitor — they still join the waitlist', async () => {
+        mockAuth = { user: { user: { userId: 'u1' } }, fetchUser: jest.fn().mockResolvedValue(null) }
+        mockInterceptGuestCta.mockReturnValue(true)
+        render()
+
+        clickDoor()
+
+        await waitFor(() => expect(mockJoinWaitlist).toHaveBeenCalled())
+        expect(mockInterceptGuestCta).not.toHaveBeenCalled()
+        expect(mockPush).not.toHaveBeenCalledWith(SETUP_ROUTE)
+    })
+})

--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -16,6 +16,8 @@ import { inflateWaitlistPosition } from '@/components/Card/doorTally.utils'
 import { Sparkle, Star } from '@/assets/illustrations'
 import { cardApi } from '@/services/card'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
 import { badgeCampaignsFromSearchParams, queuePendingBadgeCampaigns } from '@/components/Invites/badge-campaign-context'
 import { claimAndSettlePendingBadgeCampaigns, isConfirmedBadgeCampaignClaim } from '@/services/badge-campaigns'
 import { getBadgeIcon } from '@/components/Badges/badge.utils'
@@ -142,6 +144,10 @@ export default function ShhhhhLandingPage() {
     const t = useTranslations('shhhhh')
     const { user, fetchUser } = useAuth()
     const router = useRouter()
+    // pwa-sunset: the door's signup lives in the app now (see handleCTA)
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
+        surface: MIGRATION_SURFACES.LANDING_DOOR,
+    })
 
     // undefined = not joined; number|null = joined (null = joined but BE
     // returned no position). Drives the inline confirmation.
@@ -205,6 +211,13 @@ export default function ShhhhhLandingPage() {
             signed_in: !!user,
             campaign_tags: badgeCampaigns,
         })
+
+        // pwa-sunset: every signed-out door path below ends at a web signup that
+        // the migration window closes. Hand the visitor to the store instead —
+        // desktop opens the scan-to-download QR, phones deep-link — carrying
+        // /card so the app lands them back on the door's destination. Flag off
+        // (and in the native app) this is a no-op and the routes below run.
+        if (!user && interceptGuestCta({ dest: '/card' })) return
 
         if (badgeCampaigns.length > 0) {
             const queuedBadgeCampaigns = queuePendingBadgeCampaigns(badgeCampaigns, 30)
@@ -611,6 +624,7 @@ export default function ShhhhhLandingPage() {
             </section>
 
             {!isJoined && <StickyShhhhhCTA onClick={handleCTA} />}
+            {storeHandoffModal}
         </>
     )
 }

--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -142,12 +142,8 @@ function StickyShhhhhCTA({ onClick }: { onClick: () => void }) {
 
 export default function ShhhhhLandingPage() {
     const t = useTranslations('shhhhh')
-    const { user, fetchUser } = useAuth()
+    const { user, isFetchingUser, fetchUser } = useAuth()
     const router = useRouter()
-    // pwa-sunset: the door's signup lives in the app now (see handleCTA)
-    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
-        surface: MIGRATION_SURFACES.LANDING_DOOR,
-    })
 
     // undefined = not joined; number|null = joined (null = joined but BE
     // returned no position). Drives the inline confirmation.
@@ -156,6 +152,15 @@ export default function ShhhhhLandingPage() {
     const [joinError, setJoinError] = useState(false)
     const [showAllBadges, setShowAllBadges] = useState(false)
     const isJoined = joinedPosition !== undefined
+
+    // pwa-sunset: the door's signup lives in the app now (see handleCTA). The
+    // impression only counts once auth has settled and the door is the CTA on
+    // screen, so the pre-auth flash (every visitor briefly looks logged-out)
+    // never inflates the denominator.
+    const { interceptGuestCta, storeHandoffModal } = useGuestStoreHandoff({
+        surface: MIGRATION_SURFACES.LANDING_DOOR,
+        trackImpressionWhenGuest: !isFetchingUser && !user && !isJoined,
+    })
 
     const joinWaitlist = useCallback(async () => {
         setCtaBusy(true)
@@ -202,6 +207,12 @@ export default function ShhhhhLandingPage() {
     }, [user])
 
     const handleCTA = async () => {
+        // Auth has not resolved yet: every visitor looks logged-out for one
+        // round-trip. Acting now would bounce a returning signed-in user to the
+        // store (a full-page navigation on a phone, unrecoverable in-tab) or
+        // misroute them through /setup. Wait for the settled state.
+        if (isFetchingUser) return
+
         // Read opaque campaign identities at click time (client-only) to avoid
         // bailing static prerendering. The backend resolves award semantics;
         // provenance is audit-only and does not weaken an earned skip badge.
@@ -212,6 +223,12 @@ export default function ShhhhhLandingPage() {
             campaign_tags: badgeCampaigns,
         })
 
+        // Queue the campaign tag BEFORE any hand-off: the cookie queue is what
+        // buildDeferredPayload reads, so the tag rides the install referrer /
+        // QR payload and applyDeferredPayload re-queues it inside the app.
+        // Same call the campaign branch below already made, just hoisted.
+        const queuedBadgeCampaigns = badgeCampaigns.length > 0 ? queuePendingBadgeCampaigns(badgeCampaigns, 30) : []
+
         // pwa-sunset: every signed-out door path below ends at a web signup that
         // the migration window closes. Hand the visitor to the store instead —
         // desktop opens the scan-to-download QR, phones deep-link — carrying
@@ -220,7 +237,6 @@ export default function ShhhhhLandingPage() {
         if (!user && interceptGuestCta({ dest: '/card' })) return
 
         if (badgeCampaigns.length > 0) {
-            const queuedBadgeCampaigns = queuePendingBadgeCampaigns(badgeCampaigns, 30)
             if (!user) {
                 queueShhhhhCampaignContinuation()
                 router.push(shhhhhCampaignSignupRoute())
@@ -623,7 +639,9 @@ export default function ShhhhhLandingPage() {
                 </div>
             </section>
 
-            {!isJoined && <StickyShhhhhCTA onClick={handleCTA} />}
+            {/* the sticky bar is fixed z-50 and would paint over the QR
+                sheet's own close/store CTAs on a narrow desktop-mode phone */}
+            {!isJoined && !storeHandoffModal && <StickyShhhhhCTA onClick={handleCTA} />}
             {storeHandoffModal}
         </>
     )

--- a/src/components/Migration/DownloadQR.tsx
+++ b/src/components/Migration/DownloadQR.tsx
@@ -10,7 +10,7 @@ import { type MigrationSurface } from '@/constants/migration.consts'
 
 // one smart QR instead of a per-store toggle: it encodes /app, which
 // redirects to the store of whichever phone scans it.
-export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
+export default function DownloadQR({ surface, payload }: { surface: MigrationSurface; payload?: string }) {
     const t = useTranslations('migration')
 
     useEffect(() => {
@@ -24,7 +24,7 @@ export default function DownloadQR({ surface }: { surface: MigrationSurface }) {
 
     return (
         <div className="flex w-full flex-col items-center gap-3 py-2">
-            <QRCodeWrapper url={`${origin}/app`} />
+            <QRCodeWrapper url={payload ? `${origin}/app?${payload}` : `${origin}/app`} />
             <span className="text-body-xs text-foreground-secondary">{t('qr.scanHint')}</span>
             {/* desktop can install directly too (e.g. Google Play from the browser) */}
             <StoreBadges surface={surface} appearance="stacked" />

--- a/src/components/Migration/ScanToDownloadModal.tsx
+++ b/src/components/Migration/ScanToDownloadModal.tsx
@@ -10,10 +10,13 @@ export default function ScanToDownloadModal({
     visible,
     onClose,
     surface,
+    payload,
 }: {
     visible: boolean
     onClose: () => void
     surface: MigrationSurface
+    /** deferred-link querystring, so the scanning phone lands on the caller's dest */
+    payload?: string
 }) {
     const t = useTranslations('migration')
     const tCommon = useTranslations('common')
@@ -23,7 +26,7 @@ export default function ScanToDownloadModal({
             onClose={onClose}
             icon="qr-code"
             title={t('qr.title')}
-            content={<DownloadQR surface={surface} />}
+            content={<DownloadQR surface={surface} payload={payload} />}
             ctas={[
                 {
                     text: tCommon('close'),

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -68,6 +68,7 @@ export const MIGRATION_SURFACES = {
     SETUP: 'setup',
     GUEST_FLOW: 'guest_flow',
     PROFILE_UPDATE: 'profile_update',
+    LANDING_DOOR: 'landing_door',
 } as const
 
 export type MigrationSurface = (typeof MIGRATION_SURFACES)[keyof typeof MIGRATION_SURFACES]

--- a/src/hooks/__tests__/useGuestStoreHandoff.test.tsx
+++ b/src/hooks/__tests__/useGuestStoreHandoff.test.tsx
@@ -1,4 +1,5 @@
 import { act } from '@testing-library/react'
+import type { ReactElement } from 'react'
 import { renderHookWithIntl } from '@/test-utils/intl'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType } from '@/hooks/useGetDeviceType'
@@ -9,6 +10,7 @@ const mockCapture = jest.fn()
 let mockMigrationOn = true
 let mockDeviceType: DeviceType = DeviceType.WEB
 let mockIsCapacitor = false
+const mockBuildDeferredPayload = jest.fn((dest?: string, _invite?: string) => `pnutdl=1&dest=${dest ?? ''}`)
 
 jest.mock('@/hooks/useMigrationFlag', () => ({ useMigrationFlag: () => mockMigrationOn }))
 jest.mock('@/hooks/useGetDeviceType', () => {
@@ -19,10 +21,15 @@ jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => mockIsCapacitor }))
 jest.mock('@/utils/migration.utils', () => ({
     openStore: (...args: unknown[]) => mockOpenStore(...args),
 }))
+jest.mock('@/utils/deferred-link', () => ({
+    buildDeferredPayload: (dest?: string, invite?: string) => mockBuildDeferredPayload(dest, invite),
+}))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: (...a: unknown[]) => mockCapture(...a) } }))
 jest.mock('@/components/Migration/ScanToDownloadModal', () => ({
     __esModule: true,
-    default: ({ surface }: { surface: string }) => <div data-testid="scan-modal" data-surface={surface} />,
+    default: ({ surface, payload }: { surface: string; payload?: string }) => (
+        <div data-testid="scan-modal" data-surface={surface} data-payload={payload ?? ''} />
+    ),
 }))
 
 beforeEach(() => {
@@ -69,6 +76,58 @@ describe('useGuestStoreHandoff surface', () => {
 
         expect(mockOpenStore).not.toHaveBeenCalled()
         expect(result.current.storeHandoffModal).not.toBeNull()
+    })
+
+    it('carries the caller handoff into the desktop QR payload', () => {
+        const { result, rerender } = renderHookWithIntl(() =>
+            useGuestStoreHandoff({ surface: MIGRATION_SURFACES.LANDING_DOOR })
+        )
+
+        act(() => {
+            result.current.interceptGuestCta({ dest: '/card' })
+        })
+        rerender()
+
+        expect(mockBuildDeferredPayload).toHaveBeenCalledWith('/card', undefined)
+        const modal = result.current.storeHandoffModal as ReactElement<{ payload?: string }>
+        expect(modal.props.payload).toBe('pnutdl=1&dest=/card')
+    })
+
+    it('leaves the desktop QR bare when the caller passes no handoff', () => {
+        const { result, rerender } = renderHookWithIntl(() => useGuestStoreHandoff())
+
+        act(() => {
+            result.current.interceptGuestCta()
+        })
+        rerender()
+
+        expect(mockBuildDeferredPayload).not.toHaveBeenCalled()
+        const modal = result.current.storeHandoffModal as ReactElement<{ payload?: string }>
+        expect(modal.props.payload).toBeUndefined()
+    })
+
+    it('never intercepts inside the native app', () => {
+        mockIsCapacitor = true
+        mockDeviceType = DeviceType.IOS
+        const { result } = renderHookWithIntl(() => useGuestStoreHandoff({ surface: MIGRATION_SURFACES.LANDING_DOOR }))
+
+        let handled = true
+        act(() => {
+            handled = result.current.interceptGuestCta({ dest: '/card' })
+        })
+
+        expect(handled).toBe(false)
+        expect(mockOpenStore).not.toHaveBeenCalled()
+        expect(result.current.storeHandoffModal).toBeNull()
+    })
+
+    it('does not track the guest impression inside the native app', () => {
+        mockIsCapacitor = true
+        renderHookWithIntl(() =>
+            useGuestStoreHandoff({ trackImpressionWhenGuest: true, surface: MIGRATION_SURFACES.LANDING_DOOR })
+        )
+
+        expect(mockCapture).not.toHaveBeenCalled()
     })
 
     it('does not intercept while the migration flag is off', () => {

--- a/src/hooks/__tests__/useGuestStoreHandoff.test.tsx
+++ b/src/hooks/__tests__/useGuestStoreHandoff.test.tsx
@@ -1,0 +1,95 @@
+import { act } from '@testing-library/react'
+import { renderHookWithIntl } from '@/test-utils/intl'
+import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { DeviceType } from '@/hooks/useGetDeviceType'
+import { useGuestStoreHandoff } from '@/hooks/useGuestStoreHandoff'
+
+const mockOpenStore = jest.fn()
+const mockCapture = jest.fn()
+let mockMigrationOn = true
+let mockDeviceType: DeviceType = DeviceType.WEB
+let mockIsCapacitor = false
+
+jest.mock('@/hooks/useMigrationFlag', () => ({ useMigrationFlag: () => mockMigrationOn }))
+jest.mock('@/hooks/useGetDeviceType', () => {
+    const actual = jest.requireActual('@/hooks/useGetDeviceType')
+    return { ...actual, useDeviceType: () => ({ deviceType: mockDeviceType }) }
+})
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => mockIsCapacitor }))
+jest.mock('@/utils/migration.utils', () => ({
+    openStore: (...args: unknown[]) => mockOpenStore(...args),
+}))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: (...a: unknown[]) => mockCapture(...a) } }))
+jest.mock('@/components/Migration/ScanToDownloadModal', () => ({
+    __esModule: true,
+    default: ({ surface }: { surface: string }) => <div data-testid="scan-modal" data-surface={surface} />,
+}))
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockMigrationOn = true
+    mockDeviceType = DeviceType.WEB
+    mockIsCapacitor = false
+})
+
+describe('useGuestStoreHandoff surface', () => {
+    it('labels the phone store bounce with the caller surface', () => {
+        mockDeviceType = DeviceType.ANDROID
+        const { result } = renderHookWithIntl(() => useGuestStoreHandoff({ surface: MIGRATION_SURFACES.LANDING_DOOR }))
+
+        let handled = false
+        act(() => {
+            handled = result.current.interceptGuestCta({ dest: '/card' })
+        })
+
+        expect(handled).toBe(true)
+        expect(mockOpenStore).toHaveBeenCalledWith('android', 'landing_door', { dest: '/card' })
+    })
+
+    it('defaults to the guest funnel surface when the caller passes none', () => {
+        mockDeviceType = DeviceType.IOS
+        const { result } = renderHookWithIntl(() => useGuestStoreHandoff())
+
+        act(() => {
+            result.current.interceptGuestCta()
+        })
+
+        expect(mockOpenStore).toHaveBeenCalledWith('ios', MIGRATION_SURFACES.GUEST_FLOW, undefined)
+    })
+
+    it('opens the QR modal on desktop with the caller surface', () => {
+        const { result, rerender } = renderHookWithIntl(() =>
+            useGuestStoreHandoff({ surface: MIGRATION_SURFACES.LANDING_DOOR })
+        )
+
+        act(() => {
+            expect(result.current.interceptGuestCta({ dest: '/card' })).toBe(true)
+        })
+        rerender()
+
+        expect(mockOpenStore).not.toHaveBeenCalled()
+        expect(result.current.storeHandoffModal).not.toBeNull()
+    })
+
+    it('does not intercept while the migration flag is off', () => {
+        mockMigrationOn = false
+        const { result } = renderHookWithIntl(() => useGuestStoreHandoff({ surface: MIGRATION_SURFACES.LANDING_DOOR }))
+
+        let handled = true
+        act(() => {
+            handled = result.current.interceptGuestCta({ dest: '/card' })
+        })
+
+        expect(handled).toBe(false)
+        expect(mockOpenStore).not.toHaveBeenCalled()
+        expect(result.current.storeHandoffModal).toBeNull()
+    })
+
+    it('tracks the guest impression against the caller surface', () => {
+        renderHookWithIntl(() =>
+            useGuestStoreHandoff({ trackImpressionWhenGuest: true, surface: MIGRATION_SURFACES.LANDING_DOOR })
+        )
+
+        expect(mockCapture).toHaveBeenCalledWith('migration_guest_cta_shown', { surface: 'landing_door' })
+    })
+})

--- a/src/hooks/useGuestStoreHandoff.tsx
+++ b/src/hooks/useGuestStoreHandoff.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import posthog from 'posthog-js'
 import ScanToDownloadModal from '@/components/Migration/ScanToDownloadModal'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { MIGRATION_SURFACES, type MigrationSurface } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { isCapacitor } from '@/utils/capacitor'
@@ -18,10 +18,15 @@ import { openStore, type StoreHandoff } from '@/utils/migration.utils'
  * Returns `interceptGuestCta` (call it first in the CTA handler; true = the
  * click was handled here) and `storeHandoffModal` (render it next to the CTA).
  * Native app guests keep the normal in-app flow.
+ *
+ * `surface` labels the analytics for the CTA that was intercepted; it defaults
+ * to the guest claim/request funnel this hook was built for. Marketing pages
+ * that reuse the same hand-off pass their own (e.g. the /shhhhh door).
  */
 export function useGuestStoreHandoff({
     trackImpressionWhenGuest = false,
-}: { trackImpressionWhenGuest?: boolean } = {}) {
+    surface = MIGRATION_SURFACES.GUEST_FLOW,
+}: { trackImpressionWhenGuest?: boolean; surface?: MigrationSurface } = {}) {
     const migrationOn = useMigrationFlag()
     const { deviceType } = useDeviceType()
     const [qrOpen, setQrOpen] = useState(false)
@@ -34,8 +39,8 @@ export function useGuestStoreHandoff({
     useEffect(() => {
         if (!trackImpressionWhenGuest || !migrationOn || isCapacitor() || impressionFired.current) return
         impressionFired.current = true
-        posthog.capture(ANALYTICS_EVENTS.MIGRATION_GUEST_CTA_SHOWN, { surface: MIGRATION_SURFACES.GUEST_FLOW })
-    }, [trackImpressionWhenGuest, migrationOn])
+        posthog.capture(ANALYTICS_EVENTS.MIGRATION_GUEST_CTA_SHOWN, { surface })
+    }, [trackImpressionWhenGuest, migrationOn, surface])
 
     // handoff: deferred deep-link context the surface knows before any cookie is
     // written (claim page invite CTA). the desktop QR path can't carry it — the
@@ -46,12 +51,12 @@ export function useGuestStoreHandoff({
             setQrOpen(true)
             return true
         }
-        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', MIGRATION_SURFACES.GUEST_FLOW, handoff)
+        openStore(deviceType === DeviceType.ANDROID ? 'android' : 'ios', surface, handoff)
         return true
     }
 
     const storeHandoffModal = qrOpen ? (
-        <ScanToDownloadModal visible onClose={() => setQrOpen(false)} surface={MIGRATION_SURFACES.GUEST_FLOW} />
+        <ScanToDownloadModal visible onClose={() => setQrOpen(false)} surface={surface} />
     ) : null
 
     return { interceptGuestCta, storeHandoffModal }

--- a/src/hooks/useGuestStoreHandoff.tsx
+++ b/src/hooks/useGuestStoreHandoff.tsx
@@ -7,6 +7,7 @@ import { MIGRATION_SURFACES, type MigrationSurface } from '@/constants/migration
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { isCapacitor } from '@/utils/capacitor'
+import { buildDeferredPayload } from '@/utils/deferred-link'
 import { openStore, type StoreHandoff } from '@/utils/migration.utils'
 
 /**
@@ -30,6 +31,10 @@ export function useGuestStoreHandoff({
     const migrationOn = useMigrationFlag()
     const { deviceType } = useDeviceType()
     const [qrOpen, setQrOpen] = useState(false)
+    // deferred payload for the desktop QR, built at click time (the click
+    // handler is the only place the caller's handoff and the cookies are both
+    // available). null = no handoff was passed, so the QR stays the bare /app.
+    const [qrPayload, setQrPayload] = useState<string | null>(null)
 
     // guest-funnel impression (TASK-20939): fires once per mount when the CTA
     // is actually shown to a logged-out web visitor during the window. The
@@ -43,11 +48,13 @@ export function useGuestStoreHandoff({
     }, [trackImpressionWhenGuest, migrationOn, surface])
 
     // handoff: deferred deep-link context the surface knows before any cookie is
-    // written (claim page invite CTA). the desktop QR path can't carry it — the
-    // payload would need to live on the phone that scans, not this browser.
+    // written (claim page invite CTA, the /shhhhh door's dest). Phones carry it
+    // on the install referrer / clipboard; desktop encodes it in the QR so the
+    // phone that scans lands on the same destination.
     const interceptGuestCta = (handoff?: StoreHandoff): boolean => {
         if (!migrationOn || isCapacitor()) return false
         if (deviceType === DeviceType.WEB) {
+            setQrPayload(handoff ? buildDeferredPayload(handoff.dest, handoff.invite) : null)
             setQrOpen(true)
             return true
         }
@@ -56,7 +63,12 @@ export function useGuestStoreHandoff({
     }
 
     const storeHandoffModal = qrOpen ? (
-        <ScanToDownloadModal visible onClose={() => setQrOpen(false)} surface={surface} />
+        <ScanToDownloadModal
+            visible
+            onClose={() => setQrOpen(false)}
+            surface={surface}
+            payload={qrPayload ?? undefined}
+        />
     ) : null
 
     return { interceptGuestCta, storeHandoffModal }


### PR DESCRIPTION
## Summary

The `/shhhhh` door sends a signed-out visitor into `/setup` to create an account on the web. Once the `pwa-sunset` flag is on, that signup is the thing we are closing, so the door now hands the visitor to the app store instead: desktop opens the scan-to-download QR modal, phones deep-link their store, both carrying `/card` as the post-install destination so the app lands them on the door's real target.

Flag off, `/shhhhh` behaves exactly as it does on `dev`.

Part of the landing funnel work for TASK-21788 (PR 4 of 4).

## What changed

- `src/app/shhhhh/ShhhhhLandingPage.tsx`: `handleCTA` returns early while `isFetchingUser`, then captures `DOOR_TRY`, then queues any campaign tag, then `if (!user && interceptGuestCta({ dest: '/card' })) return`. Every door affordance (hero button, "or join the waitlist" link, §7 button, sticky mobile bar) calls `handleCTA`, so one branch covers all four, and both `/setup` routes below it (`/setup?redirect_uri=/card` and the campaign `/setup?step=signup`). The hook is asked for the guest impression with `trackImpressionWhenGuest: !isFetchingUser && !user && !isJoined`. The sticky mobile bar unmounts while `storeHandoffModal` is open, so it cannot paint over the QR sheet's own close / store buttons on a narrow desktop-mode phone.
- `src/hooks/useGuestStoreHandoff.tsx`: optional `surface` argument, default `MIGRATION_SURFACES.GUEST_FLOW`, labelling `openStore`, `ScanToDownloadModal` and the guest-impression event. The desktop branch now also builds the deferred payload at click time (`buildDeferredPayload(handoff.dest, handoff.invite)`) and hands it to the modal, so the phone that scans lands on the caller's `dest`.
- `src/components/Migration/ScanToDownloadModal.tsx` / `DownloadQR.tsx`: optional `payload` prop threaded to the QR URL (`${origin}/app?${payload}`; bare `${origin}/app` when absent). See divergence 5 — PR 1 owns this prop and supersedes it on merge.
- `src/constants/migration.consts.ts`: `LANDING_DOOR: 'landing_door'`.
- `src/app/shhhhh/ShhhhhLandingPage.test.tsx` (10 tests): surface + settled impression flag, no impression and no action during the pre-auth flash, campaign tag queued *before* the intercept, sticky bar hidden while the modal is open, hand-off from the door and from the waitlist link, campaign-tagged link, flag-off keeps `/setup?redirect_uri=%2Fcard`, signed-in visitor still joins the waitlist and is never intercepted.
- `src/hooks/__tests__/useGuestStoreHandoff.test.tsx` (9 tests): phone bounce carries the caller surface, default surface, desktop modal, handoff reaches the desktop QR payload, bare QR without a handoff, no interception inside Capacitor, no impression inside Capacitor, no interception with the flag off, impression event surface.

No new i18n strings, no new copy.

## How verified

- `pnpm test -- src/app/shhhhh/ShhhhhLandingPage.test.tsx src/hooks/__tests__/useGuestStoreHandoff.test.tsx` → 2 suites, 19 tests, all pass.
- `pnpm test -- src/components/Migration/__tests__/MigrationDownloadModal.test.tsx src/components/Invites/InvitesPage.test.tsx src/components/Profile/components/__tests__/PublicProfile.test.tsx` (the other `useGuestStoreHandoff` / migration consumers) → 3 suites, 53 tests, all pass.
- `pnpm lint --quiet` on the touched files → clean. `prettier --check` → clean.
- `pnpm typecheck` → 6 pre-existing `TS2307 Cannot find module` errors, none in a file this PR touches: `src/utils/web-vitals-shim.ts` (x3), `src/utils/__tests__/web-vitals-shim.test.ts`, `src/utils/app-review.ts` (x2), `src/utils/native-settings.ts`. The worktree's `node_modules` is a symlink to the shared checkout and `web-vitals`, `@capacitor/app-launcher`, `@capgo/capacitor-in-app-review` and `capacitor-native-settings` are physically absent from it (verified by `ls`). Environment gap, not a type error in source; the count is identical before and after this PR. CI runs a real install and should be clean.
- No dev server in this stage; the runtime check runs in the later stage of the workflow.

## Divergences

1. **The door does not call `openStore` itself.** The brief split the two branches between `useGuestStoreHandoff` (desktop) and a direct `openStore(store, LANDING_DOOR, {dest:'/card'})` (phone). The hook already owns both branches and hardcoded `GUEST_FLOW` in three places, so a direct call would duplicate the device split and leave the desktop modal reporting `guest_flow` while the phone reported `landing_door`. Instead the hook takes an optional `surface`, defaulting to the old value, and the door passes `LANDING_DOOR` once.
2. **`LANDING_DOOR` is added here as well as in PR 1.** PR 4 cannot compile without it and both branch off the same `origin/dev`. Same key, same value as the brief specifies. **For the merger: if PR 1 lands first, drop this one line on rebase — the key and the value are identical, there is nothing to reconcile.**
3. **The campaign-tagged door path is intercepted too, and the tag now rides the hand-off.** Verification checklist item 5 wants no `/setup` left on the door when the flag is on, and `/setup?step=signup` is the same closed web signup. `queuePendingBadgeCampaigns` is hoisted above the intercept (behaviour-preserving — the campaign branch already queued before its own `!user` check), so the tag is in the cookie queue that `buildDeferredPayload` reads and it rides the Android install referrer, the iOS clipboard hand-off and the desktop QR payload; `applyDeferredPayload` re-queues it inside the app. *Correction to the first round of this PR, which claimed the tag could not survive — it can, via the deferred-link mechanism built for exactly this.* It is still lost for a desktop visitor who ignores the QR and installs by hand from a store listing. Flag off, the campaign path is untouched.
4. **`pnpm typecheck` is not clean** — 6 pre-existing errors from the incomplete shared `node_modules`, itemized under "How verified".
5. **`payload` on `DownloadQR` / `ScanToDownloadModal` lands here, ahead of PR 1.** PR 1 owns this prop, but without it PR 4's desktop branch dropped `{dest:'/card'}` on the floor and the QR encoded a bare `/app`, so a desktop visitor who scanned landed on `/home` instead of the door's destination — the stated purpose of the PR. Same prop name and semantics as PR 1's spec. **PR-1 reconciliation: keep PR 1's version of `DownloadQR` (it also appends `&s=<surface>` and adds `size`) and drop this one on rebase.** The two other handoff-passing callers (`SendLinkActionList`, `SendWithPeanutCta`, both `{invite}`) get the same upgrade — their desktop QR now carries the invite code and the current page as `dest`, matching what `openStore` already does for them on phones. `InvitesPage` and `PublicProfile` pass no handoff and stay byte-identical.
6. **`MIGRATION_GUEST_CTA_SHOWN` for the door is gated on settled auth.** The brief says nothing about the impression event; every other migrated guest surface supplies `trackImpressionWhenGuest`, and without it `landing_door` would have hand-off clicks and no denominator. Gated with `isFetchingUser` (as in `SendWithPeanutCta` and `PublicProfile`) so the pre-auth flash never counts — and `handleCTA` returns early in that window, so a returning signed-in user who taps before auth resolves is not bounced to the store by a full-page navigation with no way back in-tab.

Full text: `run/DIVERGENCES-shhhhh.md`.

## Flag-off impact

None on `/shhhhh`: the only new behaviour is behind `interceptGuestCta`, which returns `false` whenever `useMigrationFlag()` is false or the app is running under Capacitor, and the routes below it are unchanged. The `isFetchingUser` early return applies in both flag states and is a strict improvement (a tap during the auth round-trip previously misrouted a signed-in user through `/setup`). `LANDING_DOOR` is a new constant that nothing reads while the flag is off.

Outside `/shhhhh`, also flag-gated: the `payload` prop is only ever non-empty on a path that `interceptGuestCta` already gated on the flag, so `SendLinkActionList` and `SendWithPeanutCta` see the richer QR only with the flag on.
