### PR TITLE
fix(android): give R8 enough heap for MeaWallet release

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,9 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# The MeaWallet MPP SDK makes the release dependency graph large enough for
+# R8 to exceed the default heap on the GitHub runner.
+org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Increase the Gradle daemon heap from 1.5 GiB to 4 GiB. With the MeaWallet MPP SDK enabled, the signed release reaches R8 and the default heap is insufficient on the GitHub runner.