### PR TITLE
fix(android): stop support and QR camera preflight crashes

### DIFF
--- a/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
+++ b/src/components/Global/SupportDrawer/__tests__/SupportDrawer.test.tsx
@@ -20,6 +20,7 @@ import SupportDrawer from '../index'
 import { isCapacitor } from '@/utils/capacitor'
 import { SUPPORT_EMAIL } from '@/constants/crisp'
 import { dispatchBackPress, resetBackHandlersForTests } from '@/utils/back-handler'
+import { ensureNativeCameraPermission } from '@/utils/camera-permission'
 
 const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
 
@@ -70,6 +71,7 @@ jest.mock('../../Loading', () => ({
         props.variant === 'mascot' ? <div data-testid="peanut-loading" /> : <div data-testid="loading-spinner" />,
 }))
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn() }))
+jest.mock('@/utils/camera-permission', () => ({ ensureNativeCameraPermission: jest.fn(async () => true) }))
 jest.mock('@capgo/capacitor-crisp', () => ({ CapacitorCrisp: nativeCrisp }))
 
 const supportIframe = () => screen.queryByTitle('Support Chat')
@@ -463,6 +465,7 @@ describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
         mockUseCrispTokenId.mockReset()
         mockIsCapacitor.mockReset().mockReturnValue(true)
         Object.values(nativeCrisp).forEach((fn) => fn.mockReset())
+        jest.mocked(ensureNativeCameraPermission).mockClear()
     })
 
     it('does NOT open the native messenger while a logged-in user’s token is still resolving', async () => {
@@ -499,13 +502,25 @@ describe('SupportDrawer Crisp session gate — native (Capacitor)', () => {
         await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
         expect(nativeCrisp.setTokenID).not.toHaveBeenCalled()
     })
+
+    it('opens support without probing an unrelated camera permission', async () => {
+        mockUseCrispUserData.mockReturnValue({ userId: 'user-abc', email: 'a@b.com' })
+        mockUseCrispTokenId.mockReturnValue('token-abc')
+
+        await act(async () => {
+            render(<SupportDrawer />)
+        })
+
+        await waitFor(() => expect(nativeCrisp.openMessenger).toHaveBeenCalled())
+        expect(ensureNativeCameraPermission).not.toHaveBeenCalled()
+    })
 })
 
 /*
  * The support snapshot is live state — a balance landing from the cache, or the
  * route latch firing on open, changes `userData`'s identity. `userData` is a
  * dependency of the native open effect, so a change while the effect's async
- * chain is still awaiting camera permission used to start a SECOND chain, and
+ * chain is still awaiting native Crisp configuration used to start a SECOND chain, and
  * the user's prefilled message reached the agent twice.
  */
 describe('SupportDrawer — native open runs once per open cycle', () => {
@@ -514,6 +529,7 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
         mockUseCrispTokenId.mockReset()
         mockIsCapacitor.mockReset().mockReturnValue(true)
         Object.values(nativeCrisp).forEach((fn) => fn.mockReset())
+        jest.mocked(ensureNativeCameraPermission).mockClear()
         modalsState.supportPrefilledMessage = undefined
         modalsState.isSupportModalOpen = true
     })
