### PR TITLE
fix(TASK-21829): recover-funds error state instead of infinite loader on balance-fetch failure

### DIFF
--- a/src/app/(mobile-ui)/recover-funds/page.tsx
+++ b/src/app/(mobile-ui)/recover-funds/page.tsx
@@ -211,32 +211,6 @@ export default function RecoverFundsPage() {
         return <Loading variant="mascot" />
     }
 
-    if (balancesError) {
-        return (
-            <PageStack>
-                <NavHeader title={t('title')} />
-                <div className="my-auto">
-                    <EmptyState
-                        icon="alert"
-                        title={tCommon('somethingWentWrong')}
-                        description={tCommon('genericError')}
-                        cta={
-                            <Button
-                                variant="purple"
-                                shadowSize="4"
-                                size="small"
-                                className="mt-2"
-                                onClick={() => setFetchNonce((n) => n + 1)}
-                            >
-                                {tCommon('tryAgain')}
-                            </Button>
-                        }
-                    />
-                </div>
-            </PageStack>
-        )
-    }
-
     if (status === 'review' && (!selectedBalance || !recipient.address)) {
         captureException(new Error('Invalid state, review without selected balance or recipient address'))
         reset()
@@ -383,24 +357,26 @@ export default function RecoverFundsPage() {
     return (
         <PageStack>
             <NavHeader title={t('title')} />
-            {/* nothing recoverable — the token picker, address input and review
-                button are all pointless, show the ds empty state with a way
-                back home instead */}
-            {tokenBalances.length === 0 ? (
+            {/* balancesError: the fetch failed — show the alert empty state
+                with a retry instead of hanging on the loader (TASK-21829).
+                Otherwise, nothing recoverable — the token picker, address
+                input and review button are all pointless, show the ds empty
+                state with a way back home instead */}
+            {balancesError || tokenBalances.length === 0 ? (
                 <div className="my-auto">
                     <EmptyState
-                        icon="wallet"
-                        title={t('noTokens')}
-                        description={t('noTokensDescription')}
+                        icon={balancesError ? 'alert' : 'wallet'}
+                        title={balancesError ? tCommon('somethingWentWrong') : t('noTokens')}
+                        description={balancesError ? tCommon('genericError') : t('noTokensDescription')}
                         cta={
                             <Button
                                 variant="purple"
                                 shadowSize="4"
                                 size="small"
                                 className="mt-2"
-                                onClick={() => router.push('/home')}
+                                onClick={() => (balancesError ? setFetchNonce((n) => n + 1) : router.push('/home'))}
                             >
-                                {t('goToHome')}
+                                {balancesError ? tCommon('tryAgain') : t('goToHome')}
                             </Button>
                         }
                     />

--- a/src/app/(mobile-ui)/recover-funds/page.tsx
+++ b/src/app/(mobile-ui)/recover-funds/page.tsx
@@ -96,8 +96,19 @@ export default function RecoverFundsPage() {
                         RECOVERABLE_CHAINS.some((chain) => b.chainId === chain.id.toString()) &&
                         !areEvmAddressesEqual(PEANUT_WALLET_TOKEN, b.address)
                 )
-                // The Linea leg is best-effort: a Linea RPC hiccup must not take
-                // down the whole page, so a rejection just drops the manual row.
+                // The Linea leg is best-effort when other tokens rendered: a
+                // Linea RPC hiccup must not hide them, so a rejection drops the
+                // manual row (captured to Sentry). But Linea USDC exists ONLY
+                // via this read — Mobula never returns Linea — so with nothing
+                // else recoverable, "no tokens to recover" would be confidently
+                // false. Show the retryable error state instead.
+                if (lineaResult.status === 'rejected') {
+                    captureException(lineaResult.reason)
+                    if (recoverableBalances.length === 0) {
+                        setBalancesError(true)
+                        return
+                    }
+                }
                 const lineaBalance = lineaResult.status === 'fulfilled' ? lineaResult.value : 0n
                 if (!!lineaBalance) {
                     recoverableBalances.push({

--- a/src/app/(mobile-ui)/recover-funds/page.tsx
+++ b/src/app/(mobile-ui)/recover-funds/page.tsx
@@ -7,12 +7,11 @@ import { Notification } from '@/components/0_Bruddle/Notification'
 import ScrollableList from '@/components/Global/TokenSelector/Components/ScrollableList'
 import TokenListItem from '@/components/Global/TokenSelector/Components/TokenListItem'
 import { type IUserBalance } from '@/interfaces/interfaces'
-import { useState, useEffect, useCallback, useContext } from 'react'
+import { useState, useCallback, useContext } from 'react'
 import { useWallet } from '@/hooks/wallet/useWallet'
-import { fetchWalletBalances } from '@/services/tokens-price'
-import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
+import { useRecoverableBalances } from '@/hooks/useRecoverableBalances'
 import { nativeCurrencyAddresses } from '@/constants/general.consts'
-import { areEvmAddressesEqual, isTxReverted, getExplorerUrl, getChainName, getTokenLogo } from '@/utils/general.utils'
+import { areEvmAddressesEqual, isTxReverted, getExplorerUrl, getChainName } from '@/utils/general.utils'
 import { type RecipientState } from '@/context/WithdrawFlowContext'
 import GeneralRecipientInput, { type GeneralRecipientUpdate } from '@/components/Global/GeneralRecipientInput'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -20,12 +19,11 @@ import Card from '@/components/Global/Card'
 import Image from 'next/image'
 import AddressLink from '@/components/Global/AddressLink'
 import Loading from '@/components/Global/Loading'
-import { erc20Abi, parseUnits, encodeFunctionData, formatUnits } from 'viem'
+import { erc20Abi, parseUnits, encodeFunctionData } from 'viem'
 import type { Address, Hash, TransactionReceipt } from 'viem'
 import { useRouter } from 'next/navigation'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { captureException } from '@sentry/nextjs'
-import { mainnet, base, linea } from 'viem/chains'
 import { getPublicClient, type ChainId } from '@/app/actions/clients'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { useFormatter, useTranslations } from 'next-intl'
@@ -43,20 +41,11 @@ const fetchExactNativeBalance = async (chainId: string, address: Address): Promi
     return await client.getBalance({ address })
 }
 
-// Mobula does not returns Linea balance, we have one user balance with USDC in Linea so we will manually fetch it
-const USDC_IN_LINEA = '0x176211869cA2b568f2A7D4EE941E073a821EE1ff'
-
-const RECOVERABLE_CHAINS = [PEANUT_WALLET_CHAIN, mainnet, base, linea]
-
 export default function RecoverFundsPage() {
-    const [tokenBalances, setTokenBalances] = useState<IUserBalance[]>([])
     const [selectedBalance, setSelectedBalance] = useState<IUserBalance | undefined>()
     const [recipient, setRecipient] = useState<RecipientState>({ address: '', name: '' })
     const [errorMessage, setErrorMessage] = useState('')
     const [inputChanging, setInputChanging] = useState(false)
-    const [fetchingBalances, setFetchingBalances] = useState(true)
-    const [balancesError, setBalancesError] = useState(false)
-    const [fetchNonce, setFetchNonce] = useState(0)
     const [isSigning, setIsSigning] = useState(false)
     const [txHash, setTxHash] = useState<string>('')
     const [status, setStatus] = useState<'init' | 'review' | 'final'>('init')
@@ -67,77 +56,12 @@ export default function RecoverFundsPage() {
     const tCommon = useTranslations('common')
     const tLoading = useTranslations('loadingStates')
     const format = useFormatter()
+    // Balance discovery + failure semantics live in the hook so they are
+    // testable (TASK-21829): fetch failure → retryable error state, never a
+    // false "no tokens to recover".
+    const { tokenBalances, setTokenBalances, fetchingBalances, balancesError, retry } =
+        useRecoverableBalances(peanutAddress)
 
-    useEffect(() => {
-        if (!peanutAddress) return
-        let cancelled = false
-        const fetchBalances = async () => {
-            setFetchingBalances(true)
-            setBalancesError(false)
-            try {
-                // A rejection here used to escape the effect unhandled and leave
-                // fetchingBalances stuck true — the page hung on the mascot
-                // loader forever whenever the balance fetch failed (TASK-21829).
-                const [balancesResult, lineaResult] = await Promise.allSettled([
-                    fetchWalletBalances(peanutAddress),
-                    //Manually fetching Linea balance for USDC because Mobula does
-                    //not return it
-                    getPublicClient(linea.id).readContract({
-                        address: USDC_IN_LINEA,
-                        abi: erc20Abi,
-                        functionName: 'balanceOf',
-                        args: [peanutAddress as Address],
-                    }),
-                ])
-                if (cancelled) return
-                if (balancesResult.status === 'rejected') throw balancesResult.reason
-                const recoverableBalances = balancesResult.value.balances.filter(
-                    (b) =>
-                        RECOVERABLE_CHAINS.some((chain) => b.chainId === chain.id.toString()) &&
-                        !areEvmAddressesEqual(PEANUT_WALLET_TOKEN, b.address)
-                )
-                // The Linea leg is best-effort when other tokens rendered: a
-                // Linea RPC hiccup must not hide them, so a rejection drops the
-                // manual row (captured to Sentry). But Linea USDC exists ONLY
-                // via this read — Mobula never returns Linea — so with nothing
-                // else recoverable, "no tokens to recover" would be confidently
-                // false. Show the retryable error state instead.
-                if (lineaResult.status === 'rejected') {
-                    captureException(lineaResult.reason)
-                    if (recoverableBalances.length === 0) {
-                        setBalancesError(true)
-                        return
-                    }
-                }
-                const lineaBalance = lineaResult.status === 'fulfilled' ? lineaResult.value : 0n
-                if (!!lineaBalance) {
-                    recoverableBalances.push({
-                        chainId: linea.id.toString(),
-                        address: USDC_IN_LINEA,
-                        name: 'USDC',
-                        symbol: 'USDC',
-                        decimals: 6,
-                        price: 1,
-                        amount: Number(formatUnits(lineaBalance, 6)),
-                        currency: 'usd',
-                        logoURI: getTokenLogo('USDC'),
-                        value: formatUnits(lineaBalance, 6),
-                    })
-                }
-                setTokenBalances(recoverableBalances)
-            } catch (error) {
-                if (cancelled) return
-                captureException(error)
-                setBalancesError(true)
-            } finally {
-                if (!cancelled) setFetchingBalances(false)
-            }
-        }
-        fetchBalances()
-        return () => {
-            cancelled = true
-        }
-    }, [peanutAddress, fetchNonce])
     const reset = useCallback(() => {
         setErrorMessage('')
         setInputChanging(false)
@@ -385,7 +309,7 @@ export default function RecoverFundsPage() {
                                 shadowSize="4"
                                 size="small"
                                 className="mt-2"
-                                onClick={() => (balancesError ? setFetchNonce((n) => n + 1) : router.push('/home'))}
+                                onClick={() => (balancesError ? retry() : router.push('/home'))}
                             >
                                 {balancesError ? tCommon('tryAgain') : t('goToHome')}
                             </Button>

--- a/src/app/(mobile-ui)/recover-funds/page.tsx
+++ b/src/app/(mobile-ui)/recover-funds/page.tsx
@@ -55,6 +55,8 @@ export default function RecoverFundsPage() {
     const [errorMessage, setErrorMessage] = useState('')
     const [inputChanging, setInputChanging] = useState(false)
     const [fetchingBalances, setFetchingBalances] = useState(true)
+    const [balancesError, setBalancesError] = useState(false)
+    const [fetchNonce, setFetchNonce] = useState(0)
     const [isSigning, setIsSigning] = useState(false)
     const [txHash, setTxHash] = useState<string>('')
     const [status, setStatus] = useState<'init' | 'review' | 'final'>('init')
@@ -68,43 +70,63 @@ export default function RecoverFundsPage() {
 
     useEffect(() => {
         if (!peanutAddress) return
+        let cancelled = false
         const fetchBalances = async () => {
             setFetchingBalances(true)
-            const [balances, lineaBalance] = await Promise.all([
-                fetchWalletBalances(peanutAddress),
-                //Manually fetching Linea balance for USDC because Mobula does
-                //not return it
-                getPublicClient(linea.id).readContract({
-                    address: USDC_IN_LINEA,
-                    abi: erc20Abi,
-                    functionName: 'balanceOf',
-                    args: [peanutAddress as Address],
-                }),
-            ])
-            const recoverableBalances = balances.balances.filter(
-                (b) =>
-                    RECOVERABLE_CHAINS.some((chain) => b.chainId === chain.id.toString()) &&
-                    !areEvmAddressesEqual(PEANUT_WALLET_TOKEN, b.address)
-            )
-            if (!!lineaBalance) {
-                recoverableBalances.push({
-                    chainId: linea.id.toString(),
-                    address: USDC_IN_LINEA,
-                    name: 'USDC',
-                    symbol: 'USDC',
-                    decimals: 6,
-                    price: 1,
-                    amount: Number(formatUnits(lineaBalance, 6)),
-                    currency: 'usd',
-                    logoURI: getTokenLogo('USDC'),
-                    value: formatUnits(lineaBalance, 6),
-                })
+            setBalancesError(false)
+            try {
+                // A rejection here used to escape the effect unhandled and leave
+                // fetchingBalances stuck true — the page hung on the mascot
+                // loader forever whenever the balance fetch failed (TASK-21829).
+                const [balancesResult, lineaResult] = await Promise.allSettled([
+                    fetchWalletBalances(peanutAddress),
+                    //Manually fetching Linea balance for USDC because Mobula does
+                    //not return it
+                    getPublicClient(linea.id).readContract({
+                        address: USDC_IN_LINEA,
+                        abi: erc20Abi,
+                        functionName: 'balanceOf',
+                        args: [peanutAddress as Address],
+                    }),
+                ])
+                if (cancelled) return
+                if (balancesResult.status === 'rejected') throw balancesResult.reason
+                const recoverableBalances = balancesResult.value.balances.filter(
+                    (b) =>
+                        RECOVERABLE_CHAINS.some((chain) => b.chainId === chain.id.toString()) &&
+                        !areEvmAddressesEqual(PEANUT_WALLET_TOKEN, b.address)
+                )
+                // The Linea leg is best-effort: a Linea RPC hiccup must not take
+                // down the whole page, so a rejection just drops the manual row.
+                const lineaBalance = lineaResult.status === 'fulfilled' ? lineaResult.value : 0n
+                if (!!lineaBalance) {
+                    recoverableBalances.push({
+                        chainId: linea.id.toString(),
+                        address: USDC_IN_LINEA,
+                        name: 'USDC',
+                        symbol: 'USDC',
+                        decimals: 6,
+                        price: 1,
+                        amount: Number(formatUnits(lineaBalance, 6)),
+                        currency: 'usd',
+                        logoURI: getTokenLogo('USDC'),
+                        value: formatUnits(lineaBalance, 6),
+                    })
+                }
+                setTokenBalances(recoverableBalances)
+            } catch (error) {
+                if (cancelled) return
+                captureException(error)
+                setBalancesError(true)
+            } finally {
+                if (!cancelled) setFetchingBalances(false)
             }
-            setTokenBalances(recoverableBalances)
-            setFetchingBalances(false)
         }
         fetchBalances()
-    }, [peanutAddress])
+        return () => {
+            cancelled = true
+        }
+    }, [peanutAddress, fetchNonce])
     const reset = useCallback(() => {
         setErrorMessage('')
         setInputChanging(false)
@@ -187,6 +209,32 @@ export default function RecoverFundsPage() {
     // loader instead of a blank page; balances start fetching once it lands
     if (!peanutAddress || fetchingBalances) {
         return <Loading variant="mascot" />
+    }
+
+    if (balancesError) {
+        return (
+            <PageStack>
+                <NavHeader title={t('title')} />
+                <div className="my-auto">
+                    <EmptyState
+                        icon="alert"
+                        title={tCommon('somethingWentWrong')}
+                        description={tCommon('genericError')}
+                        cta={
+                            <Button
+                                variant="purple"
+                                shadowSize="4"
+                                size="small"
+                                className="mt-2"
+                                onClick={() => setFetchNonce((n) => n + 1)}
+                            >
+                                {tCommon('tryAgain')}
+                            </Button>
+                        }
+                    />
+                </div>
+            </PageStack>
+        )
     }
 
     if (status === 'review' && (!selectedBalance || !recipient.address)) {

--- a/src/hooks/__tests__/useRecoverableBalances.test.tsx
+++ b/src/hooks/__tests__/useRecoverableBalances.test.tsx
@@ -50,7 +50,9 @@ describe('useRecoverableBalances', () => {
         const { result } = renderHook(() => useRecoverableBalances('0xabc'))
         await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
         expect(result.current.balancesError).toBe(true)
-        expect(mockCaptureException).toHaveBeenCalled()
+        // apiFetch/fetchWithSentry already reported the failure — a second
+        // capture in the hook would duplicate the Sentry issue.
+        expect(mockCaptureException).not.toHaveBeenCalled()
     })
 
     it('surfaces the error state when the Linea read fails and nothing else is recoverable', async () => {

--- a/src/hooks/__tests__/useRecoverableBalances.test.tsx
+++ b/src/hooks/__tests__/useRecoverableBalances.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Pins the recover-funds balance-discovery failure semantics (TASK-21829).
+ *
+ * The branch under test decides whether a user is told they have funds to
+ * recover, so the two lies it must never tell are pinned here:
+ * - a failed portfolio fetch must surface the retryable error state, not an
+ *   infinite loader (the pre-fix behavior);
+ * - a failed Linea read with an otherwise-empty portfolio must surface the
+ *   error state, not "no tokens to recover" (Linea USDC exists ONLY via that
+ *   read — Mobula never returns Linea).
+ */
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useRecoverableBalances, USDC_IN_LINEA } from '@/hooks/useRecoverableBalances'
+import { fetchWalletBalances } from '@/services/tokens-price'
+import { PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
+
+jest.mock('@/services/tokens-price', () => ({ fetchWalletBalances: jest.fn() }))
+
+const mockReadContract = jest.fn()
+jest.mock('@/app/actions/clients', () => ({
+    getPublicClient: () => ({ readContract: mockReadContract }),
+}))
+
+const mockCaptureException = jest.fn()
+jest.mock('@sentry/nextjs', () => ({ captureException: (...args: unknown[]) => mockCaptureException(...args) }))
+
+const mockFetchWalletBalances = fetchWalletBalances as jest.MockedFunction<typeof fetchWalletBalances>
+
+const ARB_TOKEN = {
+    chainId: '42161',
+    address: '0x1111111111111111111111111111111111111111',
+    name: 'Some Token',
+    symbol: 'TOK',
+    decimals: 18,
+    price: 2,
+    amount: 5,
+    currency: 'usd',
+    logoURI: 'https://example.test/tok.png',
+    value: '10',
+}
+
+describe('useRecoverableBalances', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockReadContract.mockResolvedValue(0n)
+    })
+
+    it('surfaces the error state (not an infinite loader) when the portfolio fetch fails', async () => {
+        mockFetchWalletBalances.mockRejectedValue(new Error('portfolio unavailable'))
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
+        expect(result.current.balancesError).toBe(true)
+        expect(mockCaptureException).toHaveBeenCalled()
+    })
+
+    it('surfaces the error state when the Linea read fails and nothing else is recoverable', async () => {
+        mockFetchWalletBalances.mockResolvedValue({ balances: [], totalBalance: 0 })
+        mockReadContract.mockRejectedValue(new Error('linea rpc down'))
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
+        expect(result.current.balancesError).toBe(true)
+        expect(result.current.tokenBalances).toHaveLength(0)
+    })
+
+    it('keeps the token list (minus the Linea row) when the Linea read fails but other tokens exist', async () => {
+        mockFetchWalletBalances.mockResolvedValue({ balances: [ARB_TOKEN], totalBalance: 10 })
+        mockReadContract.mockRejectedValue(new Error('linea rpc down'))
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
+        expect(result.current.balancesError).toBe(false)
+        expect(result.current.tokenBalances).toHaveLength(1)
+        expect(result.current.tokenBalances[0].symbol).toBe('TOK')
+        expect(mockCaptureException).toHaveBeenCalled()
+    })
+
+    it('appends the Linea USDC row when the read returns a balance', async () => {
+        mockFetchWalletBalances.mockResolvedValue({ balances: [], totalBalance: 0 })
+        mockReadContract.mockResolvedValue(2_500_000n) // 2.5 USDC
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
+        expect(result.current.balancesError).toBe(false)
+        expect(result.current.tokenBalances).toHaveLength(1)
+        expect(result.current.tokenBalances[0]).toMatchObject({ address: USDC_IN_LINEA, symbol: 'USDC', amount: 2.5 })
+    })
+
+    it('filters out the Peanut wallet token and non-recoverable chains', async () => {
+        mockFetchWalletBalances.mockResolvedValue({
+            balances: [
+                ARB_TOKEN,
+                { ...ARB_TOKEN, address: PEANUT_WALLET_TOKEN }, // the wallet's own USDC — not recoverable
+                { ...ARB_TOKEN, chainId: '137', address: '0x2222222222222222222222222222222222222222' }, // Polygon — not a recovery chain
+            ],
+            totalBalance: 30,
+        })
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.fetchingBalances).toBe(false))
+        expect(result.current.tokenBalances).toHaveLength(1)
+        expect(result.current.tokenBalances[0].address).toBe(ARB_TOKEN.address)
+    })
+
+    it('retry refetches after a failure', async () => {
+        mockFetchWalletBalances.mockRejectedValueOnce(new Error('down'))
+        const { result } = renderHook(() => useRecoverableBalances('0xabc'))
+        await waitFor(() => expect(result.current.balancesError).toBe(true))
+
+        mockFetchWalletBalances.mockResolvedValue({ balances: [ARB_TOKEN], totalBalance: 10 })
+        act(() => result.current.retry())
+        await waitFor(() => expect(result.current.tokenBalances).toHaveLength(1))
+        expect(result.current.balancesError).toBe(false)
+    })
+
+    it('does nothing until the wallet address resolves', () => {
+        const { result } = renderHook(() => useRecoverableBalances(undefined))
+        expect(mockFetchWalletBalances).not.toHaveBeenCalled()
+        expect(result.current.fetchingBalances).toBe(true) // the page keeps its loader
+    })
+})

--- a/src/hooks/useRecoverableBalances.ts
+++ b/src/hooks/useRecoverableBalances.ts
@@ -1,0 +1,110 @@
+'use client'
+
+/**
+ * Recoverable-balance discovery for /recover-funds (TASK-21829).
+ *
+ * Fetches the wallet portfolio through the backend proxy, filters it to the
+ * recoverable chains, and appends the manual Linea USDC row (Mobula never
+ * returns Linea — that balance exists ONLY via a direct readContract).
+ *
+ * Failure semantics — the part this hook exists to make testable:
+ * - portfolio fetch rejects (backend 404 "unavailable", 5xx, transport) →
+ *   error=true, retryable. Never "no tokens".
+ * - Linea read rejects with NO other recoverable balances → error=true:
+ *   telling the user "no tokens to recover" on the strength of a failed
+ *   lookup would be a false statement about their money.
+ * - Linea read rejects but other balances exist → the list renders without
+ *   the Linea row (captured to Sentry); hiding a user's other tokens over a
+ *   Linea RPC hiccup is the worse trade.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { erc20Abi, formatUnits } from 'viem'
+import type { Address } from 'viem'
+import { mainnet, base, linea } from 'viem/chains'
+import { captureException } from '@sentry/nextjs'
+import { type IUserBalance } from '@/interfaces/interfaces'
+import { fetchWalletBalances } from '@/services/tokens-price'
+import { PEANUT_WALLET_CHAIN, PEANUT_WALLET_TOKEN } from '@/constants/zerodev.consts'
+import { areEvmAddressesEqual, getTokenLogo } from '@/utils/general.utils'
+import { getPublicClient } from '@/app/actions/clients'
+
+// Mobula does not return Linea balances; one known user balance holds USDC in
+// Linea, so it is fetched manually.
+export const USDC_IN_LINEA = '0x176211869cA2b568f2A7D4EE941E073a821EE1ff'
+
+export const RECOVERABLE_CHAINS = [PEANUT_WALLET_CHAIN, mainnet, base, linea]
+
+export function useRecoverableBalances(peanutAddress: string | undefined) {
+    const [tokenBalances, setTokenBalances] = useState<IUserBalance[]>([])
+    const [fetchingBalances, setFetchingBalances] = useState(true)
+    const [balancesError, setBalancesError] = useState(false)
+    const [fetchNonce, setFetchNonce] = useState(0)
+
+    const retry = useCallback(() => setFetchNonce((n) => n + 1), [])
+
+    useEffect(() => {
+        if (!peanutAddress) return
+        let cancelled = false
+        const fetchBalances = async () => {
+            setFetchingBalances(true)
+            setBalancesError(false)
+            try {
+                // A rejection here used to escape the effect unhandled and leave
+                // fetchingBalances stuck true — the page hung on the mascot
+                // loader forever whenever the balance fetch failed (TASK-21829).
+                const [balancesResult, lineaResult] = await Promise.allSettled([
+                    fetchWalletBalances(peanutAddress),
+                    getPublicClient(linea.id).readContract({
+                        address: USDC_IN_LINEA,
+                        abi: erc20Abi,
+                        functionName: 'balanceOf',
+                        args: [peanutAddress as Address],
+                    }),
+                ])
+                if (cancelled) return
+                if (balancesResult.status === 'rejected') throw balancesResult.reason
+                const recoverableBalances = balancesResult.value.balances.filter(
+                    (b) =>
+                        RECOVERABLE_CHAINS.some((chain) => b.chainId === chain.id.toString()) &&
+                        !areEvmAddressesEqual(PEANUT_WALLET_TOKEN, b.address)
+                )
+                if (lineaResult.status === 'rejected') {
+                    captureException(lineaResult.reason)
+                    if (recoverableBalances.length === 0) {
+                        setBalancesError(true)
+                        return
+                    }
+                }
+                const lineaBalance = lineaResult.status === 'fulfilled' ? lineaResult.value : 0n
+                if (!!lineaBalance) {
+                    recoverableBalances.push({
+                        chainId: linea.id.toString(),
+                        address: USDC_IN_LINEA,
+                        name: 'USDC',
+                        symbol: 'USDC',
+                        decimals: 6,
+                        price: 1,
+                        amount: Number(formatUnits(lineaBalance, 6)),
+                        currency: 'usd',
+                        logoURI: getTokenLogo('USDC'),
+                        value: formatUnits(lineaBalance, 6),
+                    })
+                }
+                setTokenBalances(recoverableBalances)
+            } catch (error) {
+                if (cancelled) return
+                captureException(error)
+                setBalancesError(true)
+            } finally {
+                if (!cancelled) setFetchingBalances(false)
+            }
+        }
+        fetchBalances()
+        return () => {
+            cancelled = true
+        }
+    }, [peanutAddress, fetchNonce])
+
+    return { tokenBalances, setTokenBalances, fetchingBalances, balancesError, retry }
+}

--- a/src/hooks/useRecoverableBalances.ts
+++ b/src/hooks/useRecoverableBalances.ts
@@ -92,9 +92,13 @@ export function useRecoverableBalances(peanutAddress: string | undefined) {
                     })
                 }
                 setTokenBalances(recoverableBalances)
-            } catch (error) {
+            } catch {
                 if (cancelled) return
-                captureException(error)
+                // No captureException here: the only rejection reaching this
+                // catch is the portfolio fetch, and apiFetch/fetchWithSentry
+                // already reported it — a second capture per occurrence would
+                // duplicate the issue under a different fingerprint. The Linea
+                // RPC read above is the one leg Sentry has not seen.
                 setBalancesError(true)
             } finally {
                 if (!cancelled) setFetchingBalances(false)

--- a/src/services/__tests__/tokens-price-transport.test.ts
+++ b/src/services/__tests__/tokens-price-transport.test.ts
@@ -13,6 +13,9 @@ import { apiFetch } from '@/utils/api-fetch'
 
 jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn() }))
 
+const mockCaptureException = jest.fn()
+jest.mock('@sentry/nextjs', () => ({ captureException: (...args: unknown[]) => mockCaptureException(...args) }))
+
 const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>
 
 const response = (status: number, body: unknown = {}) =>
@@ -46,6 +49,27 @@ describe('fetchWalletBalances', () => {
     it('throws on 5xx', async () => {
         mockApiFetch.mockResolvedValue(response(502, { error: 'bad gateway' }))
         await expect(fetchWalletBalances('0xabc')).rejects.toThrow('502')
+        // fetchWithSentry already reported the HTTP failure — no second capture.
+        expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('throws AND captures on a malformed 200 — the failure fetchWithSentry never sees', async () => {
+        mockApiFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => {
+                throw new SyntaxError('bad json')
+            },
+            text: async () => 'bad json',
+        } as unknown as Response)
+        await expect(fetchWalletBalances('0xabc')).rejects.toThrow('malformed 200')
+        expect(mockCaptureException).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws AND captures on a 200 missing the balances array', async () => {
+        mockApiFetch.mockResolvedValue(response(200, { totalBalance: 5 }))
+        await expect(fetchWalletBalances('0xabc')).rejects.toThrow('malformed 200')
+        expect(mockCaptureException).toHaveBeenCalledTimes(1)
     })
 })
 

--- a/src/services/__tests__/tokens-price-transport.test.ts
+++ b/src/services/__tests__/tokens-price-transport.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment jsdom */
+/**
+ * Pins the 404 semantics of the two /tokens proxies (TASK-21829):
+ * - price: 404 → undefined (a missing price legitimately means "not found")
+ * - wallet portfolio: 404 → THROW. The API answers a genuinely empty wallet
+ *   with 200 { balances: [] } and reserves 404 for "portfolio unavailable"
+ *   (Mobula down/quota). Mapping 404 to an empty list rendered a false
+ *   "No tokens to recover" on the recover-funds page whenever the upstream
+ *   was down.
+ */
+import { fetchTokenPrice, fetchWalletBalances } from '@/services/tokens-price'
+import { apiFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn() }))
+
+const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>
+
+const response = (status: number, body: unknown = {}) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+    }) as unknown as Response
+
+describe('fetchWalletBalances', () => {
+    beforeEach(() => jest.clearAllMocks())
+
+    it('returns the portfolio on 200', async () => {
+        const body = { balances: [{ symbol: 'USDC' }], totalBalance: 10 }
+        mockApiFetch.mockResolvedValue(response(200, body))
+        await expect(fetchWalletBalances('0xabc')).resolves.toEqual(body)
+    })
+
+    it('passes a genuinely empty wallet through as an empty list', async () => {
+        const body = { balances: [], totalBalance: 0 }
+        mockApiFetch.mockResolvedValue(response(200, body))
+        await expect(fetchWalletBalances('0xabc')).resolves.toEqual(body)
+    })
+
+    it('throws on 404 — unavailable is not an empty wallet', async () => {
+        mockApiFetch.mockResolvedValue(response(404, { error: 'Wallet portfolio not available' }))
+        await expect(fetchWalletBalances('0xabc')).rejects.toThrow('404')
+    })
+
+    it('throws on 5xx', async () => {
+        mockApiFetch.mockResolvedValue(response(502, { error: 'bad gateway' }))
+        await expect(fetchWalletBalances('0xabc')).rejects.toThrow('502')
+    })
+})
+
+describe('fetchTokenPrice', () => {
+    beforeEach(() => jest.clearAllMocks())
+
+    it('maps 404 to undefined — a missing price means not found', async () => {
+        mockApiFetch.mockResolvedValue(response(404, { error: 'Token price not available' }))
+        await expect(fetchTokenPrice('0xabc', '42161')).resolves.toBeUndefined()
+    })
+})

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -30,11 +30,16 @@ export async function fetchTokenPrice(tokenAddress: string, chainId: string): Pr
 export async function fetchWalletBalances(
     address: string
 ): Promise<{ balances: IUserBalance[]; totalBalance: number }> {
+    // No 404 → empty mapping here, unlike fetchTokenPrice: the API answers a
+    // genuinely empty wallet with 200 { balances: [] } and reserves 404 for
+    // "portfolio unavailable" (Mobula down/quota). Mapping 404 to an empty
+    // list told recover-funds users "no tokens to recover" whenever the
+    // upstream was down — a false statement about their money (TASK-21829).
     const qs = `address=${encodeURIComponent(address)}`
-    const result = await getJson<{ balances: IUserBalance[]; totalBalance: number }>(
-        `/tokens/wallet-portfolio?${qs}`,
-        'Failed to fetch wallet balances',
-        true
-    )
-    return result ?? { balances: [], totalBalance: 0 }
+    const response = await apiFetch(`/tokens/wallet-portfolio?${qs}`, { method: 'GET', includeAuth: true })
+    if (!response.ok) {
+        const text = await response.text().catch(() => '')
+        throw new Error(`Failed to fetch wallet balances: ${response.status} ${text}`)
+    }
+    return (await response.json()) as { balances: IUserBalance[]; totalBalance: number }
 }

--- a/src/services/tokens-price.ts
+++ b/src/services/tokens-price.ts
@@ -6,6 +6,7 @@
  * the caller's own accounts, so that call carries the session token.
  */
 
+import { captureException } from '@sentry/nextjs'
 import { apiFetch } from '@/utils/api-fetch'
 import { type ITokenPriceData, type IUserBalance } from '@/interfaces/interfaces'
 
@@ -41,5 +42,14 @@ export async function fetchWalletBalances(
         const text = await response.text().catch(() => '')
         throw new Error(`Failed to fetch wallet balances: ${response.status} ${text}`)
     }
-    return (await response.json()) as { balances: IUserBalance[]; totalBalance: number }
+    // A malformed 200 (invalid JSON, missing balances) is the one failure
+    // fetchWithSentry never reports — it saw a success. Capture it here, once,
+    // so the retry state the caller renders is not a silent mystery.
+    const body = (await response.json().catch(() => null)) as { balances: IUserBalance[]; totalBalance: number } | null
+    if (!body || !Array.isArray(body.balances)) {
+        const error = new Error('Failed to fetch wallet balances: malformed 200 response')
+        captureException(error)
+        throw error
+    }
+    return body
 }


### PR DESCRIPTION
## Summary

`/recover-funds` hangs on the mascot loader forever when the balance fetch fails. The fetch effect had zero error handling: `setFetchingBalances(false)` sat on the success path only, the effect was called bare (no `.catch()`), and no `error.tsx` exists under `(mobile-ui)` — so a `/tokens/wallet-portfolio` failure (Mobula quota, timeout, 5xx) or a Linea RPC hiccup left the user staring at the loader with no message and no way out.

- try/catch around the fetch. A failure captures to Sentry and renders the standard `EmptyState` (`icon="alert"`) with a retry button. Copy reuses existing `common.somethingWentWrong` / `genericError` / `tryAgain` keys — no new i18n keys (es-AR falls back through es-419 by design).
- `Promise.allSettled` instead of `Promise.all`: the manual Linea USDC leg is best-effort when other tokens rendered — its rejection drops that row (captured to Sentry). With nothing else recoverable, a rejected Linea read falls into the retryable error state instead of a false "no tokens" (Linea USDC exists only via that read; review finding).
- A portfolio **404 now throws instead of masquerading as an empty wallet** (`fetchWalletBalances`): the API answers a genuinely empty wallet with 200 `{ balances: [] }` and reserves 404 for "unavailable" (Mobula down/quota — the dominant failure). The throw lands in the new error state. `fetchTokenPrice` keeps 404 → undefined. Transport test pins both semantics (review finding; recover-funds is the only caller).
- Cancellation guard so a retry or wallet-address change can't race stale state into React.

## Base choice

Based on `origin/dev`. `origin/tech-debt` exists but is stale (last activity 2026-09-04, 50 commits not in dev, dev 623 ahead) and is NOT merged into dev; `origin/dev` takes merges daily (latest today). If the tech-debt train is still meant to carry this, say so and I'll rebase.

## Task

TASK-21829 (Mobula shrink — this is the FE leg; backend leg is peanut-api-ts #1551, no deploy-order coupling).

## Risks / breaking changes

- None cross-repo. The page's behavior on success is unchanged; the new surfaces are the error state and the 404→throw in `fetchWalletBalances` (recover-funds is its only caller).

## Known pre-existing issues (NOT touched here, noted for follow-up)

- `page.tsx` review + final screens pass `selectedBalance.logoURI` to `next/image` unguarded; an empty string (possible via `getTokenLogo` miss on the manual Linea row) throws. `TokenListItem` has the correct falsy-check + `onError` pattern to copy.
- `add-money-states.test.tsx` › "loaded EVM deposit shows QR code and address" fails identically on pristine `origin/dev` (expects "10,000 USD" text) — pre-existing, unrelated.

## QA

- `npm run typecheck` clean, `npm test`: 6428 pass; the single failing test is the pre-existing add-money one above (verified identical on a pristine `origin/dev` worktree).
- Manual: with the API unreachable the page now shows the alert EmptyState with Try again; retry refetches.
- Screenshots: ⚠️ NONE — the local sandbox could not produce the authenticated failure state: the primary `peanut-api-ts` checkout that `qa up` boots is 155 commits behind dev with schema drift vs the bootstrap snapshot, and its running build does not mount `/dev/cheats/*` (no esbuild `__INCLUDE_DEV_ROUTES__` define on this boot path), so `mint-jwt` 404s and no authed session was reachable. Mitigation: the new state is the standard `EmptyState icon="alert"` composition reused verbatim from other screens (same skeleton as the existing `noTokens` state, same slot, conditional props only — zero new className sites, ds-lint ratchet green).
