### PR TITLE
fix(kyc): route Mexico bank enrollment through the NA intent (TASK-22333)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -46,7 +46,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { useLocale, useTranslations } from 'next-intl'
 import { localizedCountryTitle } from '@/utils/country-name.utils'
 
@@ -503,7 +503,7 @@ function BridgeBankOnrampPage() {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
                             await sumsubFlow.handleInitiateKyc(
-                                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                                getBankRegionIntent(selectedCountry),
                                 undefined,
                                 gate.kind === 'needs-enrollment' || undefined,
                                 selectedCountry?.id

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1476,7 +1476,9 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
             fireEvent.click(screen.getByTestId('kyc-verify-button'))
         })
 
-        expect(handleInitiateKyc).toHaveBeenCalledWith('NA', undefined, true, 'MX')
+        // intent + crossRegion are what the BE routes on; the 4th arg (country) is
+        // dropped by useSumsubKycFlow for non-Manteca countries, so don't pin it
+        expect(handleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
     })
 
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -705,7 +705,7 @@ jest.mock('@/components/AddMoney/consts', () => ({
         { type: 'country', id: 'BR', path: 'brazil', currency: 'BRL', iso3: 'BRA' },
         { type: 'country', id: 'US', path: 'us', currency: 'USD', iso3: 'USA' },
         { type: 'country', id: 'DE', path: 'germany', currency: 'EUR', iso3: 'DEU' },
-        { type: 'country', id: 'MX', path: 'mexico', currency: 'MXN', iso3: 'MEX' },
+        { type: 'country', id: 'MX', path: 'mexico', currency: 'MXN', iso3: 'MEX', region: 'latam' },
         { type: 'country', id: 'GB', path: 'uk', currency: 'GBP', iso3: 'GBR' },
         { type: 'country', id: 'XX', path: 'unknown', currency: 'USD', iso3: 'XXX' },
     ],
@@ -1454,6 +1454,29 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
 
         expect(mockRouterReplace).not.toHaveBeenCalled()
         expect(screen.getByText('How much do you want to add?')).toBeInTheDocument()
+    })
+
+    // Mexico is tagged `latam` but deposits over Bridge SPEI. A verified user with
+    // no SPEI rail (needs-enrollment) must unlock via the NA (Bridge) intent —
+    // LATAM + MX hits the Manteca path, which rejects MX and dead-ended in
+    // "contact support" (TASK-22333).
+    test('mexico needs-enrollment unlock sends the NA intent, not LATAM', async () => {
+        setParams({ country: 'mexico' })
+        setGate('needs-enrollment')
+        resetQueryState({ step: 'inputAmount', amount: '100' })
+        const handleInitiateKyc = jest.fn()
+        mockUseMultiPhaseKycFlow.mockReturnValue({ ...mockUseMultiPhaseKycFlow(), handleInitiateKyc })
+
+        renderWithProviders(<OnrampBankPage />)
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Continue'))
+        })
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kyc-verify-button'))
+        })
+
+        expect(handleInitiateKyc).toHaveBeenCalledWith('NA', undefined, true, 'MX')
     })
 
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -606,7 +606,7 @@ export default function WithdrawBankPage() {
                             getBankRegionIntent(countryFromPath),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
-                            getCountryFromPath(country)?.id
+                            countryFromPath?.id
                         )
                     }
                 }}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -41,7 +41,7 @@ import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
-import { isBridgeSupportedCountry, getRegionIntent } from '@/utils/regions.utils'
+import { isBridgeSupportedCountry, getBankRegionIntent } from '@/utils/regions.utils'
 import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import posthog from 'posthog-js'
@@ -603,7 +603,7 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
+                            getBankRegionIntent(countryFromPath),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             getCountryFromPath(country)?.id

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -32,7 +32,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import ProvideEmailStep from '@/components/Kyc/ProvideEmailStep'
@@ -259,7 +259,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                getBankRegionIntent(currentCountry),
                 undefined,
                 undefined,
                 currentCountry?.id
