### PR TITLE
fix(app): preserve KYC actions and gate native release capabilities

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -213,7 +213,8 @@ jobs:
                       echo "$MEA_CONFIG" | base64 -d > android/app/src/main/res/raw/mea_config
                       echo "mea_config written"
                   else
-                      echo "MEAWALLET_CONFIG_BASE64 not set — push provisioning stays stubbed"
+                      echo "::error::MEAWALLET_CONFIG_BASE64 is required for a production native release"
+                      exit 1
                   fi
 
             - name: Build signed AAB
@@ -223,8 +224,9 @@ jobs:
                   # the static export above; no new secret needed.
                   SENTRY_DSN_ANDROID: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
                   # MeaWallet MPP SDK — gradle gates both the dependency and the
-                  # plugin source on these; absent secrets build without the SDK.
+                  # plugin source on these; production must never compile the stub.
                   # Android-specific names: see the note in ios-release.yml.
+                  PEANUT_REQUIRE_PUSH_PROVISIONING: '1'
                   MEAWALLET_NEXUS_USER: ${{ secrets.MEAWALLET_NEXUS_USER_ANDROID }}
                   MEAWALLET_NEXUS_PASSWORD: ${{ secrets.MEAWALLET_NEXUS_PASSWORD_ANDROID }}
                   ANDROID_VERSION_NAME: ${{ steps.version.outputs.name }}

--- a/.github/workflows/capgo-deploy.yml
+++ b/.github/workflows/capgo-deploy.yml
@@ -215,8 +215,8 @@ jobs:
             # channel strategy, and lives in a dashboard CI cannot read — it
             # never reports that an incompatible bundle was built. The
             # fingerprint is a pure function of the tree, so the shipped binary's
-            # surface is exactly what its tag describes and no state has to be
-            # stored anywhere.
+            # code is described by its tag. The tag also attests that both
+            # release builds compiled the credential-gated native SDK.
             #
             # Failing here is the intended outcome, not an obstacle: it is
             # docs/NATIVE-RELEASE.md's "bump the native version whenever you
@@ -230,6 +230,7 @@ jobs:
                       echo "::error::no v$FLOOR tag in this checkout — cannot prove the bundle fits the binary it targets (needs fetch-depth: 0 and tags)" >&2
                       exit 1
                   fi
+                  node scripts/check-native-capabilities.mjs "v$FLOOR"
                   if ! node scripts/native-fingerprint.mjs --diff "v$FLOOR"; then
                       echo "::error::this tree's native surface differs from the v$FLOOR binary, so the JS about to ship was built against native code no released binary has. Cut a native release (Actions -> Release Native) before OTA'ing this tree." >&2
                       exit 1

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -206,6 +206,17 @@ jobs:
                   node scripts/native-build.js && npx cap sync ios
                   if [ -f scripts/native-ios-postsync.js ]; then node scripts/native-ios-postsync.js; fi
 
+            - name: Write MeaWallet config
+              env:
+                  MEA_CONFIG: ${{ secrets.MEAWALLET_CONFIG_BASE64_IOS }}
+              run: |
+                  if [ -z "$MEA_CONFIG" ]; then
+                      echo "::error::MEAWALLET_CONFIG_BASE64_IOS is required for a production native release"
+                      exit 1
+                  fi
+                  printf '%s' "$MEA_CONFIG" | base64 --decode > ios/App/App/mea_config
+                  test -s ios/App/App/mea_config
+
             - name: Install Apple distribution certificate
               uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
               with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -200,6 +200,8 @@ jobs:
                   # postsync stamps project.pbxproj; without this it would stamp
                   # package.json's version, which no longer tracks releases.
                   IOS_MARKETING_VERSION: ${{ steps.version.outputs.name }}
+                  MEAWALLET_NEXUS_USER: ${{ secrets.MEAWALLET_NEXUS_USER_IOS }}
+                  MEAWALLET_NEXUS_PASSWORD: ${{ secrets.MEAWALLET_NEXUS_PASSWORD_IOS }}
               run: |
                   node scripts/native-build.js && npx cap sync ios
                   if [ -f scripts/native-ios-postsync.js ]; then node scripts/native-ios-postsync.js; fi
