### PR TITLE
fix(TASK-22394): keep localized 404s provider-safe

### DIFF
--- a/e2e/flows/localized-404.spec.ts
+++ b/e2e/flows/localized-404.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test'
+import { DEFAULT_LOCALE, ROUTE_SLUGS, SUPPORTED_LOCALES } from '../../src/i18n/config'
+
+test('invalid localized paths return 404 across every locale and marketing route family', async ({ request }) => {
+    // Locale routing depends only on the first segment, while the default-locale
+    // cases below exercise every marketing family. Cover both dimensions
+    // without multiplying identical SSR work into a 100-request matrix.
+    const invalidPaths = [
+        ...SUPPORTED_LOCALES.map((locale) => `/${locale}/definitely-not-a-real-page`),
+        ...ROUTE_SLUGS.map((route) => `/${DEFAULT_LOCALE}/${route}/definitely-not-a-real-page`),
+    ]
+
+    for (const path of invalidPaths) {
+        const response = await request.get(path)
+        expect.soft(response.status(), path).toBe(404)
+    }
+})
+
+for (const path of ['/send', '/request']) {
+    test(`${path} remains a canonical app route`, async ({ request }) => {
+        const response = await request.get(path)
+        expect(response.status()).toBe(200)
+    })
+}

--- a/src/app/[...recipient]/layout.tsx
+++ b/src/app/[...recipient]/layout.tsx
@@ -1,5 +1,23 @@
 import PaymentLayoutWrapper from './payment-layout-wrapper'
+import { isReservedRoute } from '@/constants/routes'
+import { notFound } from 'next/navigation'
 
-export default function PaymentLayout({ children }: { children: React.ReactNode }) {
+type PaymentLayoutProps = {
+    children: React.ReactNode
+    params: Promise<{ recipient?: string[] }>
+}
+
+export default async function PaymentLayout({ children, params }: PaymentLayoutProps) {
+    const { recipient = [] } = await params
+    const firstSegment = recipient[0]
+
+    // The catch-all page repeats this guard for direct callers, but the layout
+    // must reject reserved/localized paths first. Otherwise its client shell
+    // reads Redux and modal contexts before the page can call notFound(), while
+    // localized marketing URLs intentionally omit those app providers.
+    if (firstSegment && isReservedRoute(`/${firstSegment}`)) {
+        notFound()
+    }
+
     return <PaymentLayoutWrapper>{children}</PaymentLayoutWrapper>
 }

--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import NotFound from '../not-found'
+import { ModalsProvider, useModalsContext } from '@/context/ModalsContext'
+
+jest.mock('next/dynamic', () => () => null)
+jest.mock('@/constants/ragdoll.consts', () => ({ RAGDOLL_ENABLED: false }))
+jest.mock('@/components/Global/SupportDrawer', () => ({
+    __esModule: true,
+    default: () => <div data-testid="support-drawer" />,
+}))
+jest.mock('@/components/0_Bruddle/Button', () => ({
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+    ),
+}))
+
+function ModalState() {
+    const { isSupportModalOpen, supportPrefilledMessage } = useModalsContext()
+    return (
+        <output data-testid="modal-state">
+            {isSupportModalOpen ? 'open' : 'closed'}:{supportPrefilledMessage}
+        </output>
+    )
+}
+
+describe('global not-found page', () => {
+    it('renders a safe email fallback without app providers', () => {
+        render(<NotFound />)
+
+        expect(screen.getByRole('heading', { name: "Hmm, we can't find that page." })).toBeInTheDocument()
+        expect(screen.queryByTestId('support-drawer')).not.toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'let support know' })).toHaveAttribute('href', 'mailto:help@peanut.me')
+        expect(screen.getByRole('link', { name: 'Contact support' })).toHaveAttribute('href', 'mailto:help@peanut.me')
+    })
+
+    it('keeps the provider-backed support drawer and prefilled action', () => {
+        render(
+            <ModalsProvider>
+                <NotFound />
+                <ModalState />
+            </ModalsProvider>
+        )
+
+        expect(screen.getByTestId('support-drawer')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Contact support' }))
+        expect(screen.getByTestId('modal-state')).toHaveTextContent('open:Hey! I hit a 404 — can you help?')
+        expect(screen.getByTestId('modal-state')).toHaveTextContent('Path: /')
+    })
+})

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,8 +2,9 @@
 
 import { Button } from '@/components/0_Bruddle/Button'
 import SupportDrawer from '@/components/Global/SupportDrawer'
