### PR TITLE
style: nonDsClassesInViews items 1-9 — scale renames + named 60vh utilities

### DIFF
--- a/scripts/ds-lint-baseline.json
+++ b/scripts/ds-lint-baseline.json
@@ -4,7 +4,7 @@
     "inlineStyle": 21,
     "stockTextSize": 0,
     "dsTextScale": 11,
-    "nonDsClassesInViews": 15,
+    "nonDsClassesInViews": 6,
     "useSearchParamsFiles": 44,
     "nuqsFiles": 25,
     "legacyColorClasses": 0,
@@ -19,7 +19,7 @@
     "rawDuration": 6,
     "retypedCardLiteral": 16,
     "hoverNoActiveFiles": 44,
-    "arbitraryFontSize": 111,
+    "arbitraryFontSize": 110,
     "rawErrorText": 25,
     "handRolledCloseGlyphFiles": 9,
     "_meta": [

--- a/src/app/(mobile-ui)/rewards/invites/page.tsx
+++ b/src/app/(mobile-ui)/rewards/invites/page.tsx
@@ -170,7 +170,7 @@ const InvitesPage = () => {
                                             size="small"
                                         />
                                     </div>
-                                    <div className="min-w-0 flex-1 truncate font-roboto text-[16px] font-medium">
+                                    <div className="min-w-0 flex-1 truncate font-roboto text-body-m">
                                         <VerifiedUserLabel
                                             name={displayName}
                                             username={username}

--- a/src/components/AddMoney/views/CryptoDeposit.view.tsx
+++ b/src/components/AddMoney/views/CryptoDeposit.view.tsx
@@ -77,7 +77,7 @@ const CryptoDepositView = ({
         return (
             <div className="flex min-h-inherit w-full flex-col justify-start gap-8 pb-4 md:pb-0">
                 <NavHeader title={t('title')} onPrev={onBack} />
-                <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-4">
+                <div className="flex h-full min-h-screen-60 flex-col items-center justify-center gap-4">
                     <Card>
                         <div className="flex w-full flex-col items-center justify-center gap-2">
                             <IconBubble icon="alert" size="s" color="yellow" />
@@ -111,7 +111,7 @@ const CryptoDepositView = ({
 
                 {/* loading state */}
                 {(isLoading || status === 'loading') && (
-                    <div className="flex h-[60vh] items-center justify-center">
+                    <div className="flex h-screen-60 items-center justify-center">
                         {status === 'loading' ? <CyclingLoading /> : <Loading variant="mascot" />}
                     </div>
                 )}

--- a/src/components/AddMoney/views/RhinoDeposit.view.tsx
+++ b/src/components/AddMoney/views/RhinoDeposit.view.tsx
@@ -74,7 +74,7 @@ const RhinoDepositView = ({
             <div className="flex min-h-inherit w-full flex-col justify-start gap-8 pb-4 md:pb-0">
                 <NavHeader title={headerTitle} onPrev={onBack} />
 
-                <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-4">
+                <div className="flex h-full min-h-screen-60 flex-col items-center justify-center gap-4">
                     <Card>
                         <div className="flex w-full flex-col items-center justify-center gap-2">
                             <IconBubble icon="alert" size="s" color="yellow" />
@@ -123,7 +123,7 @@ const RhinoDepositView = ({
                 />
 
                 {(isDepositAddressDataLoading || depositAddressStatus === 'loading') && (
-                    <div className="flex h-[60vh] items-center justify-center">
+                    <div className="flex h-screen-60 items-center justify-center">
                         {depositAddressStatus === 'loading' ? <CyclingLoading /> : <Loading variant="mascot" />}
                     </div>
                 )}

--- a/src/components/Claim/Link/Onchain/Confirm.view.tsx
+++ b/src/components/Claim/Link/Onchain/Confirm.view.tsx
@@ -246,7 +246,7 @@ export const ConfirmClaimLinkView = ({
                                 label={t('confirm.tokenAndNetwork')}
                                 value={
                                     <div className="flex items-center gap-2">
-                                        <div className="relative flex h-6 w-6 min-w-[24px] items-center justify-center">
+                                        <div className="relative flex h-6 w-6 min-w-6 items-center justify-center">
                                             <DisplayIcon
                                                 iconUrl={tokenIconUrl}
                                                 altText={resolvedTokenSymbol || t('confirm.tokenAlt')}

--- a/src/components/Global/TokenSelector/Components/NetworkListView.tsx
+++ b/src/components/Global/TokenSelector/Components/NetworkListView.tsx
@@ -74,7 +74,7 @@ const NetworkListView: React.FC<NetworkListViewProps> = ({
                 placeholder={t('tokenSelector.searchNetworkPlaceholder')}
             />
 
-            <div className="space-y-2 flex max-h-[60vh] flex-col gap-3 overflow-y-auto pt-2 pr-1">
+            <div className="space-y-2 flex max-h-screen-60 flex-col gap-3 overflow-y-auto pt-2 pr-1">
                 {filteredChains.length > 0 ? (
                     filteredChains.map((chain) => (
                         <NetworkListItem

--- a/src/components/Withdraw/views/Confirm.withdraw.view.tsx
+++ b/src/components/Withdraw/views/Confirm.withdraw.view.tsx
@@ -147,7 +147,7 @@ export default function ConfirmWithdrawView({
                         value={
                             <div className="flex items-center gap-2">
                                 {token && (
-                                    <div className="relative flex h-6 w-6 min-w-[24px] items-center justify-center">
+                                    <div className="relative flex h-6 w-6 min-w-6 items-center justify-center">
                                         <DisplayIcon
                                             iconUrl={tokenIconUrl}
                                             altText={resolvedTokenSymbol || t('confirm.tokenAlt')}

--- a/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
+++ b/src/features/payments/flows/semantic-request/views/SemanticRequestConfirmView.tsx
@@ -308,7 +308,7 @@ function TokenChainInfoDisplay({
     return (
         <div className="flex items-center gap-2">
             {(tokenIconUrl || chainIconUrl) && (
-                <div className="relative flex h-6 w-6 min-w-[24px] items-center justify-center">
+                <div className="relative flex h-6 w-6 min-w-6 items-center justify-center">
                     {tokenIconUrl && (
                         <DisplayIcon
                             iconUrl={tokenIconUrl}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -530,6 +530,19 @@
     min-height: inherit;
 }
 
+/* deposit panels and pick lists size against 60% of the viewport — named
+   utilities instead of the arbitrary *-[60vh] the DS lint counts as debt.
+   three utilities because one @utility cannot span three properties. */
+@utility h-screen-60 {
+    height: 60vh;
+}
+@utility min-h-screen-60 {
+    min-height: 60vh;
+}
+@utility max-h-screen-60 {
+    max-height: 60vh;
+}
+
 @utility font-roboto {
     font-family:
         var(--font-roboto), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',


### PR DESCRIPTION
## Summary

Second DS cleanup pass ruled by Kush: items 1-9 of the `nonDsClassesInViews` breakdown. Pure class renames onto the scale plus one named utility family — **visual no-op by construction** (every computed value is unchanged).

**Task:** TASK-21446 (DS 02 — lint count baselines / KR1 ratchet)

## Changes

**Scale one-liners (4)**
- `rewards/invites/page.tsx`: `text-[16px] font-medium` -> `text-body-m` (token carries the same 16px/Medium; the stacked weight class goes)
- `min-w-[24px]` -> `min-w-6` (same 24px) in the copy-pasted icon wrapper x3: `Claim/Link/Onchain/Confirm.view.tsx`, `Withdraw/views/Confirm.withdraw.view.tsx`, `semantic-request/views/SemanticRequestConfirmView.tsx`

**60vh panel family (5) via named utilities**
- New in `globals.css` (following the `min-h-inherit` precedent): `h-screen-60`, `min-h-screen-60`, `max-h-screen-60` — all exactly `60vh`; three utilities because one `@utility` cannot span three properties
- Used in: `AddMoney/views/CryptoDeposit.view.tsx` (min-h + h), `AddMoney/views/RhinoDeposit.view.tsx` (min-h + h), `Global/TokenSelector/Components/NetworkListView.tsx` (max-h)

**Deliberately NOT touched** (no ruling yet): items 10-15 — the dvh singles, `size-[250px]`, the qr-pay max-w, the safe-bottom calc, the shadow arbitrary.

## Metrics

| metric | before (dev) | after |
|---|---|---|
| nonDsClassesInViews | 15 | 6 |
| arbitraryFontSize | 111 | 110 |

(The breakdown Kush ruled on was taken pre-#2953-merge at 16; #2953 landed one of them, so dev's base is 15.) All other metrics unchanged; baseline rebased, `--check` green.

## Visual changes

None. Every replacement computes to the identical value (24px, 16px/500, 60vh). ds-shots: every screen this PR touches (add-money-crypto, rewards-invites) is pixel-identical. The 5 'moved' screens in its comment (avatar-picker 1.77%, home/add-money/badges/empty-accounts at 0.03-0.07%) are the known flaky set — the same screens move at the same magnitudes on sibling PRs #3011/#3012/#3013 that touch none of them.

## QA

- prettier clean, typecheck clean, jest 485 suites / 6077 tests green
- `node scripts/ds-lint-counts.mjs --check` green
