### PR TITLE
fix(home): start an identity restart from the activation card, not support

### DIFF
--- a/src/components/Home/ActivationCTAs.tsx
+++ b/src/components/Home/ActivationCTAs.tsx
@@ -53,6 +53,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
     const tCommon = useTranslations('common')
     const tIdentity = useTranslations('identity')
     const tRegion = useTranslations('kyc.regionRestricted')
+    const tProviderRejection = useTranslations('profile.regions.providerRejection')
     const router = useRouter()
     const { setIsQRScannerOpen, openSupportWithMessage } = useModalsContext()
     const { rails, channelOf, nextActions } = useCapabilities()
@@ -117,6 +118,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         primaryRejectionCode,
         blockedRail,
         isEmailBlocked,
+        isRestartBlocked,
     } = useMemo(() => {
         const rejectableRails = rails.filter((rail) => {
             const channel = channelOf(rail)
@@ -155,6 +157,16 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
             })(),
             blockedRail: blocked,
             isEmailBlocked: !!emailBlocked,
+            // Read off the rail the blocked arm ALREADY selected, rather than
+            // hunting for a restart-eligible rail among the blocked ones. That is
+            // `deriveGate`'s rule verbatim: the FIRST blocked verdict decides, so
+            // an account-wide terminal block still wins over a sibling's restart
+            // CTA — re-verifying cannot lift a terminal rail and it burns the
+            // user's Sumsub attempts.
+            isRestartBlocked:
+                !emailBlocked &&
+                !!blocked &&
+                railVerdict(blocked, actionByKey).blocking?.selfHealKind === 'restart-identity',
         }
     }, [rails, channelOf, nextActions])
 
@@ -317,6 +329,24 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                     href: '/profile/identity-verification',
                 }
             }
+            // Blocked, but self-fixable by verifying again with a document that
+            // carries what the provider needs — a Brazilian whose ID has no CPF is
+            // the case this exists for. Offering support here contradicts a restart
+            // endpoint that already admits them.
+            //
+            // Copy comes from the profile catalog rather than a second `home.*`
+            // key: the strings would be identical, and the catalog drift test asks
+            // for one canonical key instead of two that can diverge.
+            if (isRestartBlocked) {
+                return {
+                    icon: 'globe-lock',
+                    iconBg: 'bg-action-primary',
+                    title: tProviderRejection('restartTitle'),
+                    description: localizedRejectionMessage || tProviderRejection('restartDescription'),
+                    ctaLabel: tProviderRejection('restartTitle'),
+                    href: '', // handled in onClick
+                }
+            }
             // blocked
             return {
                 icon: 'globe-lock',
@@ -348,6 +378,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         hasProviderRejection,
         hasFixableRejection,
         isEmailBlocked,
+        isRestartBlocked,
         localizedRejectionMessage,
         isIdentityProcessing,
         isIdentityActionRequired,
@@ -355,6 +386,7 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
         hasCardAccess,
         isRegionRestricted,
         tRegion,
+        tProviderRejection,
     ])
 
     if (!step) return null
