### PR TITLE
fix(about): show comparable running version

### DIFF
--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -183,6 +183,11 @@ out of the shape that used to be maintained by hand: an OTA always sorts strictl
 the binary it targets (Capgo drops anything below it — TASK-21793), and the version alone
 says which binary a bundle belongs to.
 
+The About screen shows this three-part version of the code currently running: the native
+version for the built-in bundle, or the Capgo bundle version after an OTA. The platform
+build identifier (`versionCode` / `CFBundleVersion`) remains separate support metadata;
+it is not appended as a fourth dotted segment because it is not a comparable release.
+
 **Nobody types a number.** `scripts/release-version.mjs` resolves them from git tags
 (`v<major>.<build>.0`) plus the Capgo channel. That registry is deliberately not a file
 in the repo: `dev` and `main` both carry a `pull_request` ruleset with no bypass actors,

--- a/src/hooks/__tests__/useAppVersion.test.tsx
+++ b/src/hooks/__tests__/useAppVersion.test.tsx
@@ -19,8 +19,9 @@ describe('useAppVersion', () => {
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
-        // the release version is kept whole; the CI build is a fourth segment
-        await waitFor(() => expect(result.current).toBe('1.1.0.412'))
+        // App.getInfo().build is a separate store/CI identifier, not a fourth
+        // segment users should compare with release and OTA versions.
+        await waitFor(() => expect(result.current).toBe('1.1.0'))
     })
 
     // The binary never moves past the `.0` it shipped with, so an OTA'd install
@@ -30,7 +31,7 @@ describe('useAppVersion', () => {
 
         const { result } = renderHook(() => useAppVersion('1.0.53'))
 
-        await waitFor(() => expect(result.current).toBe('1.1.2.10048'))
+        await waitFor(() => expect(result.current).toBe('1.1.2'))
     })
 
     it('keeps the bundled version on web, where there is no binary to ask', async () => {

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -7,10 +7,11 @@ import { useEffect, useState } from 'react'
  * What to print as "the app version".
  *
  * Native reports the release version of the code actually running — the OTA
- * bundle when one is applied, otherwise the binary — plus the binary's build
- * number (see `formatRunningVersion`). The bundled fallback only stands in
- * until the bridge answers, and on web, where package.json's version is the
- * only version there is.
+ * bundle when one is applied, otherwise the binary. The platform build number
+ * stays separate in support diagnostics; it is not part of Peanut's comparable
+ * three-part release version. The bundled fallback only stands in until the
+ * bridge answers, and on web, where package.json's version is the only version
+ * there is.
  */
 export function useAppVersion(fallback: string): string {
     const [version, setVersion] = useState(fallback)

--- a/src/utils/__tests__/app-version.test.ts
+++ b/src/utils/__tests__/app-version.test.ts
@@ -1,4 +1,4 @@
-import { formatBinaryVersion, formatRunningVersion, getRunningVersion } from '@/utils/app-version'
+import { formatRunningVersion, getRunningVersion } from '@/utils/app-version'
 
 const mockGetInfo = jest.fn()
 const mockCurrent = jest.fn()
@@ -9,46 +9,24 @@ jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => true }))
 /**
  * The About screen's version line is what a support conversation starts from.
  * Peanut's release scheme is `<major>.<build>.<ota>` (scripts/release-version.mjs),
- * so all three segments are load-bearing and the CI build number is appended
- * rather than substituted for any of them.
+ * so all three segments are load-bearing. The platform build is a separate
+ * diagnostic identifier and must not become a fourth release-version segment.
  */
