### PR TITLE
feat: edit account email and unverified names (TASK-22410)

### DIFF
--- a/src/app/actions/__tests__/api-headers.test.ts
+++ b/src/app/actions/__tests__/api-headers.test.ts
@@ -30,6 +30,13 @@ jest.mock('@/utils/capacitor', () => ({
     isCapacitor: jest.fn(() => false),
 }))
 
+jest.mock('@/services/step-up', () => ({
+    withStepUpHeader: jest.fn(async (headers: Record<string, string>) => ({
+        ...headers,
+        'x-step-up-token': 'fresh-proof',
+    })),
+}))
+
 // mock getCurrencyPrice for the onramp test
 jest.mock('@/app/actions/currency', () => ({
     getCurrencyPrice: jest.fn(() => Promise.resolve({ buy: 1, sell: 1 })),
@@ -109,6 +116,16 @@ describe('action functions Content-Type headers', () => {
 
         const headers = getLastCallHeaders()
         expect(headers['Content-Type']).toBe('application/json')
+        expect(headers['x-step-up-token']).toBeUndefined()
+    })
+
+    it('requires step-up for replacement-email issuance and redemption', async () => {
+        const { requestEmailChange, updateUserById } = require('@/app/actions/users')
+        await requestEmailChange('new@example.com')
+        expect(getLastCallHeaders()['x-step-up-token']).toBe('fresh-proof')
+
+        await updateUserById({ userId: 'user', email: 'new@example.com', emailVerificationCode: '123456' })
+        expect(getLastCallHeaders()['x-step-up-token']).toBe('fresh-proof')
     })
 
     it('should include Content-Type in getKycDetails', async () => {

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -7,9 +7,11 @@ import { withStepUpHeader } from '@/services/step-up'
 
 export const updateUserById = async (payload: Record<string, unknown>): Promise<{ data?: ApiUser; error?: string }> => {
     try {
+        const requiresEmailStepUp = typeof payload.emailVerificationCode === 'string'
         const response = await serverFetch('/update-user', {
             method: 'POST',
             body: JSON.stringify(payload),
+            ...(requiresEmailStepUp ? { headers: await withStepUpHeader({}) } : {}),
         })
 
         const responseJson = await response.json()
@@ -23,7 +25,11 @@ export const updateUserById = async (payload: Record<string, unknown>): Promise<
 }
 
 export const requestEmailChange = async (email: string): Promise<{ error?: string }> => {
-    const response = await serverFetch('/users/email-change', { method: 'POST', body: JSON.stringify({ email }) })
+    const response = await serverFetch('/users/email-change', {
+        method: 'POST',
+        body: JSON.stringify({ email }),
+        headers: await withStepUpHeader({}),
+    })
     const body = await response.json()
     return response.ok ? {} : { error: body.error || 'Could not send verification code' }
 }

--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -22,6 +22,12 @@ export const updateUserById = async (payload: Record<string, unknown>): Promise<
     }
 }
 
+export const requestEmailChange = async (email: string): Promise<{ error?: string }> => {
+    const response = await serverFetch('/users/email-change', { method: 'POST', body: JSON.stringify({ email }) })
+    const body = await response.json()
+    return response.ok ? {} : { error: body.error || 'Could not send verification code' }
+}
+
 // initiate the kyc process for the logged-in user
 export const getKycDetails = async (params?: {
     endorsements: BridgeEndorsementType[]

--- a/src/components/0_Bruddle/FieldColumn.tsx
+++ b/src/components/0_Bruddle/FieldColumn.tsx
@@ -9,6 +9,7 @@ interface FieldColumnProps {
     className?: string
     /** test hook carried by the FieldError (e.g. "error-alert" in the payment flows) */
     errorTestId?: string
+    errorId?: string
 }
 
 /**
@@ -17,9 +18,13 @@ interface FieldColumnProps {
  * flex/gap utilities at every call site. Field validation only — page/flow
  * failures (API errors, submission failures) stay <Notification priority="error">.
  */
-export const FieldColumn = ({ children, error, className, errorTestId }: FieldColumnProps) => (
+export const FieldColumn = ({ children, error, className, errorTestId, errorId }: FieldColumnProps) => (
     <div className={twMerge('flex flex-col gap-1', className)}>
         {children}
-        {error ? <FieldError data-testid={errorTestId}>{error}</FieldError> : null}
+        {error ? (
+            <FieldError id={errorId} data-testid={errorTestId}>
+                {error}
+            </FieldError>
+        ) : null}
     </div>
 )

--- a/src/components/0_Bruddle/FieldError.tsx
+++ b/src/components/0_Bruddle/FieldError.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { twMerge } from '@/utils/tw'
 
 interface FieldErrorProps {
+    id?: string
     children?: React.ReactNode
     className?: string
     'data-testid'?: string

--- a/src/components/0_Bruddle/__tests__/FieldColumn.test.tsx
+++ b/src/components/0_Bruddle/__tests__/FieldColumn.test.tsx
@@ -4,13 +4,14 @@ import { FieldColumn } from '../FieldColumn'
 describe('FieldColumn', () => {
     test('stacks the input and its FieldError in the 4px board column', () => {
         const { container } = render(
-            <FieldColumn error="Invalid IBAN" errorTestId="error-alert">
+            <FieldColumn error="Invalid IBAN" errorTestId="error-alert" errorId="iban-error">
                 <input />
             </FieldColumn>
         )
         expect(container.firstChild).toHaveClass('flex', 'flex-col', 'gap-1')
         const alert = screen.getByTestId('error-alert')
         expect(alert).toHaveTextContent('Invalid IBAN')
+        expect(alert).toHaveAttribute('id', 'iban-error')
         expect(alert).toHaveAttribute('role', 'alert')
     })
 

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -237,6 +237,14 @@ const SupportDrawer = () => {
                 // seeded with the current snapshot, so this never returns.
                 if (!snapshot) return
 
+                // Bind the freshly fetched token before publishing identity. On
+                // Android, setUser writes immediately when a session is already
+                // active; doing it first could expose a replacement mailbox to
+                // the former token during a coordinated token rotation.
+                if (tokenId) {
+                    CapacitorCrisp.setTokenID({ tokenID: tokenId })
+                }
+
                 // set user data before opening
                 if (snapshot.email || snapshot.fullName) {
                     CapacitorCrisp.setUser({
@@ -244,9 +252,6 @@ const SupportDrawer = () => {
                         nickname: snapshot.fullName || snapshot.username || undefined,
                         avatar: snapshot.avatar || undefined,
                     })
-                }
-                if (tokenId) {
-                    CapacitorCrisp.setTokenID({ tokenID: tokenId })
                 }
                 /*
                  * Custom data for support agents. Every key is written

--- a/src/components/Profile/components/ProfileEditField.tsx
+++ b/src/components/Profile/components/ProfileEditField.tsx
@@ -14,6 +14,8 @@ interface ProfileEditFieldProps {
     name?: string
     onBlur?: () => void
     autoComplete?: string
+    inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode']
+    maxLength?: number
     error?: string
 }
 
@@ -40,6 +42,8 @@ const ProfileEditField = forwardRef<HTMLInputElement, ProfileEditFieldProps>(
             name,
             onBlur,
             autoComplete,
+            inputMode,
+            maxLength,
             error,
         },
         ref
@@ -64,6 +68,8 @@ const ProfileEditField = forwardRef<HTMLInputElement, ProfileEditFieldProps>(
                         name={name}
                         onBlur={onBlur}
                         autoComplete={autoComplete}
+                        inputMode={inputMode}
+                        maxLength={maxLength}
                         aria-invalid={error ? true : undefined}
                         aria-describedby={error ? `${id}-error` : undefined}
                         id={id}

--- a/src/components/Profile/components/ProfileEditField.tsx
+++ b/src/components/Profile/components/ProfileEditField.tsx
@@ -1,6 +1,7 @@
 import BaseInput from '@/components/0_Bruddle/BaseInput'
 import StatusBadge from '@/components/Global/Badges/StatusBadge'
-import React, { useId } from 'react'
+import React, { forwardRef, useId } from 'react'
+import { FieldColumn } from '@/components/0_Bruddle/FieldColumn'
 
 interface ProfileEditFieldProps {
     label: string
@@ -10,6 +11,10 @@ interface ProfileEditFieldProps {
     type?: 'text' | 'email' | 'tel' | 'url'
     badge?: string
     disabled?: boolean
+    name?: string
+    onBlur?: () => void
+    autoComplete?: string
+    error?: string
 }
 
 /**
@@ -22,37 +27,58 @@ interface ProfileEditFieldProps {
  * used to re-declare height, padding and a pink focus ring on top, which
  * diverged from the input board (17802:61538).
  */
-const ProfileEditField: React.FC<ProfileEditFieldProps> = ({
-    label,
-    value,
-    onChange,
-    placeholder,
-    type = 'text',
-    badge,
-    disabled = false,
-}) => {
-    // dropping the placeholder removed the only accessible name these inputs
-    // had, so the label has to be wired to the field properly now
-    const id = useId()
-    return (
-        <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-                <label htmlFor={id} className={disabled ? 'text-label-l text-foreground-secondary' : 'text-label-l'}>
-                    {label}
-                </label>
-                {badge && <StatusBadge status="soon" size="small" customText={badge} />}
+const ProfileEditField = forwardRef<HTMLInputElement, ProfileEditFieldProps>(
+    (
+        {
+            label,
+            value,
+            onChange,
+            placeholder,
+            type = 'text',
+            badge,
+            disabled = false,
+            name,
+            onBlur,
+            autoComplete,
+            error,
+        },
+        ref
+    ) => {
+        // dropping the placeholder removed the only accessible name these inputs
+        // had, so the label has to be wired to the field properly now
+        const id = useId()
+        return (
+            <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                    <label
+                        htmlFor={id}
+                        className={disabled ? 'text-label-l text-foreground-secondary' : 'text-label-l'}
+                    >
+                        {label}
+                    </label>
+                    {badge && <StatusBadge status="soon" size="small" customText={badge} />}
+                </div>
+                <FieldColumn error={error} errorId={`${id}-error`}>
+                    <BaseInput
+                        ref={ref}
+                        name={name}
+                        onBlur={onBlur}
+                        autoComplete={autoComplete}
+                        aria-invalid={error ? true : undefined}
+                        aria-describedby={error ? `${id}-error` : undefined}
+                        id={id}
+                        variant="sm"
+                        type={type}
+                        value={value}
+                        onChange={(e) => onChange(e.target.value)}
+                        placeholder={placeholder}
+                        disabled={disabled}
+                    />
+                </FieldColumn>
             </div>
-            <BaseInput
-                id={id}
-                variant="sm"
-                type={type}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                placeholder={placeholder}
-                disabled={disabled}
-            />
-        </div>
-    )
-}
+        )
+    }
+)
+ProfileEditField.displayName = 'ProfileEditField'
 
 export default ProfileEditField

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { updateUserById } from '@/app/actions/users'
-import { FieldColumn } from '@/components/0_Bruddle/FieldColumn'
 import { Notification } from '@/components/0_Bruddle/Notification'
 import { Button } from '@/components/0_Bruddle/Button'
 import NavHeader from '@/components/Global/NavHeader'
@@ -8,7 +7,11 @@ import { useAuth } from '@/context/authContext'
 import * as Sentry from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import isEmail from 'validator/lib/isEmail'
+import { ListItem } from '@/components/0_Bruddle/ListItem'
+import { Icon } from '@/components/Global/Icons/Icon'
 import DeleteAccountButton from '@/components/Settings/DeleteAccountButton'
 import ShowNameToggle from '../components/ShowNameToggle'
 import ProfileEditField from '../components/ProfileEditField'
@@ -16,9 +19,11 @@ import ProfileHeader from '../components/ProfileHeader'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { useSafeBack } from '@/hooks/useSafeBack'
 
-// Bio / phone / website have no backend yet. Kept as dead code behind a switch
-// (same pattern as OPEN_GATED) so the fields come back with the feature.
-const SHOW_COMING_SOON_FIELDS = false
+interface ProfileFields {
+    name: string
+    surname: string
+    email: string
+}
 
 export const ProfileEditView = () => {
     const t = useTranslations('profile.edit')
@@ -27,262 +32,134 @@ export const ProfileEditView = () => {
     const router = useRouter()
     const onBack = useSafeBack('/profile')
     const { user, fetchUser } = useAuth()
-    // Verified badge + name/surname lock reflect *identity* verification (the human is ID-verified),
-    // not rail approval. Switched from `useCapabilities().isKycApproved` (any enabled rail, including
-    // Rain) to the provider-blind identityVerification projection — a rail-only approval must NOT
-    // lock the legal-name fields because the rail's KYC was external to our identity flow.
-    const { isVerified: isKycApproved } = useIdentityVerification()
-
-    const [isLoading, setIsLoading] = useState(false)
-    // backend/API failures — rendered in the Notification. client-side name
-    // validation renders as the name field's own error instead.
-    const [errorMessage, setErrorMessage] = useState('')
-    const [nameError, setNameError] = useState('')
-    // Mirrors `showFullName` so the header above updates the moment the toggle
-    // flips, instead of waiting for the background user refetch to land.
-    const [showFullName, setShowFullName] = useState(user?.user.showFullName ?? false)
-
-    useEffect(() => {
-        setShowFullName(user?.user.showFullName ?? false)
-    }, [user?.user.showFullName])
-
-    // split the full name into name and surname
-    const splitName = useCallback((fullName: string) => {
-        const parts = fullName.trim().split(' ')
-        if (parts.length === 1) return { name: parts[0], surname: '' }
-        const surname = parts.pop() || ''
-        const name = parts.join(' ')
-        return { name, surname }
-    }, [])
-
-    // form state for all fields
-    const [formData, setFormData] = useState({
-        name: '',
-        surname: '',
-        bio: '',
-        email: user?.user.email || '',
-        phone: '',
-        website: '',
-    })
-
-    // check if email is already set
-    const isEmailSet = !!user?.user.email
-
-    // once identity-verified the name is provider-owned, so the name/surname
-    // fields are locked and never sent. one source of truth for that invariant.
+    const { isVerified: isKycApproved, isLoading: isIdentityLoading } = useIdentityVerification()
     const canEditName = !isKycApproved
-
-    // the saved values, and the only fields the user can actually change
-    const initial = useMemo(() => {
-        const { name, surname } = splitName(user?.user.fullName || '')
-        return { name, surname, email: user?.user.email || '' }
-    }, [user?.user.fullName, user?.user.email, splitName])
-
-    // What was in the fields when the form loaded. The dirty check compares
-    // against THIS, not against `initial`: `initial` re-derives on every auth
-    // refresh, so if the saved name changed elsewhere while this screen was
-    // open, an untouched form went dirty and Save wrote the stale values back
-    // over the newer ones. The baseline and the fields have to move together.
-    const [baseline, setBaseline] = useState(() => ({ name: '', surname: '', email: user?.user.email || '' }))
-
-    // Hydrate once, when the saved values first arrive. Re-applying `initial`
-    // on a later refresh would wipe whatever the user had already typed, since
-    // this screen is reachable before auth resolves.
+    const [errorMessage, setErrorMessage] = useState('')
+    const [showFullName, setShowFullName] = useState(user?.user.showFullName ?? false)
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { dirtyFields, isSubmitting },
+    } = useForm<ProfileFields>({
+        defaultValues: { name: '', surname: '', email: '' },
+        mode: 'onChange',
+    })
     const hydrated = useRef(false)
     useEffect(() => {
-        if (hydrated.current || !user) return
+        setShowFullName(user?.user.showFullName ?? false)
+        // Keep the fields and their baseline together. Background auth refreshes
+        // must not overwrite edits or make untouched values dirty.
+        if (!user || hydrated.current) return
         hydrated.current = true
-        setFormData((prev) => ({ ...prev, ...initial }))
-        setBaseline(initial)
-    }, [user, initial])
+        const parts = (user.user.fullName || '').trim().split(/\s+/)
+        const surname = parts.length > 1 ? parts.pop()! : ''
+        reset({ name: parts.join(' '), surname, email: user.user.email || '' })
+    }, [user, reset])
 
-    // Save stays disabled until something the user may edit actually changed.
-    // bio / phone / website are "Soon!" placeholders — always disabled, never
-    // sent, so they can never make the form dirty.
-    const isDirty =
-        (canEditName && (formData.name !== baseline.name || formData.surname !== baseline.surname)) ||
-        (!isEmailSet && formData.email !== baseline.email)
+    const nameChanged = canEditName && !!(dirtyFields.name || dirtyFields.surname)
+    const isDirty = nameChanged || !!dirtyFields.email
+    const disabled = !user || isIdentityLoading || isSubmitting
 
-    // handle input field changes
-    const handleChange = useCallback((field: string, value: string) => {
-        setFormData((prev) => ({
-            ...prev,
-            [field]: value,
-        }))
-        // typing in the name field releases its validation error
-        if (field === 'name') setNameError('')
-    }, [])
-
-    // handle form submission
-    const handleSave = useCallback(async () => {
+    const save = handleSubmit(async (values) => {
+        if (!user || !isDirty || isIdentityLoading) return
+        setErrorMessage('')
         try {
-            setIsLoading(true)
-            setErrorMessage('')
-            setNameError('')
-
-            // only require the name when the field is editable — requiring it
-            // while it's locked (verified user, provider owns the name) would
-            // trap users whose fullName is empty at load (can't type, can't
-            // save) when all they want is to set their email.
-            if (canEditName && !formData.name?.trim()) {
-                setNameError(t('errors.nameRequired'))
-                return
-            }
-
-            // prepare request payload
-            const payload: { userId?: string; fullName?: string; email?: string } = {
-                userId: user?.user.userId,
-            }
-
-            // only include name when the field is editable (not provider-locked)
-            if (canEditName) {
-                payload.fullName = `${formData.name} ${formData.surname}`.trim()
-            }
-
-            // only include email if it's not already set and has a value
-            if (!isEmailSet && formData.email?.trim()) {
-                payload.email = formData.email.trim()
-            }
-
-            if (!user?.user.userId) {
-                throw new Error('User ID is undefined.')
-            }
-
-            // nothing substantive to update (e.g. a verified user with email
-            // already set clicking Save unchanged) — skip the no-op round-trip.
-            if (payload.fullName === undefined && payload.email === undefined) {
-                router.replace('/profile')
-                return
-            }
-
-            // updateUserById resolves with { error } on a non-2xx response
-            // instead of throwing (e.g. 400 invalid email, 409 email already in
-            // use). Surface it instead of navigating away as a false success.
-            const result = await updateUserById(payload)
+            // Send only changed fields. An email-only edit must neither require
+            // a missing name nor overwrite a name changed by a KYC webhook.
+            const result = await updateUserById({
+                userId: user.user.userId,
+                ...(nameChanged ? { fullName: `${values.name.trim()} ${values.surname.trim()}`.trim() } : {}),
+                ...(dirtyFields.email ? { email: values.email.trim() } : {}),
+            })
             if (result?.error) {
                 setErrorMessage(result.error)
                 return
             }
-
-            // refresh user data
             await fetchUser()
-
             router.replace('/profile')
         } catch (error) {
-            console.error('Error updating profile:', error)
             setErrorMessage(tCommon('genericError'))
             Sentry.captureException(error)
-        } finally {
-            setIsLoading(false)
         }
-    }, [formData, user, fetchUser, router, isEmailSet, canEditName, t, tCommon])
+    })
 
     const username = user?.user.username || ''
-    // The header shows what the rest of the world sees: the full name only
-    // while it is public, the username otherwise.
     const displayName = showFullName && user?.user.fullName ? user.user.fullName : username
 
     return (
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-6">
             <NavHeader title={t('title')} onPrev={onBack} />
-
             <ProfileHeader name={displayName} username={username} isVerified={isKycApproved} showShareButton={false} />
-
-            {/* two groups — who you are, then how we reach you. gap-6 (XL,
-                the section step) against gap-4 (L) inside a group, so the
-                rhythm reads 8 (label → field) < 16 (field → field) < 24. */}
-            <div className="flex flex-col gap-6">
+            <form onSubmit={save} noValidate className="flex flex-col gap-6">
                 <div className="flex flex-col gap-4">
-                    <FieldColumn error={nameError}>
-                        <ProfileEditField
-                            label={t('fields.name')}
-                            value={formData.name}
-                            onChange={(value) => handleChange('name', value)}
-                            disabled={!canEditName}
-                        />
-                    </FieldColumn>
-
-                    <ProfileEditField
-                        label={t('fields.surname')}
-                        value={formData.surname}
-                        onChange={(value) => handleChange('surname', value)}
-                        disabled={!canEditName}
+                    <Controller
+                        name="name"
+                        control={control}
+                        rules={{ validate: (value) => !nameChanged || !!value.trim() || t('errors.nameRequired') }}
+                        render={({ field, fieldState }) => (
+                            <ProfileEditField
+                                {...field}
+                                label={t('fields.name')}
+                                error={fieldState.error?.message}
+                                disabled={disabled || !canEditName}
+                                autoComplete="given-name"
+                            />
+                        )}
                     />
-
-                    {SHOW_COMING_SOON_FIELDS && (
+                    <Controller
+                        name="surname"
+                        control={control}
+                        render={({ field }) => (
+                            <ProfileEditField
+                                {...field}
+                                label={t('fields.surname')}
+                                disabled={disabled || !canEditName}
+                                autoComplete="family-name"
+                            />
+                        )}
+                    />
+                    {!canEditName && <p className="text-body-s text-foreground-secondary">{t('verifiedNameHelp')}</p>}
+                </div>
+                <Controller
+                    name="email"
+                    control={control}
+                    rules={{
+                        validate: (value) => !dirtyFields.email || isEmail(value.trim()) || t('errors.invalidEmail'),
+                    }}
+                    render={({ field, fieldState }) => (
                         <ProfileEditField
-                            label={t('fields.bio')}
-                            value={formData.bio}
-                            onChange={(value) => handleChange('bio', value)}
-                            badge={t('soonBadge')}
-                            disabled
+                            {...field}
+                            label={t('fields.email')}
+                            type="email"
+                            autoComplete="email"
+                            error={fieldState.error?.message}
+                            disabled={disabled}
                         />
                     )}
-                </div>
-
-                <div className="flex flex-col gap-4">
-                    <ProfileEditField
-                        label={t('fields.email')}
-                        value={formData.email}
-                        onChange={(value) => handleChange('email', value)}
-                        type="email"
-                        disabled={isEmailSet}
-                    />
-
-                    {SHOW_COMING_SOON_FIELDS && (
-                        <>
-                            <ProfileEditField
-                                label={t('fields.phoneNumber')}
-                                value={formData.phone}
-                                onChange={(value) => handleChange('phone', value)}
-                                type="tel"
-                                badge={t('soonBadge')}
-                                disabled
-                            />
-
-                            <ProfileEditField
-                                label={t('fields.website')}
-                                value={formData.website}
-                                onChange={(value) => handleChange('website', value)}
-                                type="url"
-                                badge={t('soonBadge')}
-                                disabled
-                            />
-                        </>
-                    )}
-                </div>
-
-                {/* Name visibility belongs with the name itself; only shown
-                    once there is a name to show or hide. */}
+                />
                 {!!user?.user.fullName?.trim() && (
-                    <div className="flex items-center justify-between gap-4 py-2">
-                        <span className="text-body-m-semibold text-foreground-primary">{tMenu('showMyFullName')}</span>
-                        <div className="shrink-0">
-                            <ShowNameToggle checked={showFullName} onChange={setShowFullName} />
-                        </div>
-                    </div>
+                    <ListItem
+                        position="single"
+                        leading={<Icon name="eye" size={24} />}
+                        title={tMenu('showMyFullName')}
+                        trailing={<ShowNameToggle checked={showFullName} onChange={setShowFullName} />}
+                    />
                 )}
-            </div>
-
-            {/* Save renders inline at the end of the form and scrolls with it.
-                A sticky footer here covered the Website field, which is the
-                last row — the field was unreachable behind the button. Save
-                stays gated on `isDirty`, so an untouched form cannot submit. */}
-            <div className="flex flex-col gap-4">
-                {errorMessage && <Notification priority="error">{errorMessage}</Notification>}
-
-                <Button
-                    disabled={isLoading || !isDirty}
-                    onClick={handleSave}
-                    className="w-full"
-                    shadowSize="4"
-                    loading={isLoading}
-                >
-                    {t('saveChanges')}
-                </Button>
-
-                <DeleteAccountButton />
-            </div>
+                <div className="flex flex-col gap-4">
+                    {errorMessage && <Notification priority="error">{errorMessage}</Notification>}
+                    <Button
+                        type="submit"
+                        disabled={disabled || !isDirty}
+                        className="w-full"
+                        shadowSize="4"
+                        loading={isSubmitting}
+                    >
+                        {t('saveChanges')}
+                    </Button>
+                </div>
+            </form>
+            <DeleteAccountButton />
         </div>
     )
 }

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -115,11 +115,18 @@ export const ProfileEditView = () => {
             }
             if (hasCode) {
                 // The API rotates the server-issued Crisp bearer in the same
-                // transaction as a verified replacement. Unbind this device
-                // from the former support session before refetching the profile,
-                // then force every mounted support hook to fetch the new bearer.
-                await resetCrispProxySessions()
+                // transaction as a verified replacement. Invalidate it before
+                // any best-effort device reset so support hooks fail closed even
+                // when native Crisp cannot unbind its former session.
                 invalidateCrispTokenId(user.user.userId)
+                try {
+                    await resetCrispProxySessions()
+                } catch (error) {
+                    // The email replacement is already committed. Keep showing
+                    // the committed profile instead of turning a support-session
+                    // cleanup failure into a false save failure.
+                    Sentry.captureException(error)
+                }
             }
             await fetchUser()
             router.replace('/profile')

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { updateUserById } from '@/app/actions/users'
+import { updateUserById, requestEmailChange } from '@/app/actions/users'
 import { Notification } from '@/components/0_Bruddle/Notification'
 import { Button } from '@/components/0_Bruddle/Button'
 import NavHeader from '@/components/Global/NavHeader'
@@ -23,6 +23,7 @@ interface ProfileFields {
     name: string
     surname: string
     email: string
+    code: string
 }
 
 export const ProfileEditView = () => {
@@ -33,18 +34,22 @@ export const ProfileEditView = () => {
     const onBack = useSafeBack('/profile')
     const { user, fetchUser } = useAuth()
     const { isVerified: isKycApproved, isLoading: isIdentityLoading } = useIdentityVerification()
-    const canEditName = !isKycApproved
+    const nameLocked = user?.profileNameLocked ?? isKycApproved
+    const canEditName = !nameLocked
+    const [codeSentTo, setCodeSentTo] = useState('')
+    const [isSendingCode, setIsSendingCode] = useState(false)
     const [errorMessage, setErrorMessage] = useState('')
     const [showFullName, setShowFullName] = useState(user?.user.showFullName ?? false)
     const {
         control,
+        watch,
         handleSubmit,
         reset,
         resetField,
         setError,
         formState: { dirtyFields, isSubmitting },
     } = useForm<ProfileFields>({
-        defaultValues: { name: '', surname: '', email: '' },
+        defaultValues: { name: '', surname: '', email: '', code: '' },
         mode: 'onChange',
     })
     const hydrated = useRef(false)
@@ -52,7 +57,7 @@ export const ProfileEditView = () => {
         setShowFullName(user?.user.showFullName ?? false)
         // Keep the fields and their baseline together. Background auth refreshes
         // must not overwrite edits or make untouched values dirty.
-        if (!user || (hydrated.current && !isKycApproved)) return
+        if (!user || (hydrated.current && !nameLocked)) return
         const parts = (user.user.fullName || '').trim().split(/\s+/)
         const surname = parts.length > 1 ? parts.pop()! : ''
         if (hydrated.current) {
@@ -63,23 +68,40 @@ export const ProfileEditView = () => {
             return
         }
         hydrated.current = true
-        reset({ name: parts.join(' '), surname, email: user.user.email || '' })
-    }, [user, isKycApproved, reset, resetField])
+        reset({ name: parts.join(' '), surname, email: user.user.email || '', code: '' })
+    }, [user, nameLocked, reset, resetField])
 
     const nameChanged = canEditName && !!(dirtyFields.name || dirtyFields.surname)
     const isDirty = nameChanged || !!dirtyFields.email
-    const disabled = !user || isIdentityLoading || isSubmitting
+    const disabled = !user || isIdentityLoading || isSubmitting || isSendingCode
+
+    const emailValue = watch('email').trim()
+    const needsEmailCode = !!user?.user.email && !!dirtyFields.email
+    const hasCode = needsEmailCode && codeSentTo === emailValue
 
     const save = handleSubmit(async (values) => {
         if (!user || !isDirty || isIdentityLoading) return
         setErrorMessage('')
         try {
+            if (needsEmailCode && !hasCode) {
+                const result = await requestEmailChange(values.email.trim())
+                if (result.error) {
+                    if (result.error === 'This email is already associated with another account') {
+                        setError('email', { type: 'server', message: t('errors.emailInUse') }, { shouldFocus: true })
+                    } else setErrorMessage(result.error)
+                } else {
+                    resetField('code')
+                    setCodeSentTo(values.email.trim())
+                }
+                return
+            }
             // Send only changed fields. An email-only edit must neither require
             // a missing name nor overwrite a name changed by a KYC webhook.
             const result = await updateUserById({
                 userId: user.user.userId,
                 ...(nameChanged ? { fullName: `${values.name.trim()} ${values.surname.trim()}`.trim() } : {}),
                 ...(dirtyFields.email ? { email: values.email.trim() } : {}),
+                ...(hasCode ? { emailVerificationCode: values.code } : {}),
             })
             if (result?.error) {
                 if (result.error === 'This email is already associated with another account') {
@@ -151,6 +173,51 @@ export const ProfileEditView = () => {
                         />
                     )}
                 />
+                {hasCode && (
+                    <div className="flex flex-col gap-4">
+                        <p className="text-body-s text-foreground-secondary">
+                            {t('emailCodeHelp', { email: codeSentTo })}
+                        </p>
+                        <Controller
+                            name="code"
+                            control={control}
+                            rules={{
+                                validate: (value) => !hasCode || /^\d{6}$/.test(value) || t('errors.invalidCode'),
+                            }}
+                            render={({ field, fieldState }) => (
+                                <ProfileEditField
+                                    {...field}
+                                    label={t('emailCode')}
+                                    autoComplete="one-time-code"
+                                    inputMode="numeric"
+                                    maxLength={6}
+                                    error={fieldState.error?.message}
+                                    disabled={disabled}
+                                />
+                            )}
+                        />
+                        <Button
+                            type="button"
+                            variant="transparent"
+                            disabled={disabled}
+                            onClick={async () => {
+                                setIsSendingCode(true)
+                                setErrorMessage('')
+                                try {
+                                    const result = await requestEmailChange(emailValue)
+                                    if (result.error) setErrorMessage(result.error)
+                                    else resetField('code')
+                                } catch {
+                                    setErrorMessage(tCommon('genericError'))
+                                } finally {
+                                    setIsSendingCode(false)
+                                }
+                            }}
+                        >
+                            {t('requestNewCode')}
+                        </Button>
+                    </div>
+                )}
                 {!!user?.user.fullName?.trim() && (
                     <ListItem
                         position="single"
@@ -168,7 +235,7 @@ export const ProfileEditView = () => {
                         shadowSize="4"
                         loading={isSubmitting}
                     >
-                        {t('saveChanges')}
+                        {t(needsEmailCode && !hasCode ? 'sendCode' : 'saveChanges')}
                     </Button>
                 </div>
             </form>

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -18,6 +18,8 @@ import ProfileEditField from '../components/ProfileEditField'
 import ProfileHeader from '../components/ProfileHeader'
 import { useIdentityVerification } from '@/hooks/useIdentityVerification'
 import { useSafeBack } from '@/hooks/useSafeBack'
+import { invalidateCrispTokenId } from '@/hooks/useCrispTokenId'
+import { resetCrispProxySessions } from '@/utils/crisp'
 
 interface ProfileFields {
     name: string
@@ -110,6 +112,14 @@ export const ProfileEditView = () => {
                 }
                 setErrorMessage(result.error)
                 return
+            }
+            if (hasCode) {
+                // The API rotates the server-issued Crisp bearer in the same
+                // transaction as a verified replacement. Unbind this device
+                // from the former support session before refetching the profile,
+                // then force every mounted support hook to fetch the new bearer.
+                await resetCrispProxySessions()
+                invalidateCrispTokenId(user.user.userId)
             }
             await fetchUser()
             router.replace('/profile')

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -40,6 +40,7 @@ export const ProfileEditView = () => {
         control,
         handleSubmit,
         reset,
+        resetField,
         formState: { dirtyFields, isSubmitting },
     } = useForm<ProfileFields>({
         defaultValues: { name: '', surname: '', email: '' },
@@ -50,12 +51,19 @@ export const ProfileEditView = () => {
         setShowFullName(user?.user.showFullName ?? false)
         // Keep the fields and their baseline together. Background auth refreshes
         // must not overwrite edits or make untouched values dirty.
-        if (!user || hydrated.current) return
-        hydrated.current = true
+        if (!user || (hydrated.current && !isKycApproved)) return
         const parts = (user.user.fullName || '').trim().split(/\s+/)
         const surname = parts.length > 1 ? parts.pop()! : ''
+        if (hydrated.current) {
+            // Once verified, show the provider-owned name even if verification
+            // finished during an edit. Keep the user's email draft untouched.
+            resetField('name', { defaultValue: parts.join(' ') })
+            resetField('surname', { defaultValue: surname })
+            return
+        }
+        hydrated.current = true
         reset({ name: parts.join(' '), surname, email: user.user.email || '' })
-    }, [user, reset])
+    }, [user, isKycApproved, reset, resetField])
 
     const nameChanged = canEditName && !!(dirtyFields.name || dirtyFields.surname)
     const isDirty = nameChanged || !!dirtyFields.email

--- a/src/components/Profile/views/ProfileEdit.view.tsx
+++ b/src/components/Profile/views/ProfileEdit.view.tsx
@@ -41,6 +41,7 @@ export const ProfileEditView = () => {
         handleSubmit,
         reset,
         resetField,
+        setError,
         formState: { dirtyFields, isSubmitting },
     } = useForm<ProfileFields>({
         defaultValues: { name: '', surname: '', email: '' },
@@ -81,6 +82,10 @@ export const ProfileEditView = () => {
                 ...(dirtyFields.email ? { email: values.email.trim() } : {}),
             })
             if (result?.error) {
+                if (result.error === 'This email is already associated with another account') {
+                    setError('email', { type: 'server', message: t('errors.emailInUse') }, { shouldFocus: true })
+                    return
+                }
                 setErrorMessage(result.error)
                 return
             }

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -97,6 +97,8 @@ test('background refresh preserves edits and does not send an untouched stale na
     mockUser = { user: { ...mockUser!.user, fullName: 'New Verified Name' } }
     mockVerified = true
     view.rerender(<ProfileEditView />)
+    expect(screen.getByLabelText('Name')).toHaveValue('New Verified')
+    expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
     save()
     await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
 })

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { ProfileEditView } from '../ProfileEdit.view'
+import { updateUserById } from '@/app/actions/users'
+
+const mockReplace = jest.fn()
+const mockFetchUser = jest.fn()
+let mockVerified = false
+let mockUser: { user: { userId: string; username: string; fullName: string; email: string } } | null
+jest.mock('@/app/actions/users', () => ({ updateUserById: jest.fn() }))
+jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: mockUser, fetchUser: mockFetchUser }) }))
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isVerified: mockVerified, isLoading: false }),
+}))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ replace: mockReplace }) }))
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('../../components/ProfileHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('../../components/ShowNameToggle', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Settings/DeleteAccountButton', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
+
+const save = () => fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+const change = async (label: string, value: string) => {
+    fireEvent.change(screen.getByLabelText(label), { target: { value } })
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save Changes' })).toBeEnabled())
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockVerified = false
+    mockUser = { user: { userId: 'test-user', username: 'testuser', fullName: 'Test User', email: 'old@example.com' } }
+    jest.mocked(updateUserById).mockResolvedValue({})
+    mockFetchUser.mockResolvedValue(undefined)
+})
+
+test.each([false, true])('email is editable with verified=%s and only the changed email is sent', async (verified) => {
+    mockVerified = verified
+    renderWithIntl(<ProfileEditView />)
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled()
+    expect(screen.getByLabelText('Email')).toBeEnabled()
+    await change('Email', ' new@example.com ')
+    save()
+    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
+})
+
+test('verified names explain the lock while an unverified name can be saved', async () => {
+    const view = renderWithIntl(<ProfileEditView />)
+    await change('Name', 'New')
+    save()
+    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', fullName: 'New User' }))
+    mockVerified = true
+    view.rerender(<ProfileEditView />)
+    expect(screen.getByLabelText('Name')).toBeDisabled()
+    expect(screen.getByLabelText('Surname')).toBeDisabled()
+    expect(screen.getByText(/Your name comes from your identity verification/)).toBeVisible()
+})
+
+test.each(['', 'invalid', 'a@'])('rejects invalid changed email %s inline', async (email) => {
+    renderWithIntl(<ProfileEditView />)
+    await change('Email', email)
+    save()
+    expect(await screen.findByText('Please enter a valid email address.')).toBeVisible()
+    expect(updateUserById).not.toHaveBeenCalled()
+})
+
+test('rejects an empty changed name', async () => {
+    renderWithIntl(<ProfileEditView />)
+    await change('Name', ' ')
+    save()
+    expect(await screen.findByText('Please provide your name.')).toBeVisible()
+    expect(updateUserById).not.toHaveBeenCalled()
+})
+
+test('email-only save does not require a missing name', async () => {
+    mockUser!.user.fullName = ''
+    renderWithIntl(<ProfileEditView />)
+    await change('Email', 'new@example.com')
+    save()
+    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+})
+
+test('shows server failures and retains edits without navigating', async () => {
+    jest.mocked(updateUserById).mockResolvedValue({ error: 'This email is already associated with another account' })
+    renderWithIntl(<ProfileEditView />)
+    await change('Email', 'new@example.com')
+    save()
+    expect(await screen.findByText('This email is already associated with another account')).toBeVisible()
+    expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
+    expect(mockReplace).not.toHaveBeenCalled()
+})
+
+test('background refresh preserves edits and does not send an untouched stale name', async () => {
+    const view = renderWithIntl(<ProfileEditView />)
+    await change('Email', 'new@example.com')
+    mockUser = { user: { ...mockUser!.user, fullName: 'New Verified Name' } }
+    mockVerified = true
+    view.rerender(<ProfileEditView />)
+    save()
+    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+})
+
+test('late auth hydrates without enabling a no-op save', async () => {
+    const user = mockUser
+    mockUser = null
+    const view = renderWithIntl(<ProfileEditView />)
+    expect(screen.getByLabelText('Email')).toBeDisabled()
+    mockUser = user
+    view.rerender(<ProfileEditView />)
+    expect(screen.getByLabelText('Email')).toHaveValue('old@example.com')
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled()
+})

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -50,8 +50,8 @@ test.each([false, true])('email is editable with verified=%s and only the change
     mockVerified = verified
     renderWithIntl(<ProfileEditView />)
     expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled()
-    expect(screen.getByLabelText('Email')).toBeEnabled()
-    await change('Email', ' new@example.com ')
+    expect(screen.getByLabelText('Email for notifications')).toBeEnabled()
+    await change('Email for notifications', ' new@example.com ')
     save()
     await verify()
     await waitFor(() =>
@@ -78,7 +78,7 @@ test('verified names explain the lock while an unverified name can be saved', as
 
 test.each(['', 'invalid', 'a@'])('rejects invalid changed email %s inline', async (email) => {
     renderWithIntl(<ProfileEditView />)
-    await change('Email', email)
+    await change('Email for notifications', email)
     save()
     expect(await screen.findByText('Please enter a valid email address.')).toBeVisible()
     expect(updateUserById).not.toHaveBeenCalled()
@@ -95,7 +95,7 @@ test('rejects an empty changed name', async () => {
 test('email-only save does not require a missing name', async () => {
     mockUser!.user.fullName = ''
     renderWithIntl(<ProfileEditView />)
-    await change('Email', 'new@example.com')
+    await change('Email for notifications', 'new@example.com')
     save()
     await verify()
     await waitFor(() =>
@@ -110,22 +110,22 @@ test('email-only save does not require a missing name', async () => {
 test('shows server failures and retains edits without navigating', async () => {
     jest.mocked(updateUserById).mockResolvedValue({ error: 'Could not save your profile' })
     renderWithIntl(<ProfileEditView />)
-    await change('Email', 'new@example.com')
+    await change('Email for notifications', 'new@example.com')
     save()
     await verify()
     expect(await screen.findByText('Could not save your profile')).toBeVisible()
-    expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
+    expect(screen.getByLabelText('Email for notifications')).toHaveValue('new@example.com')
     expect(mockReplace).not.toHaveBeenCalled()
 })
 
 test('background refresh preserves edits and does not send an untouched stale name', async () => {
     const view = renderWithIntl(<ProfileEditView />)
-    await change('Email', 'new@example.com')
+    await change('Email for notifications', 'new@example.com')
     mockUser = { user: { ...mockUser!.user, fullName: 'New Verified Name' } }
     mockVerified = true
     view.rerender(<ProfileEditView />)
     expect(screen.getByLabelText('Name')).toHaveValue('New Verified')
-    expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
+    expect(screen.getByLabelText('Email for notifications')).toHaveValue('new@example.com')
     save()
     await verify()
     await waitFor(() =>
@@ -141,10 +141,10 @@ test('late auth hydrates without enabling a no-op save', async () => {
     const user = mockUser
     mockUser = null
     const view = renderWithIntl(<ProfileEditView />)
-    expect(screen.getByLabelText('Email')).toBeDisabled()
+    expect(screen.getByLabelText('Email for notifications')).toBeDisabled()
     mockUser = user
     view.rerender(<ProfileEditView />)
-    expect(screen.getByLabelText('Email')).toHaveValue('old@example.com')
+    expect(screen.getByLabelText('Email for notifications')).toHaveValue('old@example.com')
     expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled()
 })
 
@@ -153,13 +153,13 @@ test('a duplicate email error is linked to its input and can be corrected', asyn
         error: 'This email is already associated with another account',
     })
     renderWithIntl(<ProfileEditView />)
-    await change('Email', 'taken@example.com')
+    await change('Email for notifications', 'taken@example.com')
     save()
     expect(await screen.findByText('This email is already associated with another account.')).toBeVisible()
-    expect(screen.getByLabelText('Email')).toHaveAccessibleDescription(
+    expect(screen.getByLabelText('Email for notifications')).toHaveAccessibleDescription(
         'This email is already associated with another account.'
     )
-    await change('Email', 'available@example.com')
+    await change('Email for notifications', 'available@example.com')
     save()
     await verify()
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
@@ -171,14 +171,14 @@ test('a previously verified name stays locked during re-verification', () => {
     renderWithIntl(<ProfileEditView />)
     expect(screen.getByLabelText('Name')).toBeDisabled()
     expect(screen.getByText(/Your name comes from your identity verification/)).toBeVisible()
-    expect(screen.getByLabelText('Email')).toBeEnabled()
+    expect(screen.getByLabelText('Email for notifications')).toBeEnabled()
 })
 test('changing the pending mailbox requires a new code', async () => {
     renderWithIntl(<ProfileEditView />)
-    await change('Email', 'first@example.com')
+    await change('Email for notifications', 'first@example.com')
     save()
     await screen.findByLabelText('Verification code')
-    await change('Email', 'second@example.com')
+    await change('Email for notifications', 'second@example.com')
     expect(screen.queryByLabelText('Verification code')).not.toBeInTheDocument()
     save()
     await waitFor(() => expect(requestEmailChange).toHaveBeenLastCalledWith('second@example.com'))

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -131,6 +131,24 @@ test('email-only save does not require a missing name', async () => {
     )
 })
 
+test('setting an email for the first time skips verification and sends only the email', async () => {
+    mockUser!.user.email = ''
+    renderWithIntl(<ProfileEditView />)
+
+    expect(screen.queryByLabelText('Verification code')).not.toBeInTheDocument()
+    await change('Email for notifications', 'new@example.com')
+    save()
+
+    await waitFor(() =>
+        expect(updateUserById).toHaveBeenCalledWith({
+            userId: 'test-user',
+            email: 'new@example.com',
+        })
+    )
+    expect(requestEmailChange).not.toHaveBeenCalled()
+    expect(mockReplace).toHaveBeenCalledWith('/profile')
+})
+
 test('shows server failures and retains edits without navigating', async () => {
     jest.mocked(updateUserById).mockResolvedValue({ error: 'Could not save your profile' })
     renderWithIntl(<ProfileEditView />)

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithIntl } from '@/test-utils/intl'
 import { ProfileEditView } from '../ProfileEdit.view'
 import { updateUserById } from '@/app/actions/users'
@@ -22,7 +22,9 @@ jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
 
 const save = () => fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
 const change = async (label: string, value: string) => {
-    fireEvent.change(screen.getByLabelText(label), { target: { value } })
+    await act(async () => {
+        fireEvent.change(screen.getByLabelText(label), { target: { value } })
+    })
     await waitFor(() => expect(screen.getByRole('button', { name: 'Save Changes' })).toBeEnabled())
 }
 
@@ -82,11 +84,11 @@ test('email-only save does not require a missing name', async () => {
 })
 
 test('shows server failures and retains edits without navigating', async () => {
-    jest.mocked(updateUserById).mockResolvedValue({ error: 'This email is already associated with another account' })
+    jest.mocked(updateUserById).mockResolvedValue({ error: 'Could not save your profile' })
     renderWithIntl(<ProfileEditView />)
     await change('Email', 'new@example.com')
     save()
-    expect(await screen.findByText('This email is already associated with another account')).toBeVisible()
+    expect(await screen.findByText('Could not save your profile')).toBeVisible()
     expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
     expect(mockReplace).not.toHaveBeenCalled()
 })
@@ -112,4 +114,20 @@ test('late auth hydrates without enabling a no-op save', async () => {
     view.rerender(<ProfileEditView />)
     expect(screen.getByLabelText('Email')).toHaveValue('old@example.com')
     expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled()
+})
+
+test('a duplicate email error is linked to its input and can be corrected', async () => {
+    jest.mocked(updateUserById).mockResolvedValueOnce({
+        error: 'This email is already associated with another account',
+    })
+    renderWithIntl(<ProfileEditView />)
+    await change('Email', 'taken@example.com')
+    save()
+    expect(await screen.findByText('This email is already associated with another account.')).toBeVisible()
+    expect(screen.getByLabelText('Email')).toHaveAccessibleDescription(
+        'This email is already associated with another account.'
+    )
+    await change('Email', 'available@example.com')
+    save()
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
 })

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -1,13 +1,16 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithIntl } from '@/test-utils/intl'
 import { ProfileEditView } from '../ProfileEdit.view'
-import { updateUserById } from '@/app/actions/users'
+import { updateUserById, requestEmailChange } from '@/app/actions/users'
 
 const mockReplace = jest.fn()
 const mockFetchUser = jest.fn()
 let mockVerified = false
-let mockUser: { user: { userId: string; username: string; fullName: string; email: string } } | null
-jest.mock('@/app/actions/users', () => ({ updateUserById: jest.fn() }))
+let mockUser: {
+    profileNameLocked?: boolean
+    user: { userId: string; username: string; fullName: string; email: string }
+} | null
+jest.mock('@/app/actions/users', () => ({ updateUserById: jest.fn(), requestEmailChange: jest.fn() }))
 jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: mockUser, fetchUser: mockFetchUser }) }))
 jest.mock('@/hooks/useIdentityVerification', () => ({
     useIdentityVerification: () => ({ isVerified: mockVerified, isLoading: false }),
@@ -20,12 +23,18 @@ jest.mock('../../components/ShowNameToggle', () => ({ __esModule: true, default:
 jest.mock('@/components/Settings/DeleteAccountButton', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Global/Icons/Icon', () => ({ Icon: () => null }))
 
-const save = () => fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+const save = () => fireEvent.click(screen.getByRole('button', { name: /Save Changes|Send code/ }))
+const verify = async () => {
+    await screen.findByLabelText('Verification code')
+    expect(updateUserById).not.toHaveBeenCalled()
+    await change('Verification code', '123456')
+    save()
+}
 const change = async (label: string, value: string) => {
     await act(async () => {
         fireEvent.change(screen.getByLabelText(label), { target: { value } })
     })
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Save Changes' })).toBeEnabled())
+    await waitFor(() => expect(screen.getByRole('button', { name: /Save Changes|Send code/ })).toBeEnabled())
 }
 
 beforeEach(() => {
@@ -33,6 +42,7 @@ beforeEach(() => {
     mockVerified = false
     mockUser = { user: { userId: 'test-user', username: 'testuser', fullName: 'Test User', email: 'old@example.com' } }
     jest.mocked(updateUserById).mockResolvedValue({})
+    jest.mocked(requestEmailChange).mockResolvedValue({})
     mockFetchUser.mockResolvedValue(undefined)
 })
 
@@ -43,7 +53,14 @@ test.each([false, true])('email is editable with verified=%s and only the change
     expect(screen.getByLabelText('Email')).toBeEnabled()
     await change('Email', ' new@example.com ')
     save()
-    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+    await verify()
+    await waitFor(() =>
+        expect(updateUserById).toHaveBeenCalledWith({
+            userId: 'test-user',
+            email: 'new@example.com',
+            emailVerificationCode: '123456',
+        })
+    )
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
 })
 
@@ -80,7 +97,14 @@ test('email-only save does not require a missing name', async () => {
     renderWithIntl(<ProfileEditView />)
     await change('Email', 'new@example.com')
     save()
-    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+    await verify()
+    await waitFor(() =>
+        expect(updateUserById).toHaveBeenCalledWith({
+            userId: 'test-user',
+            email: 'new@example.com',
+            emailVerificationCode: '123456',
+        })
+    )
 })
 
 test('shows server failures and retains edits without navigating', async () => {
@@ -88,6 +112,7 @@ test('shows server failures and retains edits without navigating', async () => {
     renderWithIntl(<ProfileEditView />)
     await change('Email', 'new@example.com')
     save()
+    await verify()
     expect(await screen.findByText('Could not save your profile')).toBeVisible()
     expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
     expect(mockReplace).not.toHaveBeenCalled()
@@ -102,7 +127,14 @@ test('background refresh preserves edits and does not send an untouched stale na
     expect(screen.getByLabelText('Name')).toHaveValue('New Verified')
     expect(screen.getByLabelText('Email')).toHaveValue('new@example.com')
     save()
-    await waitFor(() => expect(updateUserById).toHaveBeenCalledWith({ userId: 'test-user', email: 'new@example.com' }))
+    await verify()
+    await waitFor(() =>
+        expect(updateUserById).toHaveBeenCalledWith({
+            userId: 'test-user',
+            email: 'new@example.com',
+            emailVerificationCode: '123456',
+        })
+    )
 })
 
 test('late auth hydrates without enabling a no-op save', async () => {
@@ -117,7 +149,7 @@ test('late auth hydrates without enabling a no-op save', async () => {
 })
 
 test('a duplicate email error is linked to its input and can be corrected', async () => {
-    jest.mocked(updateUserById).mockResolvedValueOnce({
+    jest.mocked(requestEmailChange).mockResolvedValueOnce({
         error: 'This email is already associated with another account',
     })
     renderWithIntl(<ProfileEditView />)
@@ -129,5 +161,26 @@ test('a duplicate email error is linked to its input and can be corrected', asyn
     )
     await change('Email', 'available@example.com')
     save()
+    await verify()
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
+})
+
+test('a previously verified name stays locked during re-verification', () => {
+    mockUser!.profileNameLocked = true
+    mockVerified = false
+    renderWithIntl(<ProfileEditView />)
+    expect(screen.getByLabelText('Name')).toBeDisabled()
+    expect(screen.getByText(/Your name comes from your identity verification/)).toBeVisible()
+    expect(screen.getByLabelText('Email')).toBeEnabled()
+})
+test('changing the pending mailbox requires a new code', async () => {
+    renderWithIntl(<ProfileEditView />)
+    await change('Email', 'first@example.com')
+    save()
+    await screen.findByLabelText('Verification code')
+    await change('Email', 'second@example.com')
+    expect(screen.queryByLabelText('Verification code')).not.toBeInTheDocument()
+    save()
+    await waitFor(() => expect(requestEmailChange).toHaveBeenLastCalledWith('second@example.com'))
+    expect(updateUserById).not.toHaveBeenCalled()
 })

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -75,7 +75,7 @@ test.each([false, true])('email is editable with verified=%s and only the change
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
 })
 
-test('keeps the replacement identity gated when the old native support session cannot reset', async () => {
+test('shows the committed replacement when the old native support session cannot reset', async () => {
     mockResetCrispSessions.mockRejectedValueOnce(new Error('native reset failed'))
     renderWithIntl(<ProfileEditView />)
     await change('Email for notifications', 'new@example.com')
@@ -83,9 +83,12 @@ test('keeps the replacement identity gated when the old native support session c
     await verify()
 
     await waitFor(() => expect(mockResetCrispSessions).toHaveBeenCalledTimes(1))
-    expect(mockInvalidateCrispToken).not.toHaveBeenCalled()
-    expect(mockFetchUser).not.toHaveBeenCalled()
-    expect(mockReplace).not.toHaveBeenCalled()
+    expect(mockInvalidateCrispToken).toHaveBeenCalledWith('test-user')
+    expect(mockFetchUser).toHaveBeenCalledTimes(1)
+    expect(mockReplace).toHaveBeenCalledWith('/profile')
+    expect(mockInvalidateCrispToken.mock.invocationCallOrder[0]).toBeLessThan(
+        mockResetCrispSessions.mock.invocationCallOrder[0]
+    )
 })
 
 test('verified names explain the lock while an unverified name can be saved', async () => {

--- a/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
+++ b/src/components/Profile/views/__tests__/ProfileEdit.test.tsx
@@ -5,6 +5,8 @@ import { updateUserById, requestEmailChange } from '@/app/actions/users'
 
 const mockReplace = jest.fn()
 const mockFetchUser = jest.fn()
+const mockResetCrispSessions = jest.fn()
+const mockInvalidateCrispToken = jest.fn()
 let mockVerified = false
 let mockUser: {
     profileNameLocked?: boolean
@@ -17,6 +19,12 @@ jest.mock('@/hooks/useIdentityVerification', () => ({
 }))
 jest.mock('next/navigation', () => ({ useRouter: () => ({ replace: mockReplace }) }))
 jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+jest.mock('@/utils/crisp', () => ({
+    resetCrispProxySessions: (...args: unknown[]) => mockResetCrispSessions(...args),
+}))
+jest.mock('@/hooks/useCrispTokenId', () => ({
+    invalidateCrispTokenId: (...args: unknown[]) => mockInvalidateCrispToken(...args),
+}))
 jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
 jest.mock('../../components/ProfileHeader', () => ({ __esModule: true, default: () => null }))
 jest.mock('../../components/ShowNameToggle', () => ({ __esModule: true, default: () => null }))
@@ -44,6 +52,7 @@ beforeEach(() => {
     jest.mocked(updateUserById).mockResolvedValue({})
     jest.mocked(requestEmailChange).mockResolvedValue({})
     mockFetchUser.mockResolvedValue(undefined)
+    mockResetCrispSessions.mockResolvedValue(undefined)
 })
 
 test.each([false, true])('email is editable with verified=%s and only the changed email is sent', async (verified) => {
@@ -61,7 +70,22 @@ test.each([false, true])('email is editable with verified=%s and only the change
             emailVerificationCode: '123456',
         })
     )
+    expect(mockResetCrispSessions).toHaveBeenCalledTimes(1)
+    expect(mockInvalidateCrispToken).toHaveBeenCalledWith('test-user')
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/profile'))
+})
+
+test('keeps the replacement identity gated when the old native support session cannot reset', async () => {
+    mockResetCrispSessions.mockRejectedValueOnce(new Error('native reset failed'))
+    renderWithIntl(<ProfileEditView />)
+    await change('Email for notifications', 'new@example.com')
+    save()
+    await verify()
+
+    await waitFor(() => expect(mockResetCrispSessions).toHaveBeenCalledTimes(1))
+    expect(mockInvalidateCrispToken).not.toHaveBeenCalled()
+    expect(mockFetchUser).not.toHaveBeenCalled()
+    expect(mockReplace).not.toHaveBeenCalled()
 })
 
 test('verified names explain the lock while an unverified name can be saved', async () => {

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -330,11 +330,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         disableDemoMode()
 
         // reset third-party sessions (non-fatal)
-        try {
-            resetCrispProxySessions()
-        } catch (e) {
-            console.warn('crisp reset failed:', e)
-        }
+        void resetCrispProxySessions().catch((e) => console.warn('crisp reset failed:', e))
         try {
             posthog.reset()
             // reset() wipes registered super properties — re-register the

--- a/src/dev/fixtures/registry.ts
+++ b/src/dev/fixtures/registry.ts
@@ -139,7 +139,12 @@ export const FIXTURES: Record<string, Fixture> = {
     // ---------------------------------------------------------------------
     home: { route: '/home', about: 'Home: balance, activity and CTAs for a verified user.' },
     profile: { route: '/profile', about: 'Profile menu, verified user, card row present.' },
-    'profile-edit': { route: '/profile/edit', about: 'Personal details form, pre-filled.' },
+    'profile-edit': { route: '/profile/edit', about: 'Verified name locked, account email editable.' },
+    'profile-edit-unverified': {
+        route: '/profile/edit',
+        about: 'Name and email editable before identity verification.',
+        responses: { 'GET /users/me': { identityVerification: { status: 'not_started' } } },
+    },
     'identity-verification': {
         route: '/profile/identity-verification',
         about: 'Unlocked regions for a user whose ID check passed.',

--- a/src/dev/fixtures/registry.ts
+++ b/src/dev/fixtures/registry.ts
@@ -139,11 +139,18 @@ export const FIXTURES: Record<string, Fixture> = {
     // ---------------------------------------------------------------------
     home: { route: '/home', about: 'Home: balance, activity and CTAs for a verified user.' },
     profile: { route: '/profile', about: 'Profile menu, verified user, card row present.' },
-    'profile-edit': { route: '/profile/edit', about: 'Verified name locked, account email editable.' },
+    'profile-edit': {
+        route: '/profile/edit',
+        about: 'Verified name locked, account email editable.',
+        responses: { 'GET /users/me': { profileNameLocked: true }, 'POST /users/email-change': { success: true } },
+    },
     'profile-edit-unverified': {
         route: '/profile/edit',
         about: 'Name and email editable before identity verification.',
-        responses: { 'GET /users/me': { identityVerification: { status: 'not_started' } } },
+        responses: {
+            'GET /users/me': { identityVerification: { status: 'not_started' }, profileNameLocked: false },
+            'POST /users/email-change': { success: true },
+        },
     },
     'identity-verification': {
         route: '/profile/identity-verification',

--- a/src/hooks/__tests__/useCrispTokenId.test.ts
+++ b/src/hooks/__tests__/useCrispTokenId.test.ts
@@ -11,12 +11,24 @@ jest.mock('@/utils/api-fetch', () => ({
     apiFetch: (...args: unknown[]) => apiFetchMock(...args),
 }))
 
+const mockResetCrispSessions = jest.fn()
+jest.mock('@/utils/crisp', () => ({
+    resetCrispProxySessions: (...args: unknown[]) => mockResetCrispSessions(...args),
+}))
+
+const mockIsCapacitor = jest.fn()
+jest.mock('@/utils/capacitor', () => ({
+    isCapacitor: () => mockIsCapacitor(),
+}))
+
 const jsonResponse = (body: unknown, ok = true) => ({ ok, json: async () => body }) as unknown as Response
 
 describe('useCrispTokenId', () => {
     beforeEach(() => {
         apiFetchMock.mockReset()
         mockUseAuth.mockReset()
+        mockResetCrispSessions.mockReset().mockResolvedValue(undefined)
+        mockIsCapacitor.mockReset().mockReturnValue(false)
     })
 
     it('returns undefined and never calls the API when unauthenticated', () => {
@@ -33,6 +45,21 @@ describe('useCrispTokenId', () => {
         const { result } = renderHook(() => useCrispTokenId())
 
         await waitFor(() => expect(result.current).toBe('tok-aaa'))
+    })
+
+    it('resets a persisted native session before the first bind after a cold process start', async () => {
+        mockIsCapacitor.mockReturnValue(true)
+        mockUseAuth.mockReturnValue({ userId: 'cold-native', user: { user: { email: 'new@example.com' } } })
+        apiFetchMock.mockResolvedValue(jsonResponse({ crispTokenId: 'new-token', userId: 'cold-native' }))
+
+        const { result } = renderHook(() => useCrispTokenId())
+
+        expect(result.current).toBeUndefined()
+        await waitFor(() => expect(mockResetCrispSessions).toHaveBeenCalledTimes(1))
+        expect(mockResetCrispSessions.mock.invocationCallOrder[0]).toBeLessThan(
+            apiFetchMock.mock.invocationCallOrder[0]
+        )
+        await waitFor(() => expect(result.current).toBe('new-token'))
     })
 
     it('takes the userId from the auth token, not a parameter — the call carries no userId', async () => {
@@ -82,5 +109,25 @@ describe('useCrispTokenId', () => {
 
         await waitFor(() => expect(apiFetchMock.mock.calls.length).toBeGreaterThan(1), { timeout: 3000 })
         expect(result.current).toBeUndefined()
+    })
+
+    it('drops and rebinds the token before exposing a replacement mailbox', async () => {
+        let email = 'old@example.com'
+        mockUseAuth.mockImplementation(() => ({ userId: 'rotating-user', user: { user: { email } } }))
+        apiFetchMock
+            .mockResolvedValueOnce(jsonResponse({ crispTokenId: 'old-token', userId: 'rotating-user' }))
+            .mockResolvedValueOnce(jsonResponse({ crispTokenId: 'new-token', userId: 'rotating-user' }))
+
+        const { result, rerender } = renderHook(() => useCrispTokenId())
+        await waitFor(() => expect(result.current).toBe('old-token'))
+
+        email = 'new@example.com'
+        rerender()
+
+        // The old token is unusable in the same render that observes the new
+        // email; SupportDrawer therefore unmounts its old session immediately.
+        expect(result.current).toBeUndefined()
+        await waitFor(() => expect(mockResetCrispSessions).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(result.current).toBe('new-token'))
     })
 })

--- a/src/hooks/useCrispTokenId.ts
+++ b/src/hooks/useCrispTokenId.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/context/authContext'
 import { apiFetch } from '@/utils/api-fetch'
+import { resetCrispProxySessions } from '@/utils/crisp'
+import { isCapacitor } from '@/utils/capacitor'
 
 /** How many times to retry the token fetch before giving up for this mount. */
 const MAX_ATTEMPTS = 3
@@ -31,15 +33,29 @@ async function fetchCrispToken(expectedUserId: string): Promise<string | undefin
 
 // In-memory cache so the token is available synchronously after the first fetch,
 // preventing an undefined→resolved state change that would cause iframe reloads.
-const tokenCache = new Map<string, string>()
+type CachedCrispToken = { tokenId: string; email: string | null }
+const tokenCache = new Map<string, CachedCrispToken>()
+
+/** Drop a token after the API rotates it; the next render must refetch. */
+export function invalidateCrispTokenId(userId: string): void {
+    tokenCache.delete(userId)
+}
 
 /**
  * Hook that returns a stable Crisp token ID for the current user.
  * Returns undefined when not authenticated or before the token resolves.
  */
 export function useCrispTokenId(): string | undefined {
-    const { userId } = useAuth()
-    const [tokenId, setTokenId] = useState<string | undefined>(userId ? tokenCache.get(userId) : undefined)
+    const { userId, user } = useAuth()
+    const email = user?.user.email ?? null
+    const initial = userId ? tokenCache.get(userId) : undefined
+    const [tokenId, setTokenId] = useState<string | undefined>(initial?.email === email ? initial.tokenId : undefined)
+
+    // Refuse the cached bearer synchronously when the profile mailbox changes.
+    // Effects run after commit; returning the old token for even one render lets
+    // SupportDrawer publish the new email to the former Crisp conversation.
+    const current = userId ? tokenCache.get(userId) : undefined
+    const visibleToken = current?.email === email && current.tokenId === tokenId ? tokenId : undefined
 
     useEffect(() => {
         if (!userId) {
@@ -51,11 +67,26 @@ export function useCrispTokenId(): string | undefined {
         // account switch never leaves the previous user's token in state while the
         // new user's token is still loading.
         const cached = tokenCache.get(userId)
-        setTokenId(cached)
-        if (cached) return
+        if (cached?.email === email) {
+            setTokenId(cached.tokenId)
+            return
+        }
 
         let cancelled = false
         ;(async () => {
+            // Native Crisp can restore a device-local conversation after a cold
+            // process start, while this in-memory cache starts empty. Reset once
+            // before the first authenticated native bind as well as on a known
+            // email/cache mismatch, then fetch the current server-issued token.
+            if (cached || isCapacitor()) {
+                tokenCache.delete(userId)
+                setTokenId(undefined)
+                // Unbind the local SDK before a fresh token can carry the new
+                // mailbox. This also covers another device changing the profile:
+                // the next /users/me refresh makes the email snapshot mismatch.
+                await resetCrispProxySessions()
+                if (cancelled) return
+            }
             for (let attempt = 0; attempt < MAX_ATTEMPTS && !cancelled; attempt++) {
                 if (attempt > 0) {
                     await new Promise((resolve) => setTimeout(resolve, 300 * attempt))
@@ -64,17 +95,22 @@ export function useCrispTokenId(): string | undefined {
                 const token = await fetchCrispToken(userId).catch(() => undefined)
                 if (cancelled) return
                 if (token) {
-                    tokenCache.set(userId, token)
+                    tokenCache.set(userId, { tokenId: token, email })
                     setTokenId(token)
                     return
                 }
             }
-        })()
+        })().catch((error) => {
+            // Keep the token unavailable when a native reset fails. A later
+            // mount may retry, but this render must never pair the replacement
+            // mailbox with the former device-local support session.
+            if (!cancelled) console.debug('[Crisp] session rotation failed:', error)
+        })
 
         return () => {
             cancelled = true
         }
-    }, [userId])
+    }, [userId, email])
 
-    return tokenId
+    return visibleToken
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -324,7 +324,7 @@
                 "name": "Name",
                 "surname": "Surname",
                 "bio": "Bio",
-                "email": "Email",
+                "email": "Email for notifications",
                 "phoneNumber": "Phone number",
                 "website": "Website"
             },

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -332,7 +332,8 @@
             "saveChanges": "Save Changes",
             "errors": {
                 "nameRequired": "Please provide your name.",
-                "invalidEmail": "Please enter a valid email address."
+                "invalidEmail": "Please enter a valid email address.",
+                "emailInUse": "This email is already associated with another account."
             },
             "verifiedNameHelp": "Your name comes from your identity verification and cannot be edited here. Contact support if it needs correcting."
         },

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -333,9 +333,14 @@
             "errors": {
                 "nameRequired": "Please provide your name.",
                 "invalidEmail": "Please enter a valid email address.",
-                "emailInUse": "This email is already associated with another account."
+                "emailInUse": "This email is already associated with another account.",
+                "invalidCode": "Enter the 6-digit code from your email."
             },
-            "verifiedNameHelp": "Your name comes from your identity verification and cannot be edited here. Contact support if it needs correcting."
+            "verifiedNameHelp": "Your name comes from your identity verification and cannot be edited here. Contact support if it needs correcting.",
+            "emailCode": "Verification code",
+            "emailCodeHelp": "We sent a code to {email}. Your current email will stay active until you verify the new one.",
+            "sendCode": "Send code",
+            "requestNewCode": "Request another code"
         },
         "regions": {
             "title": "Regions and verification",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -306,7 +306,7 @@
             "unlockBadge": "Unlock",
             "yourBadges": "Your Badges",
             "points": "Points",
-            "personalDetails": "Personal Details",
+            "personalDetails": "Edit profile",
             "unlockedRegions": "Payment Channels",
             "paymentLimits": "Payment limits",
             "showMyFullName": "Show my full name",
@@ -331,8 +331,10 @@
             "soonBadge": "Soon!",
             "saveChanges": "Save Changes",
             "errors": {
-                "nameRequired": "Please provide your name."
-            }
+                "nameRequired": "Please provide your name.",
+                "invalidEmail": "Please enter a valid email address."
+            },
+            "verifiedNameHelp": "Your name comes from your identity verification and cannot be edited here. Contact support if it needs correcting."
         },
         "regions": {
             "title": "Regions and verification",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -324,7 +324,7 @@
                 "name": "Nombre",
                 "surname": "Apellido",
                 "bio": "Bio",
-                "email": "Correo electrónico",
+                "email": "Correo para notificaciones",
                 "phoneNumber": "Número de teléfono",
                 "website": "Sitio web"
             },

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -306,7 +306,7 @@
             "unlockBadge": "Desbloquear",
             "yourBadges": "Tus insignias",
             "points": "Puntos",
-            "personalDetails": "Datos personales",
+            "personalDetails": "Editar perfil",
             "unlockedRegions": "Canales de pago",
             "paymentLimits": "Límites de pago",
             "showMyFullName": "Mostrar mi nombre completo",
@@ -331,8 +331,10 @@
             "soonBadge": "¡Pronto!",
             "saveChanges": "Guardar cambios",
             "errors": {
-                "nameRequired": "Por favor ingresa tu nombre."
-            }
+                "nameRequired": "Por favor ingresa tu nombre.",
+                "invalidEmail": "Ingresa una dirección de correo válida."
+            },
+            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar aquí. Contacta a soporte si necesitas corregirlo."
         },
         "regions": {
             "title": "Regiones y verificación",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -333,9 +333,14 @@
             "errors": {
                 "nameRequired": "Por favor ingresa tu nombre.",
                 "invalidEmail": "Ingresa una dirección de correo válida.",
-                "emailInUse": "Este correo ya está asociado a otra cuenta."
+                "emailInUse": "Este correo ya está asociado a otra cuenta.",
+                "invalidCode": "Ingresa el código de 6 dígitos que recibiste por correo."
             },
-            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar aquí. Contacta a soporte si necesitas corregirlo."
+            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar aquí. Contacta a soporte si necesitas corregirlo.",
+            "emailCode": "Código de verificación",
+            "emailCodeHelp": "Enviamos un código a {email}. Tu correo actual seguirá activo hasta que verifiques el nuevo.",
+            "sendCode": "Enviar código",
+            "requestNewCode": "Solicitar otro código"
         },
         "regions": {
             "title": "Regiones y verificación",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -332,7 +332,8 @@
             "saveChanges": "Guardar cambios",
             "errors": {
                 "nameRequired": "Por favor ingresa tu nombre.",
-                "invalidEmail": "Ingresa una dirección de correo válida."
+                "invalidEmail": "Ingresa una dirección de correo válida.",
+                "emailInUse": "Este correo ya está asociado a otra cuenta."
             },
             "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar aquí. Contacta a soporte si necesitas corregirlo."
         },

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -151,8 +151,10 @@
         },
         "edit": {
             "errors": {
-                "nameRequired": "Por favor ingresá tu nombre."
-            }
+                "nameRequired": "Por favor ingresá tu nombre.",
+                "invalidEmail": "Ingresá una dirección de correo válida."
+            },
+            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar acá. Contactá a soporte si necesitás corregirlo."
         },
         "regions": {
             "description": "Transferí y recibí desde cualquier cuenta bancaria y usá los métodos de pago disponibles.",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -152,9 +152,14 @@
         "edit": {
             "errors": {
                 "nameRequired": "Por favor ingresá tu nombre.",
-                "invalidEmail": "Ingresá una dirección de correo válida."
+                "invalidEmail": "Ingresá una dirección de correo válida.",
+                "invalidCode": "Ingresá el código de 6 dígitos que recibiste por correo."
             },
-            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar acá. Contactá a soporte si necesitás corregirlo."
+            "verifiedNameHelp": "Tu nombre proviene de la verificación de identidad y no se puede editar acá. Contactá a soporte si necesitás corregirlo.",
+            "emailCode": "Código de verificación",
+            "emailCodeHelp": "Enviamos un código a {email}. Tu correo actual seguirá activo hasta que verifiques el nuevo.",
+            "sendCode": "Enviar código",
+            "requestNewCode": "Solicitar otro código"
         },
         "regions": {
             "description": "Transferí y recibí desde cualquier cuenta bancaria y usá los métodos de pago disponibles.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -324,7 +324,7 @@
                 "name": "Nome",
                 "surname": "Sobrenome",
                 "bio": "Bio",
-                "email": "E-mail",
+                "email": "E-mail para notificações",
                 "phoneNumber": "Número de telefone",
                 "website": "Site"
             },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -332,7 +332,8 @@
             "saveChanges": "Salvar alterações",
             "errors": {
                 "nameRequired": "Informe seu nome.",
-                "invalidEmail": "Digite um endereço de e-mail válido."
+                "invalidEmail": "Digite um endereço de e-mail válido.",
+                "emailInUse": "Este e-mail já está associado a outra conta."
             },
             "verifiedNameHelp": "Seu nome vem da verificação de identidade e não pode ser editado aqui. Fale com o suporte se precisar corrigi-lo."
         },

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -306,7 +306,7 @@
             "unlockBadge": "Desbloquear",
             "yourBadges": "Seus selos",
             "points": "Pontos",
-            "personalDetails": "Dados pessoais",
+            "personalDetails": "Editar perfil",
             "unlockedRegions": "Canais de pagamento",
             "paymentLimits": "Limites de pagamento",
             "showMyFullName": "Mostrar meu nome completo",
@@ -331,8 +331,10 @@
             "soonBadge": "Em breve!",
             "saveChanges": "Salvar alterações",
             "errors": {
-                "nameRequired": "Informe seu nome."
-            }
+                "nameRequired": "Informe seu nome.",
+                "invalidEmail": "Digite um endereço de e-mail válido."
+            },
+            "verifiedNameHelp": "Seu nome vem da verificação de identidade e não pode ser editado aqui. Fale com o suporte se precisar corrigi-lo."
         },
         "regions": {
             "title": "Regiões e verificação",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -333,9 +333,14 @@
             "errors": {
                 "nameRequired": "Informe seu nome.",
                 "invalidEmail": "Digite um endereço de e-mail válido.",
-                "emailInUse": "Este e-mail já está associado a outra conta."
+                "emailInUse": "Este e-mail já está associado a outra conta.",
+                "invalidCode": "Digite o código de 6 dígitos recebido por e-mail."
             },
-            "verifiedNameHelp": "Seu nome vem da verificação de identidade e não pode ser editado aqui. Fale com o suporte se precisar corrigi-lo."
+            "verifiedNameHelp": "Seu nome vem da verificação de identidade e não pode ser editado aqui. Fale com o suporte se precisar corrigi-lo.",
+            "emailCode": "Código de verificação",
+            "emailCodeHelp": "Enviamos um código para {email}. Seu e-mail atual continuará ativo até você verificar o novo.",
+            "sendCode": "Enviar código",
+            "requestNewCode": "Solicitar outro código"
         },
         "regions": {
             "title": "Regiões e verificação",

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -299,6 +299,7 @@ export interface IUserProfile {
     // `capabilities` on /get-user. Read via useIdentityVerification(). The status
     // surfaces render this; no provider names. Optional during the migration.
     identityVerification?: IdentityVerification
+    profileNameLocked?: boolean
     // Residence-based availability derived server-side from the residence the
     // user declared at signup. Read via useResidenceRestrictions(). Advisory
     // offer-shaping only: hides bank/card surfaces the user could never use.

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -10126,6 +10126,7 @@ export interface paths {
                         telegramUsername?: string;
                         userId: string;
                         username?: string;
+                        emailVerificationCode?: string;
                     };
                 };
             };
@@ -11014,6 +11015,7 @@ export interface paths {
                                 banking: boolean;
                                 card: boolean;
                             };
+                            profileNameLocked: boolean;
                         } & {
                             [key: string]: unknown;
                         };
@@ -11434,6 +11436,96 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/email-change": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                    "api-key"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        email: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -10104,6 +10104,7 @@ export interface paths {
                 header: {
                     Authorization: string;
                     "api-key"?: string;
+                    "x-step-up-token"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -10137,6 +10138,19 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+                /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "STEP_UP_REQUIRED";
+                            error: string;
+                        };
+                    };
                 };
             };
         };
@@ -11457,6 +11471,7 @@ export interface paths {
                 header: {
                     Authorization: string;
                     "api-key"?: string;
+                    "x-step-up-token"?: string;
                 };
                 path?: never;
                 cookie?: never;
@@ -11487,6 +11502,19 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "STEP_UP_REQUIRED";
                             error: string;
                         };
                     };

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -16305,6 +16305,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "header",
+                        "name": "x-step-up-token",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "requestBody": {
@@ -16409,6 +16417,31 @@
                 },
                 "responses": {
                     "200": {
+                        "description": "Default Response"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "enum": [
+                                                "STEP_UP_REQUIRED"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error",
+                                        "code"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }
@@ -18521,6 +18554,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "header",
+                        "name": "x-step-up-token",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "requestBody": {
@@ -18572,6 +18613,31 @@
                                     },
                                     "required": [
                                         "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "enum": [
+                                                "STEP_UP_REQUIRED"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error",
+                                        "code"
                                     ],
                                     "type": "object"
                                 }

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -16392,6 +16392,10 @@
                                     },
                                     "username": {
                                         "type": "string"
+                                    },
+                                    "emailVerificationCode": {
+                                        "type": "string",
+                                        "pattern": "^[0-9]{6}$"
                                     }
                                 },
                                 "required": [
@@ -18238,11 +18242,15 @@
                                                 "card"
                                             ],
                                             "type": "object"
+                                        },
+                                        "profileNameLocked": {
+                                            "type": "boolean"
                                         }
                                     },
                                     "required": [
                                         "capabilities",
                                         "identityVerification",
+                                        "profileNameLocked",
                                         "residenceRestrictions",
                                         "residence"
                                     ],
@@ -18490,6 +18498,139 @@
                 ],
                 "responses": {
                     "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/users/email-change": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "Authorization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "name": "api-key",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "email": {
+                                        "maxLength": 320,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "email"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
                         "description": "Default Response"
                     }
                 }

--- a/src/utils/__tests__/crisp.test.ts
+++ b/src/utils/__tests__/crisp.test.ts
@@ -60,13 +60,28 @@ describe('ensureNativeCrispConfigured', () => {
         expect(configure).toHaveBeenCalledTimes(2)
     })
 
-    it('resets the native session on logout once support has been opened', async () => {
+    it('resets the native session once support has been opened', async () => {
         const { ensureNativeCrispConfigured, resetCrispProxySessions } = await import('@/utils/crisp')
 
         await expectToSettle(ensureNativeCrispConfigured())
-        resetCrispProxySessions()
-        await expectToSettle(Promise.resolve())
+        await expectToSettle(resetCrispProxySessions())
 
         expect(reset).toHaveBeenCalled()
+    })
+
+    it('configures and resets a persisted native session after a cold process start', async () => {
+        const { resetCrispProxySessions } = await import('@/utils/crisp')
+
+        await expectToSettle(resetCrispProxySessions())
+
+        expect(configure).toHaveBeenCalledTimes(1)
+        expect(reset).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails closed when the native session cannot be reset', async () => {
+        reset.mockRejectedValueOnce(new Error('reset failed'))
+        const { resetCrispProxySessions } = await import('@/utils/crisp')
+
+        await expect(expectToSettle(resetCrispProxySessions())).rejects.toThrow('reset failed')
     })
 })

--- a/src/utils/crisp.ts
+++ b/src/utils/crisp.ts
@@ -196,17 +196,17 @@ export function resetCrispSession(crispInstance: CrispInstance): void {
  * Attempts to reset currently mounted proxy iframes via postMessage,
  * and sets a sessionStorage flag for proxy pages that aren't currently mounted.
  */
-export function resetCrispProxySessions(): void {
+export async function resetCrispProxySessions(): Promise<void> {
     if (typeof window === 'undefined') return
 
-    // in capacitor, reset via native plugin — only if it was ever configured
-    // this session (i.e. support was opened); nothing to reset otherwise
+    // The native SDK can restore a device-local session after a cold process
+    // start, before this JavaScript runtime has configured Crisp. Configure and
+    // reset unconditionally so an email/token rotation cannot inherit that
+    // session. Let failures propagate: callers must keep the new identity gated
+    // until the old native binding has definitely been cleared.
     if (isCapacitor()) {
-        if (nativeCrispReady) {
-            nativeCrispReady
-                .then(({ CapacitorCrisp }) => CapacitorCrisp.reset())
-                .catch((err) => console.debug('[Crisp] native reset failed:', err))
-        }
+        const { CapacitorCrisp } = await ensureNativeCrispConfigured()
+        await CapacitorCrisp.reset()
         return
     }
 


### PR DESCRIPTION
Users can choose **Edit profile** and change their **Email for notifications**, including after identity verification. For a replacement email, **Send code** sends a verification code to the new inbox; entering it and saving activates the new address. Before identity approval, users can also edit their name. A previously verified name stays locked during re-verification, with an explicit explanation and support guidance.

The form uses react-hook-form and existing design-system primitives. It sends only changed fields, preserves drafts on errors and background refreshes, supports numeric code entry/autofill, and includes English, Latin American Spanish, Argentine Spanish, and Brazilian Portuguese copy.

Task: [TASK-22410](https://app.notion.com/p/3d58381175798129a7c5dbe43aa0342a). Paired API: https://github.com/peanutprotocol/peanut-api-ts/pull/1554. Deploy the API first; this UI consumes the new verification endpoint and durable name-lock field. Support guidance: https://github.com/peanutprotocol/mono/pull/145. The setting controls Peanut notifications through OneSignal and support replies through Crisp. Bridge, Manteca, Rain, and Sumsub records are outside this change.

Validation:
- 31 profile/locale tests pass, covering mailbox verification, changed-address invalidation, durable name locks, async hydration, validation, and draft retention.
- Local typecheck, changed-file ESLint, formatting, and design-system ratchet pass.
- CI unit tests, native export, preview build, typecheck, lint, formatting, and design-system checks pass. Visual fixture CI also passes. The current label change passes 29 focused profile/Crisp tests and local typecheck. Fresh lint, formatting, design-system, and CI typecheck checks pass; remaining CI is pending.
- OpenAPI snapshot and generated types include the new request and response fields.

Earlier mobile verification (before the notification-label update) on preview commit `7c0823094`: verified/unverified name policy, email-code entry, numeric keyboard hint, and Save reachable after scrolling at 375×667. Screenshots use fixture accounts; no real messages were sent.

| Verified identity | Before identity verification |
| --- | --- |
| ![Verified profile](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3044/profile-edit-complete.png) | ![Unverified profile](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3044/profile-edit-unverified-complete.png) |

| Email verification, verified user (scrolled) | Email verification, unverified user (scrolled) |
| --- | --- |
| ![Verified email code](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3044/profile-edit-code-bottom.png) | ![Unverified email code](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3044/profile-edit-unverified-code-bottom.png) |

Native: Needs a device pass for keyboard and safe-area behavior. Screenshots use fixture accounts and live on `pr-assets-3044`; remove the assets branch after merge.

Design note: mono's newer Field primitive is absent from this dev checkout; this uses its existing FieldColumn/FieldError primitives.