@@ -625,7 +641,7 @@ describe('SupportDrawer — native open runs once per open cycle', () => {
 
     /*
      * A boolean latch is not enough: the chain outlives the cycle that started
-     * it. Close the drawer while it is parked on the camera-permission await
+     * it. Close the drawer while it is parked on the native configure await
      * and reopen — a boolean has already been cleared, a second chain starts,
      * both finish, and the prefill is sent twice. The generation counter makes
      * the chain check, after its awaits, whether the cycle it belongs to is

--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -19,7 +19,6 @@ import {
 import type { AppLocale } from '@/i18n/app/config'
 import { notificationsApi } from '@/services/notifications'
 import { isCapacitor } from '@/utils/capacitor'
-import { ensureNativeCameraPermission } from '@/utils/camera-permission'
 import { ensureNativeCrispConfigured, nativeCrispFields } from '@/utils/crisp'
 
 const DISMISS_THRESHOLD = 100
@@ -52,7 +51,7 @@ const SupportDrawer = () => {
      *
      * The native open chain reads it AFTER its awaits, because the snapshot is
      * live: a balance can land, or verification can resolve, while Crisp
-     * configuration and the camera permission are still pending. The effect
+     * configuration is still pending. The effect
      * closure holds the payload from when the effect ran, so publishing that
      * would push a balance the user no longer has — and a `balance-unavailable`
      * segment that would route them wrongly — to the agent.
@@ -213,15 +212,20 @@ const SupportDrawer = () => {
         ensureNativeCrispConfigured()
             .then(async ({ CapacitorCrisp }) => {
                 /*
-                 * Settle the CAMERA runtime permission before the native Crisp UI
-                 * opens: the app manifest declares CAMERA (QR scanner), which makes
-                 * Crisp's "Take a photo" throw a SecurityException when it is
-                 * declared-but-ungranted — the SDK never requests it itself.
-                 * Result deliberately ignored: a denied camera must not block chat.
+                 * Do not probe or request CAMERA here. Support chat does not need
+                 * camera access to open, and an optional attachment capability must
+                 * never gate the user's route to support. The minified Android 1.5.0
+                 * shell also crashes natively inside CameraPlugin.getPermissionStates
+                 * when Camera.checkPermissions runs (PEANUT-UI-T30), before this
+                 * promise can reject back to JavaScript. Camera surfaces own their
+                 * permission flow at the point where the user actually invokes them.
                  */
-                await ensureNativeCameraPermission()
+                // Keep an async cancellation/snapshot boundary after native
+                // configuration. A close or account-state commit queued in the
+                // same turn must win before we publish data and present Crisp.
+                await new Promise<void>((resolve) => setTimeout(resolve, 0))
 
-                // The user dismissed support while we awaited. Publishing now
+                // The user dismissed support while Crisp configured. Publishing now
                 // would push the prefill into a conversation they walked away from.
                 if (cancelled) return
 

--- a/src/utils/__tests__/camera-permission.test.ts
+++ b/src/utils/__tests__/camera-permission.test.ts
@@ -1,0 +1,48 @@
+import { isAndroidNativeBridge } from '@/utils/capacitor'
+import { ensureNativeCameraPermission } from '@/utils/camera-permission'
+import { Camera } from '@capacitor/camera'
+
+jest.mock('@/utils/capacitor', () => ({ isAndroidNativeBridge: jest.fn() }))
+jest.mock('@capacitor/camera', () => ({
+    Camera: {
+        checkPermissions: jest.fn(),
+        requestPermissions: jest.fn(),
+    },
+}))
+
+const mockIsAndroidNativeBridge = jest.mocked(isAndroidNativeBridge)
+const mockCamera = jest.mocked(Camera)
+
+describe('ensureNativeCameraPermission', () => {
+    beforeEach(() => {
+        mockIsAndroidNativeBridge.mockReset().mockReturnValue(false)
+        mockCamera.checkPermissions.mockReset()
+        mockCamera.requestPermissions.mockReset()
+    })
+
+    it('lets the Android WebView own the camera prompt without calling the crashing Camera plugin', async () => {
+        mockIsAndroidNativeBridge.mockReturnValue(true)
+
+        await expect(ensureNativeCameraPermission()).resolves.toBe(true)
+
+        expect(mockCamera.checkPermissions).not.toHaveBeenCalled()
+        expect(mockCamera.requestPermissions).not.toHaveBeenCalled()
+    })
+
+    it('keeps an already granted permission on non-Android native platforms', async () => {
+        mockCamera.checkPermissions.mockResolvedValue({ camera: 'granted', photos: 'prompt' })
+
+        await expect(ensureNativeCameraPermission()).resolves.toBe(true)
+
+        expect(mockCamera.requestPermissions).not.toHaveBeenCalled()
+    })
+
+    it('requests a promptable permission on non-Android native platforms', async () => {
+        mockCamera.checkPermissions.mockResolvedValue({ camera: 'prompt', photos: 'prompt' })
+        mockCamera.requestPermissions.mockResolvedValue({ camera: 'denied', photos: 'prompt' })
+
+        await expect(ensureNativeCameraPermission()).resolves.toBe(false)
+
+        expect(mockCamera.requestPermissions).toHaveBeenCalledWith({ permissions: ['camera'] })
+    })
+})

--- a/src/utils/camera-permission.ts
+++ b/src/utils/camera-permission.ts
@@ -1,12 +1,22 @@
+import { isAndroidNativeBridge } from '@/utils/capacitor'
+
 /**
- * On native, settle the OS camera permission before a camera surface opens
- * (getUserMedia in the QR scanner, the Crisp SDK's "Take a photo"). The app
- * declares android.permission.CAMERA, which obligates a runtime grant before
- * ANY camera intent — an SDK that assumes an undeclared permission (Crisp)
- * hits a SecurityException instead of prompting. Best effort: on any plugin
- * error we return true and let the caller's own permission flow run.
+ * Settle the OS camera permission before a camera surface opens.
+ *
+ * Android deliberately uses the WebView's getUserMedia permission path instead
+ * of the Capacitor Camera plugin. Capacitor's BridgeWebChromeClient maps that
+ * request directly to android.permission.CAMERA. More importantly, the minified
+ * Android 1.5.0 shell crashes natively inside CameraPlugin.getPermissionStates
+ * before a rejected promise can reach JavaScript (PEANUT-UI-T30). Returning true
+ * here does not grant anything: it lets the real camera request prompt, deny, or
+ * resolve, and the scanner's existing error handling owns that outcome.
+ *
+ * iOS keeps the explicit plugin preflight. Best effort: on any plugin error we
+ * return true and let the caller's own permission flow run.
  */
 export async function ensureNativeCameraPermission(): Promise<boolean> {
+    if (isAndroidNativeBridge()) return true
+
     try {
         const { Camera } = await import('@capacitor/camera')
         const status = await Camera.checkPermissions()


### PR DESCRIPTION
## Summary

- remove the unrelated camera-permission preflight from native Support so chat can always open
- bypass the crashing Capacitor Camera permission API on Android and let the WebView's real `getUserMedia` request own the QR-scanner prompt
- keep the existing iOS permission preflight and SupportDrawer cancellation/snapshot semantics

## Root cause

[Sentry PEANUT-UI-T30](https://peanut-c34d84c05.sentry.io/issues/7719621109/?project=4505827431415808) shows a fatal Android `RuntimeException` / `NullPointerException` in `CameraPlugin.getPermissionStates` on release `1.5.0`. Tapping Support called `Camera.checkPermissions()` before opening Crisp even though support does not need the camera. The same shared preflight was also used by the QR scanner.

The crash became visible in the optimized 1.5.0 Android shell after R8/minification was enabled. Because it happens in native code before the promise can reject to JavaScript, the existing catch cannot recover it.

## Validation

- `pnpm exec next typegen`
- `pnpm typecheck`
- 53 focused SupportDrawer, camera-permission, and QR-scanner tests
- targeted ESLint and Prettier checks
- production native static export
- `node scripts/native-fingerprint.mjs --diff v1.5.0` — native surface unchanged; OTA-safe
