### PR TITLE
fix: kill OS long-press preview on app-shell CTAs + About rows on DS ListItem

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -28,6 +28,7 @@ import { IS_DEV } from '@/constants/general.consts'
 import { HARNESS_ENABLED } from '@/constants/harness.consts'
 import { FixtureBanner } from '@/dev/fixtures/FixtureBanner'
 import { usePullToRefresh, useShouldPullToRefresh } from '@/hooks/usePullToRefresh'
+import { useLongPressGuard } from '@/hooks/useLongPressGuard'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 import { useAccountSetupRedirect } from '@/hooks/useAccountSetupRedirect'
 import { useNativePlugins } from '@/hooks/useNativePlugins'
@@ -78,6 +79,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
     // enable pull-to-refresh for both ios and android
     usePullToRefresh({ shouldPullToRefresh: useShouldPullToRefresh() })
+
+    // no OS long-press link preview on app-shell CTAs and menu rows
+    useLongPressGuard()
 
     const isRedirecting = useRef(false)
 

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import Card from '@/components/Global/Card'
+import { ListItem } from '@/components/0_Bruddle/ListItem'
+import { getCardPosition } from '@/components/Global/Card/card.utils'
 import DocsLink from '@/components/Global/DocsLink'
 import NavHeader from '@/components/Global/NavHeader'
-import NavigationArrow from '@/components/Global/NavigationArrow'
 import { BetaUpdatesCard, useBetaUpdatesAccess } from '@/components/Profile/components/BetaUpdatesCard'
 import { useToast } from '@/components/0_Bruddle/Toast'
 import { LEGAL_POLICIES } from '@/constants/legal-policies'
@@ -16,9 +16,6 @@ import { isNativeBridge } from '@/utils/capacitor'
 import { useSafeBack } from '@/hooks/useSafeBack'
 import { useTranslations } from 'next-intl'
 import { useEffect, useRef, useState } from 'react'
-
-const cardPosition = (index: number, total: number) =>
-    index === 0 ? ('first' as const) : index === total - 1 ? ('last' as const) : ('middle' as const)
 
 const TAPS_TO_REVEAL_BETA = 5
 const TAP_WINDOW_MS = 2_000
@@ -87,13 +84,16 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
 
             <div>
                 <h1 className="mb-2 font-bold text-black">{t('policiesHeading')}</h1>
+                {/* whole row is the link: DocsLink keeps the locale + in-app
+                    browser routing, ListItem carries the DS row anatomy */}
                 {LEGAL_POLICIES.map((doc, index) => (
-                    <Card key={doc.href} position={cardPosition(index, LEGAL_POLICIES.length)}>
-                        <DocsLink href={doc.href} className="flex cursor-pointer justify-between py-1">
-                            <span className="text-body-s text-black">{t(`policies.${doc.key}`)}</span>
-                            <NavigationArrow size={24} className="fill-black" />
-                        </DocsLink>
-                    </Card>
+                    <DocsLink key={doc.href} href={doc.href} className="block">
+                        <ListItem
+                            title={t(`policies.${doc.key}`)}
+                            chevron
+                            position={getCardPosition(index, LEGAL_POLICIES.length)}
+                        />
+                    </DocsLink>
                 ))}
             </div>
 
@@ -103,16 +103,13 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
             {isNative && (
                 <div>
                     <h1 className="mb-2 font-bold text-black">{t('rateHeading')}</h1>
-                    <Card position="first">
-                        <button
-                            type="button"
-                            onClick={() => void openStoreReviewPage(store)}
-                            className="flex w-full cursor-pointer justify-between py-1"
-                        >
-                            <span className="text-body-s text-black">{t('rate')}</span>
-                            <NavigationArrow size={24} className="fill-black" />
-                        </button>
-                    </Card>
+                    {/* position single, not first: it is a lone row (grouping fix) */}
+                    <ListItem
+                        title={t('rate')}
+                        chevron
+                        position="single"
+                        onClick={() => void openStoreReviewPage(store)}
+                    />
                 </div>
             )}
 

