### PR TITLE
fix: suppress handled native fetch-rejections in PostHog exception autocapture (TASK-22408)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,6 +7,7 @@ import { posthogErrorMirror } from '@/utils/sentry-posthog-mirror'
 import { whenIdle } from '@/utils/defer-analytics'
 import { startWebVitalsShim } from '@/utils/web-vitals-shim'
 import { noteAppReviewFriction } from '@/utils/app-review-friction'
+import { isNativeFetchRejectionExceptionEvent } from '@/utils/native-fetch-rejection'
 import { installPaymentNetworkGoogleAnalyticsGuard, isPaymentNetworkExplorerPath } from '@/utils/private-routes'
 
 // Same conditions as the GA bootstrap in app/layout.tsx: with no GA to disable
@@ -54,6 +55,10 @@ if (
         // already funnels through here, so the suppressor needs no call sites.
         before_send: (event) => {
             if (isPaymentNetworkExplorerPath(window.location.pathname)) return null
+            // Handled WebKit/Chromium connectivity blips: Sentry already filters
+            // this class server-side; exception autocapture must not double-report
+            // it here (TASK-22408).
+            if (isNativeFetchRejectionExceptionEvent(event)) return null
             if (event?.event) noteAppReviewFriction(event.event)
             return event
         },

--- a/src/utils/__tests__/native-fetch-rejection.test.ts
+++ b/src/utils/__tests__/native-fetch-rejection.test.ts
@@ -1,0 +1,54 @@
+import type { CaptureResult } from 'posthog-js'
+import { isNativeFetchRejection, isNativeFetchRejectionExceptionEvent } from '../native-fetch-rejection'
+
+describe('isNativeFetchRejection', () => {
+    test.each(['Failed to fetch', 'Load failed', 'NetworkError when attempting to fetch resource.'])(
+        'matches TypeError with engine message %p',
+        (message) => {
+            expect(isNativeFetchRejection('TypeError', message)).toBe(true)
+        }
+    )
+
+    test('rejects our own wrapped copy that merely contains the engine string', () => {
+        expect(isNativeFetchRejection('Error', 'Failed to fetch charges: 500')).toBe(false)
+        expect(isNativeFetchRejection('TypeError', 'Failed to fetch charges: 500')).toBe(false)
+        expect(isNativeFetchRejection(undefined, undefined)).toBe(false)
+    })
+})
+
+function exceptionEvent(list: unknown): CaptureResult {
+    return { event: '$exception', properties: { $exception_list: list } } as unknown as CaptureResult
+}
+
+describe('isNativeFetchRejectionExceptionEvent', () => {
+    test('drops the autocaptured WebKit blip', () => {
+        expect(
+            isNativeFetchRejectionExceptionEvent(exceptionEvent([{ type: 'TypeError', value: 'Load failed' }]))
+        ).toBe(true)
+    })
+
+    test('drops only when every exception in the chain matches', () => {
+        expect(
+            isNativeFetchRejectionExceptionEvent(
+                exceptionEvent([
+                    { type: 'TypeError', value: 'Load failed' },
+                    { type: 'Error', value: 'Something went wrong' },
+                ])
+            )
+        ).toBe(false)
+    })
+
+    test('passes through everything uncertain', () => {
+        expect(isNativeFetchRejectionExceptionEvent(null)).toBe(false)
+        expect(
+            isNativeFetchRejectionExceptionEvent({ event: 'send_failed', properties: {} } as unknown as CaptureResult)
+        ).toBe(false)
+        expect(isNativeFetchRejectionExceptionEvent(exceptionEvent(undefined))).toBe(false)
+        expect(isNativeFetchRejectionExceptionEvent(exceptionEvent([]))).toBe(false)
+        expect(
+            isNativeFetchRejectionExceptionEvent(
+                exceptionEvent([{ type: 'TypeError', value: 'Failed to fetch charges: 500' }])
+            )
+        ).toBe(false)
+    })
+})

--- a/src/utils/__tests__/network-triage.test.ts
+++ b/src/utils/__tests__/network-triage.test.ts
@@ -1,6 +1,5 @@
 import {
     captureNetworkTriagedFailure,
-    isNativeFetchRejection,
     isNetworkLayerFailure,
     networkTriageTags,
     triageNetworkFailure,
@@ -39,21 +38,6 @@ function mockProbes({
 
 afterEach(() => {
     jest.clearAllMocks()
-})
-
-describe('isNativeFetchRejection', () => {
-    test.each(['Failed to fetch', 'Load failed', 'NetworkError when attempting to fetch resource.'])(
-        'matches TypeError with engine message %p',
-        (message) => {
-            expect(isNativeFetchRejection('TypeError', message)).toBe(true)
-        }
-    )
-
-    test('rejects our own wrapped copy that merely contains the engine string', () => {
-        expect(isNativeFetchRejection('Error', 'Failed to fetch charges: 500')).toBe(false)
-        expect(isNativeFetchRejection('TypeError', 'Failed to fetch charges: 500')).toBe(false)
-        expect(isNativeFetchRejection(undefined, undefined)).toBe(false)
-    })
 })
 
 // The predicate the qr-pay / withdraw catches use to report selectively: their

--- a/src/utils/friendly-error.utils.tsx
+++ b/src/utils/friendly-error.utils.tsx
@@ -1,5 +1,5 @@
 import { API_ERROR_CODES, apiErrorStatus, wireErrorCode, type ApiErrorCode } from '@/services/api-error'
-import { isNativeFetchRejection } from '@/utils/network-triage'
+import { isNativeFetchRejection } from '@/utils/native-fetch-rejection'
 
 /** Safely extract a string-form of an unknown error + its `.message` if any.
  *  Lets the matchers below use `string` methods without unsafe property access

--- a/src/utils/native-fetch-rejection.ts
+++ b/src/utils/native-fetch-rejection.ts
@@ -1,0 +1,37 @@
+import type { CaptureResult } from 'posthog-js'
+
+/*
+ * Lives in its own leaf module (no runtime imports) because
+ * instrumentation-client's posthog `before_send` needs the predicate, and that
+ * file must not pull `@sentry/nextjs` in statically — see the dynamic-import
+ * note there. network-triage.ts re-imports it from here.
+ */
+
+// Engine-exact rejection copy; also matched by the connectionLost classifier
+// in friendly-error.utils.tsx, which imports this predicate to stay in sync.
+export const NATIVE_FETCH_REJECTION_MESSAGES: readonly string[] = [
+    'Failed to fetch', // Chromium, so every Android WebView
+    'Load failed', // WebKit
+    'NetworkError when attempting to fetch resource.', // Gecko
+]
+
+export function isNativeFetchRejection(name: string | undefined, message: string | undefined): boolean {
+    return name === 'TypeError' && message !== undefined && NATIVE_FETCH_REJECTION_MESSAGES.includes(message)
+}
+
+/*
+ * PostHog exception autocapture double-reports this class: the fetch rejection
+ * is already handled in the flow (retried, triaged, reported through Sentry —
+ * where server-side filtering keeps it out of the issue list), so the raw
+ * `TypeError: Load failed` burst during an iOS connectivity blip is pure noise
+ * there (TASK-22408). Shape per posthog-js error tracking: exceptions ride in
+ * `properties.$exception_list` as `{ type, value }` entries.
+ */
+export function isNativeFetchRejectionExceptionEvent(event: CaptureResult | null): boolean {
+    if (event?.event !== '$exception') return false
+    const list = event.properties?.$exception_list as Array<{ type?: string; value?: string }> | undefined
+    if (!Array.isArray(list) || list.length === 0) return false
+    // Drop only when the match is certain: every exception in the chain is a
+    // native fetch rejection. A mixed chain passes through untouched.
+    return list.every((exception) => isNativeFetchRejection(exception?.type, exception?.value))
+}

--- a/src/utils/network-triage.ts
+++ b/src/utils/network-triage.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/nextjs'
 import posthog from 'posthog-js'
 import { PEANUT_API_URL } from '@/constants/general.consts'
+import { isNativeFetchRejection } from '@/utils/native-fetch-rejection'
 
 /*
  * `TypeError: Failed to fetch` proves nothing about the user's connection: a
@@ -12,18 +13,6 @@ import { PEANUT_API_URL } from '@/constants/general.consts'
  * required, no preflight — so it answers "did the edge answer at all" where a
  * normal fetch cannot.
  */
-
-// Engine-exact rejection copy; also matched by the connectionLost classifier
-// in friendly-error.utils.tsx, which imports this predicate to stay in sync.
-export const NATIVE_FETCH_REJECTION_MESSAGES: readonly string[] = [
-    'Failed to fetch', // Chromium, so every Android WebView
-    'Load failed', // WebKit
-    'NetworkError when attempting to fetch resource.', // Gecko
-]
-
-export function isNativeFetchRejection(name: string | undefined, message: string | undefined): boolean {
-    return name === 'TypeError' && message !== undefined && NATIVE_FETCH_REJECTION_MESSAGES.includes(message)
-}
 
 type NetworkErrorClass = 'fetch_rejection' | 'timeout' | 'service_unavailable'
 


### PR DESCRIPTION
## Summary

PostHog exception autocapture double-reports a handled error class: `TypeError: Load failed` — a WebKit connectivity blip during login on iOS native, retried and recovered in-app within 3-5s. Sentry already filters this class (no Sentry issue exists for the bursts); PostHog now drops it too. 18 events / 2 users on 2026-09-07, platform ios-native. The login flow itself needs no change.

- New leaf module `src/utils/native-fetch-rejection.ts` holds the existing `isNativeFetchRejection` predicate (moved from `network-triage.ts`, not duplicated) plus `isNativeFetchRejectionExceptionEvent`, which matches `$exception` events whose whole `$exception_list` chain is a native fetch rejection.
- `instrumentation-client.ts` `before_send` returns `null` for those events. A mixed exception chain passes through untouched — drop only when the match is certain.

## Task

TASK-22408 (Notion page `3d583811-7579-816b-ae50-d451a6f46656`)

## Design notes / accepted trade-offs

The predicate moves files because `instrumentation-client.ts` must not statically import `@sentry/nextjs` — `network-triage.ts` pulls `captureException` at runtime, and a static import would put the ~440 KB SDK back into the web entry bundle (see the dynamic-import note in `instrumentation-client.ts`). No re-export shim: the two importers (`network-triage.ts`, `friendly-error.utils.tsx`) now import from the leaf module.

## Risks / breaking changes

- None cross-repo. Analytics-only: PostHog loses an event class that Sentry already suppresses; Sentry reporting is unchanged.
- Pre-existing on `origin/dev` (829e195, unrelated): `AddWithdrawCountriesList.test.tsx` and `UnlockPayments.test.tsx` fail on a clean base checkout — not introduced or touched here.

## QA

- `npx jest src/utils/__tests__/native-fetch-rejection.test.ts src/utils/__tests__/network-triage.test.ts` — 27 tests green (predicate + filter: drop certain matches, pass mixed chains, non-exception events, empty/missing lists, wrapped copies).
- `npm run typecheck`, `npm run build`, `pnpm prettier --check .` — green.
- Event shape verified against installed posthog-js 1.418.x types (`ErrorProperties.$exception_list: Exception[]` with `{type, value}`).

Screenshots: N/A (no visible change)
