### PR TITLE
fix(kyc): route Mexico bank enrollment through the NA intent

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -292,7 +292,7 @@ function BridgeBankOnrampPage() {
             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
         } else {
             await sumsubFlow.handleInitiateKyc(
-                bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(selectedCountry),
                 undefined,
                 gate.kind === 'needs-enrollment' || undefined,
                 selectedCountry?.id

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -607,7 +607,7 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            bankRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
+                            bankRegionIntent(countryFromPath),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             getCountryFromPath(country)?.id

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -262,7 +262,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
             await sumsubFlow.handleInitiateKyc(
-                bankRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(currentCountry),
                 undefined,
                 undefined,
                 currentCountry?.id
@@ -379,7 +379,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            bankRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                            bankRegionIntent(currentCountry),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             currentCountry?.id

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -146,7 +146,7 @@ jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: str
 // under jest when consts is stubbed). The gate is mocked, so neither return value
 // affects these assertions — stub both so the real consts is never evaluated.
 jest.mock('@/utils/bridge.utils', () => ({ railJurisdictionForBank: () => 'US' }))
-jest.mock('@/utils/regions.utils', () => ({ getRegionIntent: () => 'STANDARD' }))
+jest.mock('@/utils/regions.utils', () => ({ getBankRegionIntent: () => 'STANDARD' }))
 
 jest.mock('@/components/0_Bruddle/ListItem', () => ({
     ListItem: (props: any) => (

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -15,7 +15,7 @@ import useClaimLink from '../../useClaimLink'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useAuth } from '@/context/authContext'
 import { type TCreateOfframpRequest, type TCreateOfframpResponse } from '@/services/services.types'
-import { getCountryFromAccount, getOfframpConfigFromAccount } from '@/utils/bridge.utils'
+import { getBankRailCountryFromAccount, getCountryFromAccount, getOfframpConfigFromAccount } from '@/utils/bridge.utils'
 import { getBridgeChainName, getBridgeTokenName } from '@/utils/bridge-accounts.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import { getContractAddress } from '@/utils/peanut-claim.utils'
@@ -91,7 +91,27 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
     const { gateFor } = useCapabilities()
     const bankRegionIntent = useBankRegionIntent()
     const { banking: isBankRestricted } = useResidenceRestrictions()
-    const gate = useMemo(() => gateFor('deposit', { channel: 'bank' }), [gateFor])
+    // local states for this component
+    const [localBankDetails, setLocalBankDetails] = useState<BankAccountWithId | null>(null)
+    const [receiverFullName, setReceiverFullName] = useState<string>('')
+    const [error, setError] = useState<string | null>(null)
+    const formRef = useRef<{ handleSubmit: () => void }>(null)
+    const [isProcessingKycSuccess, setIsProcessingKycSuccess] = useState(false)
+    const [_offrampData, setOfframpData] = useState<TCreateOfframpResponse | null>(null)
+
+    const bankRailCountry = useMemo(
+        () =>
+            localBankDetails
+                ? getBankRailCountryFromAccount(localBankDetails)
+                : selectedCountry
+                  ? getBankRailCountryFromAccount({ country: selectedCountry.iso2 ?? selectedCountry.id })
+                  : undefined,
+        [localBankDetails, selectedCountry]
+    )
+    const gate = useMemo(
+        () => gateFor('deposit', { channel: 'bank', country: bankRailCountry }),
+        [bankRailCountry, gateFor]
+    )
     const { guardWithTos, showBridgeTos, hideTos } = useTosGuard()
     const [showKycModal, setShowKycModal] = useState(false)
     const { setIsSupportModalOpen } = useModalsContext()
@@ -109,14 +129,6 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         },
         onManualClose: () => setIsKycModalOpen(false),
     })
-
-    // local states for this component
-    const [localBankDetails, setLocalBankDetails] = useState<BankAccountWithId | null>(null)
-    const [receiverFullName, setReceiverFullName] = useState<string>('')
-    const [error, setError] = useState<string | null>(null)
-    const formRef = useRef<{ handleSubmit: () => void }>(null)
-    const [isProcessingKycSuccess, setIsProcessingKycSuccess] = useState(false)
-    const [_offrampData, setOfframpData] = useState<TCreateOfframpResponse | null>(null)
 
     /**
      * @name handleConfirmClaim
@@ -330,7 +342,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            bankRegionIntent(selectedCountry),
+                            bankRegionIntent(bankRailCountry ?? selectedCountry),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             selectedCountry?.id
@@ -372,7 +384,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                 return {}
             }
             await sumsubFlow.handleInitiateKyc(
-                bankRegionIntent(selectedCountry),
+                bankRegionIntent(bankRailCountry ?? selectedCountry),
                 undefined,
                 undefined,
                 selectedCountry?.id

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -15,7 +15,7 @@ import useClaimLink from '../../useClaimLink'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useAuth } from '@/context/authContext'
 import { type TCreateOfframpRequest, type TCreateOfframpResponse } from '@/services/services.types'
-import { getOfframpConfigFromAccount } from '@/utils/bridge.utils'
+import { getCountryFromAccount, getOfframpConfigFromAccount } from '@/utils/bridge.utils'
 import { getBridgeChainName, getBridgeTokenName } from '@/utils/bridge-accounts.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import { getContractAddress } from '@/utils/peanut-claim.utils'
@@ -70,6 +70,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         flowStep: claimBankFlowStep,
         setFlowStep: setClaimBankFlowStep,
         selectedCountry,
+        setSelectedCountry,
         setClaimType,
         setBankDetails,
         justCompletedKyc,
@@ -329,7 +330,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                            bankRegionIntent(selectedCountry),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             selectedCountry?.id
@@ -371,7 +372,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                 return {}
             }
             await sumsubFlow.handleInitiateKyc(
-                bankRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                bankRegionIntent(selectedCountry),
                 undefined,
                 undefined,
                 selectedCountry?.id
@@ -572,6 +573,8 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
 
                         setLocalBankDetails(bankDetails)
                         setBankDetails(bankDetails)
+                        const resolvedCountry = getCountryFromAccount(account)
+                        if (resolvedCountry) setSelectedCountry(resolvedCountry)
 
                         const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
                         const userForOfframp = isGuestFlow

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -66,6 +66,7 @@ jest.mock('@/components/Common/SavedAccountsView', () => ({
 
 // --- KYC plumbing
 const mockHandleInitiateKyc = jest.fn()
+const mockGateFor = jest.fn(() => ({ kind: 'needs-enrollment' }))
 jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     useMultiPhaseKycFlow: () => ({
         handleInitiateKyc: mockHandleInitiateKyc,
@@ -77,7 +78,7 @@ jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
     }),
 }))
 jest.mock('@/hooks/useCapabilities', () => ({
-    useCapabilities: () => ({ gateFor: () => ({ kind: 'needs-enrollment' }) }),
+    useCapabilities: () => ({ gateFor: mockGateFor }),
 }))
 jest.mock('@/hooks/useResidenceRestrictions', () => ({
     useResidenceRestrictions: () => ({ banking: false }),
@@ -180,6 +181,7 @@ function renderView() {
 
 beforeEach(() => {
     jest.clearAllMocks()
+    mockGateFor.mockReturnValue({ kind: 'needs-enrollment' })
     resetCtx()
 })
 
@@ -194,9 +196,23 @@ test('clicking a saved Mexico CLABE account sets selectedCountry to Mexico', asy
     expect(mockSetSelectedCountry).toHaveBeenCalledWith(expect.objectContaining({ id: 'MX', region: 'latam' }))
 })
 
-test('a saved account with no resolvable country does not clobber the country already picked', async () => {
+test('empty CLABE country metadata still resolves Mexico from the account type', async () => {
     resetCtx({ selectedCountry: getCountryFromPath('germany') })
     mockSavedAccounts = [clabeAccount({ countryCode: '', countryName: '', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).toHaveBeenCalledWith(expect.objectContaining({ id: 'MX', region: 'latam' }))
+})
+
+test('an account with no country or rail metadata does not clobber the country already picked', async () => {
+    resetCtx({ selectedCountry: getCountryFromPath('germany') })
+    mockSavedAccounts = [
+        { ...clabeAccount({ countryCode: '', countryName: '', accountOwnerName: 'Ana Perez' }), type: 'unknown' },
+    ]
     renderView()
 
     await act(async () => {
@@ -224,5 +240,6 @@ test('unlock CTA after a saved Mexico account sends the NA intent, not LATAM', a
         fireEvent.click(screen.getByTestId('kyc-verify-button'))
     })
 
+    expect(mockGateFor).toHaveBeenCalledWith('deposit', { channel: 'bank', country: 'MX' })
     expect(mockHandleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
 })

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * BankFlowManager — saved-account claim path (TASK-22333).
+ *
+ * Only the country list used to set `selectedCountry`; a saved account skipped
+ * it, so the unlock CTA derived a rest-of-world intent. The account is the
+ * destination: clicking it must set the country, and the unlock CTA must send
+ * the bank intent for it (Mexico → NA, not LATAM). An account whose country
+ * cannot be resolved (empty countryCode/countryName — a known prod state) must
+ * not clobber a country the user already picked.
+ */
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { BankFlowManager } from '../BankFlowManager.view'
+import { getCountryFromPath } from '@/utils/bridge.utils'
+
+// --- stateful ClaimBankFlow context: re-renders triggered by the component's
+// own useState calls read the latest values back
+const mockSetSelectedCountry = jest.fn()
+const ctx: Record<string, any> = {}
+function resetCtx(overrides: Record<string, any> = {}) {
+    Object.keys(ctx).forEach((k) => delete ctx[k])
+    Object.assign(ctx, {
+        flowStep: 'saved-accounts-list',
+        setFlowStep: jest.fn((step: string | null) => {
+            ctx.flowStep = step
+        }),
+        selectedCountry: null,
+        setSelectedCountry: mockSetSelectedCountry,
+        setClaimType: jest.fn(),
+        setBankDetails: jest.fn(),
+        justCompletedKyc: false,
+        setJustCompletedKyc: jest.fn(),
+        setShowVerificationModal: jest.fn(),
+        ...overrides,
+    })
+}
+jest.mock('@/context/ClaimBankFlowContext', () => ({
+    ClaimBankFlowStep: {
+        SavedAccountsList: 'saved-accounts-list',
+        BankDetailsForm: 'bank-details-form',
+        BankConfirmClaim: 'bank-confirm-claim',
+        BankCountryList: 'bank-country-list',
+    },
+    useClaimBankFlow: () => ctx,
+}))
+
+// --- the account under test is injected through the saved-accounts hook
+let mockSavedAccounts: any[] = []
+jest.mock('@/hooks/useSavedAccounts', () => ({ __esModule: true, default: () => mockSavedAccounts }))
+jest.mock('@/components/Common/SavedAccountsView', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="saved-accounts">
+            {props.savedAccounts.map((account: any) => (
+                <button
+                    key={account.id}
+                    data-testid={`account-${account.id}`}
+                    onClick={() => props.onAccountClick(account, '')}
+                >
+                    {account.id}
+                </button>
+            ))}
+        </div>
+    ),
+}))
+
+// --- KYC plumbing
+const mockHandleInitiateKyc = jest.fn()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({
+        handleInitiateKyc: mockHandleInitiateKyc,
+        handleRestartIdentity: jest.fn(),
+        handleSelfHealResubmit: jest.fn(),
+        showWrapper: false,
+        isLoading: false,
+        error: null,
+    }),
+}))
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ gateFor: () => ({ kind: 'needs-enrollment' }) }),
+}))
+jest.mock('@/hooks/useResidenceRestrictions', () => ({
+    useResidenceRestrictions: () => ({ banking: false }),
+}))
+jest.mock('@/utils/capability-gate', () => ({
+    getKycModalVariant: () => 'needs_kyc',
+    getGateUserMessage: () => undefined,
+    getGateReasonCode: () => undefined,
+}))
+jest.mock('@/hooks/useTosGuard', () => ({
+    useTosGuard: () => ({ guardWithTos: jest.fn(), showBridgeTos: false, hideTos: jest.fn() }),
+}))
+jest.mock('@/components/Kyc/InitiateKycModal', () => ({
+    InitiateKycModal: (props: any) =>
+        props.visible ? (
+            <button data-testid="kyc-verify-button" onClick={props.onVerify}>
+                Verify
+            </button>
+        ) : null,
+}))
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/BridgeTosStep', () => ({ BridgeTosStep: () => null }))
+jest.mock('@/components/Claim/Link/views/Confirm.bank-claim.view', () => ({
+    ConfirmBankClaimView: (props: any) => (
+        <button data-testid="confirm-claim" onClick={props.onConfirm}>
+            Confirm
+        </button>
+    ),
+}))
+
+// --- everything else the view imports but this path never exercises
+jest.mock('@/hooks/useDetermineBankClaimType', () => ({
+    BankClaimType: {
+        GuestBankClaim: 'guest-bank-claim',
+        UserBankClaim: 'user-bank-claim',
+        ReceiverKycNeeded: 'receiver-kyc-needed',
+        GuestKycNeeded: 'guest-kyc-needed',
+    },
+    useDetermineBankClaimType: () => ({ claimType: 'user-bank-claim' }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { fullName: 'Ana Perez', email: 'ana@example.com' } }, fetchUser: jest.fn() }),
+}))
+jest.mock('@/context/loadingStates.context', () => {
+    const { createContext } = jest.requireActual('react')
+    return { loadingStateContext: createContext({ isLoading: false, setLoadingState: jest.fn() }) }
+})
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
+jest.mock('@/components/Claim/useClaimLink', () => ({ __esModule: true, default: () => ({ claimLink: jest.fn() }) }))
+jest.mock('@/hooks/useFriendlyError', () => ({ useFriendlyError: () => (e: unknown) => String(e) }))
+jest.mock('@/app/actions/external-accounts', () => ({ createBridgeExternalAccountForGuest: jest.fn() }))
+jest.mock('@/app/actions/offramp', () => ({
+    confirmOfframp: jest.fn(),
+    createOfframp: jest.fn(),
+    createOfframpForGuest: jest.fn(),
+}))
+jest.mock('@/app/actions/users', () => ({ addBankAccount: jest.fn(), getUserById: jest.fn() }))
+jest.mock('@/utils/general.utils', () => ({ formatTokenAmount: (n: number) => String(n) }))
+jest.mock('@/utils/bridge-accounts.utils', () => ({
+    getBridgeChainName: () => 'arbitrum',
+    getBridgeTokenName: () => 'usdc',
+}))
+jest.mock('@/utils/peanut-link.utils', () => ({ generateKeysFromString: jest.fn(), getParamsFromLink: jest.fn() }))
+jest.mock('@/utils/peanut-claim.utils', () => ({ getContractAddress: () => '0x0' }))
+jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: string) => id }))
+jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({ DynamicBankAccountForm: () => null }))
+jest.mock('@/components/Common/CountryListRouter', () => ({ CountryListRouter: () => null }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({ badgeCampaignForLegacyWire: () => undefined }))
+jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn() }))
+jest.mock('@/redux/slices/bank-form-slice', () => ({ bankFormActions: {} }))
+jest.mock('@/services/sendLinks', () => ({ sendLinksApi: {} }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }))
+jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+const claimLinkData: any = {
+    sender: { userId: 'sender-1' },
+    senderAddress: '0xsender',
+    amount: 1000000n,
+    tokenDecimals: 6,
+    tokenSymbol: 'USDC',
+    chainId: '42161',
+    contractVersion: 'v4.3',
+}
+const clabeAccount = (details: Record<string, string>) => ({
+    id: 'acc-mx',
+    type: 'clabe',
+    identifier: '002010077777777771',
+    bridgeAccountId: 'bridge-acc-1',
+    details,
+})
+
+// the view reads only claimLinkData / onCustom / setTransactionHash off IClaimScreenProps
+const props: any = { claimLinkData, onCustom: jest.fn(), setTransactionHash: jest.fn() }
+
+function renderView() {
+    return render(<BankFlowManager {...props} />)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    resetCtx()
+})
+
+test('clicking a saved Mexico CLABE account sets selectedCountry to Mexico', async () => {
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).toHaveBeenCalledWith(expect.objectContaining({ id: 'MX', region: 'latam' }))
+})
+
+test('a saved account with no resolvable country does not clobber the country already picked', async () => {
+    resetCtx({ selectedCountry: getCountryFromPath('germany') })
+    mockSavedAccounts = [clabeAccount({ countryCode: '', countryName: '', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).not.toHaveBeenCalled()
+})
+
+test('unlock CTA after a saved Mexico account sends the NA intent, not LATAM', async () => {
+    // the real context would now hold Mexico (previous test); mirror that here
+    resetCtx({ selectedCountry: getCountryFromPath('mexico') })
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    // saved account → confirm step (localBankDetails set) → confirm → gate is
+    // needs-enrollment → KYC modal → verify
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('confirm-claim'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('kyc-verify-button'))
+    })
+
+    expect(mockHandleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
+})

--- a/src/hooks/useBankRegionIntent.ts
+++ b/src/hooks/useBankRegionIntent.ts
@@ -1,7 +1,7 @@
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { type CountryData } from '@/components/AddMoney/consts'
 import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
-import { getBankRegionIntent, getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { useCallback } from 'react'
 
 /**
@@ -29,10 +29,7 @@ export const useBankRegionIntent = (): ((
 
     return useCallback(
         (countryOrRegionPath: CountryData | string | null | undefined) => {
-            const intent =
-                typeof countryOrRegionPath === 'string'
-                    ? getRegionIntent(countryOrRegionPath)
-                    : getBankRegionIntent(countryOrRegionPath)
+            const intent = getBankRegionIntent(countryOrRegionPath)
             return isBankRestricted ? 'ROW' : intent
         },
         [isBankRestricted]

--- a/src/hooks/useBankRegionIntent.ts
+++ b/src/hooks/useBankRegionIntent.ts
@@ -1,6 +1,7 @@
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
+import { type CountryData } from '@/components/AddMoney/consts'
 import { useResidenceRestrictions } from '@/hooks/useResidenceRestrictions'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent, getRegionIntent } from '@/utils/regions.utils'
 import { useCallback } from 'react'
 
 /**
@@ -21,11 +22,19 @@ import { useCallback } from 'react'
  * can verify under a second, unrestricted residence keeps the destination
  * intent, because a bank level is still winnable for them.
  */
-export const useBankRegionIntent = (): ((regionPath: string) => KYCRegionIntent) => {
+export const useBankRegionIntent = (): ((
+    countryOrRegionPath: CountryData | string | null | undefined
+) => KYCRegionIntent) => {
     const { banking: isBankRestricted } = useResidenceRestrictions()
 
     return useCallback(
-        (regionPath: string) => (isBankRestricted ? 'ROW' : getRegionIntent(regionPath)),
+        (countryOrRegionPath: CountryData | string | null | undefined) => {
+            const intent =
+                typeof countryOrRegionPath === 'string'
+                    ? getRegionIntent(countryOrRegionPath)
+                    : getBankRegionIntent(countryOrRegionPath)
+            return isBankRestricted ? 'ROW' : intent
+        },
         [isBankRestricted]
     )
 }

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+    getBankRegionIntent,
     getRegionIntent,
     pendingBankRailRegionPaths,
     providerForRegionIntent,
@@ -17,6 +18,24 @@ describe('getRegionIntent', () => {
     it('falls back to ROW for unknown paths', () => {
         expect(getRegionIntent('mars')).toBe('ROW')
         expect(getRegionIntent('')).toBe('ROW')
+    })
+})
+
+describe('getBankRegionIntent', () => {
+    it('routes Mexico bank flows through the North America intent', () => {
+        expect(getBankRegionIntent({ id: 'MX', region: 'latam' })).toBe('NA')
+    })
+
+    it('uses the rail jurisdiction for other bank destinations', () => {
+        expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'BR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'CO', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'GB', region: 'europe' })).toBe('EU')
+        expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
+        expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
+        expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')
+        expect(getBankRegionIntent({ id: 'XX' })).toBe('ROW')
+        expect(getBankRegionIntent(undefined)).toBe('ROW')
     })
 })
 

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -30,7 +30,7 @@ describe('getBankRegionIntent', () => {
         expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
         expect(getBankRegionIntent({ id: 'BR', region: 'latam' })).toBe('LATAM')
         expect(getBankRegionIntent({ id: 'CO', region: 'latam' })).toBe('LATAM')
-        expect(getBankRegionIntent({ id: 'GB', region: 'europe' })).toBe('EU')
+        expect(getBankRegionIntent({ id: 'GBR', iso2: 'GB', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
         expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')

--- a/src/utils/bridge.utils.ts
+++ b/src/utils/bridge.utils.ts
@@ -82,6 +82,25 @@ export const getOfframpCurrencyConfig = (countryId: string): CurrencyConfig => {
 }
 
 /**
+ * Resolve the capability-model country for a bank account. Bridge account
+ * types are more reliable than optional country metadata for the single-
+ * country rails (ACH, SPEI, and Faster Payments); IBAN always uses the EU
+ * SEPA rail in the capability model.
+ */
+export const getBankRailCountryFromAccount = (account: {
+    type?: string | AccountType | null
+    country?: string | null
+    details?: { countryCode?: string | null } | null
+}): string | undefined => {
+    const type = account.type?.toString().toLowerCase()
+    if (type === AccountType.US || type?.endsWith('ach') || type?.endsWith('us')) return 'US'
+    if (type === AccountType.CLABE || type?.endsWith('clabe')) return 'MX'
+    if (type === AccountType.GB || type?.endsWith('gb')) return 'GB'
+    if (type === AccountType.IBAN || type?.endsWith('iban')) return 'EU'
+    return railJurisdictionForBank(account.details?.countryCode ?? account.country)
+}
+
+/**
  * Derive the offramp destination currency + payment rail from the bank
  * account's actual `type`, falling back to country only when the type is
  * unknown.
@@ -224,9 +243,16 @@ export function getCountryFromPath(countryPath: string): CountryData | undefined
 
 export function getCountryFromAccount(account: Account): CountryData | undefined {
     const code = (account.details?.countryCode ?? '').toUpperCase()
+    const type = account.type?.toString().toLowerCase()
 
     if (account.type === AccountType.US) {
         return ALL_METHODS_DATA.find((c) => c.id === 'US')
+    }
+    if (account.type === AccountType.CLABE || type?.endsWith('clabe')) {
+        return ALL_METHODS_DATA.find((c) => c.iso2 === 'MX')
+    }
+    if (account.type === AccountType.GB || type?.endsWith('gb')) {
+        return ALL_METHODS_DATA.find((c) => c.iso2 === 'GB')
     }
     // Try countryName first; fall back to the country code. Bridge stores
     // ISO3 ('USA', 'GBR'); CountryData carries both `iso3` and `iso2` (= `id`),

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -241,8 +241,17 @@ const RAIL_COUNTRY_TO_REGION_PATH: Record<string, string> = {
  * belongs to the North America intent. Countries without a bank-rail entry
  * retain their picker-region intent.
  */
-export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
-    getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[country?.id ?? ''] ?? country?.region ?? 'rest-of-the-world')
+export const getBankRegionIntent = (
+    country: Pick<CountryData, 'id' | 'iso2' | 'region'> | string | null | undefined
+): KYCRegionIntent => {
+    if (typeof country === 'string') {
+        const code = country.toUpperCase()
+        return getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[code] ?? country)
+    }
+
+    const countryCode = country?.iso2 ?? country?.id
+    return getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[countryCode ?? ''] ?? country?.region ?? 'rest-of-the-world')
+}
 
 /**
  * Region picker paths with a mid-flight bank rail (`pending` = BE provisioning,

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -2,7 +2,7 @@ import { EUROPE_GLOBE_ICON, LATAM_GLOBE_ICON, NORTH_AMERICA_GLOBE_ICON, REST_OF_
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { type RailCapability } from '@/types/capabilities'
-import { BRIDGE_ALPHA3_TO_ALPHA2 } from '@/components/AddMoney/consts'
+import { BRIDGE_ALPHA3_TO_ALPHA2, type CountryData } from '@/components/AddMoney/consts'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { BANKING_RESTRICTED_RESIDENCE_ISO2, RESTRICTED_RESIDENCE_ISO2 } from '@/constants/residence.consts'
 import type { StaticImageData } from 'next/image'
@@ -234,6 +234,15 @@ const RAIL_COUNTRY_TO_REGION_PATH: Record<string, string> = {
     BR: 'latam',
     CO: 'latam',
 }
+
+/**
+ * Resolve the KYC intent for a bank destination from its rail jurisdiction.
+ * Mexico remains in the LATAM picker, but SPEI is a Bridge rail and therefore
+ * belongs to the North America intent. Countries without a bank-rail entry
+ * retain their picker-region intent.
+ */
+export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
+    getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[country?.id ?? ''] ?? country?.region ?? 'rest-of-the-world')
 
 /**
  * Region picker paths with a mid-flight bank rail (`pending` = BE provisioning,


### PR DESCRIPTION
Recreated from PR #3036 for the dev base.

Summary:
- Route all bank-flow KYC initiation through rail-jurisdiction intent mapping (Mexico SPEI -> NA/Bridge).
- Preserve dev's residence-restriction behavior and avoid clobbering a selected country when a saved account has unresolved country metadata.
- Add helper, hook, and saved-account regression coverage.

Validation:
- Focused Jest: 5 suites, 99 tests passed.
- Prettier and git diff checks passed.
- Full typecheck is blocked in the isolated worktree by missing generated/assets files unrelated to this change.