@@ -296,6 +298,7 @@ jobs:
                       CURRENT_PROJECT_VERSION="$IOS_BUILD_NUMBER" \
                       "${MARKETING_ARG[@]}" \
                       SENTRY_DSN="$SENTRY_DSN" \
+                      'SWIFT_ACTIVE_COMPILATION_CONDITIONS=$(inherited) PEANUT_REQUIRE_PUSH_PROVISIONING' \
                       archive
 
                   xcodebuild \

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -111,6 +111,6 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git tag -a "v$VERSION" -m "Native release $VERSION"
+                  git tag -a "v$VERSION" -m "Native release $VERSION" -m "peanut-native-capabilities-v1: android.pushProvisioning=compiled ios.pushProvisioning=compiled"
                   git push origin "v$VERSION"
                   echo "Tagged v$VERSION at ${GITHUB_SHA:0:7}"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,6 +111,10 @@ if ((meaWalletUser as boolean) != (meaWalletPass as boolean)) {
     // ship a release binary with push provisioning silently stubbed out.
     throw new GradleException('[meawallet] set both MEAWALLET_NEXUS_USER and MEAWALLET_NEXUS_PASSWORD, or neither')
 }
+if (System.getenv('PEANUT_REQUIRE_PUSH_PROVISIONING') == '1' && (!meaWalletUser || !meaWalletPass)) {
+    throw new GradleException('Production releases require the MeaWallet SDK credentials')
+}
+
 if (meaWalletUser && meaWalletPass) {
     logger.lifecycle('[meawallet] Nexus credentials present — MPP SDK enabled')
     android.sourceSets.main.java.srcDirs += 'src/meawallet/java'

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -505,7 +505,11 @@ Production Android releases require both MeaWallet Nexus credentials and the
 MeaWallet config. Production iOS archives compile with
 `PEANUT_REQUIRE_PUSH_PROVISIONING`; compilation fails if the SDK cannot be imported.
 The iOS sync step uses `MEAWALLET_NEXUS_USER_IOS` and
-`MEAWALLET_NEXUS_PASSWORD_IOS`. Local builds can still use the stub.
+`MEAWALLET_NEXUS_PASSWORD_IOS`. The archive also requires the iOS encrypted
+config in `MEAWALLET_CONFIG_BASE64_IOS`; the Xcode build phase refuses a missing
+or empty config and copies it into the app bundle. Both provisioning Swift files
+are app target sources and the bridge registers the plugin. Local builds can still
+use the stub.
 
 After both store builds succeed, Release Native writes a compiled-capability
 attestation into the annotated release tag. OTA checks that attestation in

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -357,9 +357,8 @@ own `out/` under the binary's versionName, then assert the channel serves it.
   hashing the whole name set was tried and reverted after `web-vitals`, a pure-JS library,
   would have refused every staging OTA until a native release was cut).
   Every Android source set is hashed, including the credential-gated `src/meawallet`:
-  whether it reaches a binary is not knowable from the tree, and of the two unsound
-  choices, over-claiming only forces an unnecessary native release while under-claiming
-  fails silently. **The real fix is for that variant to stop depending on a CI secret.**
+  the fingerprint proves source compatibility, while the compiled capability gate
+  below independently requires provisioning support in the released binaries.
   An unresolvable ref is an error, never an empty read, and `--root` points the CLI at
   another checkout so its tests never mutate this one. `capgo-deploy.yml` recomputes it and compares against the
   `v<major>.<build>.0` tag the bundle's floor targets; a mismatch **fails the OTA** and
@@ -499,3 +498,21 @@ one-time signing-material setup, secrets table, and manual App Store promotion.
 - Re-check Data safety, permissions (camera for QR/KYC), content rating, and the App
   access instructions in §4.
 - Promote to **production** review only after the internal track passes.
