### PR TITLE
fix(history): skip live FX lookup for pending Bridge onramp/offramp rows

### DIFF
--- a/src/app/receipt/[entryId]/__tests__/receipt-metadata.utils.test.ts
+++ b/src/app/receipt/[entryId]/__tests__/receipt-metadata.utils.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Chip review (PR #3017): completeHistoryEntry blanks a pending Bridge
+ * OFFRAMP's `currency.amount` to '' (history.utils.ts) rather than leaving
+ * the mirrored crypto-leg figure in place. `generateReceiptTitle` reads that
+ * same field for the receipt page's <title> / link-preview text — without a
+ * validity guard, `formatAmount('')` returns '0', so a pending ARS/BRL/EUR
+ * withdrawal's title read "Receipt - Withdrawal of ARS 0" while the payout
+ * was still in flight.
+ */
+import { generateReceiptTitle } from '../receipt-metadata.utils'
+import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+
+const baseTx = {
+    direction: 'withdraw',
+    amount: 30,
+    userName: undefined,
+    status: 'pending',
+    tokenSymbol: 'USDC',
+} as unknown as TransactionDetails
+
+describe('generateReceiptTitle', () => {
+    // tokenSymbol=USDC is realistic for a Peanut wallet OFFRAMP (the balance
+    // side is always USDC) — a stablecoin, so falling out of the currency
+    // branch lands on the plain `$amount` branch, not a token-amount one.
+    it('falls back to $amount when currency.amount is blanked (pending OFFRAMP)', () => {
+        const tx = { ...baseTx, currency: { amount: '', code: 'ARS' } } as TransactionDetails
+        expect(generateReceiptTitle(tx)).toBe('Receipt - Withdrawal of $30.00')
+    })
+
+    it('falls back to $amount when currency.amount is missing entirely', () => {
+        const tx = { ...baseTx, currency: { code: 'ARS' } as any } as TransactionDetails // deliberately missing `amount`
+        expect(generateReceiptTitle(tx)).toBe('Receipt - Withdrawal of $30.00')
+    })
+
+    it('uses the real converted local amount once it is valid (completed OFFRAMP)', () => {
+        const tx = { ...baseTx, status: 'completed', currency: { amount: '30000', code: 'ARS' } } as TransactionDetails
+        expect(generateReceiptTitle(tx)).toBe('Receipt - Withdrawal of ARS 30000')
+    })
+})

--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -14,10 +14,11 @@ import NavHeader from '@/components/Global/NavHeader'
 import { generateMetadata as generateBaseMetadata } from '@/app/metadata'
 import { type Metadata } from 'next'
 import { BASE_URL } from '@/constants/general.consts'
-import { formatAmount, formatCurrency, isStableCoin } from '@/utils/general.utils'
+import { formatCurrency } from '@/utils/general.utils'
 import { buildOgImageUrl } from '@/utils/og.utils'
 import getOrigin from '@/lib/hosting/get-origin'
 import PageContainer from '@/components/0_Bruddle/PageContainer'
+import { generateReceiptTitle, generateReceiptDescription } from './receipt-metadata.utils'
 
 // Helper function to map transaction card type to OG image type
 function mapTransactionTypeToOGType(transactionType: string): 'send' | 'request' {
@@ -35,76 +36,6 @@ function mapTransactionTypeToOGType(transactionType: string): 'send' | 'request'
         case 'pay':
         default:
             return 'send'
-    }
-}
-
-// Helper function to generate receipt title based on transaction details
-function generateReceiptTitle(transaction: TransactionDetails): string {
-    const { direction, amount, userName, status, currency, tokenSymbol } = transaction
-
-    // Format amount - use currency if available, otherwise tokenSymbol.
-    // Treat USDC/USDT as USD (1:1 peg) — `USDC 0.10` reads identically to
-    // `$0.10` and just clutters the title.
-    let formattedAmount: string
-    if (currency && currency.code !== 'USD' && !isStableCoin(currency.code)) {
-        formattedAmount = `${currency.code} ${formatAmount(currency.amount)}`
-    } else if (tokenSymbol && !isStableCoin(tokenSymbol)) {
-        formattedAmount = `${formatAmount(Number(amount))} ${tokenSymbol}`
-    } else {
-        formattedAmount = `$${formatCurrency(Number(amount).toString())}`
-    }
-
-    // Handle different transaction directions and statuses
-    if (status === 'failed') {
-        return 'Receipt - Failed transaction'
-    }
-
-    if (status === 'cancelled') {
-        return 'Receipt - Cancelled transaction'
-    }
-
-    switch (direction) {
-        case 'send':
-            return `Receipt - You sent ${formattedAmount}${userName ? ` to ${userName}` : ''}`
-        case 'receive':
-            return `Receipt - You received ${formattedAmount}${userName ? ` from ${userName}` : ''}`
-        case 'withdraw':
-        case 'bank_withdraw':
-            return `Receipt - Withdrawal of ${formattedAmount}`
-        case 'bank_deposit':
-        case 'add':
-            return `Receipt - Deposit of ${formattedAmount}`
-        case 'request_sent':
-            return `Receipt - Request for ${formattedAmount}${userName ? ` to ${userName}` : ''}`
-        case 'request_received':
-            return `Receipt - Request for ${formattedAmount}${userName ? ` from ${userName}` : ''}`
-        case 'bank_request_fulfillment':
-            return `Receipt - Bank payment of ${formattedAmount}${userName ? ` to ${userName}` : ''}`
-        case 'bank_claim':
-        case 'claim_external':
-            return `Receipt - Claim of ${formattedAmount}`
-        case 'qr_payment':
-            return `Receipt - Payment of ${formattedAmount}${userName ? ` to ${userName}` : ''}`
-        default:
-            return `Receipt - Transaction of ${formattedAmount}`
-    }
-}
-
-// Helper function to generate receipt description based on status
-function generateReceiptDescription(status: string): string {
-    switch (status) {
-        case 'completed':
-            return 'Transaction completed via Peanut'
-        case 'pending':
-            return 'Transaction pending'
-        case 'processing':
-            return 'Transaction processing'
-        case 'failed':
-            return 'Transaction failed'
-        case 'cancelled':
-            return 'Transaction cancelled'
-        default:
-            return 'View transaction receipt'
     }
 }
 

