### PR TITLE
fix(ui): restore pink input focus borders

### DIFF
--- a/src/app/ClientProviders.tsx
+++ b/src/app/ClientProviders.tsx
@@ -7,6 +7,7 @@
  * the root layout (server component) renders this single client boundary.
  */
 import { ConsoleGreeting } from '@/components/Global/ConsoleGreeting'
+import { InputModalityProvider } from '@/components/Accessibility/InputModalityProvider'
 import { ScreenOrientationLocker } from '@/components/Global/ScreenOrientationLocker'
 import { TranslationSafeWrapper } from '@/components/Global/TranslationSafeWrapper'
 import { UnsupportedWebViewScreen, hasUnsupportedWebViewBypass } from '@/components/Global/UnsupportedWebViewScreen'
@@ -106,7 +107,9 @@ export function ClientProviders({ children }: { children: React.ReactNode }) {
                                             <HarnessBootstrap />
                                         </Suspense>
                                     )}
-                                    {marketing ? children : <AppGlobals>{children}</AppGlobals>}
+                                    <InputModalityProvider>
+                                        {marketing ? children : <AppGlobals>{children}</AppGlobals>}
+                                    </InputModalityProvider>
                                 </TranslationSafeWrapper>
                             </FooterVisibilityProvider>
                         </ContextProvider>

--- a/src/components/Accessibility/InputModalityProvider.tsx
+++ b/src/components/Accessibility/InputModalityProvider.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+
+const KEYBOARD_NAVIGATION_KEYS = new Set([
+    'Tab',
+    'Enter',
+    ' ',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'Home',
+    'End',
+    'PageUp',
+    'PageDown',
+])
+
+/**
+ * Browsers can classify a pointer-focused text input as :focus-visible because
+ * it accepts keyboard input. Keep the modality explicit so input styling can
+ * distinguish a pointer focus from keyboard navigation consistently.
+ */
+export function InputModalityProvider({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        const root = document.documentElement
+        root.dataset.inputModality = 'keyboard'
+
+        const markPointer = () => {
+            root.dataset.inputModality = 'pointer'
+        }
+        const markKeyboard = (event: KeyboardEvent) => {
+            if (event.metaKey || event.altKey || event.ctrlKey) return
+            if (!KEYBOARD_NAVIGATION_KEYS.has(event.key)) return
+            root.dataset.inputModality = 'keyboard'
+        }
+
+        document.addEventListener('pointerdown', markPointer, true)
+        document.addEventListener('keydown', markKeyboard, true)
+
+        return () => {
+            document.removeEventListener('pointerdown', markPointer, true)
+            document.removeEventListener('keydown', markKeyboard, true)
+            delete root.dataset.inputModality
+        }
+    }, [])
+
+    return children
+}

--- a/src/components/Accessibility/InputModalityProvider.tsx
+++ b/src/components/Accessibility/InputModalityProvider.tsx
@@ -15,6 +15,25 @@ const KEYBOARD_NAVIGATION_KEYS = new Set([
     'PageUp',
     'PageDown',
 ])
