### PR TITLE
fix(landing): TASK-20600 desktop hero Download now opens the scan-to-download QR

### DIFF
--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -15,6 +15,7 @@ import underMaintenanceConfig from '@/config/underMaintenance.config'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
 import StoreBadges from '@/components/Migration/StoreBadges'
+import { Button } from '@/components/0_Bruddle/Button'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -28,6 +29,9 @@ import type { LandingContentHrefs } from './landingContentHrefs'
 // SSR stays on so crawlers still see the tweets; only the client bundle moves
 // off the critical path.
 const TweetCarousel = dynamic(() => import('@/components/LandingPage/TweetCarousel'))
+
+// desktop-only, opened on demand — keep the QR modal off the landing critical path
+const ScanToDownloadModal = dynamic(() => import('@/components/Migration/ScanToDownloadModal'))
 
 type LandingPageClientProps = {
     heroConfig: {
@@ -79,10 +83,12 @@ export function LandingPageClient({
     const doorFoldOn = !underMaintenanceConfig.disableLandingCardFold
 
     // pwa-sunset hero CTAs are device-based: phones get one "Download now"
-    // with their store's mark deep-linking to it; desktop drops the primary
-    // and shows the equal store-button pair instead (customCta below).
+    // with their store's mark deep-linking to it; desktop gets "Download now"
+    // opening the scan-to-download QR modal (the rule every other desktop
+    // download surface follows) plus the store-link pair (customCta below).
     // the permanent flag-off CTA change goes through the content system
     // post-cutover (TASK-20600).
+    const [qrModalOpen, setQrModalOpen] = useState(false)
     const primaryCta = useMemo((): CTAButton | undefined => {
         if (!migrationOn) return heroConfig.primaryCta
         if (isDesktop) return undefined
@@ -280,10 +286,18 @@ export function LandingPageClient({
                 locale={locale}
                 customCta={
                     migrationOn && isDesktop ? (
-                        <div className="flex flex-col items-center">
+                        <div className="flex flex-col items-center gap-4">
+                            <Button
+                                shadowSize="4"
+                                icon="qr-code"
+                                className="bg-white px-7 py-3 text-base font-extrabold hover:bg-white/90 md:px-9 md:py-8 md:text-xl"
+                                onClick={() => setQrModalOpen(true)}
+                            >
+                                {tMigration('downloadNow')}
+                            </Button>
                             <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
                             {heroConfig.primaryCta.subtext && (
-                                <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">
+                                <span className="block text-center text-sm italic text-n-1 md:text-base">
                                     {heroConfig.primaryCta.subtext}
                                 </span>
                             )}
@@ -291,6 +305,13 @@ export function LandingPageClient({
                     ) : undefined
                 }
             />
+            {qrModalOpen && (
+                <ScanToDownloadModal
+                    visible
+                    onClose={() => setQrModalOpen(false)}
+                    surface={MIGRATION_SURFACES.LANDING_HERO}
+                />
+            )}
             <Marquee {...marqueeProps} />
             {doorFoldOn && (
                 <>

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -14,7 +14,6 @@ import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
-import StoreBadges from '@/components/Migration/StoreBadges'
 import { Button } from '@/components/0_Bruddle/Button'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
@@ -83,9 +82,9 @@ export function LandingPageClient({
     const doorFoldOn = !underMaintenanceConfig.disableLandingCardFold
 
     // pwa-sunset hero CTAs are device-based: phones get one "Download now"
-    // with their store's mark deep-linking to it; desktop gets "Download now"
-    // opening the scan-to-download QR modal (the rule every other desktop
-    // download surface follows) plus the store-link pair (customCta below).
+    // with their store's mark deep-linking to it; desktop gets one "Download
+    // now" opening the scan-to-download QR modal (the rule every other desktop
+    // download surface follows) — the store pair lives inside the modal.
     // the permanent flag-off CTA change goes through the content system
     // post-cutover (TASK-20600).
     const [qrModalOpen, setQrModalOpen] = useState(false)
@@ -286,7 +285,7 @@ export function LandingPageClient({
                 locale={locale}
                 customCta={
                     migrationOn && isDesktop ? (
-                        <div className="flex flex-col items-center gap-4">
+                        <div className="flex flex-col items-center">
                             <Button
                                 shadowSize="4"
                                 icon="qr-code"
@@ -295,9 +294,8 @@ export function LandingPageClient({
                             >
                                 {tMigration('downloadNow')}
                             </Button>
-                            <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
                             {heroConfig.primaryCta.subtext && (
-                                <span className="block text-center text-sm italic text-n-1 md:text-base">
+                                <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">
                                     {heroConfig.primaryCta.subtext}
                                 </span>
                             )}


### PR DESCRIPTION
## Summary

Hotfix for the pwa-sunset landing hero on desktop. During the migration window the desktop hero showed only the two store web links — the one desktop download surface that skipped the scan-to-download QR rule every other surface follows (home banner, setup, guest CTAs), leaving a laptop visitor with a store web page as a dead end. The hero now shows one "Download now" primary that opens the existing `ScanToDownloadModal` — smart QR encoding `/app`, with the App Store / Google Play pair inside the modal. The hero's own store-button pair is gone (Kush's call: one CTA on the hero, the store links live in the modal).

No new components: composes the existing `ScanToDownloadModal` / `DownloadQR` used by home and the guest flow. The modal chunk is `dynamic()`-imported and only fetched on click, so the landing critical path gains nothing.

## Task

Contributes to **TASK-20600** — store links on landing + setup (this closes the gap between the task's intended desktop behavior — scan-to-download QR — and what shipped in #2591).

## Risks / breaking changes

- **Flag OFF (all users today): zero change.** Every changed line lives inside the `migrationOn && isDesktop` branch; flag-off renders the untouched `heroConfig.primaryCta` path. The only flag-off deltas are an unused `useState` and a `dynamic()` module reference that never loads.
- Flag ON, mobile: unchanged (store deep-link primary as before).
- Flag ON, desktop: the hero's store-link pair is replaced by the single "Download now" → QR modal path; the store links remain reachable inside the modal.
- No cross-repo impact, no data-flow change (the `migration_qr_shown` event with `surface: landing_hero` already existed in the analytics schema).
- Hotfix to `main` → creates main→dev back-merge debt.

## QA

1. Local dev (posthog off): `localStorage.setItem('pwa-sunset', 'true')` + reload, desktop viewport → hero shows "Download now" + store pair; clicking opens the QR modal (QR encodes `<origin>/app`).
2. Remove the key + reload → hero identical to prod today (flag-off pinned: typecheck ✅, 346 test suites ✅, build ✅).
3. Prod-like: `posthog.featureFlags.overrideFeatureFlags({ flags: { 'pwa-sunset': true } })`.

## Screenshots

Captured on the branch, local dev, desktop 1440×900. Assets live on the `pr-assets-3024` orphan branch — **delete it after merge**.

| Flag ON — hero (new) | Flag ON — Download now → QR modal (new) | Flag OFF — hero (unchanged control) |
|---|---|---|
| ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3024/hero-desktop-flag-on.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3024/hero-desktop-qr-modal.png) | ![](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3024/hero-desktop-flag-off.png) |

Mobile (flag on and off) renders no changed code path — untouched.
