### PR TITLE
Use the default black border on badge/avatar and Rain cooldown toasts

### DIFF
--- a/src/components/Badges/BadgeEarnToast.tsx
+++ b/src/components/Badges/BadgeEarnToast.tsx
@@ -106,10 +106,12 @@ export default function BadgeEarnToast() {
             id: toastId,
             type: 'success',
             duration: 6000,
-            // the compact notification carries no border of its own — this toast
-            // draws its accent border explicitly. custom content suppresses the
-            // priority icon by construction (ToastStack), no hideIcon needed.
-            className: 'border border-action-secondary bg-background-default',
+            // the floating notification already carries its default black
+            // border (border-border-default) — this only overrides the tinted
+            // success surface with an opaque white one. custom content
+            // suppresses the priority icon by construction (ToastStack), no
+            // hideIcon needed.
+            className: 'bg-background-default',
             content: (
                 <button type="button" onClick={openInspect} className="flex items-center gap-3 text-left">
                     <BadgeImage
@@ -138,7 +140,7 @@ export default function BadgeEarnToast() {
                     id: avatarToastId,
                     type: 'success',
                     duration: 6000,
-                    className: 'border border-action-secondary bg-background-default',
+                    className: 'bg-background-default',
                     content: (
                         <button type="button" onClick={chooseAvatar} className="text-left text-label-l">
                             {t('toastAvatars', { count: avatarCount })}

--- a/src/context/RainCooldownContext.tsx
+++ b/src/context/RainCooldownContext.tsx
@@ -105,9 +105,6 @@ export function RainCooldownProvider({ children }: { children: ReactNode }) {
         toast({
             id: COOLDOWN_TOAST_ID,
             duration: 'persistent',
-            // the compact notification carries no border of its own — this pill
-            // draws its accent border explicitly
-            className: 'border border-action-secondary',
             content: <CooldownPillContent endsAt={cooldownEndsAt} />,
         })
     }, [cooldownEndsAt, toast, dismiss])


### PR DESCRIPTION
## Summary
- `BadgeEarnToast` (badge-unlock + avatar-unlock toasts, PR #3013) and `RainCooldownContext`'s persistent cooldown pill both overrode the floating toast's default black border (`border-border-default`, `#161616`) with a yellow accent (`border-action-secondary`, `#ffc900`).
- Both call sites carried a stale comment claiming "the compact notification carries no border of its own" — false for the `floating` variant, which already draws `border border-border-default` (see `Notification.tsx:189`). Dropping the override restores the standard black border.
- Checked every other `toast()` call site in the repo (`ConnectivityToast`, `AvatarPicker`, etc.) — no other colored-border overrides found.

## Test plan
- [x] `BadgeEarnToast.test.tsx` + `RainCooldownContext.test.tsx` passing (15/15)
- [x] `tsc --noEmit` clean on touched files
- [x] `prettier --check` clean on touched files