+
+### Compiled capability gate (TASK-22282)
+
+Production Android releases require both MeaWallet Nexus credentials and the
+MeaWallet config. Production iOS archives compile with
+`PEANUT_REQUIRE_PUSH_PROVISIONING`; compilation fails if the SDK cannot be imported.
+The iOS sync step uses `MEAWALLET_NEXUS_USER_IOS` and
+`MEAWALLET_NEXUS_PASSWORD_IOS`. Local builds can still use the stub.
+
+After both store builds succeed, Release Native writes a compiled-capability
+attestation into the annotated release tag. OTA checks that attestation in
+addition to the source fingerprint. Older tags and manually created tags lack
+this evidence and cannot serve as OTA floors. Run Release Native to establish
+a compatible floor; do not add an attestation to an unverified old tag.
+
+This gate intentionally blocks new native releases until the MeaWallet SDK
+setup is complete. It proves SDK compilation, not vendor activation or Apple
+entitlements. Those remain separate launch checks.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		7A1C0DE7C11B0A4D2E5F3905 /* PushProvisioningPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0DE7C11B0A4D2E5F3906 /* PushProvisioningPlugin.swift */; };
+		7A1C0DE7C11B0A4D2E5F3907 /* WalletExtensionCardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1C0DE7C11B0A4D2E5F3908 /* WalletExtensionCardStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +35,8 @@
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		7A1C0DE7C11B0A4D2E5F3906 /* PushProvisioningPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushProvisioningPlugin.swift; sourceTree = "<group>"; };
+		7A1C0DE7C11B0A4D2E5F3908 /* WalletExtensionCardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletExtensionCardStore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +75,8 @@
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
 				7A1C0DE7C11B0A4D2E5F3902 /* AppViewController.swift */,
+				7A1C0DE7C11B0A4D2E5F3906 /* PushProvisioningPlugin.swift */,
+				7A1C0DE7C11B0A4D2E5F3908 /* WalletExtensionCardStore.swift */,
 				7A1C0DE7C11B0A4D2E5F3904 /* ClipboardDetectPlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
@@ -92,6 +98,7 @@
 				504EC3001FED79650016851F /* Sources */,
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
+				7A1C0DE7C11B0A4D2E5F3909 /* Bundle MeaWallet config */,
 			);
 			buildRules = (
 			);
@@ -160,6 +167,21 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		7A1C0DE7C11B0A4D2E5F3909 /* Bundle MeaWallet config */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			alwaysOutOfDate = 1;
+			files = ();
+			inputPaths = ();
+			outputPaths = ();
+			name = "Bundle MeaWallet config";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh \"$SRCROOT/../../scripts/copy-ios-mea-config.sh\"";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		504EC3001FED79650016851F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -167,6 +189,8 @@
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
 				7A1C0DE7C11B0A4D2E5F3901 /* AppViewController.swift in Sources */,
