### PR TITLE
fix(android): enable R8 release optimization

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -246,6 +246,13 @@ jobs:
                   echo "versionCode $ANDROID_VERSION_CODE (version $ANDROID_VERSION_NAME, run $GITHUB_RUN_NUMBER attempt $GITHUB_RUN_ATTEMPT)"
                   pnpm native:release
 
+            - name: Preserve R8 mapping
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+              with:
+                  name: android-r8-mapping-${{ steps.version.outputs.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+                  path: android/app/build/outputs/mapping/release/
+                  if-no-files-found: error
+
             - name: Upload to Google Play
               uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1
               with:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,8 +80,9 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,21 +1,6 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Capacitor's consumer rules preserve plugin entry points and annotated callbacks.
+# MainActivity also calls this optional plugin's static handler through reflection.
+-keep,allowoptimization class me.peanut.wallet.PushProvisioningPlugin {
+    public <init>();
+    public static boolean handleGooglePayActivityResult(int, int, android.content.Intent, android.app.Activity);
+}

--- a/android/app/src/main/res/raw/me.peanut.wallet.keep.xml
+++ b/android/app/src/main/res/raw/me.peanut.wallet.keep.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- These resources are looked up by name by MeaWallet and OneSignal. -->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/mea_config,@drawable/ic_stat_onesignal_default" />

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,3 +20,4 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+android.r8.optimizedResourceShrinking=true

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -217,6 +217,36 @@ the major comparison catches it.
 
 ---
 
+### Android release optimization
+
+Release builds use R8 code shrinking, optimization and obfuscation, plus resource
+shrinking. Capacitor supplies consumer keep rules for its plugins; app-specific
+rules preserve the reflected Google Pay callback and resources loaded by name
+(`mea_config` and the OneSignal notification icon). Keep any additional rules narrow:
+blanket package keeps can prevent meeting Google Play's optimization thresholds.
+
+For the first optimized release:
+
+1. Build with the normal release credentials so the MeaWallet SDK is included.
+   Resolve R8 errors using the relevant SDK's consumer rules; do not globally disable
+   shrinking/obfuscation or suppress all missing-class warnings.
+2. Upload to Play internal testing and inspect that exact version in App Bundle
+   Explorer. Confirm obfuscation, optimization and shrinking each meet the required
+   25% threshold (for apps with more than 10 MB of DEX code).
+3. Test the Play-installed release: startup, login/passkeys, biometric unlock,
+   identity verification/camera, Google Pay provisioning and its return callback,
+   push notification icon/tap routing, deep links, support chat and OTA updates.
+   A debug build does not exercise R8.
+4. Retain `android/app/build/outputs/mapping/release/mapping.txt` with the exact
+   released AAB. CI archives the mapping directory before uploading to Play; download
+   it for long-term retention before GitHub artifacts expire. AGP also embeds the
+   mapping in the AAB for Play. Use the matching mapping with Android's Retrace for
+   obfuscated native stack traces. This workflow does not upload native mappings to
+   Sentry, so automatic Sentry deobfuscation still needs a separate integration.
+
+References: [R8 configuration](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization)
+and [Play technical quality requirements](https://support.google.com/googleplay/android-developer/answer/17492799?hl=en).
+
 ## 7. Signing, keystore & secret management
 
 **Play App Signing is enabled** → Google holds the real signing key; the local


### PR DESCRIPTION
Google Play reports 8% obfuscation, below its 25% threshold. Android release builds currently disable R8. Enable code minification, optimization and resource shrinking using the optimized default rules and AGP 8.13's integrated resource shrinker.

Preserve the Google Pay callback invoked through reflection and the MeaWallet configuration and OneSignal icon loaded by name. Capacitor's existing consumer rules continue to protect plugin entry points. Archive the R8 mapping directory before the Play upload, and document the internal-testing and crash-decoding steps. Automatic native mapping upload to Sentry is not configured by this change.

Validation: release workflow passed actionlint (shellcheck disabled) and Prettier; resource keep XML parsed; git diff --check passed. No Android build, AAB or deployment was run, as requested. The first optimized build must still resolve any SDK-specific R8 issues, pass device smoke tests, and have its actual percentages checked in Play before production promotion.