+import { SUPPORT_EMAIL } from '@/constants/crisp'
 import { RAGDOLL_ENABLED } from '@/constants/ragdoll.consts'
-import { useModalsContext } from '@/context/ModalsContext'
+import { useModalsContextOptional } from '@/context/ModalsContext'
 import dynamic from 'next/dynamic'
 
 // Same dynamic-import + kill-switch pattern as the rewards easter egg. When
@@ -12,13 +13,16 @@ import dynamic from 'next/dynamic'
 const PeanutRagdoll = RAGDOLL_ENABLED ? dynamic(() => import('@/components/PeanutRagdoll'), { ssr: false }) : null
 
 export default function NotFound() {
-    const { openSupportWithMessage } = useModalsContext()
+    // Localized marketing misses intentionally render without AppFlowProviders.
+    // Keep their 404 page provider-free; app routes still get the support drawer.
+    const modals = useModalsContextOptional()
+    const supportHref = `mailto:${SUPPORT_EMAIL}`
 
     // Send only the pathname — query + hash can carry magic-link tokens,
     // OAuth callback secrets, or signed-share params that we don't want
     // landing in Crisp chat logs.
     const openSupport = () =>
-        openSupportWithMessage(
+        modals?.openSupportWithMessage(
             `Hey! I hit a 404 — can you help?${typeof window !== 'undefined' ? `\n\nPath: ${window.location.pathname}` : ''}`
         )
 
@@ -38,9 +42,15 @@ export default function NotFound() {
                             <h1 className="text-heading-m">Hmm, we can&apos;t find that page.</h1>
                             <p className="text-body-m text-foreground-secondary">
                                 If we&apos;ve sent you here, please{' '}
-                                <button type="button" onClick={openSupport} className="text-black underline">
-                                    let support know
-                                </button>{' '}
+                                {modals ? (
+                                    <button type="button" onClick={openSupport} className="text-black underline">
+                                        let support know
+                                    </button>
+                                ) : (
+                                    <a href={supportHref} className="text-black underline">
+                                        let support know
+                                    </a>
+                                )}{' '}
                                 so we can fix it.
                             </p>
                         </div>
@@ -52,14 +62,23 @@ export default function NotFound() {
                             <a href="/" className="btn btn-purple flex w-full text-center shadow-4">
                                 Take me home
                             </a>
-                            <Button variant="stroke" className="w-full" onClick={openSupport}>
-                                Contact support
-                            </Button>
+                            {modals ? (
+                                <Button variant="stroke" className="w-full" onClick={openSupport}>
+                                    Contact support
+                                </Button>
+                            ) : (
+                                <a
+                                    href={supportHref}
+                                    className="btn btn-stroke flex w-full items-center justify-center text-center"
+                                >
+                                    Contact support
+                                </a>
+                            )}
                         </div>
                     </div>
                 </div>
             </div>
-            <SupportDrawer />
+            {modals && <SupportDrawer />}
         </>
     )
 }


### PR DESCRIPTION
## Summary

- reject reserved and locale-prefixed paths in the recipient catch-all layout before its app-only Redux/modal shell mounts
- make the global 404 safe without `ModalsProvider`, with a `mailto:help@peanut.me` fallback
- preserve the existing provider-backed SupportDrawer and prefilled support message on app routes
- add component regression coverage plus HTTP status coverage for every supported locale and every marketing route family

## Validation

- `pnpm exec jest --runTestsByPath src/app/__tests__/not-found.test.tsx --runInBand`
- targeted ESLint and Prettier checks for the changed files
- `pnpm exec next typegen`
- focused Playwright route suite: 3 passed (localized 404 coverage; `/send` 200; `/request` 200)

## Blocked validation

`pnpm typecheck` and the production build are blocked by the existing `origin/dev` error in `instrumentation-client.ts:101`: PostHog `SessionRecordingOptions` does not accept `maskAttributeFn`, and its callback parameters are implicitly `any`. This PR does not touch that file. The production build completed webpack compilation before reaching the same typecheck failure.