--- a/src/hooks/__tests__/useLongPressGuard.test.tsx
+++ b/src/hooks/__tests__/useLongPressGuard.test.tsx
@@ -7,7 +7,13 @@ const fireContextMenu = (el: Element) => {
     return event
 }
 
+// jsdom has no matchMedia; the hook gates on (any-pointer: coarse)
+const setPointer = (coarse: boolean) => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: coarse }) as unknown as typeof window.matchMedia
+}
+
 describe('useLongPressGuard', () => {
+    beforeEach(() => setPointer(true))
     it('adds the body class while mounted and removes it on unmount', () => {
         const { unmount } = renderHook(() => useLongPressGuard())
         expect(document.body.classList.contains('app-no-callout')).toBe(true)
@@ -32,5 +38,14 @@ describe('useLongPressGuard', () => {
         button.remove()
         input.remove()
         p.remove()
+    })
+
+    it('leaves the desktop right-click menu alone (fine pointer)', () => {
+        setPointer(false)
+        renderHook(() => useLongPressGuard())
+        const a = document.createElement('a')
+        document.body.appendChild(a)
+        expect(fireContextMenu(a).defaultPrevented).toBe(false)
+        a.remove()
     })
 })

--- a/src/hooks/__tests__/useLongPressGuard.test.tsx
+++ b/src/hooks/__tests__/useLongPressGuard.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react'
+import { useLongPressGuard } from '../useLongPressGuard'
+
+const fireContextMenu = (el: Element) => {
+    const event = new Event('contextmenu', { bubbles: true, cancelable: true })
+    el.dispatchEvent(event)
+    return event
+}
+
+describe('useLongPressGuard', () => {
+    it('adds the body class while mounted and removes it on unmount', () => {
+        const { unmount } = renderHook(() => useLongPressGuard())
+        expect(document.body.classList.contains('app-no-callout')).toBe(true)
+        unmount()
+        expect(document.body.classList.contains('app-no-callout')).toBe(false)
+    })
+
+    it('prevents the context menu on anchors and buttons, but not on inputs', () => {
+        renderHook(() => useLongPressGuard())
+        const a = document.createElement('a')
+        const button = document.createElement('button')
+        const input = document.createElement('input')
+        const p = document.createElement('p')
+        document.body.append(a, button, input, p)
+
+        expect(fireContextMenu(a).defaultPrevented).toBe(true)
+        expect(fireContextMenu(button).defaultPrevented).toBe(true)
+        expect(fireContextMenu(input).defaultPrevented).toBe(false)
+        expect(fireContextMenu(p).defaultPrevented).toBe(false)
+
+        a.remove()
+        button.remove()
+        input.remove()
+        p.remove()
+    })
+})

--- a/src/hooks/useLongPressGuard.ts
+++ b/src/hooks/useLongPressGuard.ts
@@ -18,6 +18,9 @@ export function useLongPressGuard(): void {
     useEffect(() => {
         document.body.classList.add('app-no-callout')
         const onContextMenu = (e: Event) => {
+            // touch environments only: on desktop the contextmenu is the
+            // right-click menu (open in new tab, copy link) — keep it
+            if (!window.matchMedia?.('(any-pointer: coarse)').matches) return
             const target = e.target as Element | null
             if (!target?.closest) return
             if (target.closest('input,textarea,[contenteditable="true"]')) return

--- a/src/hooks/useLongPressGuard.ts
+++ b/src/hooks/useLongPressGuard.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+/**
+ * Kills the OS long-press link/HTML preview on app-shell interactive elements
+ * (nav CTAs, profile menu rows, drawer buttons):
+ *
+ * - iOS callout: the `.app-no-callout` body class applies
+ *   `-webkit-touch-callout: none` to anchors and buttons (globals.css). It
+ *   goes on <body> so portaled drawers are covered too.
+ * - Android context menu: a document-level `contextmenu` guard prevents the
+ *   default only when the press lands on an anchor or button — inputs,
+ *   textareas and selectable text keep their native menus (paste, selection).
+ *
+ * Mounted by the (mobile-ui) app layout only, so marketing and content pages
+ * keep normal link long-press behavior.
+ */
+export function useLongPressGuard(): void {
+    useEffect(() => {
+        document.body.classList.add('app-no-callout')
+        const onContextMenu = (e: Event) => {
+            const target = e.target as Element | null
+            if (!target?.closest) return
+            if (target.closest('input,textarea,[contenteditable="true"]')) return
+            if (target.closest('a,button')) e.preventDefault()
+        }
+        document.addEventListener('contextmenu', onContextMenu)
+        return () => {
+            document.body.classList.remove('app-no-callout')
+            document.removeEventListener('contextmenu', onContextMenu)
+        }
+    }, [])
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -763,6 +763,15 @@
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+/* the (mobile-ui) layout puts .app-no-callout on <body> (useLongPressGuard):
+   long-pressing an app-shell CTA or menu row must not pop the OS link
+   preview. anchors and buttons only — inputs and selectable text keep their
+   native menus. android's context menu is handled by the same hook in JS. */
+.app-no-callout a,
+.app-no-callout button {
+    -webkit-touch-callout: none;
+}
+
 /* shadow-4 is used with variants (sm:shadow-4, hover:shadow-4) — a plain
    @layer components class can't take variants in v4, so it lives here as a
    real utility. its siblings (shadow-2, shadow-primary/secondary-*) stay in


### PR DESCRIPTION
## Summary

Two Kush findings, one commit each.

**Task:** TASK-21446 (DS umbrella)

## 1. No OS long-press link preview on app-shell CTAs (`d6e6de74f`)

**Root cause:** navigation CTAs and profile-menu rows are anchor elements, and long-pressing an anchor triggers the OS link/HTML preview — native browser behavior on both iOS and Android, not a bug in any single button.

**Fix (global, not per-button):** the `(mobile-ui)` layout mounts `useLongPressGuard`, which
- puts `.app-no-callout` on `<body>` — globals.css applies `-webkit-touch-callout: none` to anchors and buttons under it (iOS). Body-level so portaled drawers are covered.
- prevents the `contextmenu` default at document level ONLY when the press lands on an anchor/button (Android).

**Scope, stated precisely:** inputs, textareas, contenteditable and selectable text (amounts, addresses) keep native menus; marketing/content pages never mount this layout, so their links keep normal long-press behavior. CSS class over inline styles per the inlineStyle ratchet (precedents qr-pay/ValidatedInput stay as they are). Regression test covers add/remove of the class and the anchor-vs-input contextmenu branch.

**On-device check for Kush:** the iOS callout kill can't be exercised in headless Chromium.

## 2. About Peanut rows -> DS ListItem (`56fdb2027`)

Policy rows (Terms, Privacy, ...) and the native rate row were hand-rolled `Card` + span + `NavigationArrow`. Now `DocsLink` (routing unchanged: locale rewrite, same-tab PWA, in-app browser on Capacitor) wraps `0_Bruddle/ListItem` — whole row is the link, board anatomy applies (body-m-semibold title, 20px `chevron-right`, 56px row). The rate row gains the pressed state + haptic. Grouping fix: the lone rate row was `position="first"`, now `single`.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3021/about-before.png) | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3021/about-after.png) |

The `pr-assets-3021` branch is deleted after merge.

## Risks

FE-only. The contextmenu guard is scoped to anchors/buttons inside the app shell — the one deliberate behavior change is that app-shell links can no longer be long-press-previewed/opened-in-new-tab, which is the point. Rate-row corner radius changes (first -> single) — deliberate grouping fix.

## QA

prettier clean · typecheck clean · jest 486 suites green (incl. new useLongPressGuard test) · ds-lint ratchet green
