### PR TITLE
fix: pre-capture share PNG so iOS share stays inside the tap gesture (TASK-22407)

### DIFF
--- a/src/components/Card/BadgeSkipCelebration.tsx
+++ b/src/components/Card/BadgeSkipCelebration.tsx
@@ -195,6 +195,7 @@ const BadgeSkipCelebration: FC<Props> = ({ badgeCode, username, badges, stats, t
                     source="celebration"
                     ready={assetReady}
                     shareUrl={profileShareUrl(username, hideUsername)}
+                    hideUsername={hideUsername}
                 />
                 <Button onClick={onContinue} variant="stroke" className="w-full">
                     {t('celebration.continueToCard')}

--- a/src/components/Card/CardUnlockDrawer.tsx
+++ b/src/components/Card/CardUnlockDrawer.tsx
@@ -97,6 +97,7 @@ export const CardUnlockDrawer: FC<Props> = ({ isOpen, onClose, entry, username, 
                             source="history-replay"
                             ready={assetReady}
                             shareUrl={profileShareUrl(username, hideUsername)}
+                            hideUsername={hideUsername}
                         />
                     </div>
                 </div>

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -95,6 +95,10 @@ interface Props {
     /** The sharer's own profile URL, appended to the share caption. Omit to ship
      *  the caption link-free — see profileShareUrl. */
     shareUrl?: string
+    /** The hide-username toggle. Flipping it re-renders the asset (username
+     *  shown / hidden), so it keys the pre-capture cache — shareUrl can't,
+     *  because it is undefined in both states for users without a handle. */
+    hideUsername?: boolean
 }
 
 export const ShareAssetActions: FC<Props> = ({
@@ -103,6 +107,7 @@ export const ShareAssetActions: FC<Props> = ({
     filename = 'peanut-card.png',
     ready = true,
     shareUrl,
+    hideUsername = false,
 }) => {
     const t = useTranslations('card.share')
     const [isSharing, setIsSharing] = useState(false)
@@ -122,27 +127,38 @@ export const ShareAssetActions: FC<Props> = ({
     // awaiting the 1-3s capture (which expires ios's gesture window — see the
     // file header). only on devices that can share files: desktop share falls
     // back to the twitter intent and web save downloads, neither needs a
-    // gesture, so capturing there would be wasted work. keyed on shareUrl
-    // because the hide-username toggle re-renders the asset (username shown /
-    // hidden), which makes a cached capture stale.
+    // gesture, so capturing there would be wasted work. keyed on hideUsername
+    // because the toggle re-renders the asset (username shown / hidden), which
+    // makes a cached capture stale — shareUrl can't key it, it is undefined in
+    // both toggle states for users without a handle.
     const cachedBlobRef = useRef<Blob | null>(null)
+    // while true, the gesture-gated buttons stay disabled: a tap mid-capture
+    // finds no cached blob, takes the slow capture-on-tap path, and reproduces
+    // the exact NotAllowedError this cache exists to fix. only ever true on
+    // the canShareImageFiles() path, so desktop is never gated.
+    const [isPrecapturing, setIsPrecapturing] = useState(false)
     useEffect(() => {
         cachedBlobRef.current = null
         if (!ready || !canShareImageFiles()) return
         const node = captureRef.current
         if (!node) return
         let stale = false
+        setIsPrecapturing(true)
         captureShareAsset(node)
             .then((blob) => {
                 if (!stale) cachedBlobRef.current = blob
             })
             .catch(() => {
-                // quiet: the tap-time fallback re-captures and reports errors.
+                // quiet: buttons re-enable and the tap-time fallback re-captures
+                // and reports — worst case equals the old capture-on-tap path.
+            })
+            .finally(() => {
+                if (!stale) setIsPrecapturing(false)
             })
         return () => {
             stale = true
         }
-    }, [ready, shareUrl, captureRef])
+    }, [ready, hideUsername, captureRef])
 
     const captureOrCached = async (): Promise<Blob> => {
         if (cachedBlobRef.current) return cachedBlobRef.current
@@ -243,7 +259,7 @@ export const ShareAssetActions: FC<Props> = ({
                 shadowSize="4"
                 className="w-full"
                 loading={isSharing}
-                disabled={isSharing || isSaving || !ready}
+                disabled={isSharing || isSaving || !ready || isPrecapturing}
                 icon={<Icon name="share" size={20} />}
             >
                 {t('share')}
@@ -254,7 +270,8 @@ export const ShareAssetActions: FC<Props> = ({
                     variant="stroke"
                     className="w-full"
                     loading={isSaving}
-                    disabled={isSharing || isSaving || !ready}
+                    // web save is a download — no gesture, no pre-capture gate.
+                    disabled={isSharing || isSaving || !ready || (saveMode === 'native-share' && isPrecapturing)}
                     icon={<Icon name="download" size={20} />}
                 >
                     {t('saveImage')}

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -22,9 +22,14 @@
  * `navigator.share()` must run inside the user gesture. Capturing on tap
  * (html-to-image, 1–3s) expired WebKit's gesture window → NotAllowedError.
  * So on devices that can share files we PRE-capture the PNG once the asset
- * is ready and the tap handler shares the cached blob synchronously. A
- * failed pre-capture retries in the background (buttons stay disabled);
- * only after all attempts fail does capture-on-tap return as the fallback.
+ * is ready and the tap handler shares the cached blob synchronously. On
+ * the file-sharing path the gesture-bound buttons enable ONLY once a blob
+ * is cached — there is no "give up and enable" branch, because any tap
+ * that has to await capture reproduces the NotAllowedError. A failed
+ * pre-capture retries in the background for as long as the component is
+ * mounted (and reports to Sentry once if the first 3 attempts fail);
+ * permanently broken capture means honestly disabled buttons — a share
+ * without the file cannot succeed on those platforms anyway.
  */
 
 import { type FC, type RefObject, useEffect, useRef, useState } from 'react'
@@ -124,6 +129,9 @@ export const ShareAssetActions: FC<Props> = ({
     // and a state snapshot would post the handle the user just opted out of.
     const text = shareUrl ? `${caption}\n\n${shareUrl}` : caption
 
+    // stable per mount, like saveMode — used for gating and the pre-capture.
+    const [canShareFiles] = useState(canShareImageFiles)
+
     // pre-captured png so the tap handler can call navigator.share() without
     // awaiting the 1-3s capture (which expires ios's gesture window — see the
     // file header). only on devices that can share files: desktop share falls
@@ -133,51 +141,57 @@ export const ShareAssetActions: FC<Props> = ({
     // makes a cached capture stale — shareUrl can't key it, it is undefined in
     // both toggle states for users without a handle.
     const cachedBlobRef = useRef<Blob | null>(null)
-    // while true, the gesture-gated buttons stay disabled: a tap mid-capture
-    // finds no cached blob, takes the slow capture-on-tap path, and reproduces
-    // the exact NotAllowedError this cache exists to fix. only ever true on
-    // the canShareImageFiles() path, so desktop is never gated.
-    const [isPrecapturing, setIsPrecapturing] = useState(false)
+    // the gesture-gated buttons enable only while this is true: a tap without
+    // a cached blob would await capture and reproduce the NotAllowedError.
+    const [hasCachedBlob, setHasCachedBlob] = useState(false)
     useEffect(() => {
         cachedBlobRef.current = null
-        if (!ready || !canShareImageFiles()) return
+        setHasCachedBlob(false)
+        if (!ready || !canShareFiles) return
         const node = captureRef.current
         if (!node) return
         let stale = false
         let retryTimer: ReturnType<typeof setTimeout> | undefined
-        setIsPrecapturing(true)
-        const attempt = (retriesLeft: number): void => {
+        const attempt = (attemptNo: number): void => {
             captureShareAsset(node)
                 .then((blob) => {
                     if (stale) return
                     cachedBlobRef.current = blob
-                    setIsPrecapturing(false)
+                    setHasCachedBlob(true)
                 })
-                .catch(() => {
+                .catch((err) => {
                     if (stale) return
-                    if (retriesLeft > 0) {
-                        // transient failures (an image mid-decode, a font race)
-                        // often clear on retry — keep the buttons gated so a tap
-                        // can't fall into the slow capture-on-tap path and hit
-                        // the gesture-window error this cache exists to fix.
-                        retryTimer = setTimeout(() => attempt(retriesLeft - 1), 500)
-                        return
+                    // never surrender to capture-on-tap: a tap that awaits
+                    // capture loses ios activation even when the capture
+                    // succeeds. retry quickly at first (an image mid-decode or
+                    // a font race clears fast), then keep trying every 5s for
+                    // as long as we're mounted. if capture is permanently
+                    // broken the buttons honestly stay disabled — a share
+                    // without the file can't succeed on this platform anyway.
+                    if (attemptNo === 3) {
+                        // one report per effect run, so persistent failure is
+                        // visible in prod instead of silent dead buttons.
+                        Sentry.captureException(err, {
+                            tags: { feature: 'share-asset', action: 'pre-capture', source },
+                            extra: {
+                                ...describeShareError(err),
+                                note: 'share-asset pre-capture failing persistently — share stays disabled until a capture succeeds',
+                            },
+                        })
                     }
-                    // three failed captures: a tap-time capture would fail the
-                    // same way, so the gesture window no longer matters. quiet
-                    // here — re-enable and let the tap-time fallback surface
-                    // the existing error message instead of leaving the
-                    // buttons dead forever.
-                    setIsPrecapturing(false)
+                    retryTimer = setTimeout(() => attempt(attemptNo + 1), attemptNo < 3 ? 500 : 5000)
                 })
         }
-        attempt(2)
+        attempt(1)
         return () => {
             stale = true
             if (retryTimer) clearTimeout(retryTimer)
         }
-    }, [ready, hideUsername, captureRef])
+    }, [ready, canShareFiles, hideUsername, captureRef, source])
 
+    // the gated buttons can only fire with a cached blob, so the tap-time
+    // capture branch below is reachable only from web save (download — no
+    // gesture needed); it also stands as belt-and-braces for the gated paths.
     const captureOrCached = async (): Promise<Blob> => {
         if (cachedBlobRef.current) return cachedBlobRef.current
         const node = captureRef.current
@@ -277,7 +291,7 @@ export const ShareAssetActions: FC<Props> = ({
                 shadowSize="4"
                 className="w-full"
                 loading={isSharing}
-                disabled={isSharing || isSaving || !ready || isPrecapturing}
+                disabled={isSharing || isSaving || !ready || (canShareFiles && !hasCachedBlob)}
                 icon={<Icon name="share" size={20} />}
             >
                 {t('share')}
@@ -289,7 +303,7 @@ export const ShareAssetActions: FC<Props> = ({
                     className="w-full"
                     loading={isSaving}
                     // web save is a download — no gesture, no pre-capture gate.
-                    disabled={isSharing || isSaving || !ready || (saveMode === 'native-share' && isPrecapturing)}
+                    disabled={isSharing || isSaving || !ready || (saveMode === 'native-share' && !hasCachedBlob)}
                     icon={<Icon name="download" size={20} />}
                 >
                     {t('saveImage')}

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -22,8 +22,9 @@
  * `navigator.share()` must run inside the user gesture. Capturing on tap
  * (html-to-image, 1–3s) expired WebKit's gesture window → NotAllowedError.
  * So on devices that can share files we PRE-capture the PNG once the asset
- * is ready and the tap handler shares the cached blob synchronously. The
- * capture-on-tap path stays as fallback when the cache is empty.
+ * is ready and the tap handler shares the cached blob synchronously. A
+ * failed pre-capture retries in the background (buttons stay disabled);
+ * only after all attempts fail does capture-on-tap return as the fallback.
  */
 
 import { type FC, type RefObject, useEffect, useRef, useState } from 'react'
@@ -143,20 +144,37 @@ export const ShareAssetActions: FC<Props> = ({
         const node = captureRef.current
         if (!node) return
         let stale = false
+        let retryTimer: ReturnType<typeof setTimeout> | undefined
         setIsPrecapturing(true)
-        captureShareAsset(node)
-            .then((blob) => {
-                if (!stale) cachedBlobRef.current = blob
-            })
-            .catch(() => {
-                // quiet: buttons re-enable and the tap-time fallback re-captures
-                // and reports — worst case equals the old capture-on-tap path.
-            })
-            .finally(() => {
-                if (!stale) setIsPrecapturing(false)
-            })
+        const attempt = (retriesLeft: number): void => {
+            captureShareAsset(node)
+                .then((blob) => {
+                    if (stale) return
+                    cachedBlobRef.current = blob
+                    setIsPrecapturing(false)
+                })
+                .catch(() => {
+                    if (stale) return
+                    if (retriesLeft > 0) {
+                        // transient failures (an image mid-decode, a font race)
+                        // often clear on retry — keep the buttons gated so a tap
+                        // can't fall into the slow capture-on-tap path and hit
+                        // the gesture-window error this cache exists to fix.
+                        retryTimer = setTimeout(() => attempt(retriesLeft - 1), 500)
+                        return
+                    }
+                    // three failed captures: a tap-time capture would fail the
+                    // same way, so the gesture window no longer matters. quiet
+                    // here — re-enable and let the tap-time fallback surface
+                    // the existing error message instead of leaving the
+                    // buttons dead forever.
+                    setIsPrecapturing(false)
+                })
+        }
+        attempt(2)
         return () => {
             stale = true
+            if (retryTimer) clearTimeout(retryTimer)
         }
     }, [ready, hideUsername, captureRef])
 

--- a/src/components/Card/share-asset/ShareAssetActions.tsx
+++ b/src/components/Card/share-asset/ShareAssetActions.tsx
@@ -17,9 +17,16 @@
  * before composing the post. In the native app WKWebView silently cancels
  * `<a download>`, so Save goes through the OS share sheet (which carries
  * "Save Image") and is hidden when files can't be shared.
+ *
+ * Gesture-window constraint (TASK-22407, Sentry PEANUT-UI-SSW): on iOS,
+ * `navigator.share()` must run inside the user gesture. Capturing on tap
+ * (html-to-image, 1–3s) expired WebKit's gesture window → NotAllowedError.
+ * So on devices that can share files we PRE-capture the PNG once the asset
+ * is ready and the tap handler shares the cached blob synchronously. The
+ * capture-on-tap path stays as fallback when the cache is empty.
  */
 
-import { type FC, type RefObject, useState } from 'react'
+import { type FC, type RefObject, useEffect, useRef, useState } from 'react'
 import * as Sentry from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/0_Bruddle/Button'
@@ -111,6 +118,39 @@ export const ShareAssetActions: FC<Props> = ({
     // and a state snapshot would post the handle the user just opted out of.
     const text = shareUrl ? `${caption}\n\n${shareUrl}` : caption
 
+    // pre-captured png so the tap handler can call navigator.share() without
+    // awaiting the 1-3s capture (which expires ios's gesture window — see the
+    // file header). only on devices that can share files: desktop share falls
+    // back to the twitter intent and web save downloads, neither needs a
+    // gesture, so capturing there would be wasted work. keyed on shareUrl
+    // because the hide-username toggle re-renders the asset (username shown /
+    // hidden), which makes a cached capture stale.
+    const cachedBlobRef = useRef<Blob | null>(null)
+    useEffect(() => {
+        cachedBlobRef.current = null
+        if (!ready || !canShareImageFiles()) return
+        const node = captureRef.current
+        if (!node) return
+        let stale = false
+        captureShareAsset(node)
+            .then((blob) => {
+                if (!stale) cachedBlobRef.current = blob
+            })
+            .catch(() => {
+                // quiet: the tap-time fallback re-captures and reports errors.
+            })
+        return () => {
+            stale = true
+        }
+    }, [ready, shareUrl, captureRef])
+
+    const captureOrCached = async (): Promise<Blob> => {
+        if (cachedBlobRef.current) return cachedBlobRef.current
+        const node = captureRef.current
+        if (!node) throw new Error('share asset not yet rendered — try again in a moment')
+        return captureShareAsset(node)
+    }
+
     const handleShare = async (): Promise<void> => {
         setError(null)
         setIsSharing(true)
@@ -130,9 +170,9 @@ export const ShareAssetActions: FC<Props> = ({
                 shareCardOnTwitter(text)
                 return
             }
-            const node = captureRef.current
-            if (!node) throw new Error('share asset not yet rendered — try again in a moment')
-            const blob = await captureShareAsset(node)
+            // cached blob = zero await before navigator.share(), keeping the
+            // call inside the tap gesture on ios.
+            const blob = await captureOrCached()
             const file = new File([blob], filename, { type: 'image/png' })
             // The link rides inside `text` — several native targets drop a
             // separate `url` member when `files` is present.
@@ -166,9 +206,9 @@ export const ShareAssetActions: FC<Props> = ({
         setError(null)
         setIsSaving(true)
         try {
-            const node = captureRef.current
-            if (!node) throw new Error('share asset not yet rendered — try again in a moment')
-            const blob = await captureShareAsset(node)
+            // native save shares through the os sheet, so it has the same ios
+            // gesture-window constraint as share — use the cached blob too.
+            const blob = await captureOrCached()
             if (saveMode === 'native-share') {
                 await navigator.share({ files: [new File([blob], filename, { type: 'image/png' })] })
             } else {

--- a/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
+++ b/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
@@ -8,6 +8,7 @@
 import React, { type ComponentProps, createRef } from 'react'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import posthog from 'posthog-js'
+import * as Sentry from '@sentry/nextjs'
 import { renderWithIntl } from '@/test-utils/intl'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { ShareAssetActions } from '../ShareAssetActions'
@@ -143,7 +144,9 @@ describe('ShareAssetActions save', () => {
  * Gesture-window regression guard (TASK-22407): on iOS `navigator.share()`
  * must run inside the tap gesture, so the PNG is pre-captured when the asset
  * is ready and the tap uses the cached blob — no capture between tap and
- * share. If pre-capture failed, the tap falls back to capture-then-share.
+ * share, ever: the buttons stay disabled until a blob is cached, and a failed
+ * pre-capture retries in the background (with one Sentry report after the
+ * first 3 attempts fail) instead of re-enabling capture-on-tap.
  */
 describe('ShareAssetActions share pre-capture', () => {
     const shareButton = () => screen.getByRole('button', { name: 'Share' })
@@ -175,7 +178,7 @@ describe('ShareAssetActions share pre-capture', () => {
         })
     })
 
-    it('stays gated through retries; after the final failure the tap falls back to capture-on-tap', async () => {
+    it('stays gated after 3 failures, reports once to Sentry, and enables when a 5s retry succeeds', async () => {
         jest.useFakeTimers()
         try {
             mockCaptureShareAsset
@@ -183,26 +186,35 @@ describe('ShareAssetActions share pre-capture', () => {
                 .mockImplementationOnce(() => Promise.reject(new Error('b')))
                 .mockImplementationOnce(() => Promise.reject(new Error('c')))
             renderActions()
-            // attempt 1 rejects; the retry timer is armed — still gated
+            // attempt 1 rejects; the retry timer is armed — gated
             await act(async () => {})
             expect(shareButton()).toBeDisabled()
-            // attempt 2 fires and rejects — still gated
+            // attempt 2 fires and rejects — gated
             await act(async () => {
                 jest.advanceTimersByTime(500)
             })
             expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
             expect(shareButton()).toBeDisabled()
-            // attempt 3 fires and rejects — final failure, buttons re-enable
+            // attempt 3 fires and rejects — STILL gated (no give-up branch),
+            // and exactly one sentry report fires
             await act(async () => {
                 jest.advanceTimersByTime(500)
             })
             expect(mockCaptureShareAsset).toHaveBeenCalledTimes(3)
+            expect(shareButton()).toBeDisabled()
+            expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+            // 5s later the background retry succeeds (default impl resolves) —
+            // cache fills, button enables, tap shares without capturing
+            await act(async () => {
+                jest.advanceTimersByTime(5000)
+            })
+            expect(mockCaptureShareAsset).toHaveBeenCalledTimes(4)
             expect(shareButton()).toBeEnabled()
-            // no cached blob, so the tap captures again (default impl resolves)
             fireEvent.click(shareButton())
             await act(async () => {})
             expect(mockShare).toHaveBeenCalledTimes(1)
             expect(mockCaptureShareAsset).toHaveBeenCalledTimes(4)
+            expect(Sentry.captureException).toHaveBeenCalledTimes(1)
             expect(screen.queryByRole('alert')).not.toBeInTheDocument()
         } finally {
             jest.useRealTimers()

--- a/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
+++ b/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
@@ -5,7 +5,7 @@
  * share sheet (which carries "Save Image") and is hidden when files can't be
  * shared at all. The SAVED event only fires once the chosen path resolved.
  */
-import React, { createRef } from 'react'
+import React, { type ComponentProps, createRef } from 'react'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import posthog from 'posthog-js'
 import { renderWithIntl } from '@/test-utils/intl'
@@ -36,10 +36,17 @@ jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
 const mockedCapture = posthog.capture as jest.Mock
 const mockShare = jest.fn(() => Promise.resolve())
 
-function renderActions() {
+type ActionProps = Partial<ComponentProps<typeof ShareAssetActions>>
+
+function renderActions(props: ActionProps = {}) {
     const captureRef = createRef<HTMLDivElement>()
     Object.defineProperty(captureRef, 'current', { value: document.createElement('div'), writable: true })
-    return renderWithIntl(<ShareAssetActions captureRef={captureRef} source="celebration" filename="card.png" />)
+    const element = (p: ActionProps) => (
+        <ShareAssetActions captureRef={captureRef} source="celebration" filename="card.png" {...p} />
+    )
+    const result = renderWithIntl(element(props))
+    // same captureRef across rerenders, so prop flips exercise the cache keying
+    return { ...result, rerenderActions: (p: ActionProps) => result.rerender(element(p)) }
 }
 
 const saveButton = () => screen.getByRole('button', { name: 'Save image' })
@@ -54,6 +61,8 @@ describe('ShareAssetActions save', () => {
 
     it('web: downloads the PNG and reports saved', async () => {
         renderActions()
+        // pre-capture briefly disables native save; wait for the cache
+        await waitFor(() => expect(saveButton()).toBeEnabled())
         fireEvent.click(saveButton())
         await waitFor(() => expect(mockDownloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'card.png'))
         expect(mockShare).not.toHaveBeenCalled()
@@ -69,6 +78,8 @@ describe('ShareAssetActions save', () => {
         let resolveShare!: () => void
         mockShare.mockImplementationOnce(() => new Promise<void>((resolve) => (resolveShare = resolve)))
         renderActions()
+        // pre-capture briefly disables native save; wait for the cache
+        await waitFor(() => expect(saveButton()).toBeEnabled())
         fireEvent.click(saveButton())
         await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
         const [{ files }] = mockShare.mock.calls[0] as unknown as [{ files: File[] }]
@@ -93,6 +104,8 @@ describe('ShareAssetActions save', () => {
         abort.name = 'AbortError'
         mockShare.mockRejectedValueOnce(abort)
         renderActions()
+        // pre-capture briefly disables native save; wait for the cache
+        await waitFor(() => expect(saveButton()).toBeEnabled())
         fireEvent.click(saveButton())
         await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
         await waitFor(() => expect(saveButton()).toBeEnabled())
@@ -105,6 +118,8 @@ describe('ShareAssetActions save', () => {
         mockCanShareImageFiles.mockReturnValue(true)
         mockShare.mockRejectedValueOnce(new Error('share broke'))
         renderActions()
+        // pre-capture briefly disables native save; wait for the cache
+        await waitFor(() => expect(saveButton()).toBeEnabled())
         fireEvent.click(saveButton())
         await waitFor(() =>
             expect(mockedCapture).toHaveBeenCalledWith(
@@ -143,8 +158,10 @@ describe('ShareAssetActions share pre-capture', () => {
 
     it('shares the pre-captured PNG without capturing inside the tap', async () => {
         renderActions()
-        // pre-capture fires on mount (ready defaults true); let it settle
+        // pre-capture fires on mount (ready defaults true); the button
+        // enables once the blob is cached
         await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(shareButton()).toBeEnabled())
         fireEvent.click(shareButton())
         await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
         // the tap did NOT trigger a second capture — it used the cached blob
@@ -162,11 +179,47 @@ describe('ShareAssetActions share pre-capture', () => {
         mockCaptureShareAsset.mockImplementationOnce(() => Promise.reject(new Error('precapture broke')))
         renderActions()
         await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        // failure re-enables the button — the tap is the retry path
+        await waitFor(() => expect(shareButton()).toBeEnabled())
         fireEvent.click(shareButton())
         await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
         // no cached blob, so the tap captured again — share still works
         expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
         expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('disables Share while pre-capture is pending and enables once cached', async () => {
+        let resolveCapture!: (blob: Blob) => void
+        mockCaptureShareAsset.mockImplementationOnce(() => new Promise<Blob>((resolve) => (resolveCapture = resolve)))
+        renderActions()
+        // a tap here would miss the cache and reproduce the gesture-window bug
+        expect(shareButton()).toBeDisabled()
+        resolveCapture(new Blob(['png'], { type: 'image/png' }))
+        await waitFor(() => expect(shareButton()).toBeEnabled())
+    })
+
+    it('re-enables the buttons when pre-capture fails', async () => {
+        let rejectCapture!: (err: Error) => void
+        mockCaptureShareAsset.mockImplementationOnce(() => new Promise<Blob>((_, reject) => (rejectCapture = reject)))
+        renderActions()
+        expect(shareButton()).toBeDisabled()
+        rejectCapture(new Error('precapture broke'))
+        // never leave the buttons dead — capture-on-tap is the retry path
+        await waitFor(() => expect(shareButton()).toBeEnabled())
+    })
+
+    it('hide-username toggle re-captures even when shareUrl is undefined in both states (no handle)', async () => {
+        const { rerenderActions } = renderActions({ hideUsername: false, shareUrl: undefined })
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        rerenderActions({ hideUsername: true, shareUrl: undefined })
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2))
+    })
+
+    it('hide-username toggle re-captures for a user with a handle', async () => {
+        const { rerenderActions } = renderActions({ hideUsername: false, shareUrl: 'https://peanut.me/kush' })
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        rerenderActions({ hideUsername: true, shareUrl: undefined })
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2))
     })
 
     it('desktop (no file sharing): never pre-captures', async () => {

--- a/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
+++ b/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
@@ -123,3 +123,63 @@ describe('ShareAssetActions save', () => {
         expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument()
     })
 })
+
+/**
+ * Gesture-window regression guard (TASK-22407): on iOS `navigator.share()`
+ * must run inside the tap gesture, so the PNG is pre-captured when the asset
+ * is ready and the tap uses the cached blob — no capture between tap and
+ * share. If pre-capture failed, the tap falls back to capture-then-share.
+ */
+describe('ShareAssetActions share pre-capture', () => {
+    const shareButton = () => screen.getByRole('button', { name: 'Share' })
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockIsNativeBridge.mockReturnValue(false)
+        mockCanShareImageFiles.mockReturnValue(true)
+        mockCaptureShareAsset.mockImplementation(() => Promise.resolve(new Blob(['png'], { type: 'image/png' })))
+        Object.defineProperty(navigator, 'share', { value: mockShare, configurable: true, writable: true })
+    })
+
+    it('shares the pre-captured PNG without capturing inside the tap', async () => {
+        renderActions()
+        // pre-capture fires on mount (ready defaults true); let it settle
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        fireEvent.click(shareButton())
+        await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
+        // the tap did NOT trigger a second capture — it used the cached blob
+        expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1)
+        const [{ files }] = mockShare.mock.calls[0] as unknown as [{ files: File[] }]
+        expect(files[0].name).toBe('card.png')
+        expect(mockedCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.CARD_SHARE_ASSET_SHARED, {
+            source: 'celebration',
+            method: 'native-share-with-file',
+            link_type: 'none',
+        })
+    })
+
+    it('falls back to capture-on-tap when pre-capture failed', async () => {
+        mockCaptureShareAsset.mockImplementationOnce(() => Promise.reject(new Error('precapture broke')))
+        renderActions()
+        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
+        fireEvent.click(shareButton())
+        await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
+        // no cached blob, so the tap captured again — share still works
+        expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('desktop (no file sharing): never pre-captures', async () => {
+        mockCanShareImageFiles.mockReturnValue(false)
+        renderActions()
+        fireEvent.click(shareButton())
+        await waitFor(() =>
+            expect(mockedCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.CARD_SHARE_ASSET_SHARED, {
+                source: 'celebration',
+                method: 'twitter-intent-fallback',
+                link_type: 'none',
+            })
+        )
+        expect(mockCaptureShareAsset).not.toHaveBeenCalled()
+    })
+})

--- a/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
+++ b/src/components/Card/share-asset/__tests__/ShareAssetActions.test.tsx
@@ -6,7 +6,7 @@
  * shared at all. The SAVED event only fires once the chosen path resolved.
  */
 import React, { type ComponentProps, createRef } from 'react'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import posthog from 'posthog-js'
 import { renderWithIntl } from '@/test-utils/intl'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
@@ -175,17 +175,60 @@ describe('ShareAssetActions share pre-capture', () => {
         })
     })
 
-    it('falls back to capture-on-tap when pre-capture failed', async () => {
-        mockCaptureShareAsset.mockImplementationOnce(() => Promise.reject(new Error('precapture broke')))
-        renderActions()
-        await waitFor(() => expect(mockCaptureShareAsset).toHaveBeenCalledTimes(1))
-        // failure re-enables the button — the tap is the retry path
-        await waitFor(() => expect(shareButton()).toBeEnabled())
-        fireEvent.click(shareButton())
-        await waitFor(() => expect(mockShare).toHaveBeenCalledTimes(1))
-        // no cached blob, so the tap captured again — share still works
-        expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
-        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    it('stays gated through retries; after the final failure the tap falls back to capture-on-tap', async () => {
+        jest.useFakeTimers()
+        try {
+            mockCaptureShareAsset
+                .mockImplementationOnce(() => Promise.reject(new Error('a')))
+                .mockImplementationOnce(() => Promise.reject(new Error('b')))
+                .mockImplementationOnce(() => Promise.reject(new Error('c')))
+            renderActions()
+            // attempt 1 rejects; the retry timer is armed — still gated
+            await act(async () => {})
+            expect(shareButton()).toBeDisabled()
+            // attempt 2 fires and rejects — still gated
+            await act(async () => {
+                jest.advanceTimersByTime(500)
+            })
+            expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
+            expect(shareButton()).toBeDisabled()
+            // attempt 3 fires and rejects — final failure, buttons re-enable
+            await act(async () => {
+                jest.advanceTimersByTime(500)
+            })
+            expect(mockCaptureShareAsset).toHaveBeenCalledTimes(3)
+            expect(shareButton()).toBeEnabled()
+            // no cached blob, so the tap captures again (default impl resolves)
+            fireEvent.click(shareButton())
+            await act(async () => {})
+            expect(mockShare).toHaveBeenCalledTimes(1)
+            expect(mockCaptureShareAsset).toHaveBeenCalledTimes(4)
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        } finally {
+            jest.useRealTimers()
+        }
+    })
+
+    it('a successful retry fills the cache and the tap shares without capturing', async () => {
+        jest.useFakeTimers()
+        try {
+            mockCaptureShareAsset.mockImplementationOnce(() => Promise.reject(new Error('first broke')))
+            renderActions()
+            await act(async () => {})
+            expect(shareButton()).toBeDisabled()
+            // retry (default impl) resolves and caches the blob
+            await act(async () => {
+                jest.advanceTimersByTime(500)
+            })
+            expect(shareButton()).toBeEnabled()
+            fireEvent.click(shareButton())
+            await act(async () => {})
+            expect(mockShare).toHaveBeenCalledTimes(1)
+            // 2 captures total: failed first attempt + successful retry — none on tap
+            expect(mockCaptureShareAsset).toHaveBeenCalledTimes(2)
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('disables Share while pre-capture is pending and enables once cached', async () => {
@@ -195,16 +238,6 @@ describe('ShareAssetActions share pre-capture', () => {
         // a tap here would miss the cache and reproduce the gesture-window bug
         expect(shareButton()).toBeDisabled()
         resolveCapture(new Blob(['png'], { type: 'image/png' }))
-        await waitFor(() => expect(shareButton()).toBeEnabled())
-    })
-
-    it('re-enables the buttons when pre-capture fails', async () => {
-        let rejectCapture!: (err: Error) => void
-        mockCaptureShareAsset.mockImplementationOnce(() => new Promise<Blob>((_, reject) => (rejectCapture = reject)))
-        renderActions()
-        expect(shareButton()).toBeDisabled()
-        rejectCapture(new Error('precapture broke'))
-        // never leave the buttons dead — capture-on-tap is the retry path
         await waitFor(() => expect(shareButton()).toBeEnabled())
     })
 


### PR DESCRIPTION
## Summary

On iOS native the card share button can throw `NotAllowedError`. The tap handler awaited `captureShareAsset()` (html-to-image, 2x retina, 1-3s) before `navigator.share()`, so WebKit's user-gesture window expired during the wait and iOS blocked the share. One user hit it 6 times on launch day (Sentry PEANUT-UI-SSW). Save has the same failure mode on native, because it shares through the same OS sheet.

Fix: pre-capture the PNG once the share asset is `ready`, cache it in a ref, and let the tap handler pass the cached blob to `navigator.share()` with no capture in between. On the file-sharing path the Share button (and native Save) enable only once a blob is cached. The cache is invalidated and rebuilt when `hideUsername` flips, because the toggle re-renders the asset (username shown / hidden) — `shareUrl` cannot key this, it is undefined in both toggle states for users without a handle. Pre-capture only runs on devices that can share files — desktop share falls back to the twitter intent and web save downloads, neither needs a gesture.

This is a pure web change, so it reaches affected users via OTA. The `@capacitor/share` alternative was rejected: it needs a new native binary release (shipped binary is 1.4.0 build 4) and a new dependency under the 14-day supply-chain floor.

## Design notes / accepted trade-offs (reviewer-agreed across 3 Chip rounds)

- **Buttons on the file-sharing path never enable without a cached PNG.** Any tap that awaits capture loses iOS activation — even when the capture itself succeeds — so there is no "give up and enable" branch.
- **A failed pre-capture retries in the background** while the component is mounted: 500ms spacing for the first 2 retries, then every 5s. The moment one succeeds, the buttons enable.
- **Persistent capture failure = disabled buttons + one Sentry report** (`share-asset pre-capture failing persistently`, fired after the first 3 attempts fail, once per effect run). This is by design: a share without the file cannot succeed on platforms that need `files`, so honestly disabled buttons beat a tap that errors.
- Buttons mount disabled for ~1-3s on mobile while the first capture runs (previously they enabled at `ready`). Accepted; no spinner added.

## Task

TASK-22407

## Risks / breaking changes

- One capture per share-drawer open on mobile (plus one per hide-username toggle). The work moved from tap time to ready time; desktop pays nothing.
- If capture is persistently broken for a user, Share / native Save stay disabled (web download is unaffected) — surfaced via the Sentry report above instead of a tap-time error.
- No cross-repo impact.

## QA

- Jest, `ShareAssetActions.test.tsx`: cached-blob share with no capture inside the tap; gated while pending; gated through all 3 failed attempts with exactly one Sentry report, then enabled by a successful 5s background retry; retry-success path; hide-username re-capture with and without a handle; desktop never pre-captures. All Card suites green (162 tests).
- `tsc --noEmit`, prettier clean.
- Real-device verification (iOS native share sheet) needs a device pass — the gesture window cannot be reproduced in jsdom.

Screenshots: N/A (no visible change beyond the buttons' initial ~1-3s disabled state while the first capture runs).