--- a/src/app/receipt/[entryId]/receipt-metadata.utils.ts
+++ b/src/app/receipt/[entryId]/receipt-metadata.utils.ts
@@ -1,0 +1,82 @@
+import { type TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { formatAmount, formatCurrency, isStableCoin } from '@/utils/general.utils'
+
+// Split out of page.tsx (which imports `next/server`'s `connection` and
+// therefore can't be imported from a jsdom/node Jest test — see PR #3017)
+// so these pure formatting helpers stay unit-testable.
+
+/** Generates the receipt page's <title> / link-preview text from a transaction. */
+export function generateReceiptTitle(transaction: TransactionDetails): string {
+    const { direction, amount, userName, status, currency, tokenSymbol } = transaction
+
+    // Format amount - use currency if available, otherwise tokenSymbol.
+    // Treat USDC/USDT as USD (1:1 peg) — `USDC 0.10` reads identically to
+    // `$0.10` and just clutters the title.
+    let formattedAmount: string
+    // A pending Bridge OFFRAMP ships `currency.amount` blanked (see
+    // completeHistoryEntry's OFFRAMP branch in history.utils.ts) rather than
+    // the unconverted crypto-leg figure mislabeled as fiat — require it to
+    // actually parse before using it, so a still-pending row falls through
+    // to the token/USD branch instead of the title reading "ARS 0".
+    const hasValidCurrencyAmount = !!currency?.amount && Number.isFinite(Number(currency.amount))
+    if (currency && currency.code !== 'USD' && !isStableCoin(currency.code) && hasValidCurrencyAmount) {
+        formattedAmount = `${currency.code} ${formatAmount(currency.amount)}`
+    } else if (tokenSymbol && !isStableCoin(tokenSymbol)) {
+        formattedAmount = `${formatAmount(Number(amount))} ${tokenSymbol}`
+    } else {
+        formattedAmount = `$${formatCurrency(Number(amount).toString())}`
+    }
+
+    // Handle different transaction directions and statuses
+    if (status === 'failed') {
+        return 'Receipt - Failed transaction'
+    }
+
+    if (status === 'cancelled') {
+        return 'Receipt - Cancelled transaction'
+    }
+
+    switch (direction) {
+        case 'send':
+            return `Receipt - You sent ${formattedAmount}${userName ? ` to ${userName}` : ''}`
+        case 'receive':
+            return `Receipt - You received ${formattedAmount}${userName ? ` from ${userName}` : ''}`
+        case 'withdraw':
+        case 'bank_withdraw':
+            return `Receipt - Withdrawal of ${formattedAmount}`
+        case 'bank_deposit':
+        case 'add':
+            return `Receipt - Deposit of ${formattedAmount}`
+        case 'request_sent':
+            return `Receipt - Request for ${formattedAmount}${userName ? ` to ${userName}` : ''}`
+        case 'request_received':
+            return `Receipt - Request for ${formattedAmount}${userName ? ` from ${userName}` : ''}`
+        case 'bank_request_fulfillment':
+            return `Receipt - Bank payment of ${formattedAmount}${userName ? ` to ${userName}` : ''}`
+        case 'bank_claim':
+        case 'claim_external':
+            return `Receipt - Claim of ${formattedAmount}`
+        case 'qr_payment':
+            return `Receipt - Payment of ${formattedAmount}${userName ? ` to ${userName}` : ''}`
+        default:
+            return `Receipt - Transaction of ${formattedAmount}`
+    }
+}
+
+/** Generates the receipt page's meta-description text from a transaction's status. */
+export function generateReceiptDescription(status: string): string {
+    switch (status) {
+        case 'completed':
+            return 'Transaction completed via Peanut'
+        case 'pending':
+            return 'Transaction pending'
+        case 'processing':
+            return 'Transaction processing'
+        case 'failed':
+            return 'Transaction failed'
+        case 'cancelled':
+            return 'Transaction cancelled'
+        default:
+            return 'View transaction receipt'
+    }
+}

--- a/src/components/TransactionDetails/TransactionCard.tsx
+++ b/src/components/TransactionDetails/TransactionCard.tsx
@@ -179,7 +179,15 @@ const TransactionCard: React.FC<TransactionCardProps> = ({
     // Skip both for USD / USD-pegged stablecoins to avoid `$0.10 / ≈ USDC 0.10` noise.
     const ccyCode = transaction.currency?.code.toUpperCase()
     const tokenSymbolUpper = (transaction.tokenSymbol ?? '').toUpperCase()
-    if (transaction.currency && ccyCode && ccyCode !== 'USD' && !isStableCoin(ccyCode)) {
+    // A pending Bridge OFFRAMP row ships `currency.amount` blanked (see
+    // completeHistoryEntry's OFFRAMP branch) rather than the unconverted
+    // crypto-leg figure mislabeled as fiat — require it to actually parse
+    // before rendering the "≈ CODE" line, so a still-pending row falls
+    // through to the token-amount line below instead of showing a number
+    // that reads as converted but isn't.
+    const hasValidCurrencyAmount =
+        !!transaction.currency?.amount && Number.isFinite(Number(transaction.currency.amount))
+    if (transaction.currency && ccyCode && ccyCode !== 'USD' && !isStableCoin(ccyCode) && hasValidCurrencyAmount) {
         const formattedCurrencyAmount = formatNumberForDisplay(transaction.currency.amount, { maxDecimals: 2 })
         currencyDisplayAmount = `≈ ${ccyCode} ${formattedCurrencyAmount}`
     } else if (

--- a/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
+++ b/src/components/TransactionDetails/__tests__/TransactionCard.test.tsx
@@ -325,3 +325,28 @@ describe('TransactionCard — open-request pending exemption', () => {
         expect(screen.getByText('+$10')).toHaveClass('opacity-40')
     })
 })
+
+// completeHistoryEntry blanks `currency.amount` to '' for a still-pending
+// Bridge OFFRAMP row (history.utils.ts) rather than leaving the mirrored
+// crypto-leg figure in place. The card must not render that blank/invalid
+// amount as if it were a real converted "≈ CODE x" figure.
+describe('TransactionCard — secondary currency line requires a valid amount', () => {
+    function currencyTx(currency: TransactionDetails['currency']): TransactionDetails {
+        return { ...eligibleTx(), currency } as TransactionDetails
+    }
+
+    it('renders the "≈ CODE x" line for a real converted amount', () => {
+        renderCard(currencyTx({ amount: '105.9', code: 'EUR' }))
+        expect(screen.getByText('≈ EUR 105.9')).toBeInTheDocument()
+    })
+
+    it('hides the line for a blanked (pending, unconverted) amount', () => {
+        renderCard(currencyTx({ amount: '', code: 'ARS' }))
+        expect(screen.queryByText(/≈ ARS/)).toBeNull()
+    })
+
+    it('hides the line when currency.amount is missing entirely', () => {
+        renderCard(currencyTx({ code: 'ARS' } as any)) // deliberately missing `amount`
+        expect(screen.queryByText(/≈ ARS/)).toBeNull()
+    })
+})

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -91,12 +91,20 @@ describe('completeHistoryEntry amount-contract guards', () => {
 })
 
 /**
- * Bridge/Manteca mirror the USD amount into `currency.amount` while an
- * ONRAMP/OFFRAMP intent is still pending — the real fiat figure lands with
- * the provider's receipt on completion. A live-rate lookup for a row that's
- * about to get its real amount for free just hammers the FX endpoint on
- * every pending render, so completeHistoryEntry must skip it until the row
- * is final.
+ * ONRAMP's `currency.amount` (the fiat source Bridge was asked to transfer)
+ * is correct from intent creation, pending or not — so its live-rate lookup
+ * (which corrects the PRIMARY `usdAmount`, not `currency.amount`) always
+ * runs when the amount looks mirrored, regardless of status.
+ *
+ * OFFRAMP's `currency.amount` (the fiat destination) is genuinely unknown
+ * until the provider's receipt lands — Bridge/Manteca mirror the crypto-leg
+ * figure into it while pending. Fetching a live rate for a row that's about
+ * to get its real amount for free just hammers the FX endpoint on every
+ * pending render, so completeHistoryEntry skips the lookup until the row is
+ * final — but showing the mirrored figure as if it were converted local
+ * currency is actively wrong (off by ~1000x for ARS/BRL), so the pending
+ * path blanks `currency.amount` instead of leaving the wrong number in
+ * place.
  */
 describe('completeHistoryEntry currency-price fallback (pending vs final)', () => {
     beforeEach(() => {
@@ -104,33 +112,39 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
         mockGetCachedCurrencyPrice.mockResolvedValue({ buy: 1.1, sell: 0.9 })
     })
 
-    it('does not fetch a live rate for a PENDING ONRAMP row with a mirrored amount', async () => {
-        const entry: HistoryEntry = {
+    it('always corrects the primary amount for a mirrored ONRAMP row, pending or final', async () => {
+        const pending: HistoryEntry = {
             ...baseEntry,
             status: 'PENDING' as HistoryEntry['status'],
             amount: '2.00',
             currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
+        }
+        const pendingResult = await completeHistoryEntry(pending)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        expect(pendingResult.extraData?.usdAmount).toBe((2 / 1.1).toString())
+
+        mockGetCachedCurrencyPrice.mockClear()
+        const final: HistoryEntry = { ...pending, status: 'COMPLETED' as HistoryEntry['status'] }
+        const finalResult = await completeHistoryEntry(final)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        expect(finalResult.extraData?.usdAmount).toBe((2 / 1.1).toString())
+    })
+
+    it('leaves a non-mirrored ONRAMP currency.amount untouched and skips the fetch', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'COMPLETED' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '105.90', code: 'eur' },
             extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
         }
         const result = await completeHistoryEntry(entry)
         expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
-        // Mirrored value passes through unconverted while pending.
         expect(result.extraData?.usdAmount).toBe('2.00')
     })
 
-    it('fetches a live rate for a COMPLETED ONRAMP row with a mirrored amount', async () => {
-        const entry: HistoryEntry = {
-            ...baseEntry,
-            status: 'COMPLETED' as HistoryEntry['status'],
-            amount: '2.00',
-            currency: { amount: '2.00', code: 'eur' },
-            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
-        }
-        await completeHistoryEntry(entry)
-        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
-    })
-
-    it('does not fetch a live rate for a PENDING OFFRAMP row with a mirrored amount', async () => {
+    it('blanks a mirrored OFFRAMP currency.amount while PENDING instead of fetching', async () => {
         const entry: HistoryEntry = {
             ...baseEntry,
             status: 'PENDING' as HistoryEntry['status'],
@@ -138,11 +152,26 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
             currency: { amount: '2.00', code: 'eur' },
             extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
         }
-        await completeHistoryEntry(entry)
+        const result = await completeHistoryEntry(entry)
         expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+        expect(result.currency?.amount).toBe('')
+        expect(result.currency?.code).toBe('EUR') // kept — the bank-country-flag lookup reads it
     })
 
-    it('fetches a live rate for a COMPLETED OFFRAMP row with a mirrored amount', async () => {
+    it('blanks an OFFRAMP row PENDING with no currency.amount at all', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'PENDING' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { code: 'ars' } as any, // deliberately missing `amount`
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+        expect(result.currency?.amount).toBe('')
+    })
+
+    it('converts a mirrored OFFRAMP currency.amount once COMPLETED', async () => {
         const entry: HistoryEntry = {
             ...baseEntry,
             status: 'COMPLETED' as HistoryEntry['status'],
@@ -150,49 +179,57 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
             currency: { amount: '2.00', code: 'eur' },
             extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
         }
-        await completeHistoryEntry(entry)
+        const result = await completeHistoryEntry(entry)
         expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        expect(result.currency?.amount).toBe((2 * 0.9).toString())
     })
 
-    // Bridge API returns lowercase terminal states — ensure these are recognized as final
-    it('fetches a live rate for a lowercase "completed" ONRAMP row (Bridge terminal state)', async () => {
-        const entry: HistoryEntry = {
-            ...baseEntry,
-            status: 'completed' as HistoryEntry['status'], // lowercase from Bridge API
-            amount: '2.00',
-            currency: { amount: '2.00', code: 'eur' },
-            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
-        }
-        await completeHistoryEntry(entry)
-        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
-    })
-
-    it('fetches a live rate for a lowercase "payment_processed" OFFRAMP row (Bridge terminal state)', async () => {
-        const entry: HistoryEntry = {
-            ...baseEntry,
-            status: 'payment_processed' as HistoryEntry['status'], // lowercase from Bridge API
-            amount: '2.00',
-            currency: { amount: '2.00', code: 'eur' },
-            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
-        }
-        await completeHistoryEntry(entry)
-        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
-    })
-
-    // OFFRAMP branch: missing currency.amount entirely (no amount to compare)
-    it('fetches a live rate for a final OFFRAMP row with no currency.amount at all', async () => {
+    it('converts an OFFRAMP row with no currency.amount once COMPLETED', async () => {
         const entry: HistoryEntry = {
             ...baseEntry,
             status: 'COMPLETED' as HistoryEntry['status'],
             amount: '2.00',
-            currency: { code: 'eur' } as any, // no amount property
+            currency: { code: 'ars' } as any, // deliberately missing `amount`
             extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
         }
-        await completeHistoryEntry(entry)
-        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
-        // Should set the currency.amount to the converted value
-        expect(entry.currency?.amount).toBeDefined()
+        const result = await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('ARS')
+        expect(result.currency?.amount).toBe((2 * 0.9).toString())
     })
+
+    // Bridge's wire status is lowercase end to end (BridgeTransferState) —
+    // isFinalState must recognize it, or a genuinely-settled OFFRAMP row
+    // stays stuck treating its mirrored amount as pending forever.
+    it.each(['completed', 'payment_processed'])(
+        'treats OFFRAMP status=%s (Bridge lowercase terminal state) as final',
+        async (status) => {
+            const entry: HistoryEntry = {
+                ...baseEntry,
+                status: status as HistoryEntry['status'],
+                amount: '2.00',
+                currency: { amount: '2.00', code: 'eur' },
+                extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+            }
+            const result = await completeHistoryEntry(entry)
+            expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+            expect(result.currency?.amount).toBe((2 * 0.9).toString())
+        }
+    )
+
+    it.each(['canceled', 'error', 'returned', 'undeliverable', 'refunded'])(
+        'treats OFFRAMP status=%s (Bridge lowercase failure terminal) as final too',
+        async (status) => {
+            const entry: HistoryEntry = {
+                ...baseEntry,
+                status: status as HistoryEntry['status'],
+                amount: '2.00',
+                currency: { amount: '2.00', code: 'eur' },
+                extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+            }
+            await completeHistoryEntry(entry)
+            expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        }
+    )
 })
 
 /**

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -197,11 +197,13 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
         expect(result.currency?.amount).toBe((2 * 0.9).toString())
     })
 
-    // Bridge's wire status is lowercase end to end (BridgeTransferState) —
-    // isFinalState must recognize it, or a genuinely-settled OFFRAMP row
-    // stays stuck treating its mirrored amount as pending forever.
-    it.each(['completed', 'payment_processed'])(
-        'treats OFFRAMP status=%s (Bridge lowercase terminal state) as final',
+    // Bridge's HistoryEntry.status is always the UPPER_CASE Prisma
+    // BridgeTransferState (peanut-api-ts src/db/history.ts:844) — Bridge's
+    // own webhook strings are lowercase, but the API normalizes them via
+    // `bridgeStateFromString` before that value is ever stored or sent to
+    // the FE, so isFinalState only ever needs to match the upper-case form.
+    it.each(['COMPLETED', 'PAYMENT_PROCESSED', 'REFUNDED', 'CANCELED', 'ERROR'])(
+        'treats OFFRAMP status=%s as final',
         async (status) => {
             const entry: HistoryEntry = {
                 ...baseEntry,
@@ -216,20 +218,24 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
         }
     )
 
-    it.each(['canceled', 'error', 'returned', 'undeliverable', 'refunded'])(
-        'treats OFFRAMP status=%s (Bridge lowercase failure terminal) as final too',
-        async (status) => {
-            const entry: HistoryEntry = {
-                ...baseEntry,
-                status: status as HistoryEntry['status'],
-                amount: '2.00',
-                currency: { amount: '2.00', code: 'eur' },
-                extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
-            }
-            await completeHistoryEntry(entry)
-            expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+    // RETURNED/UNDELIVERABLE were missing from FINAL_STATES before this fix —
+    // the one genuinely-reachable enum change here (peanut-api-ts emits both
+    // for a failed Bridge payout). Without it a returned/undeliverable OFFRAMP
+    // stayed on the pending path forever: blanked currency.amount, and (via
+    // the shared isFinalState consumers) an endless 15s receipt poll and a
+    // PENDING_TTL PDF cache that never promotes to the final one.
+    it.each(['RETURNED', 'UNDELIVERABLE'])('treats OFFRAMP status=%s as final', async (status) => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: status as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
         }
-    )
+        const result = await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        expect(result.currency?.amount).toBe((2 * 0.9).toString())
+    })
 })
 
 /**

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -21,8 +21,10 @@ import {
 } from '../history.utils'
 import type { HistoryEntry } from '../history.utils'
 import type { TransactionDetails } from '@/components/TransactionDetails/transactionTransformer'
+import { getCachedCurrencyPrice } from '@/app/actions/currency'
 
 jest.mock('@/app/actions/currency', () => ({ getCachedCurrencyPrice: jest.fn() }))
+const mockGetCachedCurrencyPrice = getCachedCurrencyPrice as jest.Mock
 jest.mock('@/utils/general.utils', () => ({
     getFromLocalStorage: jest.fn(() => null),
     getTokenDetails: jest.fn(() => ({ symbol: 'USDC', decimals: 6 })),
@@ -85,6 +87,71 @@ describe('completeHistoryEntry amount-contract guards', () => {
             extraData: { ...baseEntry.extraData, kind: 'CRYPTO_DEPOSIT' },
         }
         await expect(completeHistoryEntry(entry)).resolves.toBeDefined()
+    })
+})
+
+/**
+ * Bridge/Manteca mirror the USD amount into `currency.amount` while an
+ * ONRAMP/OFFRAMP intent is still pending — the real fiat figure lands with
+ * the provider's receipt on completion. A live-rate lookup for a row that's
+ * about to get its real amount for free just hammers the FX endpoint on
+ * every pending render, so completeHistoryEntry must skip it until the row
+ * is final.
+ */
+describe('completeHistoryEntry currency-price fallback (pending vs final)', () => {
+    beforeEach(() => {
+        mockGetCachedCurrencyPrice.mockReset()
+        mockGetCachedCurrencyPrice.mockResolvedValue({ buy: 1.1, sell: 0.9 })
+    })
+
+    it('does not fetch a live rate for a PENDING ONRAMP row with a mirrored amount', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'PENDING' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
+        }
+        const result = await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+        // Mirrored value passes through unconverted while pending.
+        expect(result.extraData?.usdAmount).toBe('2.00')
+    })
+
+    it('fetches a live rate for a COMPLETED ONRAMP row with a mirrored amount', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'COMPLETED' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+    })
+
+    it('does not fetch a live rate for a PENDING OFFRAMP row with a mirrored amount', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'PENDING' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).not.toHaveBeenCalled()
+    })
+
+    it('fetches a live rate for a COMPLETED OFFRAMP row with a mirrored amount', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'COMPLETED' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
     })
 })
 

--- a/src/utils/__tests__/history.utils.test.ts
+++ b/src/utils/__tests__/history.utils.test.ts
@@ -153,6 +153,46 @@ describe('completeHistoryEntry currency-price fallback (pending vs final)', () =
         await completeHistoryEntry(entry)
         expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
     })
+
+    // Bridge API returns lowercase terminal states — ensure these are recognized as final
+    it('fetches a live rate for a lowercase "completed" ONRAMP row (Bridge terminal state)', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'completed' as HistoryEntry['status'], // lowercase from Bridge API
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'ONRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+    })
+
+    it('fetches a live rate for a lowercase "payment_processed" OFFRAMP row (Bridge terminal state)', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'payment_processed' as HistoryEntry['status'], // lowercase from Bridge API
+            amount: '2.00',
+            currency: { amount: '2.00', code: 'eur' },
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+    })
+
+    // OFFRAMP branch: missing currency.amount entirely (no amount to compare)
+    it('fetches a live rate for a final OFFRAMP row with no currency.amount at all', async () => {
+        const entry: HistoryEntry = {
+            ...baseEntry,
+            status: 'COMPLETED' as HistoryEntry['status'],
+            amount: '2.00',
+            currency: { code: 'eur' } as any, // no amount property
+            extraData: { ...baseEntry.extraData, kind: 'OFFRAMP' },
+        }
+        await completeHistoryEntry(entry)
+        expect(mockGetCachedCurrencyPrice).toHaveBeenCalledWith('EUR')
+        // Should set the currency.amount to the converted value
+        expect(entry.currency?.amount).toBeDefined()
+    })
 })
 
 /**

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -54,6 +54,15 @@ export enum EHistoryStatus {
     expired = 'expired',
     OPEN = 'OPEN',
     CLOSED = 'CLOSED',
+    // Bridge (peanut-api-ts BridgeTransferState) sends its lifecycle lowercase
+    // end to end — see src/bridge/transfers.ts on the API side, projected
+    // straight onto `status` (src/db/history.ts). `completed`/`refunded`/
+    // `canceled` above already double as this for other providers; these
+    // four have no existing lowercase member to reuse.
+    payment_processed = 'payment_processed',
+    error = 'error',
+    returned = 'returned',
+    undeliverable = 'undeliverable',
 }
 
 export const FINAL_STATES: HistoryStatus[] = [
@@ -64,8 +73,15 @@ export const FINAL_STATES: HistoryStatus[] = [
     EHistoryStatus.PAYMENT_PROCESSED,
     EHistoryStatus.payment_processed, // Bridge terminal state (lowercase)
     EHistoryStatus.REFUNDED,
+    EHistoryStatus.refunded, // Bridge terminal state (lowercase)
     EHistoryStatus.CANCELED,
+    EHistoryStatus.canceled, // Bridge terminal state (lowercase)
     EHistoryStatus.ERROR,
+    EHistoryStatus.error, // Bridge terminal state (lowercase)
+    EHistoryStatus.RETURNED,
+    EHistoryStatus.returned, // Bridge terminal state (lowercase)
+    EHistoryStatus.UNDELIVERABLE,
+    EHistoryStatus.undeliverable, // Bridge terminal state (lowercase)
     EHistoryStatus.CLOSED,
 ]
 
@@ -431,19 +447,17 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             if (entry.currency?.code) {
                 entry.currency.code = entry.currency.code.toUpperCase()
             }
-            // Bridge/Manteca mirror the USD amount into `currency.amount` while
-            // the intent is still in flight — the real fiat figure lands with
-            // the provider's receipt on completion (verified latent: 0 of
-            // 1,130 completed onramps ship without it). Fetching a live rate
-            // for a row that's about to get its real amount for free just
-            // hammers the FX endpoint on every pending render — skip it and
-            // let the completed re-render supply the real number.
-            if (
-                isFinalState(entry) &&
-                usdAmount === entry.currency?.amount &&
-                entry.currency?.code &&
-                entry.currency?.code !== 'USD'
-            ) {
+            // ONRAMP's `currency.amount` is the fiat SOURCE amount Bridge was
+            // asked to transfer — known synchronously at intent creation, so
+            // (unlike OFFRAMP below) it's already correct even while pending.
+            // What's unreliable pre-receipt is `usdAmount` here (the PRIMARY
+            // displayed figure): a receipt-less Bridge intent books the fiat
+            // magnitude as crypto 1:1 (see bridge/legs.ts on the API side),
+            // which is off by the exchange rate for non-1:1 pairs (MXN ~18x).
+            // That's the top-line amount, not an annotation — always correct
+            // it, pending or not; unlike OFFRAMP's secondary "≈ CODE" line,
+            // there's no safe "blank it" fallback for the primary amount.
+            if (usdAmount === entry.currency?.amount && entry.currency?.code && entry.currency?.code !== 'USD') {
                 try {
                     const price = await getCachedCurrencyPrice(entry.currency.code)
                     usdAmount = (Number(entry.currency.amount) / price.buy).toString()
@@ -470,20 +484,30 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
                 const currNum = hasCurrencyAmount ? Number(entry.currency.amount) : NaN
                 const approximatelyEqual = hasCurrencyAmount && isFinite(currNum) && Math.abs(currNum - usdNum) < 0.01
 
-                // See the ONRAMP branch above: an unconverted/mirrored amount
-                // on a still-pending row is expected and self-resolves once
-                // the provider's receipt lands, so only pay for a live-rate
-                // lookup once the row is actually final.
-                if (isFinalState(entry) && (!hasCurrencyAmount || !isFinite(currNum) || approximatelyEqual)) {
-                    try {
-                        const price = await getCachedCurrencyPrice(entry.currency.code)
-                        const converted = Number.isFinite(usdNum) && price?.sell ? usdNum * price.sell : usdNum
-                        entry.currency.amount = converted.toString()
-                    } catch (error) {
-                        console.error(
-                            `[completeHistoryEntry] Failed to fetch currency price for ${entry.currency.code}:`,
-                            error
-                        )
+                if (!hasCurrencyAmount || !isFinite(currNum) || approximatelyEqual) {
+                    if (isFinalState(entry)) {
+                        try {
+                            const price = await getCachedCurrencyPrice(entry.currency.code)
+                            const converted = Number.isFinite(usdNum) && price?.sell ? usdNum * price.sell : usdNum
+                            entry.currency.amount = converted.toString()
+                        } catch (error) {
+                            console.error(
+                                `[completeHistoryEntry] Failed to fetch currency price for ${entry.currency.code}:`,
+                                error
+                            )
+                        }
+                    } else {
+                        // Unlike ONRAMP, OFFRAMP's `currency.amount` genuinely
+                        // has no correct value until the receipt lands — the
+                        // mirrored figure isn't an approximation, it's the
+                        // crypto leg mislabeled as fiat (off by ~1000x for
+                        // ARS/BRL). Blank it rather than pay for a live-rate
+                        // lookup on every pending render just to show a
+                        // number that reads as converted but isn't;
+                        // TransactionCard hides the "≈ CODE" line when the
+                        // amount doesn't parse, and `currency.code` is kept
+                        // for the bank-account country-flag lookup.
+                        entry.currency.amount = ''
                     }
                 }
             }

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -429,7 +429,19 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
             if (entry.currency?.code) {
                 entry.currency.code = entry.currency.code.toUpperCase()
             }
-            if (usdAmount === entry.currency?.amount && entry.currency?.code && entry.currency?.code !== 'USD') {
+            // Bridge/Manteca mirror the USD amount into `currency.amount` while
+            // the intent is still in flight — the real fiat figure lands with
+            // the provider's receipt on completion (verified latent: 0 of
+            // 1,130 completed onramps ship without it). Fetching a live rate
+            // for a row that's about to get its real amount for free just
+            // hammers the FX endpoint on every pending render — skip it and
+            // let the completed re-render supply the real number.
+            if (
+                isFinalState(entry) &&
+                usdAmount === entry.currency?.amount &&
+                entry.currency?.code &&
+                entry.currency?.code !== 'USD'
+            ) {
                 try {
                     const price = await getCachedCurrencyPrice(entry.currency.code)
                     usdAmount = (Number(entry.currency.amount) / price.buy).toString()
@@ -456,7 +468,11 @@ export async function completeHistoryEntry(entry: HistoryEntry): Promise<History
                 const currNum = hasCurrencyAmount ? Number(entry.currency.amount) : NaN
                 const approximatelyEqual = hasCurrencyAmount && isFinite(currNum) && Math.abs(currNum - usdNum) < 0.01
 
-                if (!hasCurrencyAmount || !isFinite(currNum) || approximatelyEqual) {
+                // See the ONRAMP branch above: an unconverted/mirrored amount
+                // on a still-pending row is expected and self-resolves once
+                // the provider's receipt lands, so only pay for a live-rate
+                // lookup once the row is actually final.
+                if (isFinalState(entry) && (!hasCurrencyAmount || !isFinite(currNum) || approximatelyEqual)) {
                     try {
                         const price = await getCachedCurrencyPrice(entry.currency.code)
                         const converted = Number.isFinite(usdNum) && price?.sell ? usdNum * price.sell : usdNum

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -54,34 +54,24 @@ export enum EHistoryStatus {
     expired = 'expired',
     OPEN = 'OPEN',
     CLOSED = 'CLOSED',
-    // Bridge (peanut-api-ts BridgeTransferState) sends its lifecycle lowercase
-    // end to end — see src/bridge/transfers.ts on the API side, projected
-    // straight onto `status` (src/db/history.ts). `completed`/`refunded`/
-    // `canceled` above already double as this for other providers; these
-    // four have no existing lowercase member to reuse.
-    payment_processed = 'payment_processed',
-    error = 'error',
-    returned = 'returned',
-    undeliverable = 'undeliverable',
 }
 
+// Bridge's HistoryEntry.status is always the UPPER_CASE Prisma
+// BridgeTransferState (peanut-api-ts src/db/history.ts:844, `status:
+// bridgeState`) — Bridge's own webhook/API strings are lowercase, but
+// `bridgeStateFromString` normalizes them before that value is ever stored
+// or projected to the FE (peanut-api-ts src/bridge/ledger.ts). RETURNED and
+// UNDELIVERABLE are terminal Bridge states that were simply missing here.
 export const FINAL_STATES: HistoryStatus[] = [
     EHistoryStatus.COMPLETED,
-    EHistoryStatus.completed, // Bridge terminal state (lowercase)
     EHistoryStatus.EXPIRED,
     EHistoryStatus.CLAIMED,
     EHistoryStatus.PAYMENT_PROCESSED,
-    EHistoryStatus.payment_processed, // Bridge terminal state (lowercase)
     EHistoryStatus.REFUNDED,
-    EHistoryStatus.refunded, // Bridge terminal state (lowercase)
     EHistoryStatus.CANCELED,
-    EHistoryStatus.canceled, // Bridge terminal state (lowercase)
     EHistoryStatus.ERROR,
-    EHistoryStatus.error, // Bridge terminal state (lowercase)
     EHistoryStatus.RETURNED,
-    EHistoryStatus.returned, // Bridge terminal state (lowercase)
     EHistoryStatus.UNDELIVERABLE,
-    EHistoryStatus.undeliverable, // Bridge terminal state (lowercase)
     EHistoryStatus.CLOSED,
 ]
 

--- a/src/utils/history.utils.ts
+++ b/src/utils/history.utils.ts
@@ -58,9 +58,11 @@ export enum EHistoryStatus {
 
 export const FINAL_STATES: HistoryStatus[] = [
     EHistoryStatus.COMPLETED,
+    EHistoryStatus.completed, // Bridge terminal state (lowercase)
     EHistoryStatus.EXPIRED,
     EHistoryStatus.CLAIMED,
     EHistoryStatus.PAYMENT_PROCESSED,
+    EHistoryStatus.payment_processed, // Bridge terminal state (lowercase)
     EHistoryStatus.REFUNDED,
     EHistoryStatus.CANCELED,
     EHistoryStatus.ERROR,


### PR DESCRIPTION
## Summary

`completeHistoryEntry` fetches a live Bridge exchange rate whenever a Bridge ONRAMP/OFFRAMP history row's amount looks "unconverted." That's expected and self-resolving for a still-*pending* row — but ONRAMP and OFFRAMP aren't the same shape, so they're handled differently:

- **ONRAMP**: `currency.amount` is the fiat *source* amount Bridge was asked to transfer — known synchronously at intent creation, correct whether the row is pending or final. What's unreliable pre-receipt is the *primary* `usdAmount` (a receipt-less Bridge intent books the fiat magnitude as crypto 1:1). That fetch corrects the primary display and runs unconditionally, same as before this PR — there's no safe way to blank a primary amount.
- **OFFRAMP**: `currency.amount` is the fiat *destination* amount, genuinely unknown until the provider's receipt lands — Bridge/Manteca mirror the crypto-leg figure into it while pending. Every pending render was firing a live-rate fetch to the Bridge FX endpoint for a value that's about to arrive for free on completion, showing up as a large chunk of the `TypeError: Failed to fetch` / `Load failed` volume in error tracking (PostHog project 138913). This fetch is now gated on `isFinalState(entry)`.
  - Critically: while pending, `currency.amount` is now **blanked** (`''`) rather than left holding the mirrored crypto-leg figure — the old code would otherwise show that number as if it were converted local currency, which is wrong by the exchange rate (~1000x for ARS/BRL, e.g. "≈ ARS 30" for a $30 pending withdrawal that should read "≈ ARS 30,000" once settled). `TransactionCard` now requires a valid, parseable `currency.amount` before rendering the "≈ CODE" line; `currency.code` is kept since the bank-account country-flag lookup also reads it.
- `FINAL_STATES` was missing the uppercase `RETURNED`/`UNDELIVERABLE` Bridge terminal states (peanut-api-ts's `HistoryEntry.status` is always the upper-case `BridgeTransferState` Prisma enum — Bridge's own webhook strings are lowercase but get normalized before ever reaching the DB or the FE). Without these, a returned/undeliverable Bridge payout stayed on the pending path forever: blanked `currency.amount`, and (via the same `isFinalState` used elsewhere) an endless 15s receipt poll and a PDF cached at the short pending TTL instead of the final one.

## Test plan
- [x] `npx jest --testPathPattern 'TransactionCard.test.tsx|history.utils.test.ts'` — 71/71 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --write` on changed files — no diff
