### PR TITLE
Refine avatar picker, profile settings, and verification cooldown UX

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -454,6 +454,7 @@ function BridgeBankOnrampPage() {
                     rendered here, and without this the button was a dead end. */}
                 <SumsubKycModals flow={sumsubFlow} />
                 <InitiateKycModal
+                    cooldownActive={!!sumsubFlow.errorCooldown}
                     visible
                     presentation="page"
                     navTitle={tUnlock('title')}
@@ -558,6 +559,7 @@ function BridgeBankOnrampPage() {
                 />
 
                 <InitiateKycModal
+                    cooldownActive={!!sumsubFlow.errorCooldown}
                     visible={showKycModal}
                     onClose={() => {
                         // dismiss = abandon: clear the uplift latch so a later

--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -452,7 +452,7 @@ function BridgeBankOnrampPage() {
                 {/* The verify CTA starts the Sumsub run, so its host has to be
                     mounted in THIS branch — the inputAmount branch below is not
                     rendered here, and without this the button was a dead end. */}
-                <SumsubKycModals flow={sumsubFlow} />
+                <SumsubKycModals flow={sumsubFlow} onCooldownClose={onBack} />
                 <InitiateKycModal
                     cooldownActive={!!sumsubFlow.errorCooldown}
                     visible
@@ -589,7 +589,13 @@ function BridgeBankOnrampPage() {
                     message={pendingModal.message}
                 />
 
-                <SumsubKycModals flow={sumsubFlow} />
+                <SumsubKycModals
+                    flow={sumsubFlow}
+                    onCooldownClose={() => {
+                        setShowKycModal(false)
+                        resetUpliftFunnel()
+                    }}
+                />
 
                 <BridgeTosStep
                     visible={showBridgeTos}

--- a/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
+++ b/src/app/(mobile-ui)/qr-pay/__tests__/qr-pay-states.test.tsx
@@ -31,6 +31,7 @@ type TestRestriction = { code: string; affectedRailIds: string[]; userMessage?: 
 // next/navigation
 const mockRouterPush = jest.fn()
 const mockRouterBack = jest.fn()
+const mockRouterReplace = jest.fn()
 const mockSearchParams = new Map<string, string>()
 
 jest.mock('next/navigation', () => ({
@@ -40,7 +41,7 @@ jest.mock('next/navigation', () => ({
     useRouter: () => ({
         push: mockRouterPush,
         back: mockRouterBack,
-        replace: jest.fn(),
+        replace: mockRouterReplace,
         prefetch: jest.fn(),
     }),
     usePathname: () => '/qr-pay',
@@ -192,11 +193,15 @@ jest.mock('@/app/actions/increase-limits', () => ({
     initiateIncreaseLimits: jest.fn(),
 }))
 
+let mockCooldown: { retryAt?: string } | null = null
+const mockDismissCooldown = jest.fn()
 const mockHandleFixableRejection = jest.fn()
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     useMultiPhaseKycFlow: () => ({
         isLoading: false,
         error: null,
+        errorCooldown: mockCooldown,
+        dismissErrorCooldown: mockDismissCooldown,
         showWrapper: false,
         accessToken: null,
         handleInitiateKyc: jest.fn(),
@@ -222,9 +227,8 @@ jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     }),
 }))
 
-jest.mock('@/components/Kyc/SumsubKycModals', () => ({
-    SumsubKycModals: () => null,
-}))
+jest.mock('@/components/Kyc/KycVerificationInProgressModal', () => ({ KycVerificationInProgressModal: () => null }))
+jest.mock('@/components/Global/IframeWrapper', () => ({ __esModule: true, default: () => null }))
 
 const mockIsPaymentProcessorQR = jest.fn()
 jest.mock('@/components/Global/DirectSendQR/utils', () => ({
@@ -669,6 +673,7 @@ function applyDefaults() {
 
 beforeEach(() => {
     jest.clearAllMocks()
+    mockCooldown = null
     mockSearchParams.clear()
     mockIsRegionRestricted = false
     applyDefaults()
@@ -2047,4 +2052,15 @@ describe('GROUP 6: Edge Cases', () => {
             expect(waitingText || orderNotReady).toBeTruthy()
         })
     })
+})
+
+test('cooldown replaces the QR provider prompt and dismissal leaves the flow', () => {
+    setCapabilitiesGate('provider_rejection_fixable', { userMessage: 'Upload a clearer ID.' })
+    mockCooldown = { retryAt: '2026-09-08T18:57:00Z' }
+    renderQrPay({ qrCode: 'mercadopago://pay?id=123', type: 'MERCADO_PAGO', t: '1' })
+    expect(screen.getAllByTestId('action-modal')).toHaveLength(1)
+    expect(screen.queryByText('Upload document')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText("I'll try later"))
+    expect(mockRouterReplace).toHaveBeenCalledWith('/home')
+    expect(mockDismissCooldown).toHaveBeenCalledTimes(1)
 })

--- a/src/app/(mobile-ui)/qr-pay/page.tsx
+++ b/src/app/(mobile-ui)/qr-pay/page.tsx
@@ -357,6 +357,7 @@ export default function QRPayPage() {
     const shouldBlockPay = kycGateState !== QrKycState.PROCEED_TO_PAY
 
     const sumsubFlow = useMultiPhaseKycFlow({})
+    const [kycPromptDismissed, setKycPromptDismissed] = useState(false)
 
     // Auto-dismiss the Sumsub flow if the user's QR-pool rails become enabled
     // server-side while a flow is mid-air. Two known sources:
@@ -1276,7 +1277,7 @@ export default function QRPayPage() {
             <div className="flex min-h-inherit flex-col gap-8">
                 <NavHeader title={tNav('pay')} />
                 <ActionModal
-                    visible
+                    visible={!kycPromptDismissed && !sumsubFlow.errorCooldown}
                     onClose={onBack}
                     title={
                         isFixable
@@ -1325,7 +1326,13 @@ export default function QRPayPage() {
                                 },
                     ]}
                 />
-                <SumsubKycModals flow={sumsubFlow} />
+                <SumsubKycModals
+                    flow={sumsubFlow}
+                    onCooldownClose={() => {
+                        setKycPromptDismissed(true)
+                        onBack()
+                    }}
+                />
             </div>
         )
     }
@@ -1340,7 +1347,11 @@ export default function QRPayPage() {
             <div className="flex min-h-inherit flex-col gap-8">
                 <NavHeader title={tNav('pay')} />
                 <ActionModal
-                    visible={kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION}
+                    visible={
+                        !kycPromptDismissed &&
+                        !sumsubFlow.errorCooldown &&
+                        kycGateState === QrKycState.REQUIRES_IDENTITY_VERIFICATION
+                    }
                     onClose={onBack}
                     title={t('kyc.unlockTitle')}
                     description={t('kyc.unlockDescription')}
@@ -1398,7 +1409,13 @@ export default function QRPayPage() {
                         },
                     ]}
                 />
-                <SumsubKycModals flow={sumsubFlow} />
+                <SumsubKycModals
+                    flow={sumsubFlow}
+                    onCooldownClose={() => {
+                        setKycPromptDismissed(true)
+                        onBack()
+                    }}
+                />
             </div>
         )
     }

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -633,7 +633,13 @@ export default function WithdrawBankPage() {
                 onClose={pendingModal.close}
                 message={pendingModal.message}
             />
-            <SumsubKycModals flow={sumsubFlow} />
+            <SumsubKycModals
+                flow={sumsubFlow}
+                onCooldownClose={() => {
+                    setShowKycModal(false)
+                    resetUpliftFunnel()
+                }}
+            />
         </div>
     )
 }

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -592,6 +592,7 @@ export default function WithdrawBankPage() {
             />
 
             <InitiateKycModal
+                cooldownActive={!!sumsubFlow.errorCooldown}
                 visible={showKycModal}
                 onClose={() => {
                     // dismiss = abandon: clear the uplift latch so a later

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -678,6 +678,7 @@ function MantecaBankWithdrawFlow() {
     return (
         <div className="flex min-h-inherit flex-col gap-8">
             <InitiateKycModal
+                cooldownActive={!!sumsubFlow.errorCooldown}
                 prepPath="extended"
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}

--- a/src/app/(mobile-ui)/withdraw/manteca/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/manteca/page.tsx
@@ -720,7 +720,7 @@ function MantecaBankWithdrawFlow() {
                 reasonCode={mantecaRejection.reasonCode ?? undefined}
                 regionName={selectedCountry && localizedCountryTitle(locale, selectedCountry)}
             />
-            <SumsubKycModals flow={sumsubFlow} />
+            <SumsubKycModals flow={sumsubFlow} onCooldownClose={() => setShowKycModal(false)} />
             <SumsubKycWrapper
                 visible={limitIncreaseFlow.showWrapper}
                 accessToken={limitIncreaseFlow.accessToken}

--- a/src/app/actions/__tests__/sumsub-refusals.test.ts
+++ b/src/app/actions/__tests__/sumsub-refusals.test.ts
@@ -160,3 +160,28 @@ describe('restartIdentityVerification — wire shape', () => {
         expect(result.error).toBeTruthy()
     })
 })
+
+describe('restart cooldown details', () => {
+    it('preserves the retry time on rate limits', async () => {
+        respondWith(429, { error: 'Please wait', retryAt: '2026-09-08T18:57:00Z' })
+        expect((await restartIdentityVerification()).cooldown).toEqual({ retryAt: '2026-09-08T18:57:00.000Z' })
+    })
+    it('does not mistake a state conflict for a cooldown', async () => {
+        respondWith(409, { error: 'Verification changed, please retry' })
+        expect((await restartIdentityVerification()).cooldown).toBeUndefined()
+    })
+    it('keeps rate limits dismissible when the retry time is invalid', async () => {
+        respondWith(429, { error: 'Please wait', retryAt: 'invalid' })
+        expect((await restartIdentityVerification()).cooldown).toEqual({ retryAt: undefined })
+    })
+})
+
+it('uses Retry-After for infrastructure rate limits', async () => {
+    mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({ 'Retry-After': 'Tue, 08 Sep 2026 18:57:00 GMT' }),
+        json: async () => ({ error: 'Too many requests' }),
+    } as Response)
+    expect((await restartIdentityVerification()).cooldown?.retryAt).toBe('2026-09-08T18:57:00.000Z')
+})

--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -149,6 +149,7 @@ export const restartIdentityVerification = async (
     data?: RestartIdentityResponse
     error?: string
     code?: SumsubActionErrorCode
+    cooldown?: { retryAt?: string }
 }> => {
     try {
         const intent = regionIntent && RESTART_REGION_INTENTS.has(regionIntent) ? regionIntent : undefined
@@ -159,7 +160,22 @@ export const restartIdentityVerification = async (
         })
         const responseJson = await response.json()
         if (!response.ok) {
-            return backendOrFallback(responseJson, 'Failed to restart identity verification', 'restart_failed')
+            const failure = backendOrFallback(responseJson, 'Failed to restart identity verification', 'restart_failed')
+            if (response.status !== 429) return failure
+            const rawRetryAt = responseJson.retryAt
+            const retryAfter = response.headers?.get('retry-after')
+            const retryAfterMs = retryAfter
+                ? /^\d+$/.test(retryAfter)
+                    ? Date.now() + Number(retryAfter) * 1000
+                    : Date.parse(retryAfter)
+                : NaN
+            const retryAt =
+                typeof rawRetryAt === 'string' && Number.isFinite(Date.parse(rawRetryAt))
+                    ? new Date(rawRetryAt).toISOString()
+                    : Number.isFinite(retryAfterMs)
+                      ? new Date(retryAfterMs).toISOString()
+                      : undefined
+            return { ...failure, cooldown: { retryAt } }
         }
         // Sanitize on the way OUT as well as in. `responseJson` is unvalidated,
         // and the caller stores `regionIntent` in the ref that `refreshToken`

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -307,7 +307,7 @@ const MantecaAddMoney: FC = () => {
                     reasonCode={mantecaRejection.reasonCode ?? undefined}
                     regionName={selectedCountry && localizedCountryTitle(locale, selectedCountry)}
                 />
-                <SumsubKycModals flow={sumsubFlow} />
+                <SumsubKycModals flow={sumsubFlow} onCooldownClose={() => setShowKycModal(false)} />
                 <InputAmountStep
                     tokenAmount={displayedAmount}
                     setTokenAmount={handleUsdAmountChange}

--- a/src/components/AddMoney/components/MantecaAddMoney.tsx
+++ b/src/components/AddMoney/components/MantecaAddMoney.tsx
@@ -269,6 +269,7 @@ const MantecaAddMoney: FC = () => {
         return (
             <>
                 <InitiateKycModal
+                    cooldownActive={!!sumsubFlow.errorCooldown}
                     prepPath="extended"
                     visible={showKycModal}
                     onClose={() => setShowKycModal(false)}

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -370,6 +370,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
     const sharedModals = (
         <>
             <InitiateKycModal
+                cooldownActive={!!sumsubFlow.errorCooldown}
                 visible={isKycModalOpen}
                 onClose={() => setIsKycModalOpen(false)}
                 onVerify={async () => {

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -413,7 +413,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                 onComplete={() => setShowProvideEmail(false)}
                 onSkip={() => setShowProvideEmail(false)}
             />
-            <SumsubKycModals flow={sumsubFlow} />
+            <SumsubKycModals flow={sumsubFlow} onCooldownClose={() => setIsKycModalOpen(false)} />
         </>
     )
 

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -104,12 +104,20 @@ jest.mock('@/context/ModalsContext', () => ({
 jest.mock('@/hooks/useTosGuard', () => ({
     useTosGuard: () => ({ guardWithTos: jest.fn(), showBridgeTos: false, hideTos: jest.fn() }),
 }))
+let mockCooldown: { retryAt?: string } | null = null
+const mockDismissCooldown = jest.fn()
+beforeEach(() => {
+    mockCooldown = null
+    mockDismissCooldown.mockClear()
+})
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     useMultiPhaseKycFlow: () => ({
         handleInitiateKyc: jest.fn(),
         handleSelfHealResubmit: jest.fn(),
         isLoading: false,
         error: null,
+        errorCooldown: mockCooldown,
+        dismissErrorCooldown: mockDismissCooldown,
         showWrapper: false,
     }),
 }))
@@ -129,7 +137,7 @@ jest.mock('@/utils/native-routes', () => ({
     rewriteMethodPath: (p: string) => p,
     withdrawBankUrl: (p: string) => `/withdraw/${p}`,
 }))
-jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false, isAndroidNative: () => false }))
 jest.mock('@/utils/color.utils', () => ({ getColorForUsername: () => ({ lightShade: '#fff' }) }))
 jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: string) => id }))
 // bridge.utils + regions.utils are direct util collaborators that transitively
@@ -164,7 +172,9 @@ jest.mock('@/components/Profile/AvatarWithBadge', () => ({ __esModule: true, def
 jest.mock('@/components/Global/EmptyStates/EmptyState', () => ({ __esModule: true, default: () => <div /> }))
 jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({ DynamicBankAccountForm: () => <div /> }))
 jest.mock('@/components/Global/TokenAndNetworkConfirmationModal', () => ({ __esModule: true, default: () => null }))
-jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/SumsubKycWrapper', () => ({ SumsubKycWrapper: () => null }))
+jest.mock('@/components/Kyc/KycVerificationInProgressModal', () => ({ KycVerificationInProgressModal: () => null }))
+jest.mock('@/components/Global/IframeWrapper', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Kyc/BridgeTosStep', () => ({ BridgeTosStep: () => null }))
 jest.mock('@/components/Kyc/ProvideEmailStep', () => ({
     __esModule: true,
@@ -348,5 +358,18 @@ describe('AddWithdrawCountriesList — PIX onramp maintenance tag', () => {
 
         expect(within(screen.getByTestId('method-pix')).queryByText('Maintenance')).toBeNull()
         expect(within(screen.getByTestId('method-bank')).queryByText('Maintenance')).toBeNull()
+    })
+})
+
+describe('restart cooldown in add and withdraw flows', () => {
+    it.each(['add', 'withdraw'] as const)('shows the shared dated cooldown for %s', (flow) => {
+        mockCooldown = { retryAt: '2026-09-08T18:57:00Z' }
+        render(<AddWithdrawCountriesList flow={flow} />)
+        expect(screen.getByText('Give it a little time')).toBeInTheDocument()
+        expect(screen.getByText(/You can try again after/)).toHaveTextContent(/Sep 8/)
+        expect(screen.queryByText('Too many requests')).not.toBeInTheDocument()
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText("I'll try later"))
+        expect(mockDismissCooldown).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -14,7 +14,7 @@
  * gate is NOT ready — so the fix didn't just delete the guard wholesale.
  */
 import React from 'react'
-import { render as rtlRender, screen, fireEvent, within } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent, within, waitFor } from '@testing-library/react'
 import { IntlWrapper } from '@/test-utils/intl'
 import AddWithdrawCountriesList from '../AddWithdrawCountriesList'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
@@ -181,7 +181,8 @@ jest.mock('@/components/Kyc/ProvideEmailStep', () => ({
     default: (props: any) => (props.visible ? <div data-testid="provide-email-sheet" /> : null),
 }))
 jest.mock('@/components/Kyc/InitiateKycModal', () => ({
-    InitiateKycModal: (props: any) => (props.visible ? <div data-testid="initiate-kyc-modal" /> : null),
+    InitiateKycModal: (props: any) =>
+        props.visible && !props.cooldownActive ? <div data-testid="initiate-kyc-modal" /> : null,
 }))
 jest.mock('next/image', () => ({ __esModule: true, default: () => null }))
 
@@ -372,4 +373,27 @@ describe('restart cooldown in add and withdraw flows', () => {
         fireEvent.click(screen.getByText("I'll try later"))
         expect(mockDismissCooldown).toHaveBeenCalledTimes(1)
     })
+})
+
+it('closing a cooldown also closes the underlying bank initiation prompt', async () => {
+    setCapabilities('needs-identity', [])
+    const { rerender } = render(<AddWithdrawCountriesList flow="add" />)
+    fireEvent.click(screen.getByTestId('method-bank'))
+    expect(screen.getByTestId('initiate-kyc-modal')).toBeInTheDocument()
+    mockCooldown = { retryAt: '2026-09-08T18:57:00Z' }
+    rerender(
+        <IntlWrapper>
+            <AddWithdrawCountriesList flow="add" />
+        </IntlWrapper>
+    )
+    expect(screen.queryByTestId('initiate-kyc-modal')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText("I'll try later"))
+    mockCooldown = null
+    rerender(
+        <IntlWrapper>
+            <AddWithdrawCountriesList flow="add" />
+        </IntlWrapper>
+    )
+    expect(screen.queryByTestId('initiate-kyc-modal')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText("I'll try later")).not.toBeInTheDocument())
 })

--- a/src/components/Avatar/AvatarPicker.module.css
+++ b/src/components/Avatar/AvatarPicker.module.css
@@ -90,23 +90,6 @@
     outline: 3px solid var(--color-action-focus);
     outline-offset: 4px;
 }
-.halo {
-    position: absolute;
-    width: min(85vw, 480px);
-    aspect-ratio: 1;
-    border-radius: 50%;
-    background: var(--color-background-brand);
-    animation: glow 2400ms ease-in-out both;
-}
-.orbit {
-    position: absolute;
-    width: min(75vw, 400px);
-    aspect-ratio: 1;
-    border: 1px solid var(--color-border-default);
-    border-radius: 50%;
-    transform: rotateX(65deg);
-    animation: ripple 2400ms ease-out both;
-}
 .scene {
     position: relative;
     width: 144px;
@@ -166,12 +149,13 @@
 }
 .shadow {
     position: absolute;
-    top: 210px;
+    top: 190px;
     left: -5%;
     width: 110%;
-    height: 20px;
+    height: 12px;
     border-radius: 50%;
     background: var(--color-foreground-primary);
+    opacity: 0.2;
     animation: shadow 2400ms both;
 }
 .rollCopy {
@@ -197,9 +181,14 @@
     80% {
         transform: rotateX(710deg) rotateY(685deg);
     }
-    90%,
+    88% {
+        transform: rotateX(697deg) rotateY(698deg) rotateZ(-3deg);
+    }
+    94% {
+        transform: rotateX(702deg) rotateY(693deg) rotateZ(2deg);
+    }
     100% {
-        transform: rotateX(700deg) rotateY(695deg);
+        transform: rotateX(700deg) rotateY(695deg) rotateZ(0deg);
     }
 }
 @keyframes bounce {
@@ -227,44 +216,91 @@
 }
 @keyframes shadow {
     0%,
-    60%,
-    80%,
-    100% {
-        scale: 1;
-        opacity: 0.15;
-    }
     30%,
     75% {
-        scale: 0.6;
-        opacity: 0.05;
+        scale: 1.15;
+        opacity: 0.06;
     }
-}
-@keyframes glow {
-    0% {
-        scale: 0.3;
-        opacity: 0;
-    }
-    45% {
-        scale: 1.2;
-        opacity: 1;
-    }
-    100% {
-        scale: 1;
-        opacity: 0.3;
-    }
-}
-@keyframes ripple {
-    0%,
     60% {
-        scale: 0.4;
-        opacity: 0;
+        scale: 0.85;
+        opacity: 0.15;
     }
     80% {
-        opacity: 1;
+        scale: 0.7;
+        opacity: 0.25;
     }
+    88% {
+        scale: 0.8;
+        opacity: 0.16;
+    }
+    96%,
     100% {
-        scale: 1.5;
+        scale: 0.75;
+        opacity: 0.2;
+    }
+}
+.impact {
+    position: absolute;
+    top: 180px;
+    left: -32px;
+    right: -32px;
+    height: 32px;
+    opacity: 0;
+    animation: impact 2400ms both;
+}
+.impact i {
+    position: absolute;
+    width: 16px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--color-foreground-primary);
+}
+.impact i:nth-child(1) {
+    left: 0;
+    top: 16px;
+    rotate: 15deg;
+}
+.impact i:nth-child(2) {
+    left: 16px;
+    top: 0;
+    rotate: 50deg;
+}
+.impact i:nth-child(3) {
+    right: 16px;
+    top: 0;
+    rotate: -50deg;
+}
+.impact i:nth-child(4) {
+    right: 0;
+    top: 16px;
+    rotate: -15deg;
+}
+@keyframes impact {
+    0%,
+    79% {
         opacity: 0;
+        scale: 0.85;
+    }
+    80%,
+    83% {
+        opacity: 1;
+        scale: 1;
+    }
+    89%,
+    100% {
+        opacity: 0;
+        scale: 1.08;
+    }
+}
+.dealtDrawer {
+    animation: drawerReveal 280ms ease-out both;
+}
+@keyframes drawerReveal {
+    from {
+        translate: 0 100%;
+    }
+    to {
+        translate: 0 0;
     }
 }
 @keyframes reveal {
@@ -279,6 +315,7 @@
 }
 @media (prefers-reduced-motion: reduce) {
     .grid,
+    .dealtDrawer,
     .rollStage *,
     .tile {
         animation: none;

--- a/src/components/Avatar/AvatarPicker.module.css
+++ b/src/components/Avatar/AvatarPicker.module.css
@@ -38,7 +38,7 @@
         background 150ms;
 }
 .tile[aria-checked='true'] {
-    background: var(--color-background-secondary, #f3edff);
+    background: var(--color-background-brand);
 }
 .art {
     width: 85%;
@@ -49,7 +49,7 @@
     margin-top: 0;
     border-radius: 0;
     overflow: hidden;
-    background: #211032;
+    background: var(--color-background-page);
 }
 .fullscreen > div:first-child {
     display: none;
@@ -69,22 +69,25 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
-    color: #fff;
-    background: radial-gradient(ellipse at 50% 40%, #70409b 0%, #352048 45%, #180e23 100%);
+    color: var(--color-foreground-primary);
+    background: var(--color-background-page);
 }
 .close {
     position: absolute;
     top: calc(env(safe-area-inset-top, 0px) + 16px);
-    right: 20px;
+    right: 16px;
     z-index: 2;
     width: 44px;
     height: 44px;
-    border: 1px solid #ffffff60;
+    border: 1px solid var(--color-border-default);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-background-default);
     border-radius: 50%;
-    font-size: 28px;
 }
 .close:focus-visible {
-    outline: 3px solid #d8c2ff;
+    outline: 3px solid var(--color-action-focus);
     outline-offset: 4px;
 }
 .halo {
@@ -92,14 +95,14 @@
     width: min(85vw, 480px);
     aspect-ratio: 1;
     border-radius: 50%;
-    background: radial-gradient(circle, #d7a3ff40, transparent 68%);
+    background: var(--color-background-brand);
     animation: glow 2400ms ease-in-out both;
 }
 .orbit {
     position: absolute;
     width: min(75vw, 400px);
     aspect-ratio: 1;
-    border: 1px solid #ffffff25;
+    border: 1px solid var(--color-border-default);
     border-radius: 50%;
     transform: rotateX(65deg);
     animation: ripple 2400ms ease-out both;
@@ -129,39 +132,37 @@
     inset: 0;
     display: grid;
     grid-template: repeat(3, 1fr) / repeat(3, 1fr);
-    gap: 13px;
-    padding: 23px;
-    border: 2px solid #372442;
+    gap: 12px;
+    padding: 24px;
+    border: 2px solid var(--color-border-default);
     border-radius: 24px;
-    background: #e6caff;
+    background: var(--color-background-brand);
     backface-visibility: hidden;
-    box-shadow: inset 0 0 18px #fff8;
 }
 .face[data-face='0'] {
     transform: translateZ(72px);
-    background: #f0dfff;
+    background: var(--color-background-brand);
 }
 .face[data-face='1'] {
     transform: rotateY(180deg) translateZ(72px);
 }
 .face[data-face='2'] {
     transform: rotateY(90deg) translateZ(72px);
-    background: #c698eb;
+    background: var(--color-action-secondary);
 }
 .face[data-face='3'] {
     transform: rotateY(-90deg) translateZ(72px);
 }
 .face[data-face='4'] {
     transform: rotateX(90deg) translateZ(72px);
-    background: #fcf2df;
+    background: var(--color-background-default);
 }
 .face[data-face='5'] {
     transform: rotateX(-90deg) translateZ(72px);
 }
 .pip {
     border-radius: 50%;
-    background: #352048;
-    box-shadow: inset 0 2px 3px #0005;
+    background: var(--color-foreground-primary);
 }
 .shadow {
     position: absolute;
@@ -170,8 +171,7 @@
     width: 110%;
     height: 20px;
     border-radius: 50%;
-    background: #10061980;
-    filter: blur(10px);
+    background: var(--color-foreground-primary);
     animation: shadow 2400ms both;
 }
 .rollCopy {
@@ -182,7 +182,7 @@
     animation: reveal 500ms ease-out both;
 }
 .rollCopy p + p {
-    color: #e0cce9;
+    color: var(--color-foreground-secondary);
 }
 @keyframes tumble {
     0% {
@@ -231,12 +231,12 @@
     80%,
     100% {
         scale: 1;
-        opacity: 0.7;
+        opacity: 0.15;
     }
     30%,
     75% {
         scale: 0.6;
-        opacity: 0.25;
+        opacity: 0.05;
     }
 }
 @keyframes glow {
@@ -250,7 +250,7 @@
     }
     100% {
         scale: 1;
-        opacity: 0.8;
+        opacity: 0.3;
     }
 }
 @keyframes ripple {

--- a/src/components/Avatar/AvatarPicker.module.css
+++ b/src/components/Avatar/AvatarPicker.module.css
@@ -1,0 +1,294 @@
+.picker {
+    --avatar-columns: 3;
+    --avatar-tile: max(
+        56px,
+        min(
+            88px,
+            calc((100vw - 40px - (var(--avatar-columns) - 1) * 8px) / var(--avatar-columns)),
+            calc((80dvh - 232px) / var(--avatar-columns) - 8px)
+        )
+    );
+}
+.initials {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 4px;
+    scroll-snap-type: x proximity;
+    scrollbar-width: thin;
+}
+.grid {
+    display: grid;
+    grid-template-columns: repeat(var(--avatar-columns), var(--avatar-tile));
+    justify-content: center;
+    gap: 8px;
+    padding: 4px;
+    animation: reveal 400ms ease-out both;
+}
+.tile {
+    width: var(--avatar-tile);
+    height: var(--avatar-tile);
+    flex: 0 0 var(--avatar-tile);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    scroll-snap-align: start;
+    transition:
+        border-color 150ms,
+        background 150ms;
+}
+.tile[aria-checked='true'] {
+    background: var(--color-background-secondary, #f3edff);
+}
+.art {
+    width: 85%;
+    height: 85%;
+}
+.fullscreen {
+    height: 100dvh;
+    margin-top: 0;
+    border-radius: 0;
+    overflow: hidden;
+    background: #211032;
+}
+.fullscreen > div:first-child {
+    display: none;
+}
+.rollArea {
+    max-height: none;
+    max-width: none;
+    height: 100dvh;
+    overflow: hidden;
+    padding: 0;
+}
+.rollStage {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    color: #fff;
+    background: radial-gradient(ellipse at 50% 40%, #70409b 0%, #352048 45%, #180e23 100%);
+}
+.close {
+    position: absolute;
+    top: calc(env(safe-area-inset-top, 0px) + 16px);
+    right: 20px;
+    z-index: 2;
+    width: 44px;
+    height: 44px;
+    border: 1px solid #ffffff60;
+    border-radius: 50%;
+    font-size: 28px;
+}
+.close:focus-visible {
+    outline: 3px solid #d8c2ff;
+    outline-offset: 4px;
+}
+.halo {
+    position: absolute;
+    width: min(85vw, 480px);
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: radial-gradient(circle, #d7a3ff40, transparent 68%);
+    animation: glow 2400ms ease-in-out both;
+}
+.orbit {
+    position: absolute;
+    width: min(75vw, 400px);
+    aspect-ratio: 1;
+    border: 1px solid #ffffff25;
+    border-radius: 50%;
+    transform: rotateX(65deg);
+    animation: ripple 2400ms ease-out both;
+}
+.scene {
+    position: relative;
+    width: 144px;
+    height: 144px;
+    perspective: 800px;
+    margin-bottom: 90px;
+}
+.bounce {
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    animation: bounce 2400ms both;
+}
+.die {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    animation: tumble 2400ms both;
+}
+.face {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+    gap: 13px;
+    padding: 23px;
+    border: 2px solid #372442;
+    border-radius: 24px;
+    background: #e6caff;
+    backface-visibility: hidden;
+    box-shadow: inset 0 0 18px #fff8;
+}
+.face[data-face='0'] {
+    transform: translateZ(72px);
+    background: #f0dfff;
+}
+.face[data-face='1'] {
+    transform: rotateY(180deg) translateZ(72px);
+}
+.face[data-face='2'] {
+    transform: rotateY(90deg) translateZ(72px);
+    background: #c698eb;
+}
+.face[data-face='3'] {
+    transform: rotateY(-90deg) translateZ(72px);
+}
+.face[data-face='4'] {
+    transform: rotateX(90deg) translateZ(72px);
+    background: #fcf2df;
+}
+.face[data-face='5'] {
+    transform: rotateX(-90deg) translateZ(72px);
+}
+.pip {
+    border-radius: 50%;
+    background: #352048;
+    box-shadow: inset 0 2px 3px #0005;
+}
+.shadow {
+    position: absolute;
+    top: 210px;
+    left: -5%;
+    width: 110%;
+    height: 20px;
+    border-radius: 50%;
+    background: #10061980;
+    filter: blur(10px);
+    animation: shadow 2400ms both;
+}
+.rollCopy {
+    position: absolute;
+    bottom: max(15%, env(safe-area-inset-bottom));
+    text-align: center;
+    padding: 0 24px;
+    animation: reveal 500ms ease-out both;
+}
+.rollCopy p + p {
+    color: #e0cce9;
+}
+@keyframes tumble {
+    0% {
+        transform: rotateX(-20deg) rotateY(-25deg) scale(0.4);
+    }
+    30% {
+        transform: rotateX(310deg) rotateY(240deg) scale(1.1);
+    }
+    60% {
+        transform: rotateX(610deg) rotateY(490deg);
+    }
+    80% {
+        transform: rotateX(710deg) rotateY(685deg);
+    }
+    90%,
+    100% {
+        transform: rotateX(700deg) rotateY(695deg);
+    }
+}
+@keyframes bounce {
+    0% {
+        translate: 0 90px;
+    }
+    30% {
+        translate: 0 -55px;
+    }
+    60% {
+        translate: 0 15px;
+    }
+    75% {
+        translate: 0 -25px;
+    }
+    80% {
+        translate: 0 0;
+    }
+    88% {
+        translate: 0 -8px;
+    }
+    100% {
+        translate: 0 0;
+    }
+}
+@keyframes shadow {
+    0%,
+    60%,
+    80%,
+    100% {
+        scale: 1;
+        opacity: 0.7;
+    }
+    30%,
+    75% {
+        scale: 0.6;
+        opacity: 0.25;
+    }
+}
+@keyframes glow {
+    0% {
+        scale: 0.3;
+        opacity: 0;
+    }
+    45% {
+        scale: 1.2;
+        opacity: 1;
+    }
+    100% {
+        scale: 1;
+        opacity: 0.8;
+    }
+}
+@keyframes ripple {
+    0%,
+    60% {
+        scale: 0.4;
+        opacity: 0;
+    }
+    80% {
+        opacity: 1;
+    }
+    100% {
+        scale: 1.5;
+        opacity: 0;
+    }
+}
+@keyframes reveal {
+    from {
+        opacity: 0;
+        translate: 0 10px;
+    }
+    to {
+        opacity: 1;
+        translate: 0 0;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .grid,
+    .rollStage *,
+    .tile {
+        animation: none;
+        transition: none;
+    }
+    .die {
+        transform: rotateX(-20deg) rotateY(-25deg);
+    }
+}
+
+.fourColumns {
+    --avatar-columns: 4;
+}

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -127,7 +127,9 @@ export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
             shouldScaleBackground={false}
         >
             <DrawerContent
-                className={phase === 'rolling' ? styles.fullscreen : 'py-4'}
+                className={
+                    phase === 'rolling' ? styles.fullscreen : twMerge('py-4', phase === 'avatars' && styles.dealtDrawer)
+                }
                 scrollAreaClassName={phase === 'rolling' ? styles.rollArea : 'px-4'}
             >
                 {phase === 'rolling' ? (

--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -5,206 +5,194 @@ import { useTranslations } from 'next-intl'
 import { updateUserById } from '@/app/actions/users'
 import { Button } from '@/components/0_Bruddle/Button'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '@/components/Global/Drawer'
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/Global/Drawer'
 import { useAuth } from '@/context/authContext'
 import { twMerge } from '@/utils/tw'
-import { badgeAvatarKeys, letterAvatarKeys, offerBasics } from './avatar.utils'
+import { avatarGridColumns, badgeAvatarKeys, dealAvatars, letterAvatarKeys } from './avatar.utils'
 import { isLetterAvatarKey, storeLetterAvatar } from './avatar-letter.storage'
-import { useAvatarKey } from './useAvatarKey'
 import { roveAvatarTiles } from './avatarPicker.utils'
 import { UserAvatar } from './UserAvatar'
+import { DiceRoll } from './DiceRoll'
+import styles from './AvatarPicker.module.css'
 
 interface AvatarPickerProps {
     open: boolean
     onOpenChange: (open: boolean) => void
 }
 
-/**
- * The profile avatar picker (TASK-22142): the a-z initials everyone has, then
- * what the user's badges unlocked, then one row of the basics. A tap saves at
- * once; the dice rerolls the offered row and never the pick. The API validates
- * the pick against the same pool, so a locked key never lands even if the
- * manifest and the catalog drift.
- *
- * The initials grid replaced a "use my initial instead" text button. That
- * button wrote `avatarKey: null`, which renders the first letter of the
- * USERNAME and follows it on rename; a `letter.<a-z>` pick is a real pick and
- * stays put. `null` remains the day-0 state of someone who never opened this.
- *
- * A letter the API still rejects (until peanut-api-ts#1529 ships) falls back to
- * a device-local mirror rather than an error toast — see avatar-letter.storage.
- * Sticker picks have no fallback by design: their unlock is enforced server-side.
- */
 export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
     const t = useTranslations('avatar')
     const tCommon = useTranslations('common')
     const { user, fetchUser } = useAuth()
     const { toast } = useToast()
-
-    const userId = user?.user.userId
     const username = user?.user.username ?? undefined
-    // the effective pick: the server's, or the device-local letter fallback
-    const saved = useAvatarKey(user?.user.avatarKey, userId)
-    const badges = user?.user.badges ?? []
-    const held = badges.map((badge) => badge.code)
-    const badgeName = Object.fromEntries(badges.map((badge) => [badge.code, badge.name]))
-    const unlocked = badgeAvatarKeys(held)
+    const userId = user?.user.userId
+    const unlocked = badgeAvatarKeys((user?.user.badges ?? []).map((badge) => badge.code))
+    const available = dealAvatars(unlocked, 16, () => 0).length
+    const initial = /^[a-z]/i.test(username?.trim() ?? '') ? `letter.${username!.trim()[0].toLowerCase()}` : null
+    const letters = letterAvatarKeys()
+    const start = Math.max(0, letters.indexOf(initial ?? ''))
+    const orderedLetters: (string | null)[] = initial
+        ? [...letters.slice(start), ...letters.slice(0, start)]
+        : [null, ...letters]
+    const [phase, setPhase] = useState<'initials' | 'rolling' | 'avatars'>('initials')
+    const [selected, setSelected] = useState<string | null>(initial)
+    const [offer, setOffer] = useState<string[]>([])
+    const [columns, setColumns] = useState(3)
+    const [saving, setSaving] = useState(false)
+    const savingRef = useRef(false)
+    const rowRef = useRef<HTMLDivElement>(null)
+    const titleRef = useRef<HTMLHeadingElement>(null)
+    const wasOpen = useRef(false)
+    const openedFor = useRef<string | undefined>(undefined)
 
-    // The tile moves on tap; the slot behind the drawer moves after fetchUser
-    // lands. `pending` overrides `saved` while a burst drains. Saves are
-    // SERIALIZED: one POST at a time, always the latest tap next, so the
-    // server can never commit an older key last. One refetch per burst, in
-    // a finally, so a thrown save cannot wedge the picker.
-    const [pending, setPending] = useState<string | null | undefined>(undefined)
-    const wanted = useRef<string | null | undefined>(undefined)
-    const draining = useRef(false)
-    const pick = pending === undefined ? saved : pending
+    useEffect(() => {
+        if (open && (!wasOpen.current || openedFor.current !== username)) {
+            setPhase('initials')
+            setSelected(initial)
+            if (rowRef.current) rowRef.current.scrollLeft = 0
+        }
+        wasOpen.current = open
+        openedFor.current = username
+    }, [open, initial, username])
 
-    const drain = async () => {
-        draining.current = true
+    useEffect(() => {
+        if (!open) return
+        const resize = () =>
+            setColumns(
+                avatarGridColumns(window.innerWidth, window.visualViewport?.height ?? window.innerHeight, available)
+            )
+        resize()
+        window.addEventListener('resize', resize)
+        window.visualViewport?.addEventListener('resize', resize)
+        return () => {
+            window.removeEventListener('resize', resize)
+            window.visualViewport?.removeEventListener('resize', resize)
+        }
+    }, [open, available])
+
+    useEffect(() => {
+        if (phase === 'avatars') titleRef.current?.focus()
+    }, [phase])
+
+    const save = async () => {
+        if (!userId || savingRef.current) return
+        savingRef.current = true
+        setSaving(true)
+        let accepted = false
         try {
-            // a tap that lands while the refetch is in flight queues on
-            // `wanted`; drain again rather than drop it with the finally
-            do {
-                while (wanted.current !== undefined) {
-                    const key = wanted.current
-                    wanted.current = undefined
-                    try {
-                        const { error } = await updateUserById({ userId, avatarKey: key })
-                        if (error) rememberOrReport(key)
-                        // the server now holds the pick, so a mirror could only
-                        // shadow it — this is also what promotes a letter to the
-                        // durable copy the day the API starts accepting one
-                        else storeLetterAvatar(userId, null)
-                    } catch {
-                        rememberOrReport(key)
-                    }
-                }
+            const result = await updateUserById({ userId, avatarKey: selected })
+            if (result.error) throw new Error(result.error)
+            storeLetterAvatar(userId, null)
+            accepted = true
+        } catch {
+            if (isLetterAvatarKey(selected)) {
+                storeLetterAvatar(userId, selected, user?.user.avatarKey ?? null)
+                accepted = true
+            } else toast({ type: 'error', message: t('saveFailed') })
+        }
+        try {
+            if (accepted) {
                 await fetchUser()
-            } while (wanted.current !== undefined)
+                onOpenChange(false)
+            }
+        } catch {
+            toast({ type: 'error', message: t('saveFailed') })
         } finally {
-            draining.current = false
-            setPending(undefined)
+            savingRef.current = false
+            setSaving(false)
         }
     }
 
-    /**
-     * A rejected letter is not a user-facing failure: the pick is kept on this
-     * device and upgrades itself on the next write the server does accept. A
-     * rejected sticker has nowhere to go, so it still reports.
-     */
-    const rememberOrReport = (key: string | null) => {
-        // stamped with the server key it stands in for, so a pick made on another
-        // device supersedes it as soon as this one refetches
-        if (isLetterAvatarKey(key)) storeLetterAvatar(userId, key, user?.user.avatarKey ?? null)
-        else toast({ type: 'error', message: t('saveFailed') })
+    const roll = () => {
+        setSelected(null)
+        setOffer(dealAvatars(unlocked, 16))
+        setPhase('rolling')
     }
-
-    const save = (key: string | null) => {
-        if (!userId) return
-        setPending(key)
-        wanted.current = key
-        if (!draining.current) void drain()
-    }
-
-    const letters = letterAvatarKeys()
-
-    // the offered row of five basics: dealt on open, redealt by the dice
-    const [offer, setOffer] = useState<string[]>([])
-    useEffect(() => {
-        if (open) setOffer(offerBasics(saved))
-        // deal once per open; the pick joins the row by being picked from it
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [open])
-    const rollDice = () => setOffer(offerBasics(pick))
-
-    // human labels: "Bug Whisperer · beetle" for a badge avatar, the slug for a basic
-    const label = (key: string) => {
+    const label = (key: string | null) => {
+        if (!key) return username?.trim()[0]?.toUpperCase() ?? t('initials')
         const [kind, code, slug] = key.split('.')
-        if (kind === 'badge') return `${badgeName[code] ?? code} · ${slug}`
-        return kind === 'letter' ? code.toUpperCase() : code
+        return kind === 'letter' ? code.toUpperCase() : (slug ?? code).replaceAll('-', ' ')
     }
-
-    // Five columns for every group, initials included. Seven fitted the 26
-    // letters in four rows but left ~42px per track at 375px and ~34px at 320px,
-    // under both the 48px tile and the 44px touch target — and the roving helper
-    // steps by AVATAR_PICKER_COLUMNS, so a second column count would also have
-    // desynced arrow keys from the visual rows.
-    const tiles = (keys: string[], groupLabel: string) => {
-        const focusIndex = Math.max(0, keys.indexOf(pick ?? ''))
-        return (
-            <div
-                role="radiogroup"
-                aria-label={groupLabel}
-                className="grid grid-cols-5 gap-2"
-                onKeyDown={roveAvatarTiles}
-            >
-                {keys.map((key, index) => {
-                    const checked = key === pick
-                    return (
-                        <button
-                            key={key}
-                            type="button"
-                            role="radio"
-                            aria-checked={checked}
-                            aria-label={label(key)}
-                            tabIndex={index === focusIndex ? 0 : -1}
-                            onClick={() => save(key)}
-                            className={twMerge(
-                                'flex min-h-11 items-center justify-center rounded-sm border border-border-disabled bg-background-default p-1 focus-visible:outline-[3px] focus-visible:outline-action-focus',
-                                checked && 'border-2 border-border-default shadow-4'
-                            )}
-                        >
-                            <UserAvatar name={username} avatarKey={key} size="small" />
-                        </button>
-                    )
-                })}
-            </div>
-        )
-    }
+    const keys = phase === 'initials' ? orderedLetters : offer.slice(0, columns * columns)
+    const focusIndex = Math.max(0, keys.indexOf(selected))
 
     return (
-        <Drawer open={open} onOpenChange={onOpenChange}>
-            {/* The horizontal padding belongs to the SCROLL AREA, not to the panel
-                around it: the panel's padding sits outside the overflow-auto box,
-                so a w-full button's 4px offset shadow fell past the scroll edge
-                and got clipped. The matching pb-2 below covers the bottom. */}
-            <DrawerContent className="py-4" scrollAreaClassName="px-4">
-                <DrawerHeader className="p-0 pb-4 text-left">
-                    <DrawerTitle className="text-heading-s text-foreground-primary">{t('title')}</DrawerTitle>
-                    <DrawerDescription>{t('description')}</DrawerDescription>
-                </DrawerHeader>
-                <div className="flex flex-col gap-6 pb-2">
-                    <section className="flex flex-col gap-2">
-                        <div className="text-label-m text-foreground-secondary uppercase">{t('initials')}</div>
-                        {tiles(letters, t('initials'))}
-                    </section>
-                    <section className="flex flex-col gap-2">
-                        <div className="flex items-baseline justify-between text-label-m text-foreground-secondary uppercase">
-                            <span>{t('fromBadges')}</span>
-                            {unlocked.length > 0 && (
-                                <span className="normal-case">{t('unlocked', { count: unlocked.length })}</span>
-                            )}
-                        </div>
-                        {unlocked.length > 0 ? (
-                            tiles(unlocked, t('fromBadges'))
-                        ) : (
-                            <p className="text-body-s text-foreground-secondary">{t('noBadgeAvatars')}</p>
+        <Drawer
+            open={open}
+            onOpenChange={(next) => {
+                if (!savingRef.current) onOpenChange(next)
+            }}
+            hideBottomNav
+            shouldScaleBackground={false}
+        >
+            <DrawerContent
+                className={phase === 'rolling' ? styles.fullscreen : 'py-4'}
+                scrollAreaClassName={phase === 'rolling' ? styles.rollArea : 'px-4'}
+            >
+                {phase === 'rolling' ? (
+                    <>
+                        <DrawerTitle className="sr-only">{t('rolling')}</DrawerTitle>
+                        {open && (
+                            <DiceRoll onComplete={() => setPhase('avatars')} onCancel={() => onOpenChange(false)} />
                         )}
-                    </section>
-                    <section className="flex flex-col gap-2">
-                        <div className="text-label-m text-foreground-secondary uppercase">{t('basics')}</div>
-                        {tiles(offer, t('basics'))}
-                    </section>
-                    <div className="flex flex-col gap-2">
-                        <Button variant="stroke" className="w-full" onClick={rollDice}>
-                            {t('rollDice')}
-                        </Button>
-                        <Button variant="purple" className="w-full" onClick={() => onOpenChange(false)}>
-                            {tCommon('done')}
-                        </Button>
+                    </>
+                ) : (
+                    <div className={twMerge(styles.picker, columns === 4 && styles.fourColumns)}>
+                        <DrawerHeader className="p-0 pb-4 text-left">
+                            <DrawerTitle
+                                ref={titleRef}
+                                tabIndex={-1}
+                                className="text-heading-s text-foreground-primary outline-none"
+                            >
+                                {phase === 'initials' ? t('initials') : t('chooseAvatar')}
+                            </DrawerTitle>
+                        </DrawerHeader>
+                        <div
+                            ref={rowRef}
+                            role="radiogroup"
+                            aria-label={phase === 'initials' ? t('initials') : t('chooseAvatar')}
+                            className={phase === 'initials' ? styles.initials : styles.grid}
+                            data-vaul-no-drag
+                            onKeyDown={(event) => roveAvatarTiles(event, phase === 'initials' ? 1 : columns)}
+                        >
+                            {keys.map((key, index) => (
+                                <button
+                                    key={key ?? 'initial'}
+                                    type="button"
+                                    role="radio"
+                                    aria-label={label(key)}
+                                    aria-checked={key === selected}
+                                    tabIndex={index === focusIndex ? 0 : -1}
+                                    disabled={saving}
+                                    onClick={() => setSelected(key)}
+                                    className={twMerge(
+                                        styles.tile,
+                                        'rounded-sm border border-border-disabled bg-background-default focus-visible:outline-[3px] focus-visible:outline-action-focus',
+                                        key === selected && 'border-2 border-border-default'
+                                    )}
+                                >
+                                    <UserAvatar name={username} avatarKey={key} size="small" className={styles.art} />
+                                </button>
+                            ))}
+                        </div>
+                        <div className="flex flex-col gap-2 pt-4 pb-2">
+                            <Button
+                                variant="purple"
+                                className="w-full"
+                                disabled={saving || !userId || (phase === 'avatars' && !keys.includes(selected))}
+                                loading={saving}
+                                onClick={() => void save()}
+                            >
+                                {phase === 'initials' ? t('useInitial') : t('useAvatar')}
+                            </Button>
+                            <span className="text-center text-body-s text-foreground-secondary">{tCommon('or')}</span>
+                            <Button variant="stroke" className="w-full" disabled={saving} onClick={roll}>
+                                {t('rollDice')}
+                            </Button>
+                        </div>
                     </div>
-                </div>
+                )}
             </DrawerContent>
         </Drawer>
     )

--- a/src/components/Avatar/DiceRoll.tsx
+++ b/src/components/Avatar/DiceRoll.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useTranslations } from 'next-intl'
+import { impactHaptic, heavyImpactHaptic, cancelHaptic } from '@/utils/haptics'
+import styles from './AvatarPicker.module.css'
+
+const PIPS = [[5], [1, 9], [1, 5, 9], [1, 3, 7, 9], [1, 3, 5, 7, 9], [1, 3, 4, 6, 7, 9]]
+export const DICE_ROLL_MS = 2400
+
+export function DiceRoll({ onComplete, onCancel }: { onComplete: () => void; onCancel: () => void }) {
+    const t = useTranslations('avatar')
+    const completeRef = useRef(onComplete)
+    completeRef.current = onComplete
+    useEffect(() => {
+        const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        const pulses = reduced
+            ? []
+            : [180, 430, 720, 1080, 1510, 1900].map((delay, index) =>
+                  window.setTimeout(() => {
+                      if (index === 5) heavyImpactHaptic()
+                      else impactHaptic()
+                  }, delay)
+              )
+        const done = window.setTimeout(() => completeRef.current(), reduced ? 200 : DICE_ROLL_MS)
+        return () => {
+            pulses.forEach(window.clearTimeout)
+            window.clearTimeout(done)
+            cancelHaptic()
+        }
+    }, [])
+    return (
+        <div className={styles.rollStage}>
+            <button type="button" className={styles.close} onClick={onCancel} aria-label={t('cancelRoll')}>
+                ×
+            </button>
+            <div className={styles.halo} aria-hidden="true" />
+            <div className={styles.orbit} aria-hidden="true" />
+            <div className={styles.scene} aria-hidden="true">
+                <div className={styles.bounce}>
+                    <div className={styles.die}>
+                        {PIPS.map((pips, face) => (
+                            <div key={face} className={styles.face} data-face={face}>
+                                {Array.from({ length: 9 }, (_, cell) => (
+                                    <span key={cell} className={pips.includes(cell + 1) ? styles.pip : undefined} />
+                                ))}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                <div className={styles.shadow} />
+            </div>
+            <div className={styles.rollCopy} role="status">
+                <p className="text-heading-l">{t('rolling')}</p>
+                <p className="mt-3 text-body-m">{t('rollingHint')}</p>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Avatar/DiceRoll.tsx
+++ b/src/components/Avatar/DiceRoll.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { impactHaptic, heavyImpactHaptic, cancelHaptic } from '@/utils/haptics'
 import styles from './AvatarPicker.module.css'
+import { Icon } from '@/components/Global/Icons/Icon'
 
 const PIPS = [[5], [1, 9], [1, 5, 9], [1, 3, 7, 9], [1, 3, 5, 7, 9], [1, 3, 4, 6, 7, 9]]
 export const DICE_ROLL_MS = 2400
@@ -32,7 +33,7 @@ export function DiceRoll({ onComplete, onCancel }: { onComplete: () => void; onC
     return (
         <div className={styles.rollStage}>
             <button type="button" className={styles.close} onClick={onCancel} aria-label={t('cancelRoll')}>
-                ×
+                <Icon name="cancel" size={20} />
             </button>
             <div className={styles.halo} aria-hidden="true" />
             <div className={styles.orbit} aria-hidden="true" />

--- a/src/components/Avatar/DiceRoll.tsx
+++ b/src/components/Avatar/DiceRoll.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { impactHaptic, heavyImpactHaptic, cancelHaptic } from '@/utils/haptics'
 import styles from './AvatarPicker.module.css'
 import { Icon } from '@/components/Global/Icons/Icon'
+import { Button } from '@/components/0_Bruddle/Button'
 
 const PIPS = [[5], [1, 9], [1, 5, 9], [1, 3, 7, 9], [1, 3, 5, 7, 9], [1, 3, 4, 6, 7, 9]]
 export const DICE_ROLL_MS = 2400
@@ -17,7 +18,7 @@ export function DiceRoll({ onComplete, onCancel }: { onComplete: () => void; onC
         const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
         const pulses = reduced
             ? []
-            : [180, 430, 720, 1080, 1510, 1900].map((delay, index) =>
+            : [180, 430, 720, 1080, 1510, 1920].map((delay, index) =>
                   window.setTimeout(() => {
                       if (index === 5) heavyImpactHaptic()
                       else impactHaptic()
@@ -32,11 +33,15 @@ export function DiceRoll({ onComplete, onCancel }: { onComplete: () => void; onC
     }, [])
     return (
         <div className={styles.rollStage}>
-            <button type="button" className={styles.close} onClick={onCancel} aria-label={t('cancelRoll')}>
+            <Button
+                variant="stroke"
+                shape="square"
+                className={styles.close}
+                onClick={onCancel}
+                aria-label={t('cancelRoll')}
+            >
                 <Icon name="cancel" size={20} />
-            </button>
-            <div className={styles.halo} aria-hidden="true" />
-            <div className={styles.orbit} aria-hidden="true" />
+            </Button>
             <div className={styles.scene} aria-hidden="true">
                 <div className={styles.bounce}>
                     <div className={styles.die}>
@@ -50,6 +55,12 @@ export function DiceRoll({ onComplete, onCancel }: { onComplete: () => void; onC
                     </div>
                 </div>
                 <div className={styles.shadow} />
+                <div className={styles.impact}>
+                    <i />
+                    <i />
+                    <i />
+                    <i />
+                </div>
             </div>
             <div className={styles.rollCopy} role="status">
                 <p className="text-heading-l">{t('rolling')}</p>

--- a/src/components/Avatar/__tests__/AvatarPicker.test.tsx
+++ b/src/components/Avatar/__tests__/AvatarPicker.test.tsx
@@ -33,38 +33,6 @@ let mockUser: {
 }
 jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: mockUser, fetchUser: mockFetchUser }) }))
 
-const radio = (key: string) => screen.getByRole('radio', { name: key })
-const A = 'Bug Whisperer · beetle'
-const B = 'Bug Whisperer · shell'
-const KEY_A = 'badge.BUG_WHISPERER.beetle'
-const KEY_B = 'badge.BUG_WHISPERER.shell'
-
-// A server model: every POST is recorded in order and settled by hand, in any
-// order; the last write the server COMMITS is what the refetch hands back.
-type Settle = (result: { data?: object; error?: string }) => void
-function fakeServer() {
-    const posts: { key: string | null; resolve: Settle; reject: (e: Error) => void }[] = []
-    let committed: string | null = null
-    mockUpdateUserById.mockImplementation(
-        ({ avatarKey }: { avatarKey: string | null }) =>
-            new Promise((resolve, reject) => posts.push({ key: avatarKey, resolve, reject }))
-    )
-    mockFetchUser.mockImplementation(async () => {
-        mockUser.user.avatarKey = committed
-        return null
-    })
-    return {
-        posts,
-        committed: () => committed,
-        settle: (i: number, result: { data?: object; error?: string } = { data: {} }) =>
-            act(async () => {
-                if (!result.error) committed = posts[i].key
-                posts[i].resolve(result)
-            }),
-        reject: (i: number) => act(async () => posts[i].reject(new Error('network'))),
-    }
-}
-
 beforeEach(() => {
     jest.clearAllMocks()
     window.localStorage.clear()
@@ -80,218 +48,93 @@ beforeEach(() => {
         },
     }
 })
+jest.mock('../DiceRoll', () => ({
+    DiceRoll: ({ onComplete }: { onComplete: () => void }) => <button onClick={onComplete}>Finish roll</button>,
+}))
+const roll = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Roll the dice' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Finish roll' }))
+}
 
-describe('AvatarPicker', () => {
-    it('lists one row of five basics and only the avatars of badges the user holds', () => {
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        // scoped per group: the 26 initials are always on top of these
-        expect(
-            screen.getByRole('radiogroup', { name: 'From your badges' }).querySelectorAll('[role="radio"]')
-        ).toHaveLength(3)
-        // human labels, not keys: badge name + slug, or the slug alone
-        expect(radio(A)).toBeInTheDocument()
-        expect(screen.getByRole('radiogroup', { name: 'Basics' }).querySelectorAll('[role="radio"]')).toHaveLength(5)
-        expect(screen.queryByRole('radio', { name: /Offramp/ })).not.toBeInTheDocument()
-        expect(screen.getByRole('radiogroup', { name: 'From your badges' })).toBeInTheDocument()
-    })
-
-    it('tells a user with no badges where avatars come from', () => {
-        mockUser.user.badges = []
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        expect(screen.getByRole('radiogroup', { name: 'Basics' }).querySelectorAll('[role="radio"]')).toHaveLength(5)
-        expect(screen.getByText('Earn a badge and its avatars appear here.')).toBeInTheDocument()
-    })
-
-    it('saves a tap at once and refreshes the user', async () => {
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(B))
-
-        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
-        expect(mockUpdateUserById).toHaveBeenCalledWith({ userId: 'u1', avatarKey: KEY_B })
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-    })
-
-    it('snaps back and says so when the save fails', async () => {
-        mockUser.user.avatarKey = KEY_A
-        mockUpdateUserById.mockResolvedValue({ error: 'Avatar not unlocked' })
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(B))
-
-        await waitFor(() => expect(radio(A)).toHaveAttribute('aria-checked', 'true'))
-        expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }))
-        // the server is the truth after a burst, failed or not
-        expect(mockFetchUser).toHaveBeenCalledTimes(1)
-    })
-
-    // Chip (#2929): saves are serialized, so the server can never commit an
-    // older key last, whatever order the responses come back in.
-    it('sends one save at a time, always the latest tap next, and the server ends on the last tap', async () => {
-        const server = fakeServer()
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(A))
-        fireEvent.click(radio(B))
-
-        // (a) the second POST is not sent before the first settles
-        expect(server.posts.map((p) => p.key)).toEqual([KEY_A])
-        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
-
-        await server.settle(0)
-        expect(server.posts.map((p) => p.key)).toEqual([KEY_A, KEY_B])
-        expect(mockFetchUser).not.toHaveBeenCalled()
-
-        await server.settle(1)
-
-        // (b) the server's last write is the last tap, refetched once
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-        expect(server.committed()).toBe(KEY_B)
-        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
-        expect(radio(A)).toHaveAttribute('aria-checked', 'false')
-    })
-
-    it('a tap during the closing refetch is sent, not dropped', async () => {
-        const server = fakeServer()
-        // hold the refetch open so a tap can land while it is in flight
-        let releaseFetch: () => void = () => {}
-        mockFetchUser.mockImplementation(
-            () =>
-                new Promise<null>((resolve) => {
-                    releaseFetch = () => {
-                        mockUser.user.avatarKey = server.committed()
-                        resolve(null)
-                    }
-                })
-        )
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(A))
-        await server.settle(0)
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-
-        fireEvent.click(radio(B))
-        expect(server.posts.map((p) => p.key)).toEqual([KEY_A])
-        await act(async () => releaseFetch())
-
-        // the queued tap drains after the refetch: B is posted, committed, refetched
-        await waitFor(() => expect(server.posts.map((p) => p.key)).toEqual([KEY_A, KEY_B]))
-        await server.settle(1)
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(2))
-        await act(async () => releaseFetch())
-        expect(server.committed()).toBe(KEY_B)
-        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
-    })
-
-    it('a rejected first save still lets the second go through and clears pending', async () => {
-        const server = fakeServer()
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(A))
-        fireEvent.click(radio(B))
-        await server.reject(0)
-
-        expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }))
-        expect(server.posts.map((p) => p.key)).toEqual([KEY_A, KEY_B])
-
-        await server.settle(1)
-
-        await waitFor(() => expect(mockFetchUser).toHaveBeenCalledTimes(1))
-        expect(server.committed()).toBe(KEY_B)
-        expect(radio(B)).toHaveAttribute('aria-checked', 'true')
-        // pending is cleared: a later refetch that says otherwise wins
-        mockUser.user.avatarKey = KEY_A
-        fireEvent.click(screen.getByRole('button', { name: 'Roll the dice' }))
-        expect(radio(A)).toHaveAttribute('aria-checked', 'true')
-    })
-
-    it('the dice redeals the basics row and never changes the pick', () => {
-        mockUser.user.avatarKey = 'basic.apple'
-        const random = jest.spyOn(Math, 'random').mockReturnValue(0)
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-        const rowOf = () =>
-            Array.from(screen.getByRole('radiogroup', { name: 'Basics' }).querySelectorAll('[role="radio"]')).map(
-                (el) => el.getAttribute('aria-label')
-            )
-        const before = rowOf()
-
-        random.mockReturnValue(0.99)
-        act(() => fireEvent.click(screen.getByRole('button', { name: 'Roll the dice' })))
-
-        expect(rowOf()).not.toEqual(before)
-        expect(rowOf()).toContain('apple')
-        expect(radio('apple')).toHaveAttribute('aria-checked', 'true')
-        expect(mockUpdateUserById).not.toHaveBeenCalled()
-        random.mockRestore()
-    })
-
-    it('offers every letter as its own pick, ahead of the sticker groups', () => {
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-        const groups = screen.getAllByRole('radiogroup').map((el) => el.getAttribute('aria-label'))
-
-        expect(groups[0]).toBe('Initials')
-        expect(screen.getByRole('radiogroup', { name: 'Initials' }).querySelectorAll('[role="radio"]')).toHaveLength(26)
-        expect(screen.getByRole('radio', { name: 'A' })).toBeInTheDocument()
-        expect(screen.getByRole('radio', { name: 'Z' })).toBeInTheDocument()
-    })
-
-    it('keeps a letter this API build still rejects, on the device, without an error toast', async () => {
-        const server = fakeServer()
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(screen.getByRole('radio', { name: 'K' }))
-        await server.settle(0, { error: 'body/avatarKey must match pattern' })
-
-        // the pick survives the rejection and the user is not told off for it
-        await waitFor(() => expect(readLetterAvatar('u1')?.key).toBe('letter.k'))
-        expect(mockToast).not.toHaveBeenCalled()
-        await waitFor(() => expect(radio('K')).toHaveAttribute('aria-checked', 'true'))
-    })
-
-    it('still reports a rejected sticker — those have no device-local fallback', async () => {
-        const server = fakeServer()
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(radio(A))
-        await server.settle(0, { error: 'Avatar not unlocked' })
-
-        expect(mockToast).toHaveBeenCalledWith({ type: 'error', message: 'Could not save your avatar. Try again.' })
-        expect(readLetterAvatar('u1')).toBeNull()
-    })
-
-    it('a server write that lands drops the mirror, so the durable copy wins', async () => {
-        const server = fakeServer()
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(screen.getByRole('radio', { name: 'K' }))
-        await server.settle(0, { error: 'body/avatarKey must match pattern' })
-        await waitFor(() => expect(readLetterAvatar('u1')?.key).toBe('letter.k'))
-
-        // the API now accepts it (peanut-api-ts#1529 deployed)
-        fireEvent.click(screen.getByRole('radio', { name: 'M' }))
-        await server.settle(1)
-
-        await waitFor(() => expect(readLetterAvatar('u1')).toBeNull())
-        expect(server.committed()).toBe('letter.m')
-    })
-
-    it('a letter is a real pick, not a clear back to the username initial', () => {
-        mockUser.user.avatarKey = 'basic.apple'
-        renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
-
-        fireEvent.click(screen.getByRole('radio', { name: 'K' }))
-
-        expect(mockUpdateUserById).toHaveBeenCalledWith({ userId: 'u1', avatarKey: 'letter.k' })
-    })
-
-    it('closes on done', () => {
-        const onOpenChange = jest.fn()
-        renderWithIntl(<AvatarPicker open onOpenChange={onOpenChange} />)
-
-        fireEvent.click(screen.getByRole('button', { name: 'Done' }))
-
-        expect(onOpenChange).toHaveBeenCalledWith(false)
-    })
+it('starts with the username initial selected at the left of a single row', () => {
+    renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+    const letters = screen.getAllByRole('radio')
+    expect(letters).toHaveLength(26)
+    expect(letters[0]).toHaveAttribute('aria-label', 'S')
+    expect(letters[0]).toHaveAttribute('aria-checked', 'true')
+    expect(mockUpdateUserById).not.toHaveBeenCalled()
+})
+it('stages a letter and saves only on confirmation', async () => {
+    const close = jest.fn()
+    renderWithIntl(<AvatarPicker open onOpenChange={close} />)
+    fireEvent.click(screen.getByRole('radio', { name: 'K' }))
+    expect(mockUpdateUserById).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Use the Initial' }))
+    await waitFor(() => expect(close).toHaveBeenCalledWith(false))
+    expect(mockUpdateUserById).toHaveBeenCalledWith({ userId: 'u1', avatarKey: 'letter.k' })
+    expect(mockFetchUser).toHaveBeenCalledTimes(1)
+})
+it('deals a square of distinct non-letter art after animation and requires selection', async () => {
+    const close = jest.fn()
+    renderWithIntl(<AvatarPicker open onOpenChange={close} />)
+    roll()
+    const options = screen.getAllByRole('radio')
+    expect([9, 16, 25]).toContain(options.length)
+    const images = options.map((el) => el.querySelector('img')!.getAttribute('src'))
+    expect(new Set(images).size).toBe(images.length)
+    expect(images.every((src) => !src?.includes('/letter/'))).toBe(true)
+    const use = screen.getByRole('button', { name: 'Use the Avatar' })
+    expect(use).toBeDisabled()
+    fireEvent.click(options[0])
+    expect(use).toBeEnabled()
+    expect(mockUpdateUserById).not.toHaveBeenCalled()
+    fireEvent.click(use)
+    await waitFor(() => expect(close).toHaveBeenCalledWith(false))
+})
+it('reroll clears selection without saving', () => {
+    renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+    roll()
+    fireEvent.click(screen.getAllByRole('radio')[0])
+    roll()
+    expect(screen.getByRole('button', { name: 'Use the Avatar' })).toBeDisabled()
+    expect(mockUpdateUserById).not.toHaveBeenCalled()
+})
+it('keeps rejected letters in the existing device mirror', async () => {
+    mockUpdateUserById.mockResolvedValue({ error: 'unsupported letter' })
+    renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Use the Initial' }))
+    await waitFor(() => expect(readLetterAvatar('u1')?.key).toBe('letter.s'))
+    expect(mockToast).not.toHaveBeenCalled()
+})
+it('reports a rejected avatar and keeps the drawer open for retry', async () => {
+    mockUpdateUserById.mockRejectedValue(new Error('offline'))
+    const close = jest.fn()
+    renderWithIntl(<AvatarPicker open onOpenChange={close} />)
+    roll()
+    fireEvent.click(screen.getAllByRole('radio')[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Use the Avatar' }))
+    await waitFor(() => expect(mockToast).toHaveBeenCalled())
+    expect(close).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Use the Avatar' })).toBeEnabled()
+})
+it('prevents duplicate confirmation requests', async () => {
+    let resolve!: (value: object) => void
+    mockUpdateUserById.mockReturnValue(
+        new Promise((r) => {
+            resolve = r
+        })
+    )
+    renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+    const use = screen.getByRole('button', { name: 'Use the Initial' })
+    fireEvent.click(use)
+    fireEvent.click(use)
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(1)
+    await act(async () => resolve({ data: {} }))
+})
+it('resets to the initial when reopened', () => {
+    const { rerender } = renderWithIntl(<AvatarPicker open onOpenChange={jest.fn()} />)
+    roll()
+    rerender(<AvatarPicker open={false} onOpenChange={jest.fn()} />)
+    rerender(<AvatarPicker open onOpenChange={jest.fn()} />)
+    expect(screen.getByRole('radio', { name: 'S' })).toHaveAttribute('aria-checked', 'true')
 })

--- a/src/components/Avatar/__tests__/DiceRoll.test.tsx
+++ b/src/components/Avatar/__tests__/DiceRoll.test.tsx
@@ -1,0 +1,36 @@
+import { act } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { DiceRoll, DICE_ROLL_MS } from '../DiceRoll'
+import { impactHaptic, heavyImpactHaptic, cancelHaptic } from '@/utils/haptics'
+jest.mock('@/utils/haptics', () => ({ impactHaptic: jest.fn(), heavyImpactHaptic: jest.fn(), cancelHaptic: jest.fn() }))
+beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false })
+})
+afterEach(() => jest.useRealTimers())
+it('syncs haptics with the tumble and completes once', () => {
+    const done = jest.fn()
+    renderWithIntl(<DiceRoll onComplete={done} onCancel={jest.fn()} />)
+    act(() => jest.advanceTimersByTime(DICE_ROLL_MS))
+    expect(impactHaptic).toHaveBeenCalledTimes(5)
+    expect(heavyImpactHaptic).toHaveBeenCalledTimes(1)
+    expect(done).toHaveBeenCalledTimes(1)
+})
+it('cancels all scheduled work when closed', () => {
+    const done = jest.fn()
+    const { unmount } = renderWithIntl(<DiceRoll onComplete={done} onCancel={jest.fn()} />)
+    unmount()
+    act(() => jest.runAllTimers())
+    expect(done).not.toHaveBeenCalled()
+    expect(impactHaptic).not.toHaveBeenCalled()
+    expect(cancelHaptic).toHaveBeenCalled()
+})
+it('skips the tumble and pulses for reduced motion', () => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true })
+    const done = jest.fn()
+    renderWithIntl(<DiceRoll onComplete={done} onCancel={jest.fn()} />)
+    act(() => jest.advanceTimersByTime(200))
+    expect(done).toHaveBeenCalledTimes(1)
+    expect(impactHaptic).not.toHaveBeenCalled()
+})

--- a/src/components/Avatar/__tests__/avatarDeal.test.ts
+++ b/src/components/Avatar/__tests__/avatarDeal.test.ts
@@ -1,0 +1,20 @@
+import { avatarGridColumns, avatarSrc, badgeAvatarKeys, dealAvatars } from '../avatar.utils'
+it('deals only unique eligible art, even with duplicate badges or letters in input', () => {
+    const unlocked = badgeAvatarKeys(['BUG_WHISPERER', 'BUG_WHISPERER'])
+    for (let seed = 1; seed <= 30; seed++) {
+        let state = seed
+        const random = () => ((state = (state * 16807) % 2147483647) - 1) / 2147483646
+        const hand = dealAvatars([...unlocked, 'letter.a', 'unknown'], 16, random)
+        expect(hand).toHaveLength(16)
+        expect(new Set(hand.map(avatarSrc)).size).toBe(16)
+        expect(hand.some((key) => unlocked.includes(key))).toBe(true)
+        expect(hand.some((key) => key.startsWith('letter.'))).toBe(false)
+    }
+})
+it('fits square grids to viewport and eligible pool', () => {
+    expect(avatarGridColumns(320, 568, 40)).toBe(3)
+    expect(avatarGridColumns(393, 852, 40)).toBe(4)
+    expect(avatarGridColumns(430, 932, 40)).toBe(4)
+    expect(avatarGridColumns(1440, 1080, 20)).toBe(4)
+    expect(dealAvatars([], 25)).toHaveLength(20)
+})

--- a/src/components/Avatar/avatar.utils.ts
+++ b/src/components/Avatar/avatar.utils.ts
@@ -54,6 +54,42 @@ export function offerBasics(pick: string | null, n = 5, random: () => number = M
     return [...keep, ...rest].slice(0, n)
 }
 
+const distinctArt = (keys: readonly string[]): string[] => {
+    const taken = new Set<string>()
+    return keys.filter((key) => {
+        const src = avatarSrc(key)
+        if (!src || taken.has(src)) return false
+        taken.add(src)
+        return true
+    })
+}
+
+/** PR #3014's art-deduped deal, adapted to a square, non-letter hand. */
+export function dealAvatars(unlocked: readonly string[], count: number, random: () => number = Math.random): string[] {
+    const deck = distinctArt([...basicAvatarKeys(), ...unlocked]).filter((key) => !key.startsWith('letter.'))
+    const earned = deck.filter((key) => unlocked.includes(key))
+    const hand: string[] = earned.length ? [earned[Math.floor(random() * earned.length)]] : []
+    const rest = deck.filter((key) => !hand.includes(key))
+    while (hand.length < count && rest.length) hand.push(rest.splice(Math.floor(random() * rest.length), 1)[0])
+    for (let i = hand.length - 1; i > 0; i--) {
+        const j = Math.floor(random() * (i + 1))
+        ;[hand[i], hand[j]] = [hand[j], hand[i]]
+    }
+    return hand
+}
+
+export function avatarGridColumns(width: number, height: number, available: number): number {
+    return Math.max(
+        3,
+        Math.min(
+            4,
+            Math.floor((Math.min(width, 576) - 24) / 80),
+            Math.floor((height * 0.8 - 220) / 80),
+            Math.floor(Math.sqrt(available))
+        )
+    )
+}
+
 /** Public path of the avatar art, or null for a key the manifest does not know. */
 export function avatarSrc(key: string | null | undefined): string | null {
     if (!key) return null

--- a/src/components/Avatar/avatarPicker.utils.ts
+++ b/src/components/Avatar/avatarPicker.utils.ts
@@ -1,14 +1,12 @@
 import type { KeyboardEvent } from 'react'
 
-export const AVATAR_PICKER_COLUMNS = 5
-
 /** One tab stop per radiogroup; arrows move between tiles and wrap. */
-export function roveAvatarTiles(event: KeyboardEvent<HTMLDivElement>): void {
+export function roveAvatarTiles(event: KeyboardEvent<HTMLDivElement>, columns: number): void {
     const step = {
         ArrowRight: 1,
         ArrowLeft: -1,
-        ArrowDown: AVATAR_PICKER_COLUMNS,
-        ArrowUp: -AVATAR_PICKER_COLUMNS,
+        ArrowDown: columns,
+        ArrowUp: -columns,
     }[event.key]
     if (!step) return
     const radios = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]'))

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -150,6 +150,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 {sumsubFlow.error && <Notification priority="error">{sumsubFlow.error}</Notification>}
             </div>
             <InitiateKycModal
+                cooldownActive={!!sumsubFlow.errorCooldown}
                 prepPath="extended"
                 visible={showKycModal}
                 onClose={() => setShowKycModal(false)}

--- a/src/components/Claim/Link/MantecaFlowManager.tsx
+++ b/src/components/Claim/Link/MantecaFlowManager.tsx
@@ -192,7 +192,7 @@ const MantecaFlowManager: FC<MantecaFlowManagerProps> = ({ claimLinkData, amount
                 reasonCode={mantecaRejection.reasonCode ?? undefined}
                 regionName={selectedCountry ? localizedCountryTitle(locale, selectedCountry) : undefined}
             />
-            <SumsubKycModals flow={sumsubFlow} />
+            <SumsubKycModals flow={sumsubFlow} onCooldownClose={() => setShowKycModal(false)} />
         </div>
     )
 }

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -317,36 +317,39 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     // claim path refuses inside handleSuccess, and the modal has to exist where
     // that refusal happens or the submit is a silent no-op.
     const kycModal = (
-        <InitiateKycModal
-            cooldownActive={!!sumsubFlow.errorCooldown}
-            visible={showKycModal}
-            onClose={() => setShowKycModal(false)}
-            onVerify={async () => {
-                if (gate.kind === 'restart-identity') {
-                    await sumsubFlow.handleRestartIdentity()
-                } else if (gate.kind === 'fixable-rejection') {
-                    await sumsubFlow.handleSelfHealResubmit('BRIDGE')
-                } else {
-                    await sumsubFlow.handleInitiateKyc(
-                        bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
-                        undefined,
-                        gate.kind === 'needs-enrollment' || undefined,
-                        selectedCountry?.id
-                    )
-                }
-                // only close if sdk opened — if it errored, keep modal open to show error
-                if (sumsubFlow.showWrapper) setShowKycModal(false)
-            }}
-            onContactSupport={() => {
-                setShowKycModal(false)
-                setIsSupportModalOpen(true)
-            }}
-            isLoading={sumsubFlow.isLoading}
-            error={sumsubFlow.error}
-            variant={getKycModalVariant(gate.kind)}
-            providerMessage={getGateUserMessage(gate)}
-            reasonCode={getGateReasonCode(gate)}
-        />
+        <>
+            <InitiateKycModal
+                cooldownActive={!!sumsubFlow.errorCooldown}
+                visible={showKycModal}
+                onClose={() => setShowKycModal(false)}
+                onVerify={async () => {
+                    if (gate.kind === 'restart-identity') {
+                        await sumsubFlow.handleRestartIdentity()
+                    } else if (gate.kind === 'fixable-rejection') {
+                        await sumsubFlow.handleSelfHealResubmit('BRIDGE')
+                    } else {
+                        await sumsubFlow.handleInitiateKyc(
+                            bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                            undefined,
+                            gate.kind === 'needs-enrollment' || undefined,
+                            selectedCountry?.id
+                        )
+                    }
+                    // only close if sdk opened — if it errored, keep modal open to show error
+                    if (sumsubFlow.showWrapper) setShowKycModal(false)
+                }}
+                onContactSupport={() => {
+                    setShowKycModal(false)
+                    setIsSupportModalOpen(true)
+                }}
+                isLoading={sumsubFlow.isLoading}
+                error={sumsubFlow.error}
+                variant={getKycModalVariant(gate.kind)}
+                providerMessage={getGateUserMessage(gate)}
+                reasonCode={getGateReasonCode(gate)}
+            />
+            <SumsubKycModals flow={sumsubFlow} onCooldownClose={() => setShowKycModal(false)} />
+        </>
     )
 
     const handleSuccess = async (
@@ -623,7 +626,6 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         error={error}
                     />
                     {kycModal}
-                    <SumsubKycModals flow={sumsubFlow} />
                 </div>
             )
         case ClaimBankFlowStep.BankConfirmClaim:

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -318,6 +318,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     // that refusal happens or the submit is a silent no-op.
     const kycModal = (
         <InitiateKycModal
+            cooldownActive={!!sumsubFlow.errorCooldown}
             visible={showKycModal}
             onClose={() => setShowKycModal(false)}
             onVerify={async () => {

--- a/src/components/Kyc/InitiateKycModal.tsx
+++ b/src/components/Kyc/InitiateKycModal.tsx
@@ -27,6 +27,7 @@ type InitiateKycVariant =
     | 'region-unavailable'
 
 interface InitiateKycModalProps {
+    cooldownActive?: boolean
     visible: boolean
     onClose: () => void
     onVerify: () => void
@@ -70,6 +71,7 @@ interface InitiateKycModalProps {
 // no bank provider onboards.
 export const InitiateKycModal = ({
     visible,
+    cooldownActive,
     onClose,
     onVerify,
     onContactSupport,
@@ -204,6 +206,8 @@ export const InitiateKycModal = ({
     }
 
     const cta = getCta()
+
+    if (cooldownActive) return null
 
     // Outage outranks everything, including the region screen: whatever the
     // user's state, opening the SDK during a verification outage burns an

--- a/src/components/Kyc/KycRestartCooldownModal.tsx
+++ b/src/components/Kyc/KycRestartCooldownModal.tsx
@@ -1,0 +1,34 @@
+import { useLocale, useTranslations } from 'next-intl'
+import ActionModal from '@/components/Global/ActionModal'
+
+export const KycRestartCooldownModal = ({
+    cooldown,
+    onClose,
+}: {
+    cooldown?: { retryAt?: string } | null
+    onClose: () => void
+}) => {
+    const t = useTranslations('profile.unlockPayments.cooldown')
+    const locale = useLocale()
+    return (
+        <ActionModal
+            visible={!!cooldown}
+            onClose={onClose}
+            title={t('title')}
+            description={
+                cooldown?.retryAt
+                    ? t('until', {
+                          until: new Date(cooldown.retryAt).toLocaleString(locale, {
+                              month: 'short',
+                              day: 'numeric',
+                              hour: 'numeric',
+                              minute: '2-digit',
+                          }),
+                      })
+                    : t('short')
+            }
+            tone="warning"
+            ctas={[{ text: t('dismiss'), variant: 'purple', onClick: onClose }]}
+        />
+    )
+}

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -1,3 +1,4 @@
+import { KycRestartCooldownModal } from './KycRestartCooldownModal'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { KycVerificationInProgressModal } from '@/components/Kyc/KycVerificationInProgressModal'
 import IframeWrapper from '@/components/Global/IframeWrapper'
@@ -17,6 +18,7 @@ interface SumsubKycModalsProps {
 export const SumsubKycModals = ({ flow }: SumsubKycModalsProps) => {
     return (
         <>
+            <KycRestartCooldownModal cooldown={flow.errorCooldown} onClose={flow.dismissErrorCooldown} />
             <SumsubKycWrapper
                 visible={flow.showWrapper}
                 accessToken={flow.accessToken}

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -6,6 +6,7 @@ import { type useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 
 interface SumsubKycModalsProps {
     flow: ReturnType<typeof useMultiPhaseKycFlow>
+    onCooldownClose?: () => void
 }
 
 /**
@@ -15,10 +16,16 @@ interface SumsubKycModalsProps {
  *
  * pair with useMultiPhaseKycFlow hook for the logic.
  */
-export const SumsubKycModals = ({ flow }: SumsubKycModalsProps) => {
+export const SumsubKycModals = ({ flow, onCooldownClose }: SumsubKycModalsProps) => {
     return (
         <>
-            <KycRestartCooldownModal cooldown={flow.errorCooldown} onClose={flow.dismissErrorCooldown} />
+            <KycRestartCooldownModal
+                cooldown={flow.errorCooldown}
+                onClose={() => {
+                    onCooldownClose?.()
+                    flow.dismissErrorCooldown()
+                }}
+            />
             <SumsubKycWrapper
                 visible={flow.showWrapper}
                 accessToken={flow.accessToken}

--- a/src/components/Profile/components/ProfileHeader.tsx
+++ b/src/components/Profile/components/ProfileHeader.tsx
@@ -121,10 +121,15 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                         onSuccess={() => posthog.capture(ANALYTICS_EVENTS.REFERRAL_CTA_CLICKED, REFERRAL_PILL_PROPS)}
                         className="h-10 w-fit rounded-full py-3 pr-4 pl-6"
                     >
-                        <div className="text-label-l">{profileUrl.replace('https://', '')}</div>
-                        <div className="-ml-2">
-                            <Icon name="share" size={16} fill="black" />
-                        </div>
+                        <span className="flex items-center gap-4">
+                            <span className="text-label-l" aria-label={profileUrl.replace(/^https?:\/\//, '')}>
+                                <span className="font-normal">
+                                    {profileUrl.slice(0, -username.length).replace(/^https?:\/\//, '')}
+                                </span>
+                                <span>{username}</span>
+                            </span>
+                            <Icon name="share" size={16} className="shrink-0 text-foreground-primary" />
+                        </span>
                     </ShareButton>
                 )}
             </div>

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -85,18 +85,6 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
 
             <p className="text-body-s">{t('intro')}</p>
 
-            <div>
-                <h1 className="mb-2 font-bold text-black">{t('policiesHeading')}</h1>
-                {LEGAL_POLICIES.map((doc, index) => (
-                    <Card key={doc.href} position={cardPosition(index, LEGAL_POLICIES.length)}>
-                        <DocsLink href={doc.href} className="flex cursor-pointer justify-between py-1">
-                            <span className="text-body-s text-black">{t(`policies.${doc.key}`)}</span>
-                            <NavigationArrow size={24} className="fill-black" />
-                        </DocsLink>
-                    </Card>
-                ))}
-            </div>
-
             {/* Native only: the web has no store listing to review against.
                 A row the user taps themselves, never a prompt — see
                 utils/app-review.ts for why that distinction is the whole rule. */}
@@ -107,14 +95,29 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
                         <button
                             type="button"
                             onClick={() => void openStoreReviewPage(store)}
-                            className="flex w-full cursor-pointer justify-between py-1"
+                            className="flex w-full cursor-pointer items-center justify-between gap-3 py-1"
                         >
                             <span className="text-body-s text-black">{t('rate')}</span>
-                            <NavigationArrow size={24} className="fill-black" />
+                            <NavigationArrow size={24} className="shrink-0 fill-black" />
                         </button>
                     </Card>
                 </div>
             )}
+
+            <div>
+                <h1 className="mb-2 font-bold text-black">{t('policiesHeading')}</h1>
+                {LEGAL_POLICIES.map((doc, index) => (
+                    <Card key={doc.href} position={cardPosition(index, LEGAL_POLICIES.length)}>
+                        <DocsLink
+                            href={doc.href}
+                            className="flex cursor-pointer items-center justify-between gap-3 py-1"
+                        >
+                            <span className="text-body-s text-black">{t(`policies.${doc.key}`)}</span>
+                            <NavigationArrow size={24} className="shrink-0 fill-black" />
+                        </DocsLink>
+                    </Card>
+                ))}
+            </div>
 
             {betaRevealed && (
                 <div ref={betaCardRef}>

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -9,8 +9,6 @@ import * as Sentry from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ListItem } from '@/components/0_Bruddle/ListItem'
-import { Icon } from '@/components/Global/Icons/Icon'
 import DeleteAccountButton from '@/components/Settings/DeleteAccountButton'
 import ShowNameToggle from '../components/ShowNameToggle'
 import ProfileEditField from '../components/ProfileEditField'
@@ -257,12 +255,12 @@ export const ProfileEditView = () => {
                 {/* Name visibility belongs with the name itself; only shown
                     once there is a name to show or hide. */}
                 {!!user?.user.fullName?.trim() && (
-                    <ListItem
-                        position="single"
-                        leading={<Icon name="eye" size={24} />}
-                        title={tMenu('showMyFullName')}
-                        trailing={<ShowNameToggle checked={showFullName} onChange={setShowFullName} />}
-                    />
+                    <div className="flex items-center justify-between gap-4 py-2">
+                        <span className="text-body-m-semibold text-foreground-primary">{tMenu('showMyFullName')}</span>
+                        <div className="shrink-0">
+                            <ShowNameToggle checked={showFullName} onChange={setShowFullName} />
+                        </div>
+                    </div>
                 )}
             </div>
 

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -682,6 +682,7 @@ const UnlockSection = ({
                     return (
                         <ListItem
                             key={row.id}
+                            className="min-h-18"
                             disabled={row.chip === 'notAvailable'}
                             leading={<IconBubble icon={row.icon as IconName} size="s" color={BUBBLE_COLOR[row.chip]} />}
                             title={<span className="break-words whitespace-normal">{t(`rows.${row.labelKey}`)}</span>}

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -565,42 +565,65 @@ const UnlockPayments = () => {
                 visible={!!flow.error && !errorAcknowledged}
                 onClose={() => setErrorAcknowledged(true)}
                 title={
-                    failedRegionRetriable
-                        ? tRegions('initError.retriableTitle')
-                        : tRegions('initError.notAvailableTitle')
+                    flow.errorCooldown
+                        ? t('cooldown.title')
+                        : failedRegionRetriable
+                          ? tRegions('initError.retriableTitle')
+                          : tRegions('initError.notAvailableTitle')
                 }
-                description={flow.error || tCommon('genericError')}
-                tone="error"
+                description={
+                    flow.errorCooldown
+                        ? flow.errorCooldown.retryAt
+                            ? t('cooldown.until', {
+                                  until: new Date(flow.errorCooldown.retryAt).toLocaleString(locale, {
+                                      month: 'short',
+                                      day: 'numeric',
+                                      hour: 'numeric',
+                                      minute: '2-digit',
+                                  }),
+                              })
+                            : t('cooldown.short')
+                        : flow.error || tCommon('genericError')
+                }
+                tone={flow.errorCooldown ? 'warning' : 'error'}
                 ctas={
-                    failedRegionRetriable
+                    flow.errorCooldown
                         ? [
                               {
-                                  text: tCommon('tryAgain'),
+                                  text: t('cooldown.dismiss'),
                                   variant: 'purple',
-                                  shadowSize: '4',
-                                  disabled: flow.isLoading,
-                                  onClick: () => {
-                                      if (reverifyRequested) void flow.handleRestartIdentity(activeRegionIntent)
-                                      else void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
-                                  },
-                              },
-                              {
-                                  text: tCommon('contactSupport'),
-                                  variant: 'stroke',
-                                  onClick: () => {
-                                      setErrorAcknowledged(true)
-                                      setIsSupportModalOpen(true)
-                                  },
-                              },
-                          ]
-                        : [
-                              {
-                                  text: tCommon('gotIt'),
-                                  variant: 'purple',
-                                  shadowSize: '4',
                                   onClick: () => setErrorAcknowledged(true),
                               },
                           ]
+                        : failedRegionRetriable
+                          ? [
+                                {
+                                    text: tCommon('tryAgain'),
+                                    variant: 'purple',
+                                    shadowSize: '4',
+                                    disabled: flow.isLoading,
+                                    onClick: () => {
+                                        if (reverifyRequested) void flow.handleRestartIdentity(activeRegionIntent)
+                                        else void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
+                                    },
+                                },
+                                {
+                                    text: tCommon('contactSupport'),
+                                    variant: 'stroke',
+                                    onClick: () => {
+                                        setErrorAcknowledged(true)
+                                        setIsSupportModalOpen(true)
+                                    },
+                                },
+                            ]
+                          : [
+                                {
+                                    text: tCommon('gotIt'),
+                                    variant: 'purple',
+                                    shadowSize: '4',
+                                    onClick: () => setErrorAcknowledged(true),
+                                },
+                            ]
                 }
             />
 

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -698,7 +698,10 @@ const UnlockSection = ({
                         Everywhere group always states that — it is the one limit
                         that exists before any unlock. */}
                     {group.id === 'everywhere' && (
-                        <p className="text-body-s text-foreground-secondary">{t('limits.p2pNoLimit')}</p>
+                        <div className="flex flex-col gap-1">
+                            <p className="text-body-s text-foreground-secondary">{t('limits.p2pNoLimit')}</p>
+                            <ProgressBar value={100} />
+                        </div>
                     )}
                     {limitSummaries.map((summary) =>
                         summary.kind === 'manteca' ? (

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -656,9 +656,19 @@ const UnlockSection = ({
                 return <StatusBadge status="processing" customText={t('chips.processing')} />
             case 'attention':
                 return <StatusBadge status="pending" customText={t('chips.attention')} />
-            case 'unlock':
             case 'notAvailable':
-                return <span className="text-body-s text-foreground-secondary">{t(`chips.${row.chip}`)}</span>
+                if (row.labelKey === 'card') {
+                    return (
+                        <StatusBadge
+                            status="custom"
+                            customText={t('chips.notAvailable')}
+                            className="bg-background-badge-helper"
+                        />
+                    )
+                }
+                return <span className="text-body-s text-foreground-secondary">{t('chips.notAvailable')}</span>
+            case 'unlock':
+                return <span className="text-body-s text-foreground-secondary">{t('chips.unlock')}</span>
         }
     }
 

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -684,7 +684,7 @@ const UnlockSection = ({
                             key={row.id}
                             disabled={row.chip === 'notAvailable'}
                             leading={<IconBubble icon={row.icon as IconName} size="s" color={BUBBLE_COLOR[row.chip]} />}
-                            title={t(`rows.${row.labelKey}`)}
+                            title={<span className="break-words whitespace-normal">{t(`rows.${row.labelKey}`)}</span>}
                             trailing={rowTrailing(row)}
                             chevron={tappable}
                             onClick={tappable ? () => onRowClick(row) : undefined}

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -562,68 +562,45 @@ const UnlockPayments = () => {
             />
 
             <ActionModal
-                visible={!!flow.error && !errorAcknowledged}
+                visible={!!flow.error && !flow.errorCooldown && !errorAcknowledged}
                 onClose={() => setErrorAcknowledged(true)}
                 title={
-                    flow.errorCooldown
-                        ? t('cooldown.title')
-                        : failedRegionRetriable
-                          ? tRegions('initError.retriableTitle')
-                          : tRegions('initError.notAvailableTitle')
+                    failedRegionRetriable
+                        ? tRegions('initError.retriableTitle')
+                        : tRegions('initError.notAvailableTitle')
                 }
-                description={
-                    flow.errorCooldown
-                        ? flow.errorCooldown.retryAt
-                            ? t('cooldown.until', {
-                                  until: new Date(flow.errorCooldown.retryAt).toLocaleString(locale, {
-                                      month: 'short',
-                                      day: 'numeric',
-                                      hour: 'numeric',
-                                      minute: '2-digit',
-                                  }),
-                              })
-                            : t('cooldown.short')
-                        : flow.error || tCommon('genericError')
-                }
-                tone={flow.errorCooldown ? 'warning' : 'error'}
+                description={flow.error || tCommon('genericError')}
+                tone="error"
                 ctas={
-                    flow.errorCooldown
+                    failedRegionRetriable
                         ? [
                               {
-                                  text: t('cooldown.dismiss'),
+                                  text: tCommon('tryAgain'),
                                   variant: 'purple',
+                                  shadowSize: '4',
+                                  disabled: flow.isLoading,
+                                  onClick: () => {
+                                      if (reverifyRequested) void flow.handleRestartIdentity(activeRegionIntent)
+                                      else void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
+                                  },
+                              },
+                              {
+                                  text: tCommon('contactSupport'),
+                                  variant: 'stroke',
+                                  onClick: () => {
+                                      setErrorAcknowledged(true)
+                                      setIsSupportModalOpen(true)
+                                  },
+                              },
+                          ]
+                        : [
+                              {
+                                  text: tCommon('gotIt'),
+                                  variant: 'purple',
+                                  shadowSize: '4',
                                   onClick: () => setErrorAcknowledged(true),
                               },
                           ]
-                        : failedRegionRetriable
-                          ? [
-                                {
-                                    text: tCommon('tryAgain'),
-                                    variant: 'purple',
-                                    shadowSize: '4',
-                                    disabled: flow.isLoading,
-                                    onClick: () => {
-                                        if (reverifyRequested) void flow.handleRestartIdentity(activeRegionIntent)
-                                        else void flow.handleInitiateKyc(activeRegionIntent, undefined, true)
-                                    },
-                                },
-                                {
-                                    text: tCommon('contactSupport'),
-                                    variant: 'stroke',
-                                    onClick: () => {
-                                        setErrorAcknowledged(true)
-                                        setIsSupportModalOpen(true)
-                                    },
-                                },
-                            ]
-                          : [
-                                {
-                                    text: tCommon('gotIt'),
-                                    variant: 'purple',
-                                    shadowSize: '4',
-                                    onClick: () => setErrorAcknowledged(true),
-                                },
-                            ]
                 }
             />
 

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -49,7 +49,7 @@ describe('AboutView', () => {
         try {
             render(<AboutView appVersion="1.2.3" />)
             const invitation = await screen.findByRole('heading', { name: 'Liking it so far?' })
-            const policies = screen.getByRole('heading', { name: 'Policies' })
+            const policies = screen.getByRole('heading', { name: 'The official bits' })
             expect(invitation.compareDocumentPosition(policies) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
             expect(screen.getByRole('button', { name: 'Leave a review' })).toBeInTheDocument()
         } finally {

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -10,6 +10,7 @@ import { IntlWrapper } from '@/test-utils/intl'
 import { loadMessages } from '@/i18n/app/messages'
 import en from '@/i18n/app/messages/en.json'
 import { AboutView } from '../About.view'
+import * as capacitor from '@/utils/capacitor'
 
 const render = (ui: React.ReactElement) => rtlRender(ui, { wrapper: IntlWrapper })
 
@@ -43,6 +44,19 @@ const tapVersion = (times: number) => {
 }
 
 describe('AboutView', () => {
+    it('puts the native review invitation before policies', async () => {
+        const native = jest.spyOn(capacitor, 'isNativeBridge').mockReturnValue(true)
+        try {
+            render(<AboutView appVersion="1.2.3" />)
+            const invitation = await screen.findByRole('heading', { name: 'Liking it so far?' })
+            const policies = screen.getByRole('heading', { name: 'Policies' })
+            expect(invitation.compareDocumentPosition(policies) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+            expect(screen.getByRole('button', { name: 'Leave a review' })).toBeInTheDocument()
+        } finally {
+            native.mockRestore()
+        }
+    })
+
     it('lists every policy under its catalog name', () => {
         render(<AboutView appVersion="1.2.3" />)
         const names = Object.values(en.profile.about.policies)

--- a/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
+++ b/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
@@ -146,7 +146,7 @@ describe('UnlockPayments', () => {
         mockKycDegraded = true
         render()
         expect(screen.getByText('Verification is temporarily down')).toBeInTheDocument()
-        fireEvent.click(screen.getByText('Bank Transfers'))
+        fireEvent.click(screen.getByText('EUR/GBP Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
     })
 
@@ -161,7 +161,7 @@ describe('UnlockPayments', () => {
     it('a region-restricted user gets the region screen instead of an unlock offer', () => {
         mockRegionRestricted = true
         render()
-        fireEvent.click(screen.getByText('Bank Transfers'))
+        fireEvent.click(screen.getByText('EUR/GBP Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
         expect(screen.getByText('region-restricted-modal')).toBeInTheDocument()
         expect(mockInitiateKyc).not.toHaveBeenCalled()
@@ -169,8 +169,8 @@ describe('UnlockPayments', () => {
 
     it('a bank-method tap opens the method-worded unlock modal and NEVER routes to /card', () => {
         render()
-        fireEvent.click(screen.getByText('Bank Transfers'))
-        expect(screen.getByText('unlock-modal-open:Bank Transfers')).toBeInTheDocument()
+        fireEvent.click(screen.getByText('EUR/GBP Bank Transfers'))
+        expect(screen.getByText('unlock-modal-open:EUR/GBP Bank Transfers')).toBeInTheDocument()
         expect(mockPush).not.toHaveBeenCalled()
     })
 
@@ -195,7 +195,7 @@ describe('UnlockPayments', () => {
         render()
         expect(screen.getAllByText('Not available').length).toBeGreaterThanOrEqual(4)
         expect(screen.getByText('Always on')).toBeInTheDocument()
-        fireEvent.click(screen.getByText('Bank Transfers'))
+        fireEvent.click(screen.getByText('EUR/GBP Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
     })
 

--- a/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
+++ b/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
@@ -227,13 +227,14 @@ describe('UnlockPayments', () => {
     })
 
     it('shows a dated cooldown with one dismiss button', async () => {
-        mockFlowError = 'Please wait'
+        mockFlowError = 'Too many requests'
         mockFlowCooldown = { retryAt: '2026-09-08T18:57:00Z' }
         render()
         expect(screen.getByText('Give it a little time')).toBeInTheDocument()
         expect(screen.getByText(/You can try again after/)).toHaveTextContent(/Sep 8/)
         expect(screen.queryByText('Try again')).not.toBeInTheDocument()
         expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+        expect(screen.queryByText('Too many requests')).not.toBeInTheDocument()
         fireEvent.click(screen.getByText("I'll try later"))
         await waitFor(() => expect(screen.queryByText('Give it a little time')).not.toBeInTheDocument())
     })

--- a/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
+++ b/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
@@ -143,7 +143,7 @@ describe('UnlockPayments', () => {
         mockKycDegraded = true
         render()
         expect(screen.getByText('Verification is temporarily down')).toBeInTheDocument()
-        fireEvent.click(screen.getByText('SEPA transfers'))
+        fireEvent.click(screen.getByText('Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
     })
 
@@ -158,7 +158,7 @@ describe('UnlockPayments', () => {
     it('a region-restricted user gets the region screen instead of an unlock offer', () => {
         mockRegionRestricted = true
         render()
-        fireEvent.click(screen.getByText('SEPA transfers'))
+        fireEvent.click(screen.getByText('Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
         expect(screen.getByText('region-restricted-modal')).toBeInTheDocument()
         expect(mockInitiateKyc).not.toHaveBeenCalled()
@@ -166,8 +166,8 @@ describe('UnlockPayments', () => {
 
     it('a bank-method tap opens the method-worded unlock modal and NEVER routes to /card', () => {
         render()
-        fireEvent.click(screen.getByText('SEPA transfers'))
-        expect(screen.getByText('unlock-modal-open:SEPA transfers')).toBeInTheDocument()
+        fireEvent.click(screen.getByText('Bank Transfers'))
+        expect(screen.getByText('unlock-modal-open:Bank Transfers')).toBeInTheDocument()
         expect(mockPush).not.toHaveBeenCalled()
     })
 
@@ -192,7 +192,7 @@ describe('UnlockPayments', () => {
         render()
         expect(screen.getAllByText('Not available').length).toBeGreaterThanOrEqual(4)
         expect(screen.getByText('Always on')).toBeInTheDocument()
-        fireEvent.click(screen.getByText('SEPA transfers'))
+        fireEvent.click(screen.getByText('Bank Transfers'))
         expect(screen.queryByText(/unlock-modal-open/)).not.toBeInTheDocument()
     })
 

--- a/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
+++ b/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
@@ -7,7 +7,7 @@
  * the residence anchor renders, and restricted residences read Not available.
  */
 import React from 'react'
-import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { IntlWrapper } from '@/test-utils/intl'
 import UnlockPayments from '@/components/Profile/views/UnlockPayments.view'
@@ -78,6 +78,7 @@ jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSu
 
 const mockInitiateKyc = jest.fn()
 const mockRestartIdentity = jest.fn()
+const mockDismissCooldown = jest.fn()
 let mockFlowCooldown: { retryAt?: string } | null = null
 let mockFlowError: string | null = null
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
@@ -88,12 +89,15 @@ jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
         isLoading: false,
         error: mockFlowError,
         errorCooldown: mockFlowCooldown,
+        dismissErrorCooldown: mockDismissCooldown,
     }),
 }))
 
 // Heavy children are irrelevant to the list contract under test.
 jest.mock('@/components/Home/PendingVerificationTasks', () => ({ __esModule: true, default: () => null }))
-jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/SumsubKycWrapper', () => ({ SumsubKycWrapper: () => null }))
+jest.mock('@/components/Kyc/KycVerificationInProgressModal', () => ({ KycVerificationInProgressModal: () => null }))
+jest.mock('@/components/Global/IframeWrapper', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Kyc/modals/KycProcessingModal', () => ({ KycProcessingModal: () => null }))
 jest.mock('@/components/Kyc/modals/KycActionRequiredModal', () => ({ KycActionRequiredModal: () => null }))
 jest.mock('@/components/Kyc/modals/KycFailedModal', () => ({ KycFailedModal: () => null }))
@@ -236,7 +240,7 @@ describe('UnlockPayments', () => {
         expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
         expect(screen.queryByText('Too many requests')).not.toBeInTheDocument()
         fireEvent.click(screen.getByText("I'll try later"))
-        await waitFor(() => expect(screen.queryByText('Give it a little time')).not.toBeInTheDocument())
+        expect(mockDismissCooldown).toHaveBeenCalled()
     })
 
     it('an active LATAM rail shows the inline monthly limit bar on Brazil', () => {

--- a/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
+++ b/src/components/Profile/views/__tests__/UnlockPayments.test.tsx
@@ -7,7 +7,7 @@
  * the residence anchor renders, and restricted residences read Not available.
  */
 import React from 'react'
-import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { IntlWrapper } from '@/test-utils/intl'
 import UnlockPayments from '@/components/Profile/views/UnlockPayments.view'
@@ -78,6 +78,7 @@ jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSu
 
 const mockInitiateKyc = jest.fn()
 const mockRestartIdentity = jest.fn()
+let mockFlowCooldown: { retryAt?: string } | null = null
 let mockFlowError: string | null = null
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     useMultiPhaseKycFlow: () => ({
@@ -86,6 +87,7 @@ jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
         handleRestartIdentity: mockRestartIdentity,
         isLoading: false,
         error: mockFlowError,
+        errorCooldown: mockFlowCooldown,
     }),
 }))
 
@@ -123,6 +125,7 @@ describe('UnlockPayments', () => {
         mockRegionRestricted = false
         mockKycDegraded = false
         mockFlowError = null
+        mockFlowCooldown = null
     })
 
     it('shows the in-review line with the submitted date while identity is processing', () => {
@@ -221,6 +224,18 @@ describe('UnlockPayments', () => {
         expect(mockRestartIdentity).toHaveBeenCalledTimes(2)
         expect(mockRestartIdentity).toHaveBeenLastCalledWith('LATAM')
         expect(mockInitiateKyc).not.toHaveBeenCalled()
+    })
+
+    it('shows a dated cooldown with one dismiss button', async () => {
+        mockFlowError = 'Please wait'
+        mockFlowCooldown = { retryAt: '2026-09-08T18:57:00Z' }
+        render()
+        expect(screen.getByText('Give it a little time')).toBeInTheDocument()
+        expect(screen.getByText(/You can try again after/)).toHaveTextContent(/Sep 8/)
+        expect(screen.queryByText('Try again')).not.toBeInTheDocument()
+        expect(screen.queryByText('Contact support')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText("I'll try later"))
+        await waitFor(() => expect(screen.queryByText('Give it a little time')).not.toBeInTheDocument())
     })
 
     it('an active LATAM rail shows the inline monthly limit bar on Brazil', () => {

--- a/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
+++ b/src/components/Settings/__tests__/DeleteAccountButton.test.tsx
@@ -75,7 +75,7 @@ beforeEach(() => {
 describe('DeleteAccountButton', () => {
     it('opens the confirm modal and fires the initiated event', () => {
         render(<DeleteAccountButton />)
-        fireEvent.click(screen.getByText('Delete My Account'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
 
         expect(screen.getByText("Aw, you're leaving?")).toBeInTheDocument()
         expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.DELETE_ACCOUNT_INITIATED)
@@ -85,7 +85,7 @@ describe('DeleteAccountButton', () => {
         mockRequestDeletion.mockResolvedValueOnce(undefined)
         render(<DeleteAccountButton />)
 
-        fireEvent.click(screen.getByText('Delete My Account'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
         fireEvent.click(screen.getByText('Yes, delete it'))
 
         expect(mockCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.DELETE_ACCOUNT_CONFIRMED)
@@ -100,7 +100,7 @@ describe('DeleteAccountButton', () => {
         mockRequestDeletion.mockRejectedValueOnce(new Error('boom'))
         render(<DeleteAccountButton />)
 
-        fireEvent.click(screen.getByText('Delete My Account'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
         fireEvent.click(screen.getByText('Yes, delete it'))
 
         await waitFor(() => expect(mockToastError).toHaveBeenCalled())
@@ -115,7 +115,7 @@ describe('DeleteAccountButton', () => {
         mockRequestDeletion.mockReturnValueOnce(new Promise<void>((r) => (resolveDeletion = () => r())))
         render(<DeleteAccountButton />)
 
-        fireEvent.click(screen.getByText('Delete My Account'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
         // confirm step is dismissible
         expect(screen.getByTestId('modal').dataset.preventClose).toBe('false')
         expect(screen.getByTestId('modal').dataset.hideClose).toBe('false')
@@ -134,7 +134,7 @@ describe('DeleteAccountButton', () => {
 
     it('cancel closes the modal without calling the API', () => {
         render(<DeleteAccountButton />)
-        fireEvent.click(screen.getByText('Delete My Account'))
+        fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
         fireEvent.click(screen.getByText("Never mind, I'll stay"))
 
         expect(screen.queryByText("Aw, you're leaving?")).not.toBeInTheDocument()
@@ -147,7 +147,7 @@ describe('DeleteAccountButton', () => {
             mockWallet.formattedSpendableBalance = '500.00'
             render(<DeleteAccountButton />)
 
-            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
 
             expect(screen.getByText('Move your money first')).toBeInTheDocument()
             expect(screen.getByText(/You still have \$500\.00/)).toBeInTheDocument()
@@ -160,7 +160,7 @@ describe('DeleteAccountButton', () => {
             mockWallet.spendableBalance = 500_000_000n
             render(<DeleteAccountButton />)
 
-            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
             fireEvent.click(screen.getByText('Move my money'))
 
             expect(mockPush).toHaveBeenCalledWith('/withdraw')
@@ -171,7 +171,7 @@ describe('DeleteAccountButton', () => {
             mockWallet.spendableBalance = 9_999n
             render(<DeleteAccountButton />)
 
-            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
 
             expect(screen.getByText("Aw, you're leaving?")).toBeInTheDocument()
         })
@@ -180,7 +180,7 @@ describe('DeleteAccountButton', () => {
             mockWallet.spendableBalance = undefined
             render(<DeleteAccountButton />)
 
-            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
 
             expect(screen.getByText("Aw, you're leaving?")).toBeInTheDocument()
         })
@@ -190,7 +190,7 @@ describe('DeleteAccountButton', () => {
             mockRequestDeletion.mockRejectedValueOnce(new AccountHasBalanceError('12.34'))
             render(<DeleteAccountButton />)
 
-            fireEvent.click(screen.getByText('Delete My Account'))
+            fireEvent.click(screen.getByRole('button', { name: 'Delete my account' }))
             fireEvent.click(screen.getByText('Yes, delete it'))
 
             await waitFor(() => expect(screen.getByText('Move your money first')).toBeInTheDocument())

--- a/src/hooks/__tests__/usePullToRefresh.test.tsx
+++ b/src/hooks/__tests__/usePullToRefresh.test.tsx
@@ -230,3 +230,15 @@ describe('overlay gesture isolation', () => {
         expect(invalidate).not.toHaveBeenCalled()
     })
 })
+
+it('allows refresh with the closed always-mounted support dialog', () => {
+    const invalidate = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined)
+    renderHook(() => usePullToRefresh(), { wrapper })
+    const support = document.createElement('div')
+    support.setAttribute('role', 'dialog')
+    support.setAttribute('aria-modal', 'false')
+    document.body.appendChild(support)
+    pullPastThreshold()
+    touch('touchend', 200)
+    expect(invalidate).toHaveBeenCalledTimes(1)
+})

--- a/src/hooks/__tests__/usePullToRefresh.test.tsx
+++ b/src/hooks/__tests__/usePullToRefresh.test.tsx
@@ -161,3 +161,46 @@ describe('usePullToRefresh', () => {
         expect(impactHaptic).not.toHaveBeenCalled()
     })
 })
+
+describe('overlay gesture isolation', () => {
+    const openDialog = () => {
+        const dialog = document.createElement('div')
+        dialog.setAttribute('role', 'dialog')
+        dialog.setAttribute('data-state', 'open')
+        document.body.appendChild(dialog)
+        return dialog
+    }
+
+    it('ignores pulls while a drawer is open and resumes after it closes', () => {
+        const invalidate = jest.spyOn(queryClient, 'invalidateQueries').mockResolvedValue(undefined)
+        renderHook(() => usePullToRefresh(), { wrapper })
+        const dialog = openDialog()
+        pullPastThreshold()
+        touch('touchend', 200)
+        expect(indicator()?.style.opacity).toBe('0')
+        expect(impactHaptic).not.toHaveBeenCalled()
+        expect(invalidate).not.toHaveBeenCalled()
+        dialog.remove()
+        pullPastThreshold()
+        touch('touchend', 200)
+        expect(invalidate).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels a pending refresh when a drawer opens before release', () => {
+        const invalidate = jest.spyOn(queryClient, 'invalidateQueries')
+        renderHook(() => usePullToRefresh(), { wrapper })
+        pullPastThreshold()
+        openDialog()
+        touch('touchend', 200)
+        expect(invalidate).not.toHaveBeenCalled()
+        expect(indicator()?.style.opacity).toBe('0')
+    })
+
+    it('never refreshes a gesture cancelled by the browser', () => {
+        const invalidate = jest.spyOn(queryClient, 'invalidateQueries')
+        renderHook(() => usePullToRefresh(), { wrapper })
+        pullPastThreshold()
+        touch('touchcancel', 200)
+        expect(invalidate).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -985,3 +985,17 @@ it('clears cooldown details when a later restart fails for another reason', asyn
     expect(result.current.errorCooldown).toBeNull()
     expect(result.current.error).toBe('Verification changed, please retry')
 })
+
+it('routes restart throttles to the shared cooldown dialog and clears them on dismissal', async () => {
+    mockRestart.mockReset()
+    mockRestart.mockResolvedValueOnce({ error: 'Too many requests', cooldown: { retryAt: '2026-09-08T18:57:00Z' } })
+    const { result } = renderHook(() => useSumsubKycFlow({}))
+    await act(async () => {
+        await result.current.handleRestartIdentity()
+    })
+    expect(result.current.error).toBeNull()
+    expect(result.current.errorCooldown?.retryAt).toBe('2026-09-08T18:57:00Z')
+    act(() => result.current.dismissErrorCooldown())
+    expect(result.current.errorCooldown).toBeNull()
+    expect(result.current.error).toBeNull()
+})

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -969,3 +969,19 @@ describe('useSumsubKycFlow — restart forwards only an explicit override', () =
         expect(mockRestart).toHaveBeenCalledWith('LATAM')
     })
 })
+
+it('clears cooldown details when a later restart fails for another reason', async () => {
+    mockRestart.mockReset()
+    mockRestart.mockResolvedValueOnce({ error: 'Please wait', cooldown: { retryAt: '2026-09-08T18:57:00Z' } })
+    const { result } = renderHook(() => useSumsubKycFlow({}))
+    await act(async () => {
+        await result.current.handleRestartIdentity()
+    })
+    expect(result.current.errorCooldown?.retryAt).toBe('2026-09-08T18:57:00Z')
+    mockRestart.mockResolvedValueOnce({ error: 'Verification changed, please retry' })
+    await act(async () => {
+        await result.current.handleRestartIdentity()
+    })
+    expect(result.current.errorCooldown).toBeNull()
+    expect(result.current.error).toBe('Verification changed, please retry')
+})

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -251,6 +251,7 @@ export const useMultiPhaseKycFlow = ({
         isLoading,
         error,
         errorCooldown,
+        dismissErrorCooldown,
         isTerminalError,
         showWrapper,
         accessToken,
@@ -545,6 +546,7 @@ export const useMultiPhaseKycFlow = ({
         isLoading,
         error,
         errorCooldown,
+        dismissErrorCooldown,
         // terminal = the user has no action that changes the outcome; consumers
         // must suppress their retry CTA on it (TASK-21882)
         isTerminalError,

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -250,6 +250,7 @@ export const useMultiPhaseKycFlow = ({
     const {
         isLoading,
         error,
+        errorCooldown,
         isTerminalError,
         showWrapper,
         accessToken,
@@ -543,6 +544,7 @@ export const useMultiPhaseKycFlow = ({
         handleFixableRejection,
         isLoading,
         error,
+        errorCooldown,
         // terminal = the user has no action that changes the outcome; consumers
         // must suppress their retry CTA on it (TASK-21882)
         isTerminalError,

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -166,8 +166,17 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
             setIndicator(0, true)
         }
 
+        const hasOpenDialog = () =>
+            !!document.querySelector(
+                '[role="dialog"]:not([data-state="closed"]):not([hidden]), [role="alertdialog"]:not([data-state="closed"]):not([hidden])'
+            )
+
         const onTouchStart = (e: TouchEvent) => {
-            if (refreshing || e.touches.length !== 1) return
+            if (refreshing) return
+            if (hasOpenDialog() || e.touches.length !== 1) {
+                resetPull()
+                return
+            }
             const allowed = shouldPullToRefreshRef.current ? shouldPullToRefreshRef.current() : window.scrollY === 0
             if (!allowed) return
             // a new pull can start inside the retract window — put the arrow back
@@ -183,6 +192,10 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
 
         const onTouchMove = (e: TouchEvent) => {
             if (!pulling || refreshing) return
+            if (hasOpenDialog()) {
+                resetPull()
+                return
+            }
             const dx = e.touches[0].clientX - startX
             const dy = e.touches[0].clientY - startY
             if (!axisLock && (Math.abs(dx) > AXIS_LOCK_SLOP_PX || Math.abs(dy) > AXIS_LOCK_SLOP_PX)) {
@@ -237,6 +250,10 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
 
         const onTouchEnd = () => {
             if (!pulling || refreshing) return
+            if (hasOpenDialog()) {
+                resetPull()
+                return
+            }
             const triggered = pullDistance >= DIST_RELOAD
             if (!triggered) {
                 resetPull()
@@ -273,13 +290,13 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
         document.addEventListener('touchstart', onTouchStart, listenerOptions)
         document.addEventListener('touchmove', onTouchMove, listenerOptions)
         document.addEventListener('touchend', onTouchEnd, listenerOptions)
-        document.addEventListener('touchcancel', onTouchEnd, listenerOptions)
+        document.addEventListener('touchcancel', resetPull, listenerOptions)
 
         return () => {
             document.removeEventListener('touchstart', onTouchStart)
             document.removeEventListener('touchmove', onTouchMove)
             document.removeEventListener('touchend', onTouchEnd)
-            document.removeEventListener('touchcancel', onTouchEnd)
+            document.removeEventListener('touchcancel', resetPull)
             timers.forEach(clearTimeout)
             spinAnimation?.cancel()
             indicator.remove()

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -168,7 +168,7 @@ export const usePullToRefresh = (options: UsePullToRefreshOptions = {}) => {
 
         const hasOpenDialog = () =>
             !!document.querySelector(
-                '[role="dialog"]:not([data-state="closed"]):not([hidden]), [role="alertdialog"]:not([data-state="closed"]):not([hidden])'
+                ':is([role="dialog"], [role="alertdialog"]):is([data-state="open"], [aria-modal="true"]):not([hidden])'
             )
 
         const onTouchStart = (e: TouchEvent) => {

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -721,10 +721,13 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         [handleStartAction, handleSelfHealResubmit]
     )
 
+    const dismissErrorCooldown = useCallback(() => setError(null), [setError])
+
     return {
         isLoading,
-        error,
+        error: errorCooldown ? null : error,
         errorCooldown,
+        dismissErrorCooldown,
         isTerminalError,
         showWrapper,
         accessToken,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -109,7 +109,12 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const [accessToken, setAccessToken] = useState<string | null>(null)
     const [showWrapper, setShowWrapper] = useState(false)
     const [isLoading, setIsLoading] = useState(false)
-    const [error, setError] = useState<string | null>(null)
+    const [error, setErrorState] = useState<string | null>(null)
+    const [errorCooldown, setErrorCooldown] = useState<{ retryAt?: string } | null>(null)
+    const setError = useCallback((message: string | null) => {
+        setErrorState(message)
+        setErrorCooldown(null)
+    }, [])
     // Some initiate failures are terminal: the user has no action that could
     // change the outcome, so offering a retry is worse than offering nothing.
     // Callers must suppress their retry CTA on this rather than inferring
@@ -586,6 +591,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 if (response.error) {
                     userInitiatedRef.current = false
                     setError(actionErrorMessage(response))
+                    setErrorCooldown(response.cooldown ?? null)
                     return
                 }
                 if (response.data?.token) {
@@ -718,6 +724,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     return {
         isLoading,
         error,
+        errorCooldown,
         isTerminalError,
         showWrapper,
         accessToken,

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3699,6 +3699,12 @@
         "noBadgeAvatars": "Earn a badge and its avatars appear here.",
         "rollDice": "Roll the dice",
         "change": "Change avatar",
-        "saveFailed": "Could not save your avatar. Try again."
+        "saveFailed": "Could not save your avatar. Try again.",
+        "useInitial": "Use the Initial",
+        "useAvatar": "Use the Avatar",
+        "chooseAvatar": "Choose your avatar",
+        "rolling": "Rolling the dice…",
+        "rollingHint": "A little luck. A whole new look.",
+        "cancelRoll": "Cancel roll"
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -387,7 +387,7 @@
                 "arQr": "QR payments (Argentina)",
                 "arBank": "Bank transfers (Argentina)",
                 "naBank": "ACH, Wire (US) & SPEI (Mexico)",
-                "sepa": "SEPA transfers"
+                "sepa": "Bank Transfers"
             },
             "chips": {
                 "active": "Active",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -588,7 +588,7 @@
             "title": "Language"
         },
         "deleteAccount": {
-            "button": "Delete My Account",
+            "button": "Delete my account",
             "confirmTitle": "Aw, you're leaving?",
             "confirmDescription": "Deleting your account is permanent. We'll switch it off right away and wipe your data within 30 days. This little guy would really rather you stayed.",
             "confirmCta": "Yes, delete it",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -545,7 +545,7 @@
         "about": {
             "title": "About Peanut",
             "intro": "Peanut makes dollars easy: hold your balance, send to any @username, and move money on local rails after one ID check. Built by Squirrel Labs.",
-            "policiesHeading": "Policies",
+            "policiesHeading": "The official bits",
             "policies": {
                 "terms": "Terms of Service",
                 "privacy": "Privacy Policy",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -387,7 +387,7 @@
                 "arQr": "QR payments (Argentina)",
                 "arBank": "Bank transfers (Argentina)",
                 "naBank": "ACH, Wire (US) & SPEI (Mexico)",
-                "sepa": "Bank Transfers"
+                "sepa": "EUR/GBP Bank Transfers"
             },
             "chips": {
                 "active": "Active",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -431,6 +431,12 @@
                 "monthlyLeft": "{remaining} of {limit} left this month",
                 "perTransfer": "Up to {amount} per transfer",
                 "p2pNoLimit": "No limits on Peanut-to-Peanut payments"
+            },
+            "cooldown": {
+                "title": "Give it a little time",
+                "until": "Verification attempts are temporarily limited. You can try again after {until}.",
+                "short": "Verification attempts are temporarily limited. Please try again in a little while.",
+                "dismiss": "I'll try later"
             }
         },
         "backup": {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -299,25 +299,25 @@
         },
         "language": "Language",
         "menu": {
-            "inviteFriends": "Invite friends to Peanut",
+            "inviteFriends": "Invite Friends to Peanut",
             "yourCard": "Your Card",
             "peanutCard": "Peanut Card",
             "newBadge": "New!",
             "unlockBadge": "Unlock",
             "yourBadges": "Your Badges",
             "points": "Points",
-            "personalDetails": "Personal details",
-            "unlockedRegions": "Unlock payments",
+            "personalDetails": "Personal Details",
+            "unlockedRegions": "Payment Channels",
             "paymentLimits": "Payment limits",
             "showMyFullName": "Show my full name",
             "backup": "Backup",
-            "exchangeRatesAndFees": "Exchange rates and fees",
+            "exchangeRatesAndFees": "Exchange Rates and Fees",
             "starAlt": "star",
             "help": "Help Center",
             "about": "About Peanut",
-            "updateAvailable": "Update available"
+            "updateAvailable": "Update Available"
         },
-        "logOut": "Log out",
+        "logOut": "Log Out",
         "edit": {
             "title": "Edit Profile",
             "fields": {
@@ -358,7 +358,7 @@
             }
         },
         "unlockPayments": {
-            "title": "Unlock payments",
+            "title": "Payment Channels",
             "description": "Everything you can use today, and what opens after ID verification.",
             "residence": {
                 "label": "Residence: {country}",
@@ -673,7 +673,7 @@
         }
     },
     "exchangeRate": {
-        "title": "Exchange rate & fees",
+        "title": "Exchange Rates and Fees",
         "balanceNote": "Your Peanut balance is shown in USD. Where a local bank rail is supported, you can withdraw in that local currency.",
         "tryIt": "Withdraw now",
         "addMoneyCta": "Add money",
@@ -3193,7 +3193,7 @@
             "shareTitle": "Share your profile"
         },
         "inviteFriendsModal": {
-            "title": "Invite friends!",
+            "title": "Invite Friends!",
             "description": "Share your link. Every time a friend you brought makes a payment, you earn rewards.",
             "shareSheetTitle": "Share your invite link",
             "shareCta": "Share Invite Link",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -556,7 +556,7 @@
                 "cardProhibitedActivities": "Prohibited Activities Policy",
                 "securityDisclosure": "Security Disclosure"
             },
-            "rateHeading": "Rate the app",
+            "rateHeading": "Liking it so far?",
             "rate": "Leave a review",
             "version": "Version {version}",
             "beta": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -387,7 +387,7 @@
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",
                 "naBank": "ACH, Wire (EE. UU.) y SPEI (México)",
-                "sepa": "Transferencias SEPA"
+                "sepa": "Transferencias bancarias"
             },
             "chips": {
                 "active": "Activo",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3699,6 +3699,12 @@
         "noBadgeAvatars": "Gana una insignia y sus avatares aparecen aquí.",
         "rollDice": "Tirar los dados",
         "change": "Cambiar avatar",
-        "saveFailed": "No pudimos guardar tu avatar. Inténtalo de nuevo."
+        "saveFailed": "No pudimos guardar tu avatar. Inténtalo de nuevo.",
+        "useInitial": "Usar la inicial",
+        "useAvatar": "Usar el avatar",
+        "chooseAvatar": "Elige tu avatar",
+        "rolling": "Lanzando el dado…",
+        "rollingHint": "Un poco de suerte. Un nuevo look.",
+        "cancelRoll": "Cancelar lanzamiento"
     }
 }

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -556,7 +556,7 @@
                 "cardProhibitedActivities": "Política de actividades prohibidas",
                 "securityDisclosure": "Divulgación de seguridad"
             },
-            "rateHeading": "Calificar la app",
+            "rateHeading": "¿Te está gustando?",
             "rate": "Dejar una reseña",
             "version": "Versión {version}",
             "beta": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -387,7 +387,7 @@
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",
                 "naBank": "ACH, Wire (EE. UU.) y SPEI (México)",
-                "sepa": "Transferencias bancarias"
+                "sepa": "Transferencias bancarias en EUR/GBP"
             },
             "chips": {
                 "active": "Activo",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -307,7 +307,7 @@
             "yourBadges": "Tus insignias",
             "points": "Puntos",
             "personalDetails": "Datos personales",
-            "unlockedRegions": "Desbloquea pagos",
+            "unlockedRegions": "Canales de pago",
             "paymentLimits": "Límites de pago",
             "showMyFullName": "Mostrar mi nombre completo",
             "backup": "Respaldo",
@@ -358,7 +358,7 @@
             }
         },
         "unlockPayments": {
-            "title": "Desbloquea pagos",
+            "title": "Canales de pago",
             "description": "Todo lo que puedes usar hoy, y lo que se abre después de verificar tu identidad.",
             "residence": {
                 "label": "Residencia: {country}",
@@ -679,7 +679,7 @@
         }
     },
     "exchangeRate": {
-        "title": "Tipo de cambio y comisiones",
+        "title": "Tipos de cambio y comisiones",
         "balanceNote": "Tu saldo de Peanut se muestra en USD. Donde haya un canal bancario local disponible, puedes retirar en esa moneda local.",
         "tryIt": "Retirar ahora",
         "addMoneyCta": "Agregar dinero",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -545,7 +545,7 @@
         "about": {
             "title": "Acerca de Peanut",
             "intro": "Peanut hace fáciles los dólares: guarda tu saldo, envía a cualquier @usuario y mueve dinero por rieles locales después de una sola verificación de identidad. Creado por Squirrel Labs.",
-            "policiesHeading": "Políticas",
+            "policiesHeading": "La parte oficial",
             "policies": {
                 "terms": "Términos de servicio",
                 "privacy": "Política de privacidad",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -431,6 +431,12 @@
                 "monthlyLeft": "Te quedan {remaining} de {limit} este mes",
                 "perTransfer": "Hasta {amount} por transferencia",
                 "p2pNoLimit": "Los pagos de Peanut a Peanut no tienen límite"
+            },
+            "cooldown": {
+                "title": "Espera un poco",
+                "until": "Los intentos de verificación están limitados temporalmente. Puedes volver a intentarlo después de {until}.",
+                "short": "Los intentos de verificación están limitados temporalmente. Vuelve a intentarlo en un rato.",
+                "dismiss": "Lo intentaré más tarde"
             }
         },
         "backup": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -198,7 +198,7 @@
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",
                 "naBank": "ACH, Wire (EE. UU.) y SPEI (México)",
-                "sepa": "Transferencias bancarias"
+                "sepa": "Transferencias bancarias en EUR/GBP"
             },
             "chips": {
                 "active": "Activo",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -198,7 +198,7 @@
                 "arQr": "Pagos QR (Argentina)",
                 "arBank": "Transferencias bancarias (Argentina)",
                 "naBank": "ACH, Wire (EE. UU.) y SPEI (México)",
-                "sepa": "Transferencias SEPA"
+                "sepa": "Transferencias bancarias"
             },
             "chips": {
                 "active": "Activo",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -317,7 +317,7 @@
         "about": {
             "title": "Acerca de Peanut",
             "intro": "Peanut hace fáciles los dólares: guardá tu saldo, enviá a cualquier @usuario y mové dinero por rieles locales después de una sola verificación de identidad. Creado por Squirrel Labs.",
-            "policiesHeading": "Políticas",
+            "policiesHeading": "La parte oficial",
             "policies": {
                 "terms": "Términos de servicio",
                 "privacy": "Política de privacidad",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -242,6 +242,12 @@
                 "monthlyLeft": "Te quedan {remaining} de {limit} este mes",
                 "perTransfer": "Hasta {amount} por transferencia",
                 "p2pNoLimit": "Los pagos de Peanut a Peanut no tienen límite"
+            },
+            "cooldown": {
+                "title": "Esperá un poco",
+                "until": "Los intentos de verificación están limitados temporalmente. Podés volver a intentarlo después de {until}.",
+                "short": "Los intentos de verificación están limitados temporalmente. Volvé a intentarlo en un rato.",
+                "dismiss": "Lo intentaré más tarde"
             }
         },
         "backup": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1615,5 +1615,13 @@
         "ready": {
             "subtitle": "Probá la puerta."
         }
+    },
+    "avatar": {
+        "useInitial": "Usar la inicial",
+        "useAvatar": "Usar el avatar",
+        "chooseAvatar": "Elegí tu avatar",
+        "rolling": "Tirando el dado…",
+        "rollingHint": "Un poco de suerte. Un nuevo look.",
+        "cancelRoll": "Cancelar tirada"
     }
 }

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -144,7 +144,7 @@
     "profile": {
         "menu": {
             "inviteFriends": "Invitá amigos a Peanut",
-            "unlockedRegions": "Desbloqueá pagos",
+            "unlockedRegions": "Canales de pago",
             "help": "Centro de Ayuda",
             "about": "Acerca de Peanut",
             "updateAvailable": "Actualización disponible"
@@ -169,7 +169,7 @@
             }
         },
         "unlockPayments": {
-            "title": "Desbloqueá pagos",
+            "title": "Canales de pago",
             "description": "Todo lo que podés usar hoy, y lo que se abre después de verificar tu identidad.",
             "residence": {
                 "label": "Residencia: {country}",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -387,7 +387,7 @@
                 "arQr": "Pagamentos QR (Argentina)",
                 "arBank": "Transferências bancárias (Argentina)",
                 "naBank": "ACH, Wire (EUA) e SPEI (México)",
-                "sepa": "Transferências SEPA"
+                "sepa": "Transferências bancárias"
             },
             "chips": {
                 "active": "Ativo",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -307,7 +307,7 @@
             "yourBadges": "Seus selos",
             "points": "Pontos",
             "personalDetails": "Dados pessoais",
-            "unlockedRegions": "Desbloqueie pagamentos",
+            "unlockedRegions": "Canais de pagamento",
             "paymentLimits": "Limites de pagamento",
             "showMyFullName": "Mostrar meu nome completo",
             "backup": "Backup",
@@ -358,7 +358,7 @@
             }
         },
         "unlockPayments": {
-            "title": "Desbloqueie pagamentos",
+            "title": "Canais de pagamento",
             "description": "Tudo o que você pode usar hoje, e o que se abre depois de verificar sua identidade.",
             "residence": {
                 "label": "Residência: {country}",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3699,6 +3699,12 @@
         "noBadgeAvatars": "Ganhe um selo e seus avatares aparecem aqui.",
         "rollDice": "Jogar os dados",
         "change": "Trocar avatar",
-        "saveFailed": "Não foi possível salvar seu avatar. Tente de novo."
+        "saveFailed": "Não foi possível salvar seu avatar. Tente de novo.",
+        "useInitial": "Usar a inicial",
+        "useAvatar": "Usar o avatar",
+        "chooseAvatar": "Escolha seu avatar",
+        "rolling": "Rolando o dado…",
+        "rollingHint": "Um pouco de sorte. Um novo visual.",
+        "cancelRoll": "Cancelar rolagem"
     }
 }

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -556,7 +556,7 @@
                 "cardProhibitedActivities": "Política de Atividades Proibidas",
                 "securityDisclosure": "Divulgação de Segurança"
             },
-            "rateHeading": "Avaliar o app",
+            "rateHeading": "Está gostando?",
             "rate": "Deixar uma avaliação",
             "version": "Versão {version}",
             "beta": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -387,7 +387,7 @@
                 "arQr": "Pagamentos QR (Argentina)",
                 "arBank": "Transferências bancárias (Argentina)",
                 "naBank": "ACH, Wire (EUA) e SPEI (México)",
-                "sepa": "Transferências bancárias"
+                "sepa": "Transferências bancárias em EUR/GBP"
             },
             "chips": {
                 "active": "Ativo",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -545,7 +545,7 @@
         "about": {
             "title": "Sobre o Peanut",
             "intro": "O Peanut torna os dólares fáceis: guarde seu saldo, envie para qualquer @usuário e mova dinheiro pelos trilhos locais após uma única verificação de identidade. Criado pela Squirrel Labs.",
-            "policiesHeading": "Políticas",
+            "policiesHeading": "A parte oficial",
             "policies": {
                 "terms": "Termos de Serviço",
                 "privacy": "Política de Privacidade",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -431,6 +431,12 @@
                 "monthlyLeft": "Restam {remaining} de {limit} neste mês",
                 "perTransfer": "Até {amount} por transferência",
                 "p2pNoLimit": "Os pagamentos de Peanut para Peanut não têm limite"
+            },
+            "cooldown": {
+                "title": "Espere um pouco",
+                "until": "As tentativas de verificação estão temporariamente limitadas. Você pode tentar novamente após {until}.",
+                "short": "As tentativas de verificação estão temporariamente limitadas. Tente novamente daqui a pouco.",
+                "dismiss": "Vou tentar mais tarde"
             }
         },
         "backup": {


### PR DESCRIPTION
Avatar selection now starts with a horizontal initials row and an explicit confirmation. Rolling the dice plays a full-screen CSS animation with haptics, then offers a unique 3×3 or 4×4 avatar grid sized for the screen. The flow selectively incorporates the avatar-dealing logic from #3014 and uses existing app colors and components without adding libraries.

- Keep the username's first letter selected and visible first; match initial and avatar tile sizes. Exclude initials and repeated artwork from random deals, and require selection before confirming an avatar.
- Replace the pink background circle/ripples with a grounded dice landing; support reduced motion and cancellation.
- Make the profile link username bold, domain regular, with more space before the share icon.
- Move “Liking it so far?” above “The official bits” on About; retain dev's vertically centered ListItem rows.
- Rename the verification screen/menu to Payment Channels and update English menu capitalization. Use Bank Transfers for Europe, wrap long row labels, align row heights, show a full green unlimited Peanut-to-Peanut bar, and use a status pill for unavailable cards.
- Put the full-name visibility toggle on the page background without its eye icon/container; use sentence case for Delete my account.
- Show verification rate limits with their retry date/time and one “I'll try later” action. Preserve recovery actions for state conflicts and other errors.
- Prevent background pull-to-refresh while dialogs are open and cancel pending/cancelled gestures.

Latest dev is merged, including its long-press callout guard, drawer body drag handling, and shadow-padding fixes. Those fixes remain intact; the avatar layout is reconciled with the updated shared drawer padding.

Backend companion: https://github.com/peanutprotocol/peanut-api-ts/pull/1543. It allows reopening unfinished uploads without another reset cooldown and advances the longer cooldown on completed provider decisions.

Validation: 148 tests passed across 14 focused suites; UI TypeScript check and diff whitespace check passed. Native device checks remain for long-press behavior, drawer gestures, VoiceOver/TalkBack, and haptics. No deployment performed.