-describe('formatBinaryVersion', () => {
-    it('appends the CI build to the release version, replacing nothing', () => {
-        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '34534' })).toBe('1.1.0.34534')
-    })
-
-    it('keeps the OTA counter intact', () => {
-        expect(formatBinaryVersion({ appVersion: '1.1.4', appBuild: '34534' })).toBe('1.1.4.34534')
-        expect(formatBinaryVersion({ appVersion: '2.17.3', appBuild: '7' })).toBe('2.17.3.7')
-    })
-
-    // Android is `10000 + run_number`, iOS is the run number: the same release
-    // legitimately shows a ~10000 gap, and the format must not hide or "fix" it.
-    it('shows each platform its own build number verbatim', () => {
-        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '44534' })).toBe('1.1.0.44534')
-        expect(formatBinaryVersion({ appVersion: '1.1.0', appBuild: '34534' })).toBe('1.1.0.34534')
-    })
-
-    // Never render `undefined` or a leading dot into the one number support asks for.
-    it.each([
-        ['', '99', '99'],
-        ['1.1.0', '', '1.1.0'],
-    ])('degrades cleanly when a component is missing (%s / %s)', (appVersion, appBuild, expected) => {
-        expect(formatBinaryVersion({ appVersion, appBuild })).toBe(expected)
-    })
-})
-
 describe('formatRunningVersion', () => {
     // The binary is frozen at the `.0` it shipped with; the OTA counter only
     // moves in the bundle, so the bundle is what names the running revision.
-    it('names the OTA bundle when one is applied, keeping the binary build', () => {
-        expect(formatRunningVersion({ appVersion: '1.1.0', appBuild: '10048', otaVersion: '1.1.2' })).toBe(
-            '1.1.2.10048'
-        )
+    it('names the OTA bundle when one is applied', () => {
+        expect(formatRunningVersion({ appVersion: '1.5.0', appBuild: '21653381', otaVersion: '1.5.1' })).toBe('1.5.1')
     })
 
     it('falls back to the binary on the builtin bundle', () => {
-        expect(formatRunningVersion({ appVersion: '1.1.0', appBuild: '10048', otaVersion: null })).toBe('1.1.0.10048')
+        expect(formatRunningVersion({ appVersion: '1.5.0', appBuild: '21653381', otaVersion: null })).toBe('1.5.0')
+    })
+
+    it('keeps an automatic staging bundle version intact', () => {
+        expect(formatRunningVersion({ appVersion: '1.5.0', appBuild: '21653381', otaVersion: '1.5.11715' })).toBe(
+            '1.5.11715'
+        )
     })
 })
 

--- a/src/utils/app-version.ts
+++ b/src/utils/app-version.ts
@@ -59,29 +59,14 @@ export async function getRunningVersion(): Promise<RunningVersionInfo | null> {
 }
 
 /**
- * How the app version reads on screen: `<major>.<build>.<ota>.<ci-build>`.
+ * The user-facing release version of the code actually running.
  *
- * The first three segments are the release version of the code that is running
- * — Peanut's scheme (scripts/release-version.mjs): major generation, native
- * build counter, and the OTA counter within that build. On an OTA'd install
- * that is the bundle's version, not the binary's: the binary is frozen at the
- * `.0` it shipped with, so reporting it would name a revision the user stopped
- * running the moment the OTA applied.
- *
- * The CI build number is appended as a fourth segment rather than parenthesised
- * so the whole identifier reads as one string a user can dictate. It is the
- * release workflow's run number, and it is NOT comparable across platforms:
- * android-release.yml sets the version code to `10000 + run_number` while
- * ios-release.yml uses the run number as-is, so the same release shows a
- * ~10000 gap between an Android and an iOS device. That is a property of the
- * build numbering, not of this format — it identifies a build, not an ordering.
+ * Peanut's three segments are `<major>.<native-build>.<ota>`. On an OTA'd
+ * install the Capgo bundle owns that version; otherwise the native shell does.
+ * `appBuild` is a separate platform/CI identifier used by the stores and support
+ * diagnostics. Appending it as a fourth dotted segment (for example,
+ * `1.5.0.21653381`) makes it look like part of the comparable release version.
  */
-export function formatBinaryVersion({ appVersion, appBuild }: BinaryInfo): string {
-    if (!appVersion) return appBuild
-    if (!appBuild) return appVersion
-    return `${appVersion}.${appBuild}`
-}
-
-export function formatRunningVersion({ appVersion, appBuild, otaVersion }: RunningVersionInfo): string {
-    return formatBinaryVersion({ appVersion: otaVersion || appVersion, appBuild })
+export function formatRunningVersion({ appVersion, otaVersion }: RunningVersionInfo): string {
+    return otaVersion || appVersion
 }


### PR DESCRIPTION
## Summary
- show the native or applied OTA release version in About without appending the platform build identifier
- preserve the native build identifier in support diagnostics
- document the distinction and cover native, production OTA, and staging OTA versions

## Validation
- pnpm exec jest --runInBand --runTestsByPath src/utils/__tests__/app-version.test.ts src/hooks/__tests__/useAppVersion.test.tsx
- pnpm exec jest --runInBand --runTestsByPath src/components/Profile/views/__tests__/About.view.test.tsx
- pnpm exec eslint src/utils/app-version.ts src/hooks/useAppVersion.ts src/utils/__tests__/app-version.test.ts src/hooks/__tests__/useAppVersion.test.tsx
- pnpm exec prettier --check src/utils/app-version.ts src/hooks/useAppVersion.ts src/utils/__tests__/app-version.test.ts src/hooks/__tests__/useAppVersion.test.tsx docs/NATIVE-RELEASE.md
- git diff --check