+const ACTIVATION_KEYS = new Set(['Enter', ' '])
+const NON_EDITABLE_INPUT_TYPES = new Set([
+    'button',
+    'checkbox',
+    'color',
+    'file',
+    'hidden',
+    'image',
+    'radio',
+    'range',
+    'reset',
+    'submit',
+])
+
+function isEditableControl(target: EventTarget | null) {
+    if (target instanceof HTMLTextAreaElement) return true
+    if (target instanceof HTMLInputElement) return !NON_EDITABLE_INPUT_TYPES.has(target.type)
+    return target instanceof HTMLElement && target.isContentEditable
+}
 
 /**
  * Browsers can classify a pointer-focused text input as :focus-visible because
@@ -32,6 +51,7 @@ export function InputModalityProvider({ children }: { children: React.ReactNode 
         const markKeyboard = (event: KeyboardEvent) => {
             if (event.metaKey || event.altKey || event.ctrlKey) return
             if (!KEYBOARD_NAVIGATION_KEYS.has(event.key)) return
+            if (ACTIVATION_KEYS.has(event.key) && isEditableControl(event.target)) return
             root.dataset.inputModality = 'keyboard'
         }
 

--- a/src/components/Accessibility/__tests__/InputModalityProvider.test.tsx
+++ b/src/components/Accessibility/__tests__/InputModalityProvider.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render } from '@testing-library/react'
+import { InputModalityProvider } from '../InputModalityProvider'
+
+describe('InputModalityProvider', () => {
+    afterEach(() => {
+        document.documentElement.removeAttribute('data-input-modality')
+    })
+
+    it('records pointer and keyboard modality explicitly', () => {
+        render(
+            <InputModalityProvider>
+                <div />
+            </InputModalityProvider>
+        )
+
+        fireEvent.pointerDown(document.body)
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
+
+        fireEvent.keyDown(document.body, { key: 'k' })
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
+
+        fireEvent.keyDown(document.body, { key: 'Tab' })
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'keyboard')
+    })
+})

--- a/src/components/Accessibility/__tests__/InputModalityProvider.test.tsx
+++ b/src/components/Accessibility/__tests__/InputModalityProvider.test.tsx
@@ -7,11 +7,24 @@ describe('InputModalityProvider', () => {
     })
 
     it('records pointer and keyboard modality explicitly', () => {
-        render(
+        const { getByRole, getByTestId } = render(
             <InputModalityProvider>
-                <div />
+                <button type="button">Activate</button>
+                <input data-testid="text-input" />
             </InputModalityProvider>
         )
+        const button = getByRole('button')
+        const input = getByTestId('text-input')
+
+        fireEvent.pointerDown(input)
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
+
+        fireEvent.keyDown(input, { key: ' ' })
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
+
+        fireEvent.pointerDown(button)
+        fireEvent.keyDown(button, { key: ' ' })
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'keyboard')
 
         fireEvent.pointerDown(document.body)
         expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
@@ -21,5 +34,20 @@ describe('InputModalityProvider', () => {
 
         fireEvent.keyDown(document.body, { key: 'Tab' })
         expect(document.documentElement).toHaveAttribute('data-input-modality', 'keyboard')
+    })
+
+    it('keeps pointer modality while typing a whitespace character in a textarea', () => {
+        render(
+            <InputModalityProvider>
+                <textarea data-testid="text-area" />
+            </InputModalityProvider>
+        )
+        const textArea = document.querySelector('[data-testid="text-area"]')!
+
+        fireEvent.pointerDown(textArea)
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
+
+        fireEvent.keyDown(textArea, { key: ' ' })
+        expect(document.documentElement).toHaveAttribute('data-input-modality', 'pointer')
     })
 })

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -177,7 +177,9 @@ const ValidatedInput = ({
                     // pass layout classes at most (input board has no valid state).
                     // The composed box owns the focus border so it encloses both
                     // the text field and the trailing clear (×) affordance.
-                    'relative w-full rounded-sm border border-border-default bg-background-default focus-within:border-action-primary',
+                    // Pointer focus is pink; keyboard focus gets the shared 3px
+                    // blue ring, replacing the border rather than stacking it.
+                    'relative w-full rounded-sm border border-border-default bg-background-default focus-within:border-action-primary has-[:focus-visible]:border-transparent has-[:focus-visible]:outline-[3px] has-[:focus-visible]:outline-action-focus has-[:focus-visible]:outline-solid',
                     value && !isValidating && !isValid && debouncedValue === value ? 'border-border-error' : '',
                     className
                 )}
@@ -250,7 +252,7 @@ const ValidatedInput = ({
                                         e.preventDefault()
                                         onUpdate({ value: '', isValid: false, isChanging: false })
                                     }}
-                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 focus-visible:outline-[3px] focus-visible:outline-action-primary active:opacity-60 md:w-8 md:pr-0"
+                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid active:opacity-60 md:w-8 md:pr-0"
                                 >
                                     <Icon className="h-6 w-6" name="cancel" />
                                 </button>

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -177,12 +177,13 @@ const ValidatedInput = ({
                     // pass layout classes at most (input board has no valid state).
                     // The composed box owns the focus border so it encloses both
                     // the text field and the trailing clear (×) affordance.
-                    // Pointer focus is pink; keyboard focus gets the shared 3px
-                    // blue ring, replacing the border rather than stacking it.
-                    'relative w-full rounded-sm border border-border-default bg-background-default focus-within:border-action-primary has-[:focus-visible]:border-transparent has-[:focus-visible]:outline-[3px] has-[:focus-visible]:outline-action-focus has-[:focus-visible]:outline-solid',
+                    // Pointer focus is pink; InputModalityProvider applies the
+                    // shared 3px blue ring for keyboard focus.
+                    'relative w-full rounded-sm border border-border-default bg-background-default focus-within:border-action-primary',
                     value && !isValidating && !isValid && debouncedValue === value ? 'border-border-error' : '',
                     className
                 )}
+                data-input-container="true"
                 translate="no"
             >
                 <div className="absolute top-1/2 left-1 z-10 flex -translate-y-1/2 items-center gap-1">
@@ -252,7 +253,8 @@ const ValidatedInput = ({
                                         e.preventDefault()
                                         onUpdate({ value: '', isValid: false, isChanging: false })
                                     }}
-                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid active:opacity-60 md:w-8 md:pr-0"
+                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 active:opacity-60 md:w-8 md:pr-0"
+                                    data-input-clear="true"
                                 >
                                     <Icon className="h-6 w-6" name="cancel" />
                                 </button>

--- a/src/components/Global/ValidatedInput/index.tsx
+++ b/src/components/Global/ValidatedInput/index.tsx
@@ -175,9 +175,9 @@ const ValidatedInput = ({
                 className={twMerge(
                     // the composed box IS the input chrome: DS states only, callers
                     // pass layout classes at most (input board has no valid state).
-                    // same state model as .input: 3px blue ring replaces the border
-                    // on focus; base outline-color stops the black->blue flash
-                    'relative w-full rounded-sm border border-border-default bg-background-default outline-action-focus focus-within:border-transparent focus-within:outline-[3px] focus-within:outline-action-focus focus-within:outline-solid',
+                    // The composed box owns the focus border so it encloses both
+                    // the text field and the trailing clear (×) affordance.
+                    'relative w-full rounded-sm border border-border-default bg-background-default focus-within:border-action-primary',
                     value && !isValidating && !isValid && debouncedValue === value ? 'border-border-error' : '',
                     className
                 )}
@@ -250,7 +250,7 @@ const ValidatedInput = ({
                                         e.preventDefault()
                                         onUpdate({ value: '', isValid: false, isChanging: false })
                                     }}
-                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 focus-visible:outline-[3px] focus-visible:outline-action-focus active:opacity-60 md:w-8 md:pr-0"
+                                    className="relative flex h-full w-6 items-center justify-center pr-2 transition-opacity duration-instant after:absolute after:-inset-x-3 focus-visible:outline-[3px] focus-visible:outline-action-primary active:opacity-60 md:w-8 md:pr-0"
                                 >
                                     <Icon className="h-6 w-6" name="cancel" />
                                 </button>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1052,12 +1052,12 @@
     .btn-shadow-secondary-8 {
         @apply shadow-[0.5rem_-0.5rem_0_#000000] dark:shadow-[0.5rem_-0.5rem_0_rgba(255,255,255,.25)];
     }
-    /* input board 17802:61538 / set 17360:4441: 1px border/default at rest,
-       pink action-primary border on focus, red on aria-invalid, gray fill +
-       subtle border when disabled. height 48px per ruling (touch law; board's
-       40px sits under the 44px minimum). */
+    /* input board 17802:61538 / set 17360:4441: pink action-primary border
+       on pointer focus, 3px blue action-focus ring on keyboard focus, red on
+       aria-invalid, gray fill + subtle border when disabled. The focus-visible
+       ring replaces the border so the states never stack. */
     .input {
-        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-action-primary focus:outline-none focus-visible:border-action-primary focus-visible:outline-none disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
+        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-action-primary focus:outline-none focus-visible:border-transparent focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
     }
     .bg-peanut-repeat-normal {
         @apply bg-[url('../assets/bg/peanut-bg.svg')] bg-[length:100px_100px] bg-repeat;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1053,18 +1053,11 @@
         @apply shadow-[0.5rem_-0.5rem_0_#000000] dark:shadow-[0.5rem_-0.5rem_0_rgba(255,255,255,.25)];
     }
     /* input board 17802:61538 / set 17360:4441: 1px border/default at rest,
-       3px blue action-focus ring on focus — the ring REPLACES the border
-       (border-transparent), never stacks on it (stacking was the
-       double-border bug). browsers keep text inputs :focus-visible on any
-       focus, pointer included, so the ring is the ONLY focus state a text
-       input can have — the board's 2px black pointer step exists only on
-       non-text controls (BaseSelect). base outline-color is set so
-       transition-colors cannot animate the ring in from black (the flash
-       bug). red on aria-invalid, gray fill + subtle border when disabled.
-       height 48px per ruling (touch law; board's 40px sits under the 44px
-       minimum). */
+       pink action-primary border on focus, red on aria-invalid, gray fill +
+       subtle border when disabled. height 48px per ruling (touch law; board's
+       40px sits under the 44px minimum). */
     .input {
-        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary outline-action-focus transition-colors outline-none placeholder:text-foreground-secondary focus-visible:border-transparent focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
+        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-action-primary focus:outline-none focus-visible:border-action-primary focus-visible:outline-none disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
     }
     .bg-peanut-repeat-normal {
         @apply bg-[url('../assets/bg/peanut-bg.svg')] bg-[length:100px_100px] bg-repeat;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1054,10 +1054,40 @@
     }
     /* input board 17802:61538 / set 17360:4441: pink action-primary border
        on pointer focus, 3px blue action-focus ring on keyboard focus, red on
-       aria-invalid, gray fill + subtle border when disabled. The focus-visible
-       ring replaces the border so the states never stack. */
+       aria-invalid, gray fill + subtle border when disabled. The keyboard ring
+       replaces the border so the states never stack. */
     .input {
-        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-action-primary focus:outline-none focus-visible:border-transparent focus-visible:outline-[3px] focus-visible:outline-action-focus focus-visible:outline-solid disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
+        @apply h-12 w-full rounded-sm border border-border-default bg-background-default px-4 text-sm font-bold text-foreground-primary transition-colors outline-none placeholder:text-foreground-secondary focus:border-action-primary focus:outline-none disabled:border-border-subtle disabled:bg-background-disabled disabled:text-foreground-secondary aria-invalid:border-border-error;
+    }
+    /* :focus-visible is not a reliable pointer/keyboard discriminator for text
+       inputs: Chromium also matches it after tapping an editable control. The
+       provider records the last modality on the root so both states remain
+       reachable. */
+    :root[data-input-modality='pointer'] .input:focus {
+        border-color: var(--color-action-primary);
+        outline: none;
+    }
+    :root[data-input-modality='keyboard'] .input:focus {
+        border-color: transparent;
+        outline: 3px solid var(--color-action-focus);
+        outline-style: solid;
+    }
+    :root[data-input-modality='pointer'] [data-input-container]:focus-within {
+        border-color: var(--color-action-primary);
+        outline: none;
+    }
+    :root[data-input-modality='keyboard'] [data-input-container]:focus-within {
+        border-color: transparent;
+        outline: 3px solid var(--color-action-focus);
+        outline-style: solid;
+    }
+    :root[data-input-modality='pointer'] [data-input-clear]:focus,
+    :root[data-input-modality='pointer'] [data-input-clear]:focus-visible {
+        outline: none;
+    }
+    :root[data-input-modality='keyboard'] [data-input-clear]:focus {
+        outline: 3px solid var(--color-action-focus);
+        outline-style: solid;
     }
     .bg-peanut-repeat-normal {
         @apply bg-[url('../assets/bg/peanut-bg.svg')] bg-[length:100px_100px] bg-repeat;


### PR DESCRIPTION
## Summary
- Restore pink focus borders for shared inputs.
- Apply the focus border to the full ValidatedInput container, including the trailing clear (×) control.
- Keep the clear control focus indicator pink.

## Verification
- Prettier check passed.
- BaseInput and JoinWaitlistPage tests passed (10 tests).