### PR TITLE
fix(i18n): signup strings overflow their slots — placeholders become role labels

### DIFF
--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -122,7 +122,7 @@ const NavHeader = ({
                             // moment Heading/S moves.
                             // min-w-max let a long title run under the 40px side buttons
                             // on 360px screens; cap it to the space between them instead
-                            'absolute top-1/2 left-1/2 max-w-[calc(100%-8rem)] -translate-x-1/2 -translate-y-1/2 transform pb-1 text-center text-heading-s',
+                            'absolute top-1/2 left-1/2 max-w-[calc(100%-8rem)] -translate-x-1/2 -translate-y-1/2 transform truncate pb-1 text-heading-s',
                             titleClassName
                         )}
                     >

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -122,7 +122,7 @@ const NavHeader = ({
                             // moment Heading/S moves.
                             // min-w-max let a long title run under the 40px side buttons
                             // on 360px screens; cap it to the space between them instead
-                            'absolute top-1/2 left-1/2 max-w-[calc(100%-8rem)] -translate-x-1/2 -translate-y-1/2 transform truncate pb-1 text-heading-s',
+                            'absolute top-1/2 left-1/2 max-w-[calc(100%-8rem)] -translate-x-1/2 -translate-y-1/2 transform pb-1 text-center text-heading-s',
                             titleClassName
                         )}
                     >

