### PR TITLE
fix: real iOS App Store URLs before pwa-sunset flag-on (hotfix)

### DIFF
--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -26,9 +26,9 @@ export const MIGRATION_URGENCY_THRESHOLD_DAYS = 14
 export const NOTIF_PROMPT_SNOOZE_DAYS = 14
 
 // store review deep links ("Love it" on the review prompt). the ios
-// write-review action needs the real numeric app id — placeholder until launch.
+// write-review action needs the real numeric app id.
 export const REVIEW_URL = {
-    ios: 'https://apps.apple.com/app/peanut?action=write-review',
+    ios: 'https://apps.apple.com/us/app/id6786373552?action=write-review',
     android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
 } as const
 
@@ -40,10 +40,9 @@ export const KEEP_WEB_COOKIE = 'keep-web'
 export const KEEP_WEB_TOKEN = 'walnut-still-cracks'
 export const KEEP_WEB_COOKIE_DAYS = 90
 
-// placeholder store URLs — real App Store numeric id + Play listing must be
-// confirmed before flag-on (also needed for the review deep link).
+// real store listings (App Store Connect app 6786373552, Play me.peanut.wallet)
 export const STORE_URL = {
-    ios: 'https://apps.apple.com/app/peanut',
+    ios: 'https://apps.apple.com/us/app/id6786373552',
     android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
 } as const
 


### PR DESCRIPTION
## Summary

Prod (`main`) still ships the placeholder `apps.apple.com/app/peanut` in `STORE_URL.ios` and `REVIEW_URL.ios` — enabling the `pwa-sunset` flag for iOS users today would send every store CTA to a wrong/dead App Store page. This ports the real listing URLs (numeric app id `6786373552`) that are already on `dev`, so flag-on for the iOS 10% cohort is unblocked.

## Task

TASK-21044 §2 (launch-blocker: real store URLs) — https://app.notion.com/p/3ae83811757980db9db8e6c636939b2e

## Risks / breaking changes

None — two constants, values byte-identical to `dev` (no back-merge debt for this file). All consuming surfaces stay dark behind the `pwa-sunset` flag; flag OFF is unchanged.

## QA

- typecheck + full jest suite green (4262 tests); prettier clean; no tests pin the old placeholder.
- Listing to verify by hand (iOS app is published): https://apps.apple.com/us/app/id6786373552 and review deep-link https://apps.apple.com/us/app/id6786373552?action=write-review
- Android URL unchanged (`id=me.peanut.wallet`, still in review — 404 for non-testers is expected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated iOS App Store links so users can open the correct app listing and submit reviews.
  - Android store and review links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->