### PR TITLE
Split badge/avatar earn toast into two sequential toasts

### DIFF
--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -6,7 +6,9 @@
  * Globally mounted (ClientProviders), self-contained. When the signed-in user
  * lands on /home with freshly-earned badges they haven't seen, it fires ONE
  * coalesced toast ("Badge unlocked: X" / "You unlocked N badges") that taps
- * through to the shared BadgeDetailModal (or the badges list for several).
+ * through to the shared BadgeDetailModal (or the badges list for several). A
+ * badge that ships avatars (TASK-22142) gets a SECOND toast, 500ms later, so
+ * the two announcements read as sequential events rather than one crowded card.
  *
  * Why a toast (not a fullscreen): every badge that fires at/around the card
  * launch is incidental — BETA_TESTER (signup), SHHHHH (everyone getting the
@@ -31,6 +33,8 @@ import { badgeAvatarKeys } from '@/components/Avatar/avatar.utils'
 import { AVATAR_PICKER_PATH } from '@/components/Avatar/avatar.consts'
 
 const HOME_PATH = '/home'
+/** Gap between the badge toast and the avatar-unlock toast that follows it. */
+const AVATAR_TOAST_DELAY_MS = 500
 
 type ModalBadge = { code: string; title: string; description: string; logo: string }
 
@@ -42,9 +46,12 @@ export default function BadgeEarnToast() {
     const { toast, dismiss } = useToast()
     const { pending, markSeen } = useBadgeEarnToast()
     const [modalBadge, setModalBadge] = useState<ModalBadge | null>(null)
-    // Id of the toast currently on screen, so we can dismiss it when the user
-    // navigates away from /home (it would otherwise linger over the next route).
-    const liveToastIdRef = useRef<string | null>(null)
+    // Ids of the toast(s) currently on screen, so we can dismiss them when the
+    // user navigates away from /home (they'd otherwise linger over the next route).
+    const liveToastIdsRef = useRef<string[]>([])
+    // Pending timer for the delayed avatar toast, so a route change (or unmount)
+    // before it fires can cancel it instead of popping a toast on the wrong page.
+    const avatarTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     useEffect(() => {
         // Only surface on /home (never mid-onboarding) and only when there's
@@ -64,10 +71,10 @@ export default function BadgeEarnToast() {
         // seen but never shown. Keying on the codes lets a distinct later batch
         // surface, while still de-duping a re-render of the same batch.
         const toastId = `badge-earn:${codes.join(',')}`
+        const avatarToastId = `badge-earn-avatar:${codes.join(',')}`
 
         const openInspect = () => {
             dismiss(toastId)
-            liveToastIdRef.current = null
             posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_TAPPED, { count, target: 'badge_detail' })
             if (count === 1) {
                 setModalBadge({
@@ -83,13 +90,12 @@ export default function BadgeEarnToast() {
 
         const label = count === 1 ? t('toastSingle', { name: newestName }) : t('toastMultiple', { count })
 
-        // A badge that ships avatars (TASK-22142) announces the unlock and
-        // links to the picker. The badge tap keeps its detail view, so these
-        // are two controls.
+        // A badge that ships avatars (TASK-22142) gets its own follow-up toast
+        // linking to the picker, fired AVATAR_TOAST_DELAY_MS after the badge
+        // toast so the two announcements read as sequential events.
         const avatarCount = badgeAvatarKeys(codes).length
         const chooseAvatar = () => {
-            dismiss(toastId)
-            liveToastIdRef.current = null
+            dismiss(avatarToastId)
             posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_TAPPED, { count, target: 'avatar_picker' })
             router.push(AVATAR_PICKER_PATH)
         }
@@ -103,44 +109,70 @@ export default function BadgeEarnToast() {
             // priority icon by construction (ToastStack), no hideIcon needed.
             className: 'border border-action-secondary bg-background-default',
             content: (
-                <div className="flex flex-col gap-1">
-                    <button type="button" onClick={openInspect} className="flex items-center gap-3 text-left">
-                        <BadgeImage
-                            src={newestIcon}
-                            alt=""
-                            width={28}
-                            height={28}
-                            className="size-7 shrink-0 object-contain"
-                            unoptimized
-                        />
-                        <span className="text-label-l">
-                            {label} <span className="font-medium underline">{t('toastTapToView')}</span>
-                        </span>
-                    </button>
-                    {avatarCount > 0 && (
-                        <button type="button" onClick={chooseAvatar} className="min-h-11 pl-10 text-left text-label-l">
-                            {t('toastAvatars', { count: avatarCount })}{' '}
-                            <span className="font-medium underline">{t('toastChooseAvatar')}</span>
-                        </button>
-                    )}
-                </div>
+                <button type="button" onClick={openInspect} className="flex items-center gap-3 text-left">
+                    <BadgeImage
+                        src={newestIcon}
+                        alt=""
+                        width={28}
+                        height={28}
+                        className="size-7 shrink-0 object-contain"
+                        unoptimized
+                    />
+                    <span className="text-label-l">
+                        {label}
+                        <br />
+                        <span className="font-medium underline">{t('toastTapToView')}</span>
+                    </span>
+                </button>
             ),
         })
-        liveToastIdRef.current = toastId
+        liveToastIdsRef.current.push(toastId)
         posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_SHOWN, { count })
+
+        if (avatarCount > 0) {
+            avatarTimeoutRef.current = setTimeout(() => {
+                avatarTimeoutRef.current = null
+                toast({
+                    id: avatarToastId,
+                    type: 'success',
+                    duration: 6000,
+                    className: 'border border-action-secondary bg-background-default',
+                    content: (
+                        <button type="button" onClick={chooseAvatar} className="text-left text-label-l">
+                            {t('toastAvatars', { count: avatarCount })}
+                            <br />
+                            <span className="font-medium underline">{t('toastChooseAvatar')}</span>
+                        </button>
+                    ),
+                })
+                liveToastIdsRef.current.push(avatarToastId)
+            }, AVATAR_TOAST_DELAY_MS)
+        }
+
         markSeen(codes)
     }, [pathname, pending, toast, dismiss, markSeen, router, t, badgeCopy])
 
-    // Dismiss the toast when the user leaves /home so it doesn't ride over the
-    // next route for its remaining duration. Guarded on pathname so the
-    // markSeen-triggered re-render (still on /home) never kills the live toast.
+    // Dismiss the toast(s) when the user leaves /home so they don't ride over
+    // the next route for their remaining duration, and cancel a not-yet-fired
+    // avatar toast so it can't pop up on the new page. Guarded on pathname so
+    // the markSeen-triggered re-render (still on /home) never kills the live
+    // toast.
     useEffect(() => {
         if (pathname === HOME_PATH) return
-        if (liveToastIdRef.current) {
-            dismiss(liveToastIdRef.current)
-            liveToastIdRef.current = null
+        if (avatarTimeoutRef.current) {
+            clearTimeout(avatarTimeoutRef.current)
+            avatarTimeoutRef.current = null
         }
+        liveToastIdsRef.current.forEach((id) => dismiss(id))
+        liveToastIdsRef.current = []
     }, [pathname, dismiss])
+
+    // Unmount-only: cancel a still-pending avatar toast timer.
+    useEffect(() => {
+        return () => {
+            if (avatarTimeoutRef.current) clearTimeout(avatarTimeoutRef.current)
+        }
+    }, [])
 
     return modalBadge ? (
         <BadgeDetailModal

--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -49,9 +49,11 @@ export default function BadgeEarnToast() {
     // Ids of the toast(s) currently on screen, so we can dismiss them when the
     // user navigates away from /home (they'd otherwise linger over the next route).
     const liveToastIdsRef = useRef<string[]>([])
-    // Pending timer for the delayed avatar toast, so a route change (or unmount)
-    // before it fires can cancel it instead of popping a toast on the wrong page.
-    const avatarTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // Pending timers for delayed avatar toasts, so a route change (or unmount)
+    // before one fires can cancel it instead of popping a toast on the wrong
+    // page. A Set (not a single ref) because a later batch's effect run must
+    // not clobber an earlier batch's still-pending timer.
+    const avatarTimeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
 
     useEffect(() => {
         // Only surface on /home (never mid-onboarding) and only when there's
@@ -130,8 +132,8 @@ export default function BadgeEarnToast() {
         posthog.capture(ANALYTICS_EVENTS.BADGE_EARN_TOAST_SHOWN, { count })
 
         if (avatarCount > 0) {
-            avatarTimeoutRef.current = setTimeout(() => {
-                avatarTimeoutRef.current = null
+            const avatarTimeout = setTimeout(() => {
+                avatarTimeoutsRef.current.delete(avatarTimeout)
                 toast({
                     id: avatarToastId,
                     type: 'success',
@@ -147,6 +149,7 @@ export default function BadgeEarnToast() {
                 })
                 liveToastIdsRef.current.push(avatarToastId)
             }, AVATAR_TOAST_DELAY_MS)
+            avatarTimeoutsRef.current.add(avatarTimeout)
         }
 
         markSeen(codes)
@@ -159,18 +162,16 @@ export default function BadgeEarnToast() {
     // toast.
     useEffect(() => {
         if (pathname === HOME_PATH) return
-        if (avatarTimeoutRef.current) {
-            clearTimeout(avatarTimeoutRef.current)
-            avatarTimeoutRef.current = null
-        }
+        avatarTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout))
+        avatarTimeoutsRef.current.clear()
         liveToastIdsRef.current.forEach((id) => dismiss(id))
         liveToastIdsRef.current = []
     }, [pathname, dismiss])
 
-    // Unmount-only: cancel a still-pending avatar toast timer.
+    // Unmount-only: cancel any still-pending avatar toast timers.
     useEffect(() => {
         return () => {
-            if (avatarTimeoutRef.current) clearTimeout(avatarTimeoutRef.current)
+            avatarTimeoutsRef.current.forEach((timeout) => clearTimeout(timeout))
         }
     }, [])
 

--- a/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
+++ b/src/components/Badges/__tests__/BadgeEarnToast.test.tsx
@@ -92,7 +92,7 @@ describe('BadgeEarnToast', () => {
         expect(captureMock).toHaveBeenCalledWith('badge_earn_toast_shown', { count: 1 })
 
         render(mockToast.mock.calls[0][0].content)
-        act(() => fireEvent.click(screen.getByRole('button', { name: /tap to view/ })))
+        act(() => fireEvent.click(screen.getByRole('button', { name: /tap to view/i })))
 
         expect(mockDismissToast).toHaveBeenCalledWith('badge-earn:PRODUCT_HUNT')
         expect(captureMock).toHaveBeenCalledWith('badge_earn_toast_tapped', { count: 1, target: 'badge_detail' })
@@ -119,25 +119,39 @@ describe('BadgeEarnToast', () => {
         expect(screen.getByText(/Backend Name/)).toBeInTheDocument()
     })
 
-    it('announces unlocked avatars and hands the user to the picker (TASK-22142)', () => {
+    it('announces unlocked avatars in a second toast 500ms later and hands the user to the picker (TASK-22142)', () => {
+        jest.useFakeTimers()
         mockPending = [badge('BUG_WHISPERER', 'Bug Whisperer')]
         render(<BadgeEarnToast />)
 
-        render(mockToast.mock.calls[0][0].content)
+        // badge toast fires immediately; the avatar toast hasn't yet
+        expect(mockToast).toHaveBeenCalledTimes(1)
+
+        act(() => jest.advanceTimersByTime(499))
+        expect(mockToast).toHaveBeenCalledTimes(1)
+
+        act(() => jest.advanceTimersByTime(1))
+        expect(mockToast).toHaveBeenCalledTimes(2)
+        expect(mockToast.mock.calls[1][0].id).toBe('badge-earn-avatar:BUG_WHISPERER')
+
+        render(mockToast.mock.calls[1][0].content)
         expect(screen.getByText(/3 new avatars unlocked/)).toBeInTheDocument()
 
         act(() => fireEvent.click(screen.getByRole('button', { name: /Choose avatar/ })))
-        expect(mockDismissToast).toHaveBeenCalledWith('badge-earn:BUG_WHISPERER')
+        expect(mockDismissToast).toHaveBeenCalledWith('badge-earn-avatar:BUG_WHISPERER')
         expect(mockRouterPush).toHaveBeenCalledWith('/profile?avatarPicker=true')
         expect(screen.queryByTestId('badge-detail-modal')).not.toBeInTheDocument()
+        jest.useRealTimers()
     })
 
     it('says nothing about avatars for a badge that has none', () => {
+        jest.useFakeTimers()
         mockPending = [badge('PRODUCT_HUNT', 'Product Hunt')]
         render(<BadgeEarnToast />)
 
-        render(mockToast.mock.calls[0][0].content)
-        expect(screen.queryByText(/avatar/i)).not.toBeInTheDocument()
+        act(() => jest.advanceTimersByTime(500))
+        expect(mockToast).toHaveBeenCalledTimes(1)
+        jest.useRealTimers()
     })
 
     it('coalesces multiple badges and routes to /badges on tap', () => {
@@ -150,7 +164,7 @@ describe('BadgeEarnToast', () => {
         render(mockToast.mock.calls[0][0].content)
         expect(screen.getByText(/You unlocked 2 badges/)).toBeInTheDocument()
 
-        act(() => fireEvent.click(screen.getByRole('button', { name: /tap to view/ })))
+        act(() => fireEvent.click(screen.getByRole('button', { name: /tap to view/i })))
         expect(mockRouterPush).toHaveBeenCalledWith('/badges')
         expect(screen.queryByTestId('badge-detail-modal')).not.toBeInTheDocument()
     })

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -2333,7 +2333,7 @@
         "shareText": "I earned {badge} badge on Peanut!\n\nJoin Peanut now and start earning points, unlocking achievements and moving money worldwide\n\n{link}",
         "toastSingle": "Badge unlocked: {name}",
         "toastMultiple": "You unlocked {count, plural, one {# badge} other {# badges}}",
-        "toastTapToView": "— tap to view",
+        "toastTapToView": "Tap to view",
         "catalog": {
             "FIRST_INVITE": {
                 "name": "First Invite",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -2333,7 +2333,7 @@
         "shareText": "¡Gané la insignia {badge} en Peanut!\n\nÚnete a Peanut y empieza a ganar puntos, desbloquear logros y mover dinero por todo el mundo\n\n{link}",
         "toastSingle": "Insignia desbloqueada: {name}",
         "toastMultiple": "¡Desbloqueaste {count, plural, one {# insignia} other {# insignias}}!",
-        "toastTapToView": "— toca para ver",
+        "toastTapToView": "Toca para ver",
         "catalog": {
             "FIRST_INVITE": {
                 "name": "Primera invitación",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1044,7 +1044,7 @@
     "badges": {
         "emptyDescription": "Ganá insignias a medida que usás Peanut. Hacé pagos, invitá amigos y participá en eventos para desbloquearlas y mostrarlas en tu perfil.",
         "shareText": "¡Gané la insignia {badge} en Peanut!\n\nUnite a Peanut y empezá a ganar puntos, desbloquear logros y mover dinero por todo el mundo\n\n{link}",
-        "toastTapToView": "— tocá para ver"
+        "toastTapToView": "Tocá para ver"
     },
     "notifications": {
         "setupDescription": "Activá las notificaciones y recibí alertas de toda la actividad de tu billetera."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -2333,7 +2333,7 @@
         "shareText": "Ganhei o selo {badge} no Peanut!\n\nEntre no Peanut e comece a ganhar pontos, desbloquear conquistas e movimentar dinheiro pelo mundo\n\n{link}",
         "toastSingle": "Selo desbloqueado: {name}",
         "toastMultiple": "Você desbloqueou {count, plural, one {# selo} other {# selos}}",
-        "toastTapToView": "— toque para ver",
+        "toastTapToView": "Toque para ver",
         "catalog": {
             "FIRST_INVITE": {
                 "name": "Primeiro convite",


### PR DESCRIPTION
## Summary
- Split the badge-unlock and avatar-unlock announcements into two separate toasts, the avatar one firing 500ms after the badge one, instead of stacking two links inside a single toast.
- Each toast's link now always sits on its own line (line break before it).
- Dropped the leading dash from "tap to view" copy and capitalized it ("Tap to view") across en / es-419 / es-AR / pt-BR.

## Test plan
- [x] `BadgeEarnToast.test.tsx` updated and passing (9/9), including new coverage for the 500ms delay between toasts
- [x] `tsc --noEmit` clean on touched files
- [x] `prettier --check` clean on touched files
- [ ] Manual check of the toast in a live session with a fresh badge that ships avatars (not verified live — needs a real earned-badge state)