@@ -404,6 +436,11 @@ export default function ActivationCTAs({ activationStep, onDismissCard }: Activa
                             router.push(REGION_RESTRICTED_CTA_HREF)
                         } else if (isEmailBlocked) {
                             setShowProvideEmail(true)
+                        } else if (hasProviderRejection && isRestartBlocked && !hasFixableRejection) {
+                            // Self-fixable by a fresh ID check, so it must not open
+                            // support — same rank as the terminal arm below, only a
+                            // different destination.
+                            void kycFlow.handleRestartIdentity()
                         } else if (hasProviderRejection && hasBlockedRejection && !hasFixableRejection) {
                             // REQUIRES_SUPPORT class (or any blocked rail) — pre-fill Crisp
                             // with the failure context so support can dispatch without

--- a/src/components/Home/__tests__/ActivationCTAs.test.tsx
+++ b/src/components/Home/__tests__/ActivationCTAs.test.tsx
@@ -25,14 +25,21 @@ let mockRails: Array<{
     operations?: Record<string, string>
     reason?: { userMessage: string }
     resolved?: {
-        status: 'fixable'
-        blocking: { code: string; userMessage: string; selfHealable: true; selfHealKind: 'document-resubmit' }
-        nextAction: { key: string; kind: 'sumsub'; purpose: string; levelKey: string }
+        status: 'fixable' | 'blocked'
+        blocking: {
+            code: string
+            userMessage: string
+            selfHealable: boolean
+            selfHealKind: 'document-resubmit' | 'restart-identity'
+        }
+        nextAction?: { key: string; kind: 'sumsub'; purpose: string; levelKey: string }
     }
 }> = []
 let mockUser: { user?: { isActivated?: boolean; userId?: string } } | null = null
 let mockHasCardAccess: boolean | undefined = false
 const mockHeal = jest.fn()
+const mockRestartIdentity = jest.fn()
+const mockOpenSupport = jest.fn()
 const mockPush = jest.fn()
 const mockSetIsQRScannerOpen = jest.fn()
 
@@ -77,7 +84,10 @@ jest.mock('@/components/Home/GettingStartedChecklist', () => ({
     default: () => <div>getting-started-checklist</div>,
 }))
 jest.mock('@/context/ModalsContext', () => ({
-    useModalsContext: () => ({ setIsQRScannerOpen: mockSetIsQRScannerOpen, openSupportWithMessage: jest.fn() }),
+    useModalsContext: () => ({
+        setIsQRScannerOpen: mockSetIsQRScannerOpen,
+        openSupportWithMessage: mockOpenSupport,
+    }),
 }))
 jest.mock('@/hooks/useCardInfo', () => ({
     useCardInfo: () => ({ hasCardAccess: mockHasCardAccess }),
@@ -107,7 +117,10 @@ jest.mock('@/components/Home/CardLaunchCTA/CardLaunchCTABanner', () => ({
 }))
 
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
-    useMultiPhaseKycFlow: () => ({ handleFixableRejection: mockHeal }),
+    useMultiPhaseKycFlow: () => ({
+        handleFixableRejection: mockHeal,
+        handleRestartIdentity: mockRestartIdentity,
+    }),
 }))
 jest.mock('@/components/Kyc/SumsubKycModals', () => ({
     SumsubKycModals: () => null,
@@ -377,5 +390,87 @@ describe('ActivationCTAs — happy path renders the checklist', () => {
     it('completed without rejection renders nothing', () => {
         const { container } = render(<ActivationCTAs activationStep="completed" />)
         expect(container.firstChild).toBeNull()
+    })
+})
+
+describe('ActivationCTAs — a restart-eligible block starts a fresh ID check, not support', () => {
+    // The Brazilian this exists for: their pool-tier PIX_BR row is published
+    // `blocked` with `selfHealKind: 'restart-identity'` because the document on
+    // file carries no CPF. The restart endpoint admits them, but the Home CTA
+    // read "no longer enabled" as terminal and opened Crisp — so the main CTA
+    // contradicted the remediation.
+    const restartBlockedPix = {
+        id: 'manteca.pix_br',
+        provider: 'manteca',
+        channel: 'qr-only',
+        status: 'blocked',
+        reason: { userMessage: 'We could not resolve a tax ID from your document.' },
+        resolved: {
+            status: 'blocked' as const,
+            blocking: {
+                code: 'tax_id_unresolved',
+                userMessage: 'We could not resolve a tax ID from your document.',
+                selfHealable: false,
+                selfHealKind: 'restart-identity' as const,
+            },
+        },
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockRegionRestricted = false
+        mockResidenceRestrictions = { banking: false, card: false }
+        mockHasCardAccess = false
+        mockUser = { user: { userId: 'user-1' } }
+        mockRails = [restartBlockedPix]
+    })
+
+    it('offers the restart copy instead of "Verification issue"', () => {
+        render(<ActivationCTAs activationStep="deposit" />)
+
+        // Title and CTA share the string, as they do in UnlockPayments.
+        expect(screen.getByRole('button', { name: 'Verify with a different document' })).toBeInTheDocument()
+        // ...and the description is the localized reason for THIS code, which
+        // already tells the user QR still works — the point of the whole change.
+        expect(
+            screen.getByText(
+                "We couldn't read the tax ID that local deposits and withdrawals need. You can verify again to provide it. QR payments aren't affected."
+            )
+        ).toBeInTheDocument()
+        expect(screen.queryByText('Verification issue')).not.toBeInTheDocument()
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+    })
+
+    it('starts the identity restart on click, and never opens support', () => {
+        render(<ActivationCTAs activationStep="deposit" />)
+        fireEvent.click(screen.getByRole('button', { name: 'Verify with a different document' }))
+
+        expect(mockRestartIdentity).toHaveBeenCalled()
+        expect(mockOpenSupport).not.toHaveBeenCalled()
+    })
+
+    it('a terminal block still goes to support — restart cannot lift it', () => {
+        // The discriminator is `selfHealKind`, not merely being blocked. Sending a
+        // terminal rejection into a fresh ID check burns the user's Sumsub
+        // attempts on something re-verifying can never fix.
+        mockRails = [
+            {
+                ...restartBlockedPix,
+                resolved: {
+                    status: 'blocked' as const,
+                    blocking: {
+                        code: 'terminal_rejection',
+                        userMessage: 'Your verification was declined.',
+                        selfHealable: false,
+                        selfHealKind: 'document-resubmit' as const,
+                    },
+                },
+            },
+        ]
+        render(<ActivationCTAs activationStep="deposit" />)
+        fireEvent.click(screen.getByRole('button', { name: 'Contact support' }))
+
+        expect(mockOpenSupport).toHaveBeenCalled()
+        expect(mockRestartIdentity).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## What

The Home activation card sent a restart-eligible user to support instead of into an identity restart.

For a Brazilian whose pool-tier `PIX_BR` rail is published `blocked` with `selfHealKind: 'restart-identity'` — the document on file carries no CPF — `ActivationCTAs` branched on `selfHealKind` for exactly one value (`'provide-email'`) and let every other blocked rail fall to the terminal arm: **"Verification issue → Contact support"**.

The restart endpoint already admits that user, so the app's main CTA contradicted its own remediation and routed a self-fixable case to a human.

## Why here

Raised on peanut-api-ts#1537, whose backend side is already correct: `resolveCapabilities` publishes `blocked` + `restart-identity` deliberately, reproducing the AR verdict so the same state reads the same way in both countries, while `operations.pay` stays ENABLED so QR is untouched. Nothing in that repo can fix a consumer in this one, so it lands here. **No API change.**

## The precedence question

Restart is a *different destination at the same rank*, not a new rank.

The kind is read off the rail the blocked arm **already selected**, rather than hunting for a restart-eligible rail among the blocked ones. That is `deriveGate`'s documented rule verbatim — the first blocked verdict decides — so an account-wide terminal block still outranks a sibling's restart CTA. Re-verifying cannot lift a terminal rail and it burns the user's Sumsub attempts. Nothing else in the email → fixable → blocked order moves.

## Copy

Reuses `profile.regions.providerRejection.restartTitle` / `restartDescription`, already translated in all four locales and already used by `UnlockPayments.view` for this exact state. A new `home.activation.*` key would carry an identical English string, and the catalog's duplicate-value drift test explicitly asks for one canonical key over two that can diverge.

The description prefers the localized reason for the code, which already tells the user *"QR payments aren't affected"* — accurate here, since the rail stays ENABLED for `pay`.

## Tests

Three cases in `ActivationCTAs.test.tsx`, on the exact capability shape:

- the restart copy replaces "Verification issue", and the description renders the localized `tax_id_unresolved` reason
- clicking calls `handleRestartIdentity` and never opens support
- **a terminal block still goes to support** — the discriminator is `selfHealKind`, not merely being blocked

Verified each discriminates by mutation: routing the click back to support, treating any blocked rail as restart-eligible, and removing the copy arm each fail only their own test. The first is the failure mode this file has shipped before — copy saying one thing while the button does another — so copy and destination are pinned independently.

27/27 in the suite, 242/242 i18n, ds-lint ratchet unchanged, eslint clean on both files, `tsc` clean.