@@ -374,7 +374,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                            getBankRegionIntent(currentCountry),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             currentCountry?.id

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -135,7 +135,7 @@ jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: str
 // under jest when consts is stubbed). The gate is mocked, so neither return value
 // affects these assertions — stub both so the real consts is never evaluated.
 jest.mock('@/utils/bridge.utils', () => ({ railJurisdictionForBank: () => 'US' }))
-jest.mock('@/utils/regions.utils', () => ({ getRegionIntent: () => 'STANDARD' }))
+jest.mock('@/utils/regions.utils', () => ({ getBankRegionIntent: () => 'STANDARD' }))
 
 jest.mock('@/components/ActionListCard', () => ({
     ActionListCard: (props: any) => (

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -15,7 +15,7 @@ import useClaimLink from '../../useClaimLink'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useAuth } from '@/context/authContext'
 import { type TCreateOfframpRequest, type TCreateOfframpResponse } from '@/services/services.types'
-import { getOfframpConfigFromAccount } from '@/utils/bridge.utils'
+import { getCountryFromAccount, getOfframpConfigFromAccount } from '@/utils/bridge.utils'
 import { getBridgeChainName, getBridgeTokenName } from '@/utils/bridge-accounts.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import { getContractAddress } from '@/utils/peanut-claim.utils'
@@ -69,6 +69,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         flowStep: claimBankFlowStep,
         setFlowStep: setClaimBankFlowStep,
         selectedCountry,
+        setSelectedCountry,
         setClaimType,
         setBankDetails,
         justCompletedKyc,
@@ -522,6 +523,10 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
 
                         setLocalBankDetails(bankDetails)
                         setBankDetails(bankDetails)
+                        // only the country list sets selectedCountry; a saved
+                        // account skips it, so the unlock CTA below derived a
+                        // rest-of-world intent. The account is the destination.
+                        setSelectedCountry(getCountryFromAccount(account) ?? null)
 
                         const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
                         const userForOfframp = isGuestFlow

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,7 +32,7 @@ import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
@@ -321,7 +321,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                getBankRegionIntent(selectedCountry),
                 undefined,
                 undefined,
                 selectedCountry?.id
@@ -617,7 +617,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                     await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                                 } else {
                                     await sumsubFlow.handleInitiateKyc(
-                                        getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                                        getBankRegionIntent(selectedCountry),
                                         undefined,
                                         gate.kind === 'needs-enrollment' || undefined,
                                         selectedCountry?.id

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -525,8 +525,12 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         setBankDetails(bankDetails)
                         // only the country list sets selectedCountry; a saved
                         // account skips it, so the unlock CTA below derived a
-                        // rest-of-world intent. The account is the destination.
-                        setSelectedCountry(getCountryFromAccount(account) ?? null)
+                        // rest-of-world intent. The account is the destination —
+                        // but an account with no resolvable country (empty
+                        // countryCode/countryName, a known prod state) must not
+                        // clobber a country the user already picked.
+                        const accountCountry = getCountryFromAccount(account)
+                        if (accountCountry) setSelectedCountry(accountCountry)
 
                         const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
                         const userForOfframp = isGuestFlow

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- jest.mock factories stub component props with `any`; matches the sibling add-money-states.test.tsx style. */
 /**
  * BankFlowManager — saved-account claim path (TASK-22333).
  *
@@ -169,8 +168,11 @@ const clabeAccount = (details: Record<string, string>) => ({
     details,
 })
 
+// the view reads only claimLinkData / onCustom / setTransactionHash off IClaimScreenProps
+const props: any = { claimLinkData, onCustom: jest.fn(), setTransactionHash: jest.fn() }
+
 function renderView() {
-    return render(<BankFlowManager claimLinkData={claimLinkData} onCustom={jest.fn()} setTransactionHash={jest.fn()} />)
+    return render(<BankFlowManager {...props} />)
 }
 
 beforeEach(() => {

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -1,0 +1,223 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- jest.mock factories stub component props with `any`; matches the sibling add-money-states.test.tsx style. */
+/**
+ * BankFlowManager — saved-account claim path (TASK-22333).
+ *
+ * Only the country list used to set `selectedCountry`; a saved account skipped
+ * it, so the unlock CTA derived a rest-of-world intent. The account is the
+ * destination: clicking it must set the country, and the unlock CTA must send
+ * the bank intent for it (Mexico → NA, not LATAM). An account whose country
+ * cannot be resolved (empty countryCode/countryName — a known prod state) must
+ * not clobber a country the user already picked.
+ */
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { BankFlowManager } from '../BankFlowManager.view'
+import { getCountryFromPath } from '@/utils/bridge.utils'
+
+// --- stateful ClaimBankFlow context: re-renders triggered by the component's
+// own useState calls read the latest values back
+const mockSetSelectedCountry = jest.fn()
+const ctx: Record<string, any> = {}
+function resetCtx(overrides: Record<string, any> = {}) {
+    Object.keys(ctx).forEach((k) => delete ctx[k])
+    Object.assign(ctx, {
+        flowStep: 'saved-accounts-list',
+        setFlowStep: jest.fn((step: string | null) => {
+            ctx.flowStep = step
+        }),
+        selectedCountry: null,
+        setSelectedCountry: mockSetSelectedCountry,
+        setClaimType: jest.fn(),
+        setBankDetails: jest.fn(),
+        justCompletedKyc: false,
+        setJustCompletedKyc: jest.fn(),
+        setShowVerificationModal: jest.fn(),
+        ...overrides,
+    })
+}
+jest.mock('@/context/ClaimBankFlowContext', () => ({
+    ClaimBankFlowStep: {
+        SavedAccountsList: 'saved-accounts-list',
+        BankDetailsForm: 'bank-details-form',
+        BankConfirmClaim: 'bank-confirm-claim',
+        BankCountryList: 'bank-country-list',
+    },
+    useClaimBankFlow: () => ctx,
+}))
+
+// --- the account under test is injected through the saved-accounts hook
+let mockSavedAccounts: any[] = []
+jest.mock('@/hooks/useSavedAccounts', () => ({ __esModule: true, default: () => mockSavedAccounts }))
+jest.mock('@/components/Common/SavedAccountsView', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="saved-accounts">
+            {props.savedAccounts.map((account: any) => (
+                <button
+                    key={account.id}
+                    data-testid={`account-${account.id}`}
+                    onClick={() => props.onAccountClick(account, '')}
+                >
+                    {account.id}
+                </button>
+            ))}
+        </div>
+    ),
+}))
+
+// --- KYC plumbing
+const mockHandleInitiateKyc = jest.fn()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({
+        handleInitiateKyc: mockHandleInitiateKyc,
+        handleRestartIdentity: jest.fn(),
+        handleSelfHealResubmit: jest.fn(),
+        showWrapper: false,
+        isLoading: false,
+        error: null,
+    }),
+}))
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ gateFor: () => ({ kind: 'needs-enrollment' }) }),
+}))
+jest.mock('@/utils/capability-gate', () => ({
+    getKycModalVariant: () => 'needs_kyc',
+    getGateUserMessage: () => undefined,
+    getGateReasonCode: () => undefined,
+}))
+jest.mock('@/hooks/useTosGuard', () => ({
+    useTosGuard: () => ({ guardWithTos: jest.fn(), showBridgeTos: false, hideTos: jest.fn() }),
+}))
+jest.mock('@/components/Kyc/InitiateKycModal', () => ({
+    InitiateKycModal: (props: any) =>
+        props.visible ? (
+            <button data-testid="kyc-verify-button" onClick={props.onVerify}>
+                Verify
+            </button>
+        ) : null,
+}))
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/BridgeTosStep', () => ({ BridgeTosStep: () => null }))
+jest.mock('@/components/Claim/Link/views/Confirm.bank-claim.view', () => ({
+    ConfirmBankClaimView: (props: any) => (
+        <button data-testid="confirm-claim" onClick={props.onConfirm}>
+            Confirm
+        </button>
+    ),
+}))
+
+// --- everything else the view imports but this path never exercises
+jest.mock('@/hooks/useDetermineBankClaimType', () => ({
+    BankClaimType: {
+        GuestBankClaim: 'guest-bank-claim',
+        UserBankClaim: 'user-bank-claim',
+        ReceiverKycNeeded: 'receiver-kyc-needed',
+        GuestKycNeeded: 'guest-kyc-needed',
+    },
+    useDetermineBankClaimType: () => ({ claimType: 'user-bank-claim' }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { fullName: 'Ana Perez', email: 'ana@example.com' } }, fetchUser: jest.fn() }),
+}))
+jest.mock('@/context/loadingStates.context', () => {
+    const { createContext } = jest.requireActual('react')
+    return { loadingStateContext: createContext({ isLoading: false, setLoadingState: jest.fn() }) }
+})
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
+jest.mock('@/components/Claim/useClaimLink', () => ({ __esModule: true, default: () => ({ claimLink: jest.fn() }) }))
+jest.mock('@/hooks/useFriendlyError', () => ({ useFriendlyError: () => (e: unknown) => String(e) }))
+jest.mock('@/app/actions/external-accounts', () => ({ createBridgeExternalAccountForGuest: jest.fn() }))
+jest.mock('@/app/actions/offramp', () => ({
+    confirmOfframp: jest.fn(),
+    createOfframp: jest.fn(),
+    createOfframpForGuest: jest.fn(),
+}))
+jest.mock('@/app/actions/users', () => ({ addBankAccount: jest.fn(), getUserById: jest.fn() }))
+jest.mock('@/utils/general.utils', () => ({ formatTokenAmount: (n: number) => String(n) }))
+jest.mock('@/utils/bridge-accounts.utils', () => ({
+    getBridgeChainName: () => 'arbitrum',
+    getBridgeTokenName: () => 'usdc',
+}))
+jest.mock('@/utils/peanut-link.utils', () => ({ generateKeysFromString: jest.fn(), getParamsFromLink: jest.fn() }))
+jest.mock('@/utils/peanut-claim.utils', () => ({ getContractAddress: () => '0x0' }))
+jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: string) => id }))
+jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({ DynamicBankAccountForm: () => null }))
+jest.mock('@/components/Common/CountryListRouter', () => ({ CountryListRouter: () => null }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({ badgeCampaignForLegacyWire: () => undefined }))
+jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn() }))
+jest.mock('@/redux/slices/bank-form-slice', () => ({ bankFormActions: {} }))
+jest.mock('@/services/sendLinks', () => ({ sendLinksApi: {} }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }))
+jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+const claimLinkData: any = {
+    sender: { userId: 'sender-1' },
+    senderAddress: '0xsender',
+    amount: 1000000n,
+    tokenDecimals: 6,
+    tokenSymbol: 'USDC',
+    chainId: '42161',
+    contractVersion: 'v4.3',
+}
+const clabeAccount = (details: Record<string, string>) => ({
+    id: 'acc-mx',
+    type: 'clabe',
+    identifier: '002010077777777771',
+    bridgeAccountId: 'bridge-acc-1',
+    details,
+})
+
+function renderView() {
+    return render(<BankFlowManager claimLinkData={claimLinkData} onCustom={jest.fn()} setTransactionHash={jest.fn()} />)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    resetCtx()
+})
+
+test('clicking a saved Mexico CLABE account sets selectedCountry to Mexico', async () => {
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).toHaveBeenCalledWith(expect.objectContaining({ id: 'MX', region: 'latam' }))
+})
+
+test('a saved account with no resolvable country does not clobber the country already picked', async () => {
+    resetCtx({ selectedCountry: getCountryFromPath('germany') })
+    mockSavedAccounts = [clabeAccount({ countryCode: '', countryName: '', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).not.toHaveBeenCalled()
+})
+
+test('unlock CTA after a saved Mexico account sends the NA intent, not LATAM', async () => {
+    // the real context would now hold Mexico (previous test); mirror that here
+    resetCtx({ selectedCountry: getCountryFromPath('mexico') })
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    // saved account → confirm step (localBankDetails set) → confirm → gate is
+    // needs-enrollment → KYC modal → verify
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('confirm-claim'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('kyc-verify-button'))
+    })
+
+    expect(mockHandleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
+})

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -1,4 +1,9 @@
-import { getRegionIntent, pendingBankRailRegionPaths, providerForRegionIntent } from '../regions.utils'
+import {
+    getBankRegionIntent,
+    getRegionIntent,
+    pendingBankRailRegionPaths,
+    providerForRegionIntent,
+} from '../regions.utils'
 import { type RailCapability } from '@/types/capabilities'
 
 describe('getRegionIntent', () => {
@@ -18,6 +23,23 @@ describe('getRegionIntent', () => {
 // Mirrors the BE registry (crossRegionProvider in peanut-api-ts
 // src/kyc/level-registry.ts) — if these expectations change, the BE
 // registry changed and both sides must move together.
+describe('getBankRegionIntent', () => {
+    // Mexico is a `latam` picker region but deposits/withdraws over Bridge SPEI —
+    // LATAM + MX hits the Manteca path, which rejects MX (TASK-22333)
+    it('routes Mexico bank flows as NA (Bridge), not LATAM', () => {
+        expect(getBankRegionIntent({ id: 'MX', region: 'latam' })).toBe('NA')
+    })
+
+    it('falls back to the region intent for every other country', () => {
+        expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
+        expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
+        expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')
+        expect(getBankRegionIntent({ id: 'XX' })).toBe('ROW')
+        expect(getBankRegionIntent(undefined)).toBe('ROW')
+    })
+})
+
 describe('providerForRegionIntent', () => {
     it('maps Bridge intents (EU / NA + legacy STANDARD) to bridge', () => {
         expect(providerForRegionIntent('EU')).toBe('bridge')

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -32,6 +32,9 @@ describe('getBankRegionIntent', () => {
 
     it('falls back to the region intent for every other country', () => {
         expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'BR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'CO', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'GB', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
         expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -114,13 +114,16 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
 
 /**
  * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
- * Mexico is `region: 'latam'` for the region picker, but its bank rail (SPEI)
- * is a Bridge rail. Sending LATAM + MX asks the Manteca path for a country it
- * does not serve; the BE rejects it and the UI collapsed that into "contact
- * support" (TASK-22333). Route it as NA (Bridge), like the US.
+ * A `latam` picker country whose bank rail is Bridge (today: Mexico / SPEI)
+ * must unlock as NA (Bridge), like the US. Sending LATAM + MX asks the Manteca
+ * path for a country it does not serve; the BE rejects it and the UI collapsed
+ * that into "contact support" (TASK-22333). Every other country keeps the
+ * picker-region intent.
  */
 export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
-    country?.id === 'MX' ? 'NA' : getRegionIntent(country?.region ?? 'rest-of-the-world')
+    country?.region === 'latam' && isBridgeSupportedCountry(country.id)
+        ? 'NA'
+        : getRegionIntent(country?.region ?? 'rest-of-the-world')
 
 /**
  * Which provider serves a region intent — an exact FE mirror of the BE registry

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -2,7 +2,7 @@ import { EUROPE_GLOBE_ICON, LATAM_GLOBE_ICON, NORTH_AMERICA_GLOBE_ICON, REST_OF_
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { type RailCapability } from '@/types/capabilities'
-import { BRIDGE_ALPHA3_TO_ALPHA2 } from '@/components/AddMoney/consts'
+import { BRIDGE_ALPHA3_TO_ALPHA2, type CountryData } from '@/components/AddMoney/consts'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import type { StaticImageData } from 'next/image'
 
@@ -111,6 +111,16 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
             return 'ROW'
     }
 }
+
+/**
+ * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
+ * Mexico is `region: 'latam'` for the region picker, but its bank rail (SPEI)
+ * is a Bridge rail. Sending LATAM + MX asks the Manteca path for a country it
+ * does not serve; the BE rejects it and the UI collapsed that into "contact
+ * support" (TASK-22333). Route it as NA (Bridge), like the US.
+ */
+export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
+    country?.id === 'MX' ? 'NA' : getRegionIntent(country?.region ?? 'rest-of-the-world')
 
 /**
  * Which provider serves a region intent — an exact FE mirror of the BE registry

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -113,19 +113,6 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
 }
 
 /**
- * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
- * A `latam` picker country whose bank rail is Bridge (today: Mexico / SPEI)
- * must unlock as NA (Bridge), like the US. Sending LATAM + MX asks the Manteca
- * path for a country it does not serve; the BE rejects it and the UI collapsed
- * that into "contact support" (TASK-22333). Every other country keeps the
- * picker-region intent.
- */
-export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
-    country?.region === 'latam' && isBridgeSupportedCountry(country.id)
-        ? 'NA'
-        : getRegionIntent(country?.region ?? 'rest-of-the-world')
-
-/**
  * Which provider serves a region intent — an exact FE mirror of the BE registry
  * (`crossRegionProvider` in peanut-api-ts `src/kyc/level-registry.ts`). Used for
  * DISPLAY only (which provider rail backs a clicked region); the BE stays the
@@ -226,6 +213,18 @@ const RAIL_COUNTRY_TO_REGION_PATH: Record<string, string> = {
     BR: 'latam',
     CO: 'latam',
 }
+
+/**
+ * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
+ * The picker region is not the rail jurisdiction: Mexico is `region: 'latam'`
+ * for the picker, but its bank rail (SPEI) is Bridge, and the jurisdiction
+ * table above says `north-america`. Sending LATAM + MX asked the Manteca path
+ * for a country it does not serve; the BE rejects it and the UI collapsed that
+ * into "contact support" (TASK-22333). Countries with no rail entry keep the
+ * picker region.
+ */
+export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
+    getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[country?.id ?? ''] ?? country?.region ?? 'rest-of-the-world')
 
 /**
  * Region picker paths with a mid-flight bank rail (`pending` = BE provisioning,


### PR DESCRIPTION
## Summary

A newly approved Mexico user who taps "Add money → bank" reaches "contact support" instead of the SPEI deposit flow. No bank customer, SPEI/MXN rail, intent or entry is created. 8 approved Mexico users have no SPEI rail today (1 approved in the last 7 days). $0 moved or lost — the flow is blocked before any transfer.

**Root cause.** Mexico is `region: 'latam'` in the country table (the region picker bucket), but its bank rail (SPEI) is a Bridge rail. Every bank-flow unlock CTA derived the KYC intent from that picker region via `getRegionIntent(country.region)` and sent `LATAM + targetCountry=MX`. `initiate-kyc.ts` intentionally rejects MX for the Manteca (LATAM) path, and the UI collapsed that typed rejection into the support dead-end. This is a coverage regression of hotfix #2163, which fixed the `'STANDARD'` literal at the same call sites but kept region as the source of the intent.

**Fix.** One helper, `getBankRegionIntent(country)` in `regions.utils.ts`: the intent comes from the rail-jurisdiction table `RAIL_COUNTRY_TO_REGION_PATH` (the one the pending-rail badges already use — `MX → north-america`), falling back to the picker region for countries with no rail entry. Output is identical to before for every country except Mexico. All six bank-flow call sites route through it (add-money bank page, withdraw bank page, `AddWithdrawCountriesList` ×2, `BankFlowManager` ×2) — the task names one page, but the same derivation is copied at every bank flow, so fixing only the reported one would have left withdraw / claim-to-bank / countries-list still dead for Mexico. `UnlockedRegions` keeps `getRegionIntent`: it works off the clicked picker region, not a country.

The bank-claim flow had a second gap on the same line: only the country list sets `selectedCountry`, so a saved account (CLABE) reached the unlock CTA with no country and a rest-of-world intent. `onAccountClick` now sets it from the account (`getCountryFromAccount`) — the account is the destination. The write is guarded: an account whose country cannot be resolved (empty `countryCode`/`countryName`, a known prod state) leaves an already-picked country alone instead of resetting it to rest-of-world.

On the BE, `NA` is a Bridge intent: `isBridgeIntent('NA')` → bridge-requirements level, and `autoEnrollUserRails(userId, 'STANDARD')` enrolls `ACH_US, SEPA_EU, SPEI_MX, FASTER_PAYMENTS_GB`, so the SPEI rail is created after enrollment. The `targetCountry` arg is dropped by `useSumsubKycFlow` for non-Manteca countries before the request, so the BE never sees MX — no BE change needed.

**Cohort check (prod, read-only, 2026-09-08).** Exactly 8 approved `sumsub_geo = MX` users have no `SPEI_MX` rail. Stored region intent: 1 × LATAM (the 09-06 report), 7 × null; none NA, none holds any Bridge rail — so every one of them takes the cross-region / Bridge-enrollment-recovery path with the new intent. The "stored NA + live Bridge rail + no SPEI" state that would loop silently does not exist in the cohort.

## Task

TASK-22333 — https://app.notion.com/p/3d3838117579811c8861ea26ee1b0b95

## Risks / breaking changes

- FE-only, no API contract change. Base `main` (P2 production issue, user-blocking) → creates main→dev back-merge debt.
- Blast radius: only `country.id === 'MX'` changes behaviour (LATAM → NA). Every other country resolves exactly as before (covered by the helper's unit test).
- `NA` vs `EU` for Mexico is a wash on the BE (both → bridge-requirements + the same Bridge rail set); `NA` is what the US bank flow sends and what the task specifies.

## Design notes / accepted trade-offs

- **Why not flip Mexico's `region` to `north-america` in the country table?** `region` is the picker bucket (Mexico sits under the LATAM tile in the UI and in `deriveRegionAccess`), so the row stays `latam`; the bank intent is a rail fact and now comes from the rail table.
- **Reviewed, deferred to a follow-up (not this PR):** the BE `initiate-kyc.ts` still routes on `regionIntent === 'LATAM'` alone and would mis-route an older client that sends LATAM for a Mexico user; a boundary coercion there needs the FE to stop stripping non-Manteca countries first. Filed as a follow-up in the readiness report.
- **Skipped by decision (Chip round 4, MINOR advisory):** a page-level test for the withdraw bank page's unlock CTA. The mapping is unit-tested in `regions.utils.test.ts`, the add-money page and the bank claim have page-level tests, and the withdraw wiring is the same one-line helper call; a 40-mock harness for that one assertion is not worth it.
- **Revealed, not changed:** the six bank-flow sites copy the same 4-arg `handleInitiateKyc(intent, undefined, needs-enrollment, country.id)` call; a `handleInitiateBankKyc(country, gate)` would collapse them. Out of this PR's blast radius.

## QA

- `regions.utils.test.ts`: `getBankRegionIntent` MX → NA; AR/US/DE/ROW/unknown/undefined unchanged.
- `add-money-states.test.tsx` GROUP 5: Mexico + `needs-enrollment` gate → Continue → Verify calls `handleInitiateKyc` with `('NA', undefined, true, …)`. The country fixture now carries `region: 'latam'` so the test reproduces the real routing (pre-fix it sends `LATAM`).
- `BankFlowManager.savedAccount.test.tsx` (new, first test for that view): saved MX CLABE account → `selectedCountry` = Mexico; an account with no resolvable country does not clobber an already-picked country; unlock CTA from the saved account → `handleInitiateKyc('NA', undefined, true, …)`.
- `AddWithdrawCountriesList.test.tsx` mock updated to the new helper name.
- Full suite: 346 suites / 4265 tests green; typecheck + prettier clean.
- Manual (sandbox): approved Bridge user with no SPEI rail → `/add-money/mexico/bank` → Continue → KYC modal → Verify → Sumsub opens on `bridge-requirements`, and after completion `user_rails` gains `SPEI_MX`.

Screenshots: N/A (no visible change — the same modal opens; only the intent it sends differs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bank-flow KYC routing for country-specific banking rails, including Mexico, to ensure the correct verification region is selected.
  * Preserved the currently selected country when saved-account details cannot be resolved.
* **Tests**
  * Added regression coverage for bank KYC routing and saved-account claim flows.
  * Expanded validation for country and fallback region handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->