+				7A1C0DE7C11B0A4D2E5F3905 /* PushProvisioningPlugin.swift in Sources */,
+				7A1C0DE7C11B0A4D2E5F3907 /* WalletExtensionCardStore.swift in Sources */,
 				7A1C0DE7C11B0A4D2E5F3903 /* ClipboardDetectPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/App/App/AppViewController.swift
+++ b/ios/App/App/AppViewController.swift
@@ -5,5 +5,6 @@ import UIKit
 class AppViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(ClipboardDetectPlugin())
+        bridge?.registerPluginInstance(PushProvisioningPlugin())
     }
 }

--- a/ios/App/App/PushProvisioningPlugin.swift
+++ b/ios/App/App/PushProvisioningPlugin.swift
@@ -1,6 +1,9 @@
 import Capacitor
 import PassKit
 import UIKit
+#if PEANUT_REQUIRE_PUSH_PROVISIONING && !canImport(MeaPushProvisioning)
+#error("Production releases require the MeaWallet SDK")
+#endif
 #if canImport(MeaPushProvisioning)
 import MeaPushProvisioning
 #endif

--- a/scripts/__tests__/check-native-capabilities.test.js
+++ b/scripts/__tests__/check-native-capabilities.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+const assert = require('node:assert/strict')
+const { execFileSync, spawnSync } = require('node:child_process')
+const { mkdtempSync, rmSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
+
+const cwd = mkdtempSync(join(tmpdir(), 'native-capabilities-'))
+const git = (...args) =>
+    execFileSync('git', ['-c', 'tag.gpgSign=false', '-c', 'commit.gpgSign=false', ...args], { cwd, stdio: 'pipe' })
+const script = join(__dirname, '..', 'check-native-capabilities.mjs')
+const check = (tag) => spawnSync(process.execPath, [script, tag], { cwd, encoding: 'utf8' }).status
+const attestation = 'peanut-native-capabilities-v1: android.pushProvisioning=compiled ios.pushProvisioning=compiled'
+git('init')
+git('-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '--allow-empty', '-m', attestation)
+afterAll(() => rmSync(cwd, { recursive: true, force: true }))
+
+test('rejects missing tags and malformed names', () => {
+    assert.notEqual(check('v1.1.0'), 0)
+    assert.notEqual(check('--all'), 0)
+})
+test('rejects a lightweight tag even when its commit claims capabilities', () => {
+    git('tag', 'v1.2.0')
+    assert.notEqual(check('v1.2.0'), 0)
+})
+test('requires both compiled platforms in the release annotation', () => {
+    git(
+        '-c',
+        'user.name=Test',
+        '-c',
+        'user.email=test@example.invalid',
+        'tag',
+        '-a',
+        'v1.3.0',
+        '-m',
+        'peanut-native-capabilities-v1: android.pushProvisioning=compiled'
+    )
+    assert.notEqual(check('v1.3.0'), 0)
+    git('-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'tag', '-a', 'v1.4.0', '-m', attestation)
+    assert.equal(check('v1.4.0'), 0)
+})

--- a/scripts/__tests__/copy-ios-mea-config.test.js
+++ b/scripts/__tests__/copy-ios-mea-config.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+const { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } = require('node:fs')
+const { spawnSync } = require('node:child_process')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
+const script = join(__dirname, '..', 'copy-ios-mea-config.sh')
+let root
+beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'ios-mea-config-'))
+    mkdirSync(join(root, 'App'))
+    mkdirSync(join(root, 'build', 'App.app'), { recursive: true })
+})
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+const target = () => join(root, 'build', 'App.app', 'mea_config')
+const run = (required = true) =>
+    spawnSync('sh', [script], {
+        env: {
+            ...process.env,
+            SRCROOT: root,
+            TARGET_BUILD_DIR: join(root, 'build'),
+            UNLOCALIZED_RESOURCES_FOLDER_PATH: 'App.app',
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: required ? 'OTHER PEANUT_REQUIRE_PUSH_PROVISIONING' : '',
+        },
+        encoding: 'utf8',
+    })
+test('production fails for missing or empty config', () => {
+    expect(run().status).not.toBe(0)
+    writeFileSync(join(root, 'App', 'mea_config'), '')
+    expect(run().status).not.toBe(0)
+})
+test('copies config bytes into the archived bundle', () => {
+    const bytes = Buffer.from([0, 1, 255, 10])
+    writeFileSync(join(root, 'App', 'mea_config'), bytes)
+    expect(run().status).toBe(0)
+    expect(readFileSync(target())).toEqual(bytes)
+})
+test('a local stub build removes stale bundled config', () => {
+    writeFileSync(target(), 'stale')
+    expect(run(false).status).toBe(0)
+    expect(existsSync(target())).toBe(false)
+})

--- a/scripts/check-native-capabilities.mjs
+++ b/scripts/check-native-capabilities.mjs
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process'
+
+const tag = process.argv[2]
+if (!/^v\d+\.\d+\.\d+$/.test(tag ?? '')) throw new Error('Expected a native release tag')
+const contents = execFileSync('git', ['for-each-ref', '--format=%(objecttype)%0a%(contents)', `refs/tags/${tag}`], {
+    encoding: 'utf8',
+})
+const attestation = 'peanut-native-capabilities-v1: android.pushProvisioning=compiled ios.pushProvisioning=compiled'
+if (contents.split('\n')[0] !== 'tag' || !contents.split('\n').includes(attestation)) {
+    throw new Error(
+        `${tag} does not attest compiled provisioning on both platforms. Run Release Native before publishing an OTA.`
+    )
+}
+console.log(`${tag}: provisioning compiled on Android and iOS`)

--- a/scripts/copy-ios-mea-config.sh
+++ b/scripts/copy-ios-mea-config.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+source_config="$SRCROOT/App/mea_config"
+target_config="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/mea_config"
+if [ -s "$source_config" ]; then
+    mkdir -p "$(dirname "$target_config")"
+    cp "$source_config" "$target_config"
+else
+    # Remove a stale bundle resource when switching to a local stub build.
+    rm -f "$target_config"
+    case " ${SWIFT_ACTIVE_COMPILATION_CONDITIONS:-} " in
+        *" PEANUT_REQUIRE_PUSH_PROVISIONING "*)
+            echo "error: Non-empty MeaWallet config is required for production releases" >&2
+            exit 1
+            ;;
+    esac
+fi

--- a/src/app/(mobile-ui)/dev/ds/audit/audit-data.ts
+++ b/src/app/(mobile-ui)/dev/ds/audit/audit-data.ts
@@ -64,7 +64,7 @@ export const LAYER_STATS: LayerStat[] = [
     },
     {
         layer: 'primitives',
-        distinct: 74,
+        distinct: 73,
         target: 28,
     },
     {
@@ -3648,17 +3648,6 @@ export const AUDIT_ITEMS: AuditItem[] = [
         status: 'duplicate',
         source: 'src/components/Migration/ScanToDownloadModal.tsx',
         notes: 'NEW since June. It is MigrationDownloadModal minus the device/deadline logic — the two are surface variants of one download prompt.',
-    },
-    {
-        name: 'ReviewPromptModal',
-        cat: 'modals',
-        catLabel: 'Modals / dialogs',
-        layer: 'primitives',
-        role: 'ActionModal: app-store review ask, gated on transaction history and a migration flag.',
-        usages: 1,
-        status: 'variant',
-        source: 'src/components/Migration/ReviewPromptModal.tsx',
-        notes: 'NEW since June. Mounted from HomeModals. Clean ActionModal delegation; all of its 90 lines are gating logic, not chrome.',
     },
     {
         name: 'PageContainer (0_Bruddle/PageContainer.tsx)',

--- a/src/app/(mobile-ui)/dev/ds/audit/components/audit-components-data.ts
+++ b/src/app/(mobile-ui)/dev/ds/audit/components/audit-components-data.ts
@@ -374,14 +374,6 @@ export const BIG_COMPONENT_CATEGORIES: UsageCategory[] = [
                 divergence: 'New since the last sweep. Second half of the migration pair, mounted from HomeModals.',
             },
             {
-                name: 'ReviewPromptModal',
-                realUsages: 1,
-                status: 'live',
-                source: 'components/Migration/ReviewPromptModal.tsx',
-                divergence:
-                    'New since the last sweep. App-store review prompt on ActionModal, mounted from HomeModals.',
-            },
-            {
                 name: 'QRScannerOverlay (BaseModal ad-hoc)',
                 realUsages: 2,
                 status: 'adhoc',

--- a/src/components/Kyc/SumsubNativeSdk.tsx
+++ b/src/components/Kyc/SumsubNativeSdk.tsx
@@ -119,27 +119,14 @@ export const SumsubNativeSdk = ({
                         reportFailure(result.errorType || 'sdk-failed', new Error(result.errorMsg || result.status))
                         return
                     }
-                    // The promise resolves on close, whatever the user did — so
-                    // the status decides between "submitted, go show progress"
-                    // and "backed out, just close".
-                    //
-                    // Multi-level cannot trust `hasSubmitted` on its own: Pending
-                    // fires after Level 1 with the questionnaire still outstanding,
-                    // so a Level-1 submit followed by backing out of Level 2 looks
-                    // identical to a finished workflow. The plugin dismisses after
-                    // the LAST level, so there a close whose OWN status is not a
-                    // submitted one is the user leaving mid-workflow — report it as
-                    // a close, or the flow hooks consume the deferred
-                    // ACTION_REQUIRED and strand them on a stale progress modal.
-                    // Single-level keeps trusting `hasSubmitted`: one submit IS the
-                    // whole flow there, and the closing status often lies (Initial).
+                    // Native status is per level. Only the backend confirms a complete workflow.
                     const closedSubmitted = SUBMITTED_STATES.has(result?.status ?? '')
-                    if (isMultiLevelRef.current ? closedSubmitted : hasSubmitted || closedSubmitted) {
+                    if (!isMultiLevelRef.current && (hasSubmitted || closedSubmitted)) {
                         onCompleteRef.current()
                     } else {
                         // The level they DID finish still counts for the funnel —
                         // routing this as a close must not also lose the submit.
-                        if (hasSubmitted) onSubmittedRef.current?.()
+                        if (hasSubmitted || closedSubmitted) onSubmittedRef.current?.()
                         onCloseRef.current()
                     }
                 },

--- a/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
@@ -159,20 +159,6 @@ describe('SumsubNativeSdk', () => {
         expect(props.onSubmitted).toHaveBeenCalledTimes(1)
     })
 
-    // ...but a genuinely finished multi-level workflow still completes: the plugin
-    // dismisses after the last level and the closing status is a submitted one.
-    it('multi-level completes when the closing status is itself a submission', async () => {
-        launch.mockResolvedValue({ success: true, status: 'Pending' })
-        const props = { ...baseProps(), isMultiLevel: true }
-        const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
-        await act(async () => {
-            rerender(<SumsubNativeSdk visible {...props} />)
-        })
-
-        await waitFor(() => expect(props.onComplete).toHaveBeenCalled())
-        expect(props.onClose).not.toHaveBeenCalled()
-    })
-
     it('closes without completing when the user backs out', async () => {
         launch.mockResolvedValue({ success: true, status: 'Initial' })
         const props = baseProps()
@@ -185,6 +171,19 @@ describe('SumsubNativeSdk', () => {
         await waitFor(() => expect(props.onClose).toHaveBeenCalled())
         expect(props.onComplete).not.toHaveBeenCalled()
     })
+
+    it.each(['Pending', 'Approved', 'ActionCompleted'])(
+        'multi-level close with %s does not prove workflow completion',
+        async (status) => {
+            launch.mockResolvedValue({ success: true, status })
+            const props = { ...baseProps(), isMultiLevel: true, onSubmitted: jest.fn() }
+            await act(async () => {
+                render(<SumsubNativeSdk visible {...props} />)
+            })
+            await waitFor(() => expect(props.onClose).toHaveBeenCalled())
+            expect(props.onComplete).not.toHaveBeenCalled()
+        }
+    )
 
     // The whole point of moving off the WebSDK: a Sumsub-side failure used to
     // paint their "Initialization error" screen inside a cross-origin iframe and

--- a/src/hooks/__tests__/useSumsubKycFlow.test.ts
+++ b/src/hooks/__tests__/useSumsubKycFlow.test.ts
@@ -561,7 +561,7 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
     // the held (now stale) transition would close it in the same breath and dump
     // the user on an ACTION_REQUIRED drawer for documents they just resubmitted.
     // handleSdkComplete consumes the deferred status instead.
-    it('a submission close consumes the deferred transition — the progress modal stays open', async () => {
+    it('an ambiguous multi-level completion replays the deferred transition', async () => {
         const { result } = await openSdkOverProgressModal('EU')
 
         await act(async () => {
@@ -575,7 +575,7 @@ describe('useSumsubKycFlow — ACTION_REQUIRED during a multi-level session', ()
         })
 
         expect(result.current.showWrapper).toBe(false)
-        expect(result.current.isVerificationProgressModalOpen).toBe(true)
+        expect(result.current.isVerificationProgressModalOpen).toBe(false)
     })
 
     // The counterpart: a MANUAL close always replays. handleSdkComplete is the

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -178,7 +178,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         //
         // The one close that must NOT replay it is a submission — the user just
         // acted, so the held transition is stale for what they submitted.
-        // handleSdkComplete consumes it by advancing prevStatusRef itself.
+        // Only a single-level completion consumes it; multi-level completion comes from the backend.
         //
         // Both flags are committed state rather than refs, so an interrupted render
         // can never leak a value this guard acts on.
@@ -475,23 +475,19 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         userInitiatedRef.current = true
         selfHealProviderRef.current = null
         actionKeyRef.current = null
-        // Consume a deferred ACTION_REQUIRED (see the transition effect): this
-        // close IS a submission, so the held transition is stale — replaying it
-        // would close the progress modal this handler opens (in-session resubmit
-        // after a RED decline). The manual close keeps the replay: abandoning
-        // really does leave the action required.
-        if (liveKycStatus === 'ACTION_REQUIRED') prevStatusRef.current = 'ACTION_REQUIRED'
+        // Only a single-level submission proves the deferred action was completed.
+        if (!isMultiLevel && liveKycStatus === 'ACTION_REQUIRED') prevStatusRef.current = 'ACTION_REQUIRED'
         setShowWrapper(false)
         setIsActionFlow(false)
         setIsMultiLevel(false)
         setIsVerificationProgressModalOpen(true)
-    }, [liveKycStatus])
+    }, [isMultiLevel, liveKycStatus])
 
     // Called when the user manually closes the SDK modal. Every manual close
     // replays a deferred ACTION_REQUIRED: the wrapper cannot tell "submitted the
     // required follow-up" from "submitted level 1 and walked away", so treating
     // any close as a submission would swallow a real action-required state.
-    // handleSdkComplete is the one unambiguous submission, and it consumes.
+    // Only single-level completion consumes the deferred action.
     const handleClose = useCallback(() => {
         setShowWrapper(false)
         setIsActionFlow(false)


### PR DESCRIPTION
Multi-level KYC closes no longer consume a deferred action-required state, so leaving a follow-up questionnaire does not strand the user on a stale verification screen. The design audit also drops the deleted ReviewPromptModal entry.

Native production releases now require compiled MeaWallet provisioning support. Release Native records an annotated capability tag only after both platform builds succeed; OTA rejects release tags without that attestation as well as incompatible source fingerprints.

Tasks: [TASK-22067](https://www.notion.so/3ce838117579817ca757c67b7576b77b), [TASK-22282](https://www.notion.so/3d18381175798162a287d938656f7ae2), [TASK-22226](https://www.notion.so/3d083811757981a0b456d51b66d39ffe).

Validation: full frontend suite run; its three dependency/asset setup failures passed on rerun after installing the declared native packages and generating flag assets. KYC regressions (60 tests), native tag fixtures (3 tests), typecheck, Prettier, and changed-file ESLint against dev pass.

Release requirement: configure the Android/iOS MeaWallet credentials and Android config before releasing. Existing tags have no capability attestation and must be superseded by a successful Release Native run. Provisioning activation and Apple entitlements remain separate requirements. Native archives require CI/device verification with the real SDK and signing setup.

Screenshots: N/A; no layout or visual styling changes.

Docs follow-up: mono/product/card.md and mono/engineering/native/{release-ios,release-android,ota-capgo}.md must reflect the production prerequisites. No legal changes identified.

Review follow-up: restored iOS app target membership for PushProvisioningPlugin and WalletExtensionCardStore, registered the provisioning bridge, and restored validated config bundling. Production archive requires MEAWALLET_CONFIG_BASE64_IOS in addition to the iOS Nexus secrets. Xcode project syntax and six native gate/config fixture tests pass; a credentialed native archive remains a release verification requirement.