--- a/src/components/Setup/Views/__tests__/Residence.test.tsx
+++ b/src/components/Setup/Views/__tests__/Residence.test.tsx
@@ -99,9 +99,9 @@ describe('ResidenceStep', () => {
 
     it('reveals the second selector via the multi-doc link', () => {
         render(<ResidenceStep />)
-        expect(screen.queryByPlaceholderText('Select your second country')).not.toBeInTheDocument()
+        expect(screen.queryByPlaceholderText('Second country')).not.toBeInTheDocument()
         fireEvent.click(screen.getByText('Have documents from more than one country?'))
-        expect(screen.getByPlaceholderText('Select your second country')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText('Second country')).toBeInTheDocument()
     })
 
     it('clears the stored second residence when the selector is collapsed', () => {

--- a/src/i18n/app/__tests__/messages.test.ts
+++ b/src/i18n/app/__tests__/messages.test.ts
@@ -32,6 +32,8 @@ const CONTEXT_DIVERGENT: Record<string, string> = {
     Failed: 'generic status vs. KYC status agreeing with "verificación" (Fallido / Fallida)',
     Verified: 'badge/KYC status vs. residence chip agreeing with "residencia" (Verificado / Verificada)',
     'Settings → Passwords → Search "Peanut"': 'iOS and Android name the settings app differently',
+    Username:
+        "signup asks for your own new handle (Tu usuario) vs. waitlist asks for the inviter's (Nombre de usuario)",
 }
 
 describe('deepMerge fallback', () => {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -779,7 +779,7 @@
             "loginUnexpectedError": "An unexpected error occurred during login."
         },
         "signupStep": {
-            "usernamePlaceholder": "Enter a username",
+            "usernamePlaceholder": "Username",
             "errors": {
                 "required": "Username is required",
                 "tooShort": "Username must be at least 4 characters long",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -771,7 +771,7 @@
             "recoverWallet": "Need to recover your Peanut account?"
         },
         "waitlist": {
-            "inviterUsernamePlaceholder": "Their username",
+            "inviterUsernamePlaceholder": "Username",
             "inviterNotFound": "No Peanut member with that username. Double-check your inviter's exact handle.",
             "joinWaitlist": "Join waitlist",
             "loginCanceled": "Login was canceled. Please try again.",
@@ -794,7 +794,7 @@
         },
         "residenceStep": {
             "countryPlaceholder": "Select your country",
-            "secondCountryPlaceholder": "Select your second country",
+            "secondCountryPlaceholder": "Second country",
             "multiDocLink": "Have documents from more than one country?",
             "errors": {
                 "invalidEmail": "Please enter a valid email address"
@@ -1056,7 +1056,7 @@
         "linkCreatedToast": "Link created successfully!",
         "linkCreatedAndCopiedToast": "Link created and copied to clipboard!",
         "requestUpdatedToast": "Request updated successfully!",
-        "recipientPlaceholder": "Enter a username, an address or ENS",
+        "recipientPlaceholder": "Username, address, or ENS",
         "errors": {
             "createFailed": "Failed to create link",
             "updateFailed": "Failed to update request",
@@ -1198,7 +1198,7 @@
         },
         "initial": {
             "receiveOn": "Receive on",
-            "recipientPlaceholder": "Enter a username, an address or ENS",
+            "recipientPlaceholder": "Username, address, or ENS",
             "usdcArbitrumOnly": "You can only claim USDC on Arbitrum for Peanut Wallet users."
         },
         "addressCompatible": {
@@ -1455,7 +1455,7 @@
             "canceledTitle": "Card canceled",
             "canceledBody": "It can no longer be used for payments. You can request a new card, subject to eligibility.",
             "feedbackLabel": "Help us improve our product for you",
-            "feedbackPlaceholder": "Why did you cancel the card?",
+            "feedbackPlaceholder": "Why did you cancel?",
             "submit": "Submit",
             "thanksTitle": "Thank you for the feedback",
             "thanksBody": "We appreciate your feedback, it helps us improve the experience of our app.",
@@ -1854,8 +1854,8 @@
             "bankTransfer": "Bank Transfer"
         },
         "initial": {
-            "placeholderEns": "Enter an address or ENS",
-            "placeholderAddress": "Enter an address",
+            "placeholderEns": "Address or ENS",
+            "placeholderAddress": "Address",
             "detailsMissing": "Withdrawal details are missing"
         },
         "confirm": {
@@ -1880,7 +1880,7 @@
         "pixKey": {
             "title": "Send with Pix",
             "heading": "Enter Pix key",
-            "placeholder": "PIX Key (Include +55 in case of phone number)",
+            "placeholder": "PIX key",
             "info": "Send to any Pix key — email, phone, CPF/CNPJ or random key.",
             "invalid": "Invalid Pix key"
         },
@@ -3071,7 +3071,7 @@
         "selectToken": "Select a token to recover",
         "noTokens": "No tokens to recover",
         "noTokensDescription": "Tokens sent to your address on other networks will show up here.",
-        "recipientPlaceholder": "Enter the address where you want to receive the funds",
+        "recipientPlaceholder": "Wallet address",
         "review": "Review",
         "youWillReceiveTo": "You will receive to",
         "sentTo": "Sent to",
@@ -3100,7 +3100,7 @@
             "crossChainUnavailable": "Cross-chain transactions are temporarily unavailable. You can use USDC on Arbitrum.",
             "selectANetwork": "Select a network",
             "moreNetworksButton": "more",
-            "searchTokenPlaceholder": "Search for a token or paste address",
+            "searchTokenPlaceholder": "Token or address",
             "sponsoredHint": "Transactions using USDC on Arbitrum are sponsored",
             "availableToken": "Available token",
             "searchResults": "Search Results",
@@ -3110,7 +3110,7 @@
             "noMatchingTokensDescription": "Try searching for a different token",
             "noPopularTokensTitle": "No popular tokens available",
             "moreNetworksTitle": "More networks",
-            "searchNetworkPlaceholder": "Search for a network",
+            "searchNetworkPlaceholder": "Search network",
             "noNetworksFoundTitle": "No networks found matching {search}",
             "noNetworksFoundDescription": "Try searching for a different network",
             "searchPlaceholder": "Search...",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -1881,7 +1881,7 @@
             "title": "Send with Pix",
             "heading": "Enter Pix key",
             "placeholder": "PIX key",
-            "info": "Send to any Pix key — email, phone, CPF/CNPJ or random key.",
+            "info": "Send to any Pix key — email, phone (include +55), CPF/CNPJ or random key.",
             "invalid": "Invalid Pix key"
         },
         "bank": {
@@ -3071,7 +3071,7 @@
         "selectToken": "Select a token to recover",
         "noTokens": "No tokens to recover",
         "noTokensDescription": "Tokens sent to your address on other networks will show up here.",
-        "recipientPlaceholder": "Wallet address",
+        "recipientPlaceholder": "Destination address",
         "review": "Review",
         "youWillReceiveTo": "You will receive to",
         "sentTo": "Sent to",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -771,7 +771,7 @@
             "recoverWallet": "¿Necesitas recuperar tu cuenta de Peanut?"
         },
         "waitlist": {
-            "inviterUsernamePlaceholder": "Su nombre de usuario",
+            "inviterUsernamePlaceholder": "Nombre de usuario",
             "inviterNotFound": "No hay ningún miembro de Peanut con ese nombre de usuario. Verifica el usuario exacto de quien te invitó.",
             "joinWaitlist": "Unirme a la lista de espera",
             "loginCanceled": "El inicio de sesión fue cancelado. Inténtalo de nuevo.",
@@ -794,7 +794,7 @@
         },
         "residenceStep": {
             "countryPlaceholder": "Selecciona tu país",
-            "secondCountryPlaceholder": "Selecciona tu segundo país",
+            "secondCountryPlaceholder": "Segundo país",
             "multiDocLink": "¿Tienes documentos de más de un país?",
             "errors": {
                 "invalidEmail": "Ingresa un correo electrónico válido"
@@ -1056,7 +1056,7 @@
         "linkCreatedToast": "¡Enlace creado con éxito!",
         "linkCreatedAndCopiedToast": "¡Enlace creado y copiado al portapapeles!",
         "requestUpdatedToast": "¡Solicitud actualizada con éxito!",
-        "recipientPlaceholder": "Ingresa un nombre de usuario, una dirección o ENS",
+        "recipientPlaceholder": "Usuario, dirección o ENS",
         "errors": {
             "createFailed": "No se pudo crear el enlace",
             "updateFailed": "No se pudo actualizar la solicitud",
@@ -1198,7 +1198,7 @@
         },
         "initial": {
             "receiveOn": "Recibir en",
-            "recipientPlaceholder": "Ingresa un nombre de usuario, una dirección o ENS",
+            "recipientPlaceholder": "Usuario, dirección o ENS",
             "usdcArbitrumOnly": "Solo puedes reclamar USDC en Arbitrum para usuarios de Peanut Wallet."
         },
         "addressCompatible": {
@@ -1455,7 +1455,7 @@
             "canceledTitle": "Tarjeta cancelada",
             "canceledBody": "Ya no se puede usar para pagos. Puedes pedir una tarjeta nueva, según tu elegibilidad.",
             "feedbackLabel": "Ayúdanos a mejorar nuestro producto para ti",
-            "feedbackPlaceholder": "¿Por qué cancelaste la tarjeta?",
+            "feedbackPlaceholder": "¿Por qué cancelaste?",
             "submit": "Enviar",
             "thanksTitle": "Gracias por tus comentarios",
             "thanksBody": "Agradecemos tus comentarios, nos ayudan a mejorar la experiencia de nuestra app.",
@@ -1854,8 +1854,8 @@
             "bankTransfer": "Transferencia bancaria"
         },
         "initial": {
-            "placeholderEns": "Ingresa una dirección o ENS",
-            "placeholderAddress": "Ingresa una dirección",
+            "placeholderEns": "Dirección o ENS",
+            "placeholderAddress": "Dirección",
             "detailsMissing": "Faltan los datos del retiro"
         },
         "confirm": {
@@ -1880,7 +1880,7 @@
         "pixKey": {
             "title": "Enviar con Pix",
             "heading": "Ingresa la clave Pix",
-            "placeholder": "Clave PIX (incluye +55 si es un número de teléfono)",
+            "placeholder": "Clave PIX",
             "info": "Envía a cualquier clave Pix: email, teléfono, CPF/CNPJ o clave aleatoria.",
             "invalid": "Clave Pix inválida"
         },
@@ -3071,7 +3071,7 @@
         "selectToken": "Selecciona un token para recuperar",
         "noTokens": "No hay tokens para recuperar",
         "noTokensDescription": "Los tokens enviados a tu dirección en otras redes aparecerán aquí.",
-        "recipientPlaceholder": "Ingresa la dirección donde quieres recibir los fondos",
+        "recipientPlaceholder": "Dirección de destino",
         "review": "Revisar",
         "youWillReceiveTo": "Vas a recibir en",
         "sentTo": "Enviado a",
@@ -3100,7 +3100,7 @@
             "crossChainUnavailable": "Las transacciones entre cadenas no están disponibles temporalmente. Puedes usar USDC en Arbitrum.",
             "selectANetwork": "Elige una red",
             "moreNetworksButton": "más",
-            "searchTokenPlaceholder": "Busca un token o pega una dirección",
+            "searchTokenPlaceholder": "Token o dirección",
             "sponsoredHint": "Las transacciones con USDC en Arbitrum son patrocinadas",
             "availableToken": "Token disponible",
             "searchResults": "Resultados de búsqueda",
@@ -3110,7 +3110,7 @@
             "noMatchingTokensDescription": "Intenta buscar otro token",
             "noPopularTokensTitle": "No hay tokens populares disponibles",
             "moreNetworksTitle": "Más redes",
-            "searchNetworkPlaceholder": "Busca una red",
+            "searchNetworkPlaceholder": "Buscar red",
             "noNetworksFoundTitle": "No se encontraron redes que coincidan con {search}",
             "noNetworksFoundDescription": "Intenta buscar otra red",
             "searchPlaceholder": "Buscar...",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -1881,7 +1881,7 @@
             "title": "Enviar con Pix",
             "heading": "Ingresa la clave Pix",
             "placeholder": "Clave PIX",
-            "info": "Envía a cualquier clave Pix: email, teléfono, CPF/CNPJ o clave aleatoria.",
+            "info": "Envía a cualquier clave Pix: email, teléfono (incluye +55), CPF/CNPJ o clave aleatoria.",
             "invalid": "Clave Pix inválida"
         },
         "bank": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -754,7 +754,7 @@
         "installPwa": {
             "openPeanutApp": "Abrir la app de Peanut",
             "installing": "Instalando",
-            "addToHomeScreen": "Agregar Peanut a la pantalla de inicio",
+            "addToHomeScreen": "Agregar a la pantalla de inicio",
             "installCancelled": "Instalación cancelada. Puedes intentar agregarlo a la pantalla de inicio de nuevo.",
             "manualInstallHint": "Para instalar la app, agrégala a tu pantalla de inicio desde el menú de tu navegador.",
             "mobileFirstTitle": "¡Peanut está hecho para el celular!",
@@ -779,7 +779,7 @@
             "loginUnexpectedError": "Ocurrió un error inesperado al iniciar sesión."
         },
         "signupStep": {
-            "usernamePlaceholder": "Escribe un nombre de usuario",
+            "usernamePlaceholder": "Tu usuario",
             "errors": {
                 "required": "El nombre de usuario es obligatorio",
                 "tooShort": "El nombre de usuario debe tener al menos 4 caracteres",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -926,7 +926,7 @@
         },
         "pixKey": {
             "heading": "Ingresá la clave Pix",
-            "info": "Enviá a cualquier clave Pix: email, teléfono, CPF/CNPJ o clave aleatoria."
+            "info": "Enviá a cualquier clave Pix: email, teléfono (incluí +55), CPF/CNPJ o clave aleatoria."
         },
         "bank": {
             "confirmPending": "Tu transferencia se está procesando. Los fondos se enviaron on-chain correctamente: la confirmación puede tardar unos minutos. Si no ves el retiro en tu actividad dentro de 30 minutos, contactá a soporte."

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -451,7 +451,7 @@
             "noPasskey": "No se encontró ninguna passkey. Primero creá una billetera."
         },
         "signupStep": {
-            "usernamePlaceholder": "Escribí un nombre de usuario",
+            "usernamePlaceholder": "Tu usuario",
             "errors": {
                 "invalid": "El nombre de usuario no es válido, usá uno diferente",
                 "checkFailed": "No pudimos verificar la disponibilidad del usuario. Intentalo de nuevo.",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -461,7 +461,7 @@
         },
         "residenceStep": {
             "countryPlaceholder": "Seleccioná tu país",
-            "secondCountryPlaceholder": "Seleccioná tu segundo país",
+            "secondCountryPlaceholder": "Segundo país",
             "multiDocLink": "¿Tenés documentos de más de un país?",
             "errors": {
                 "invalidEmail": "Ingresá un correo electrónico válido"
@@ -602,7 +602,7 @@
     },
     "request": {
         "leaveEmptyHint": "Dejalo vacío para que quien paga elija el monto.",
-        "recipientPlaceholder": "Ingresá un nombre de usuario, una dirección o ENS",
+        "recipientPlaceholder": "Usuario, dirección o ENS",
         "errors": {
             "enterRecipient": "Ingresá una dirección de destinatario"
         },
@@ -652,7 +652,7 @@
             "createWalletHint": "Creá una billetera para recibir enlaces en el futuro."
         },
         "initial": {
-            "recipientPlaceholder": "Ingresá un nombre de usuario, una dirección o ENS",
+            "recipientPlaceholder": "Usuario, dirección o ENS",
             "usdcArbitrumOnly": "Solo podés reclamar USDC en Arbitrum para usuarios de Peanut Wallet."
         },
         "addressCompatible": {
@@ -915,8 +915,8 @@
         "noAccountsTitle": "Aún no tenés cuentas",
         "noAccountsDescription": "Agregá los datos de tus cuentas una vez<br></br>y retirá con un solo toque.",
         "initial": {
-            "placeholderEns": "Ingresá una dirección o ENS",
-            "placeholderAddress": "Ingresá una dirección"
+            "placeholderEns": "Dirección o ENS",
+            "placeholderAddress": "Dirección"
         },
         "confirm": {
             "youPay": "Pagás"
@@ -1346,7 +1346,7 @@
     },
     "recoverFunds": {
         "selectToken": "Seleccioná un token para recuperar",
-        "recipientPlaceholder": "Ingresá la dirección donde querés recibir los fondos",
+        "recipientPlaceholder": "Dirección de destino",
         "recoveryUnavailable": "La recuperación aún no está disponible para {chain}. Contactá a soporte o intentalo de nuevo más tarde.",
         "sessionExpired": "Tu sesión expiró. Actualizá la página e intentalo de nuevo.",
         "sendFailed": "Error al enviar la transacción, intentalo de nuevo",
@@ -1358,9 +1358,9 @@
             "drawerTitle": "Elegí token y red",
             "crossChainUnavailable": "Las transacciones entre cadenas no están disponibles temporalmente. Podés usar USDC en Arbitrum.",
             "selectANetwork": "Elegí una red",
-            "searchTokenPlaceholder": "Buscá un token o pegá una dirección",
+            "searchTokenPlaceholder": "Token o dirección",
             "noMatchingTokensDescription": "Intentá buscar otro token",
-            "searchNetworkPlaceholder": "Buscá una red",
+            "searchNetworkPlaceholder": "Buscar red",
             "noNetworksFoundDescription": "Intentá buscar otra red"
         },
         "qrScanner": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -771,7 +771,7 @@
             "recoverWallet": "Precisa recuperar sua conta Peanut?"
         },
         "waitlist": {
-            "inviterUsernamePlaceholder": "Nome de usuário da pessoa",
+            "inviterUsernamePlaceholder": "Nome de usuário",
             "inviterNotFound": "Não há nenhum membro do Peanut com esse nome de usuário. Confira o usuário exato de quem convidou você.",
             "joinWaitlist": "Entrar na lista de espera",
             "loginCanceled": "O login foi cancelado. Tente de novo.",
@@ -794,7 +794,7 @@
         },
         "residenceStep": {
             "countryPlaceholder": "Selecione seu país",
-            "secondCountryPlaceholder": "Selecione seu segundo país",
+            "secondCountryPlaceholder": "Segundo país",
             "multiDocLink": "Tem documentos de mais de um país?",
             "errors": {
                 "invalidEmail": "Digite um e-mail válido"
@@ -1056,7 +1056,7 @@
         "linkCreatedToast": "Link criado com sucesso!",
         "linkCreatedAndCopiedToast": "Link criado e copiado para a área de transferência!",
         "requestUpdatedToast": "Cobrança atualizada com sucesso!",
-        "recipientPlaceholder": "Insira um nome de usuário, um endereço ou ENS",
+        "recipientPlaceholder": "Usuário, endereço ou ENS",
         "errors": {
             "createFailed": "Não foi possível criar o link",
             "updateFailed": "Não foi possível atualizar a cobrança",
@@ -1198,7 +1198,7 @@
         },
         "initial": {
             "receiveOn": "Receber em",
-            "recipientPlaceholder": "Insira um nome de usuário, um endereço ou ENS",
+            "recipientPlaceholder": "Usuário, endereço ou ENS",
             "usdcArbitrumOnly": "Você só pode resgatar USDC na Arbitrum para usuários da Peanut Wallet."
         },
         "addressCompatible": {
@@ -1455,7 +1455,7 @@
             "canceledTitle": "Cartão cancelado",
             "canceledBody": "Ele não pode mais ser usado para pagamentos. Você pode pedir um novo cartão, conforme sua elegibilidade.",
             "feedbackLabel": "Ajude a gente a melhorar nosso produto para você",
-            "feedbackPlaceholder": "Por que você cancelou o cartão?",
+            "feedbackPlaceholder": "Por que cancelou?",
             "submit": "Enviar",
             "thanksTitle": "Obrigado pelo feedback",
             "thanksBody": "Agradecemos seu feedback, ele ajuda a gente a melhorar a experiência do app.",
@@ -1854,8 +1854,8 @@
             "bankTransfer": "Transferência bancária"
         },
         "initial": {
-            "placeholderEns": "Digite um endereço ou ENS",
-            "placeholderAddress": "Digite um endereço",
+            "placeholderEns": "Endereço ou ENS",
+            "placeholderAddress": "Endereço",
             "detailsMissing": "Faltam os dados do saque"
         },
         "confirm": {
@@ -1880,7 +1880,7 @@
         "pixKey": {
             "title": "Enviar com Pix",
             "heading": "Digite a chave Pix",
-            "placeholder": "Chave PIX (inclua +55 se for número de telefone)",
+            "placeholder": "Chave PIX",
             "info": "Envie para qualquer chave Pix: email, telefone, CPF/CNPJ ou chave aleatória.",
             "invalid": "Chave Pix inválida"
         },
@@ -3071,7 +3071,7 @@
         "selectToken": "Selecione um token para recuperar",
         "noTokens": "Nenhum token para recuperar",
         "noTokensDescription": "Tokens enviados para seu endereço em outras redes aparecerão aqui.",
-        "recipientPlaceholder": "Digite o endereço onde você quer receber os fundos",
+        "recipientPlaceholder": "Endereço de destino",
         "review": "Revisar",
         "youWillReceiveTo": "Você vai receber em",
         "sentTo": "Enviado para",
@@ -3100,7 +3100,7 @@
             "crossChainUnavailable": "As transações entre redes estão temporariamente indisponíveis. Você pode usar USDC na Arbitrum.",
             "selectANetwork": "Escolha uma rede",
             "moreNetworksButton": "mais",
-            "searchTokenPlaceholder": "Busque um token ou cole um endereço",
+            "searchTokenPlaceholder": "Token ou endereço",
             "sponsoredHint": "As transações com USDC na Arbitrum são patrocinadas",
             "availableToken": "Token disponível",
             "searchResults": "Resultados da busca",
@@ -3110,7 +3110,7 @@
             "noMatchingTokensDescription": "Tente buscar outro token",
             "noPopularTokensTitle": "Nenhum token popular disponível",
             "moreNetworksTitle": "Mais redes",
-            "searchNetworkPlaceholder": "Busque uma rede",
+            "searchNetworkPlaceholder": "Buscar rede",
             "noNetworksFoundTitle": "Nenhuma rede encontrada para {search}",
             "noNetworksFoundDescription": "Tente buscar outra rede",
             "searchPlaceholder": "Buscar...",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -1881,7 +1881,7 @@
             "title": "Enviar com Pix",
             "heading": "Digite a chave Pix",
             "placeholder": "Chave PIX",
-            "info": "Envie para qualquer chave Pix: email, telefone, CPF/CNPJ ou chave aleatória.",
+            "info": "Envie para qualquer chave Pix: email, telefone (inclua +55), CPF/CNPJ ou chave aleatória.",
             "invalid": "Chave Pix inválida"
         },
         "bank": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -779,7 +779,7 @@
             "loginUnexpectedError": "Ocorreu um erro inesperado ao fazer login."
         },
         "signupStep": {
-            "usernamePlaceholder": "Digite um nome de usuário",
+            "usernamePlaceholder": "Seu usuário",
             "errors": {
                 "required": "O nome de usuário é obrigatório",
                 "tooShort": "O nome de usuário deve ter pelo menos 4 caracteres",


### PR DESCRIPTION
## Summary

Localized strings overflowed their slots in the signup/setup flow — a critical surface: it renders from the shipped bundle before any OTA update applies. Kush's ruling: fix STRINGS only (no font shrinking, no slot widening), and no CI gate for now — humans plus the new design.md copy rule guard this (rule added on mono PR #139).

Root principle: **a placeholder is a role label, not a sentence** — 1-2 words; instructions belong in the body text above the field, which already explains the username.

**Task:** TASK-21446 (DS umbrella; Discord escalation Hugo/Slava)

## Changed keys (old -> new)

`setup.signupStep.usernamePlaceholder` — shares a row with the Next button; the es string rendered cut off at 375px:
| locale | old | new |
|---|---|---|
| en | Enter a username | Username |
| es-419 | Escribe un nombre de usuario | Tu usuario |
| es-AR | Escribí un nombre de usuario | Tu usuario |
| pt-BR | Digite um nome de usuário | Seu usuário |

`setup.installPwa.addToHomeScreen` — full-width button, the es string (38ch) wraps at 375px:
| locale | old | new |
|---|---|---|
| es-419 | Agregar Peanut a la pantalla de inicio | Agregar a la pantalla de inicio |

## Swept and deliberately left

Full (setup) tree audited across en / es-419 / es-AR / pt-BR (es-AR only overrides a subset; it falls back to es-419):
- full-width buttons and links (joinWaitlist, existingSession, recoverWallet, installPwa rest): all fit at 375px
- `waitlist.inviterUsernamePlaceholder` (es 'Su nombre de usuario', pt 'Nome de usuário da pessoa'): full-width input, fits; role-phrase, not a sentence
- `residenceStep.*Placeholder` ('Selecciona tu país', ≤26ch): full-width comboboxes, fit; select-prompt convention, not a text-input placeholder
- pt-BR `addToHomeScreen` (33ch) measures within the button at 375px — left

Observed nit, out of scope: the "Iniciar sesión" login link overlaps a star of the header illustration at 375px in es (see shots) — illustration layering, not string length.

## Screenshots (es-419, 375x667, username step)

Captured with the mobile-Chrome UA + CDP virtual-authenticator pipeline; API stubbed (no backend). Before = dev tip, after = this branch.

| before (placeholder edge-to-edge, truncates on device) | after |
|---|---|
| ![before](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3025/signup-before.png) | ![after](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3025/signup-after.png) |

The `pr-assets-3025` branch is deleted after merge.

## Risks

String-only change, four locale JSON files. No component, no layout, no CI change (by ruling — noted explicitly).

## QA

prettier clean · typecheck clean · jest 486 suites green · ds-lint ratchet green
