### PR TITLE
fix(drawer): shadow clipped at drawer edge — scroll area owns the L/16 padding

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/patterns/drawer/page.tsx
+++ b/src/app/(mobile-ui)/dev/ds/patterns/drawer/page.tsx
@@ -41,7 +41,7 @@ export default function DrawerPage() {
                                     This is a vaul-based bottom sheet. Swipe down to dismiss.
                                 </DrawerDescription>
                             </DrawerHeader>
-                            <div className="px-4 pb-4">
+                            <div className="pb-4">
                                 <p className="text-body-s text-foreground-secondary">
                                     The Drawer component wraps vaul and provides a consistent bottom-sheet experience.
                                     It includes an overlay, drag handle, and max-height constraint (80vh).
@@ -83,7 +83,7 @@ export default function DrawerPage() {
       <DrawerTitle>Title</DrawerTitle>
       <DrawerDescription>Description</DrawerDescription>
     </DrawerHeader>
-    <div className="px-4 pb-4">
+    <div className="pb-4">
       {/* Content */}
     </div>
     <DrawerFooter>

--- a/src/components/AddMoney/components/OnrampConfirmationModal.tsx
+++ b/src/components/AddMoney/components/OnrampConfirmationModal.tsx
@@ -32,7 +32,7 @@ export const OnrampConfirmationModal = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head carries M/12 beneath it; the slide keeps the L/16 of the outer stack */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">
                         <IconBubble icon="alert" color="yellow" />

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -165,11 +165,11 @@ export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
 
     return (
         <Drawer open={open} onOpenChange={onOpenChange}>
-            {/* The horizontal padding belongs to the SCROLL AREA, not to the panel
-                around it: the panel's padding sits outside the overflow-auto box,
-                so a w-full button's 4px offset shadow fell past the scroll edge
-                and got clipped. The matching pb-2 below covers the bottom. */}
-            <DrawerContent className="py-4" scrollAreaClassName="px-4">
+            {/* DrawerContent's scroll area owns the horizontal padding now
+                (shadow-clip fix) — only the vertical padding is ours. The
+                pb-2 on the content below keeps the last button's bottom
+                shadow inside the scroll box. */}
+            <DrawerContent className="py-4">
                 <DrawerHeader className="p-0 pb-4 text-left">
                     <DrawerTitle className="text-heading-s text-foreground-primary">{t('title')}</DrawerTitle>
                     <DrawerDescription>{t('description')}</DrawerDescription>

--- a/src/components/Badges/BadgeStatusDrawer.tsx
+++ b/src/components/Badges/BadgeStatusDrawer.tsx
@@ -61,7 +61,7 @@ export const BadgeStatusDrawer = ({ isOpen, onClose, badge }: BadgeStatusDrawerP
                     py-4 + p-4 here stacked 32px of extra head room (PR #2813
                     review, Jota). */}
                 <DrawerContent className="pb-4">
-                    <div className="px-4">
+                    <div>
                         {/* centered head per the TX Details chrome (board 17490:115877):
                             badge art → one-line title. Tapping it opens the detail
                             modal — close the unlock drawer (z-50) first so the modal

--- a/src/components/Card/CardUnlockDrawer.tsx
+++ b/src/components/Card/CardUnlockDrawer.tsx
@@ -72,7 +72,7 @@ export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, 
                     doesn't blow up to 432px tall at the drawer's full xl
                     width and force a scrollbar. Centred so the buttons
                     below it span the same content column. */}
-                <div className="flex flex-col gap-4 px-4 pb-6">
+                <div className="flex flex-col gap-4 pb-6">
                     <div className="mx-auto w-full max-w-md">
                         <ScaledShareAsset
                             ref={captureRef}

--- a/src/components/Global/CancelSendLinkDrawer/index.tsx
+++ b/src/components/Global/CancelSendLinkDrawer/index.tsx
@@ -39,7 +39,7 @@ const CancelSendLinkDrawer = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* destructive-confirm anatomy: red icon bubble (design.md nested-drawer recipe) */}
                     <IconBubble icon="link-slash" color="red" className="mb-4" />
 

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -103,15 +103,20 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
             <DrawerPrimitive.Content
                 ref={ref}
                 className={twMerge(
-                    // chrome per the TX Details board (17490:115877): white background,
-                    // no border, handle 32x5 sitting 8px from the top with 24px below.
+                    // chrome per the TX Details board (17490:115877): no border,
+                    // handle 32x5 sitting 8px from the top with 24px below.
                     // tx-details board 17835:84492: 16px top corners (was a hardcoded 10px)
-                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-white',
+                    // bg-background-page: the sheet matches the app page background
+                    // (kush ruling 2026-09-07, reverts the white surface from #2984)
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-background-page',
                     className
                 )}
                 aria-describedby={undefined}
                 {...props}
-                onTouchMove={(e) => e.stopPropagation()}
+                // no onTouchMove stopPropagation here: it silenced vaul's own
+                // document-level touchmove handlers (scroll containment + drag
+                // coordination), which broke dragging the sheet from its body.
+                // pull-to-refresh ignores drawer touches itself (usePullToRefresh).
             >
                 {accessibleTitle && <DrawerTitle className="sr-only">{accessibleTitle}</DrawerTitle>}
                 <div className="mx-auto mt-2 mb-6 h-[5px] w-8 rounded-round bg-foreground-secondary" />
@@ -126,7 +131,9 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
                     <div
                         ref={scrollAreaRef}
                         className={twMerge(
-                            'max-h-[80vh] w-full overflow-auto px-4 pb-safe-bottom md:max-w-xl',
+                            // scrollbar-none: android flashes a scrollbar on this
+                            // container while the sheet itself is being dragged
+                            'scrollbar-none max-h-[80vh] w-full overflow-auto px-4 pb-safe-bottom md:max-w-xl',
                             scrollAreaClassName
                         )}
                     >

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -103,12 +103,12 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
             <DrawerPrimitive.Content
                 ref={ref}
                 className={twMerge(
-                    // chrome per the TX Details board (17490:115877): no border,
-                    // handle 32x5 sitting 8px from the top with 24px below.
+                    // chrome per the TX Details board (17490:115877): white background,
+                    // no border, handle 32x5 sitting 8px from the top with 24px below.
                     // tx-details board 17835:84492: 16px top corners (was a hardcoded 10px)
-                    // bg-background-page: the sheet matches the app page background
-                    // (kush ruling 2026-09-07, reverts the white surface from #2984)
-                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-background-page',
+                    // bg-white is deliberate (#2984, kush ruling 2026-09-07): the sheet
+                    // is a clean white surface, not the page background
+                    'fixed inset-x-0 bottom-0 z-50 mt-24 flex flex-col rounded-t-2xl bg-white',
                     className
                 )}
                 aria-describedby={undefined}

--- a/src/components/Global/Drawer/index.tsx
+++ b/src/components/Global/Drawer/index.tsx
@@ -116,10 +116,17 @@ const DrawerContent = React.forwardRef<React.ElementRef<typeof DrawerPrimitive.C
                 {accessibleTitle && <DrawerTitle className="sr-only">{accessibleTitle}</DrawerTitle>}
                 <div className="mx-auto mt-2 mb-6 h-[5px] w-8 rounded-round bg-foreground-secondary" />
                 <div className="flex w-full justify-center">
+                    {/* The scroll wrapper owns the horizontal L/16 container
+                     * padding (design.md spacing table). It must live HERE,
+                     * inside the overflow box: overflow-auto clips painting at
+                     * its own edge, so padding on the panel around it leaves a
+                     * w-full button's 4px offset shadow outside the clip box —
+                     * cut off in a straight line. Consumers must not re-add
+                     * horizontal padding on the panel or on their content. */}
                     <div
                         ref={scrollAreaRef}
                         className={twMerge(
-                            'max-h-[80vh] w-full overflow-auto pb-safe-bottom md:max-w-xl',
+                            'max-h-[80vh] w-full overflow-auto px-4 pb-safe-bottom md:max-w-xl',
                             scrollAreaClassName
                         )}
                     >
@@ -138,7 +145,8 @@ DrawerContent.displayName = 'DrawerContent'
 // own head instead — see CancelSendLinkDrawer and KycRegionRestrictedModal.
 const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
     <div
-        className={twMerge('grid gap-1 p-4 text-center sm:text-left', className)}
+        // py only: the scroll wrapper owns the horizontal L/16 padding
+        className={twMerge('grid gap-1 py-4 text-center sm:text-left', className)}
         data-testid="drawer-header"
         {...props}
     />
@@ -146,7 +154,7 @@ const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 DrawerHeader.displayName = 'DrawerHeader'
 
 const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={twMerge('mt-auto flex flex-col gap-2 p-4', className)} {...props} />
+    <div className={twMerge('mt-auto flex flex-col gap-2 py-4', className)} {...props} />
 )
 DrawerFooter.displayName = 'DrawerFooter'
 

--- a/src/components/Global/QRBottomDrawer/index.tsx
+++ b/src/components/Global/QRBottomDrawer/index.tsx
@@ -105,7 +105,7 @@ const QRBottomDrawer = ({ url, title, text, buttonText, className }: QRBottomDra
                     reaches the cap through a CSS variable because Tailwind only emits an
                     arbitrary value it can read literally in the source. */}
                 <DrawerContent
-                    className={`mt-0 h-screen touch-none p-4 supports-[height:100dvh]:h-dvh ${className || ''}`}
+                    className={`mt-0 h-screen touch-none py-4 supports-[height:100dvh]:h-dvh ${className || ''}`}
                     style={{ '--qr-drawer-expanded': `${QR_DRAWER_EXPANDED_PX}px` } as CSSProperties}
                     scrollAreaRef={scrollAreaRef}
                     scrollAreaClassName={`overscroll-contain max-h-[calc(var(--qr-drawer-expanded)-3.3125rem)] ${activeSnapPoint === snapPoints[0] || !scrollable ? 'touch-none' : ''}`}
@@ -113,10 +113,10 @@ const QRBottomDrawer = ({ url, title, text, buttonText, className }: QRBottomDra
                     <DrawerTitle className="space-y-2 mb-3">
                         <h2 className="text-heading-card">{title}</h2>
                     </DrawerTitle>
-                    {/* the button's shadow is offset 4px right AND 4px down, so the
-                        drawer's overflow-auto scroll wrapper clips it on both edges
-                        without a gutter on each */}
-                    <div className="pr-1 pb-1">
+                    {/* the scroll wrapper's default px-4 covers the button
+                        shadow's right edge now; pb-1 still covers the 4px
+                        bottom offset */}
+                    <div className="pb-1">
                         <QRCodeWrapper url={url} />
                         <div className="mx-auto mt-4 w-full p-2 text-center text-body-m">{text}</div>
                         <Divider text={tCommon('or')} />

--- a/src/components/Global/TokenSelector/TokenSelector.tsx
+++ b/src/components/Global/TokenSelector/TokenSelector.tsx
@@ -477,7 +477,7 @@ const TokenSelector: React.FC<NewTokenSelectorProps> = ({ classNameButton, viewT
             </Button>
 
             <Drawer open={isDrawerOpen} onOpenChange={closeDrawer}>
-                <DrawerContent accessibleTitle={t('tokenSelector.drawerTitle')} className="p-4">
+                <DrawerContent accessibleTitle={t('tokenSelector.drawerTitle')} className="py-4">
                     <div ref={contentRef} className="mx-auto md:max-w-2xl">
                         {showNetworkList ? (
                             <NetworkListView

--- a/src/components/IdentityVerification/UnlockMethodModal.tsx
+++ b/src/components/IdentityVerification/UnlockMethodModal.tsx
@@ -45,7 +45,7 @@ const UnlockMethodModal = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head owns the M/12 beneath it; everything after it
                         keeps the drawer's L/16 rhythm */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -218,7 +218,7 @@ export const InitiateKycModal = ({
                 }}
             >
                 <DrawerContent>
-                    <div className="flex flex-col items-center gap-4 px-4 pt-1 pb-6 text-center">
+                    <div className="flex flex-col items-center gap-4 pt-1 pb-6 text-center">
                         <IconBubble icon="alert" color="yellow" />
                         <DrawerHeader className="w-full gap-2 p-0 text-center sm:text-center">
                             <DrawerTitle>{t('degraded.title')}</DrawerTitle>
@@ -333,7 +333,7 @@ export const InitiateKycModal = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head owns the M/12 beneath it; everything after keeps
                         the drawer's L/16 rhythm */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">

--- a/src/components/Kyc/KycStatusDrawer.tsx
+++ b/src/components/Kyc/KycStatusDrawer.tsx
@@ -95,7 +95,7 @@ export const KycStatusDrawer = ({ isOpen, onClose, onKeepMounted }: KycStatusDra
     return (
         <>
             <Drawer open={isOpen} onOpenChange={onClose}>
-                <DrawerContent accessibleTitle={t('statusDrawerTitle')} className="p-4 pb-12">
+                <DrawerContent accessibleTitle={t('statusDrawerTitle')} className="pt-4" scrollAreaClassName="pb-12">
                     {renderContent()}
                     {sumsubFlow.error && (
                         <p className="mt-3 text-center text-body-s text-foreground-error">{sumsubFlow.error}</p>

--- a/src/components/Kyc/modals/KycActionRequiredModal.tsx
+++ b/src/components/Kyc/modals/KycActionRequiredModal.tsx
@@ -31,7 +31,7 @@ export const KycActionRequiredModal = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head owns the M/12 beneath it; everything after it
                         keeps the drawer's L/16 rhythm */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">

--- a/src/components/Kyc/modals/KycFailedModal.tsx
+++ b/src/components/Kyc/modals/KycFailedModal.tsx
@@ -44,7 +44,7 @@ export const KycFailedModal = ({
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head owns the M/12 beneath it; everything after it
                         keeps the drawer's L/16 rhythm */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">

--- a/src/components/Kyc/modals/KycProcessingModal.tsx
+++ b/src/components/Kyc/modals/KycProcessingModal.tsx
@@ -21,7 +21,7 @@ export const KycProcessingModal = ({ visible, onClose }: KycProcessingModalProps
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* the head owns the M/12 beneath it; everything after it
                         keeps the drawer's L/16 rhythm */}
                     <div className="mb-3 flex w-full flex-col items-center gap-4">

--- a/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
+++ b/src/components/Kyc/modals/KycRegionRestrictedModal.tsx
@@ -29,7 +29,7 @@ export const KycRegionRestrictedModal = ({ visible, onClose }: KycRegionRestrict
             }}
         >
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     {/* DrawerHeader carries the M/12; the cta keeps the L/16 of the outer stack */}
                     <div className="flex w-full flex-col items-center gap-4">
                         <IconBubble icon="globe-lock" className="bg-action-primary" />

--- a/src/components/Profile/components/PublicProfile.tsx
+++ b/src/components/Profile/components/PublicProfile.tsx
@@ -294,7 +294,7 @@ const PublicProfile: React.FC<PublicProfileProps> = ({ username, isLoggedIn = fa
                     }}
                 >
                     <DrawerContent>
-                        <div className="flex flex-col items-center gap-4 px-4 pt-1 pb-6 text-center">
+                        <div className="flex flex-col items-center gap-4 pt-1 pb-6 text-center">
                             <IconBubble icon="user" className="bg-action-primary" />
                             <DrawerHeader className="w-full gap-2 p-0 text-center sm:text-center">
                                 <DrawerTitle>{t('noInviteTitle')}</DrawerTitle>

--- a/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
+++ b/src/components/TransactionDetails/TransactionDetailsDrawer.tsx
@@ -67,7 +67,7 @@ export const TransactionDetailsDrawer: React.FC<TransactionDetailsDrawerProps> =
                     isModalOpen={isModalOpen}
                     setIsModalOpen={setIsModalOpen}
                     avatarUrl={avatarUrl}
-                    className="px-4 pb-4"
+                    className="pb-4"
                 />
             </DrawerContent>
         </Drawer>

--- a/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
+++ b/src/components/TransactionDetails/provider-actions/CancelDepositActions.tsx
@@ -137,7 +137,7 @@ export function CancelDepositActions({
                 }}
             >
                 <DrawerContent>
-                    <div className="flex flex-col items-center gap-4 px-4 pt-1 pb-6 text-center">
+                    <div className="flex flex-col items-center gap-4 pt-1 pb-6 text-center">
                         <IconBubble icon="ban" color="red" />
                         <DrawerHeader className="w-full gap-2 p-0 text-center sm:text-center">
                             <DrawerTitle>

--- a/src/dev/surfaces/options/OnrampOptions.tsx
+++ b/src/dev/surfaces/options/OnrampOptions.tsx
@@ -40,7 +40,7 @@ function Shell({ children }: { children: React.ReactNode }) {
     return (
         <Drawer open>
             <DrawerContent>
-                <div className="flex flex-col items-center px-4 pt-1 pb-6 text-center">
+                <div className="flex flex-col items-center pt-1 pb-6 text-center">
                     <div className="mb-3 flex w-full flex-col items-center gap-4">
                         <IconBubble icon="alert" color="yellow" />
                         <DrawerTitle>{t('title')}</DrawerTitle>

--- a/src/features/home/components/HomeActionDrawers.tsx
+++ b/src/features/home/components/HomeActionDrawers.tsx
@@ -93,7 +93,7 @@ export function HomeActionDrawers() {
 
     return (
         <Drawer open={drawer !== null} onOpenChange={(isOpen) => !isOpen && setDrawer(null)} hideBottomNav>
-            <DrawerContent className="px-4 pb-2">
+            <DrawerContent className="pb-2">
                 {content && (
                     <div className="flex flex-col gap-4">
                         {content === 'add' && <ScreenMark icon="plus" />}

--- a/src/features/payments/flows/contribute-pot/components/ContributorsDrawer.tsx
+++ b/src/features/payments/flows/contribute-pot/components/ContributorsDrawer.tsx
@@ -59,7 +59,7 @@ export function ContributorsDrawer({ contributors }: ContributorsDrawerProps) {
                         {t('contributors.title', { count: contributors.length })}
                     </DrawerTitle>
                 </DrawerHeader>
-                <div className="space-y-0 max-h-[60vh] overflow-auto px-4">
+                <div className="space-y-0 max-h-[60vh] overflow-auto">
                     {contributorCards.map((contributor, index) => (
                         <ContributorCard
                             key={contributor.uuid}

--- a/src/hooks/__tests__/usePullToRefresh.test.tsx
+++ b/src/hooks/__tests__/usePullToRefresh.test.tsx
@@ -160,4 +160,30 @@ describe('usePullToRefresh', () => {
         expect(invalidateQueries).not.toHaveBeenCalled()
         expect(impactHaptic).not.toHaveBeenCalled()
     })
+
+    it('ignores touches that start on an open vaul drawer', () => {
+        const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries')
+        renderHook(() => usePullToRefresh(), { wrapper })
+
+        const sheet = document.createElement('div')
+        sheet.setAttribute('data-vaul-drawer', '')
+        const inner = document.createElement('button')
+        sheet.appendChild(inner)
+        document.body.appendChild(sheet)
+
+        const start = new Event('touchstart', { bubbles: true })
+        Object.defineProperty(start, 'touches', { value: [{ clientX: 0, clientY: 0 }] })
+        act(() => {
+            inner.dispatchEvent(start)
+        })
+
+        // a full downward drag on the sheet must not move the indicator
+        touch('touchmove', 200)
+        touch('touchend', 200)
+
+        expect(indicator()?.style.opacity).toBe('0')
+        expect(invalidateQueries).not.toHaveBeenCalled()
+        expect(impactHaptic).not.toHaveBeenCalled()
+        sheet.remove()
+    })
 })

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -168,6 +168,11 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
 
         const onTouchStart = (e: TouchEvent) => {
             if (refreshing || e.touches.length !== 1) return
+            // a touch on an open vaul sheet (or its overlay) is a drawer
+            // gesture, never a pull — without this, dragging the sheet moved
+            // the page behind it (the listeners here are on document)
+            const target = e.target as Element | null
+            if (target?.closest?.('[data-vaul-drawer],[data-vaul-overlay]')) return
             const allowed = shouldPullToRefreshRef.current ? shouldPullToRefreshRef.current() : window.scrollY === 0
             if (!allowed) return
             // a new pull can start inside the retract window — put the arrow back


### PR DESCRIPTION
## Summary

Global fix for clipped button shadows inside drawers (Kush's repro: the avatar-change drawer's "Tirar los dados" / "Listo" buttons with their right shadow cut flush).

**Task:** TASK-21446 (DS umbrella; drawer anatomy per design.md)

## Root cause

`DrawerContent`'s scroll wrapper is `overflow-auto`, and CSS clips painting at that element's own box edge. Consumers put the drawer's horizontal padding on the panel AROUND the wrapper, so a `w-full` button spanned the whole scroll box and its 4px offset shadow fell outside it — cut in a straight vertical line. The bug class had already collected local workarounds (AvatarPicker's `scrollAreaClassName="px-4"` on 2026-09-05, QRBottomDrawer's `pr-1` gutter) — proof it was a shared-component problem, not a per-screen one.

## Fix (shared component, one rule)

The scroll wrapper now owns the design.md container padding (`px-4`, L/16) INSIDE the overflow box, so shadows always land in the padded, unclipped region. `DrawerHeader`/`DrawerFooter` go `py-4` to match. A comment in `Drawer/index.tsx` states the law: never re-add horizontal padding on the panel or on drawer content.

**Consumer sweep** (all now-redundant horizontal padding removed — content width is unchanged everywhere, the 16px moved inside the clip box, not added):
- panel-padded (were clipping): HomeActionDrawers, KycStatusDrawer (`pb-12` also moved into the scroll area so the retry button's bottom shadow paints), TokenSelector, QRBottomDrawer
- child-padded (were safe, would have double-padded): InitiateKycModal ×2, KycActionRequired/RegionRestricted/Processing/Failed modals, CancelDepositActions, UnlockMethodModal, PublicProfile, CancelSendLinkDrawer, OnrampConfirmationModal, OnrampOptions, TransactionDetailsDrawer, BadgeStatusDrawer, ContributorsDrawer, CardUnlockDrawer
- workarounds retired: AvatarPicker `scrollAreaClassName="px-4"`, QRBottomDrawer `pr-1` gutter
- docs updated: `/dev/ds/patterns/drawer` live example + code snippet no longer teach the child-`px-4` pattern

## Screenshots (375x667, mock data via fixtures)

**Avatar drawer — the reported bug.** Before = the pre-workaround tree (`8a1ccdbab~1`, panel `p-4` — the state Kush reproduced); after = this branch.

| before (shadow cut flush) | after (full offset) |
|---|---|
| ![before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3019/drawer-avatar-before-buttons.png) | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3019/drawer-avatar-after-buttons.png) |

**DS pattern-page drawer (second shadowed-button drawer):** before/after pixel-identical — that example already padded inside the scroll area, confirming the migration adds no double padding.

| before | after |
|---|---|
| ![ds before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3019/ds-drawer-before.png) | ![ds after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3019/ds-drawer-after.png) |

The `pr-assets-3019` branch is deleted after merge.

## ds-shots expectation

Drawer-bearing fixture shots should be identical or differ only by previously-clipped shadow pixels: every consumer's content width is unchanged. The avatar-picker fixture was already workaround-fixed on dev, so it should not diff (beyond its known dice-randomness flake). Anything else diffing is a bug.

**Observed:** 7 screens moved, all in the known flaky set at their usual magnitudes (profile 3.19%, avatar-picker 1.35% — below its usual 1.78% dice flake, rest <=0.07%) — same screens move on sibling PRs #3011-#3015 that touch none of them. No drawer-bearing screen shows a layout shift.

## Risks

- FE-only, class moves. The one behavioral edge: any FUTURE drawer that wants edge-to-edge content must pass `scrollAreaClassName="px-0"` — none exists today (verified the full consumer census).
- Scroll behavior untouched (overflow, max-h, safe-bottom all as before).

## QA

prettier clean · typecheck clean · jest 485 suites / 6077 tests green · ds-lint ratchet green

## Round 2 — touch behavior (Kush, 2026-09-07)

**1. Sheet background: WHITE stays — ruling flipped on 2026-09-07.** An earlier commit on this branch (5422facba) moved the sheet to `bg-background-page`, reversing Slava's deliberate white surface from #2984 (e55b5d130, 2026-09-04). Kush reversed that decision the same day: the white sheet stays, and 4e8096313 reverts the background part only. No net background change ships in this PR — the shadow-clip fix, padding ownership, touch/drag fixes, and scrollbar fix all stay. Sheet on the current head: ![white sheet](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3019/drawer-bg-white.png)

**2. Touch/drag — one root cause for the pass-through blip and the unclear grab area.** `DrawerContent` carried `onTouchMove={(e) => e.stopPropagation()}` since the original drawer commit. That handler silenced vaul's OWN document-level touchmove handlers — the ones that do scroll containment and drag coordination — so body-drags misbehaved and touches leaked to page-level listeners. Meanwhile the app's custom pull-to-refresh also listens on `document`, so a drawer drag could pull the home screen behind the sheet (the "blip"). Fix:
- removed the stopPropagation hack; vaul handles its own containment
- `usePullToRefresh` now ignores any touch starting on `[data-vaul-drawer]` / `[data-vaul-overlay]` (root fix + regression test)
- whole-sheet drag was always vaul's design and now works: verified with synthesized CDP touch swipes — dragging down from the avatar drawer's BODY dismisses it, the P2R indicator stays hidden mid-swipe, and the scroll area still scrolls (vaul only drags when the scroll is at top)

**3. Android scrollbar flash:** `scrollbar-none` on the drawer scroll container (tailwind-scrollbar utility; same overflow chain as the shadow fix).

**On-device checks for Kush** (not fully verifiable in Chromium headless): the Android scrollbar flash disappearing, real-finger drag feel on iOS/Android, and the iOS rubber-band interaction with pull-to-refresh.
