### PR TITLE
style(home): use light green checklist background

### DIFF
--- a/src/components/0_Bruddle/ListItem.tsx
+++ b/src/components/0_Bruddle/ListItem.tsx
@@ -80,7 +80,7 @@ export const ListItem = ({
                 'flex items-center justify-between gap-3 p-4',
                 onClick &&
                     !disabled &&
-                    'duration-instant focus-visible:outline-action-focus active:bg-background-disabled cursor-pointer transition-colors focus-visible:outline-[3px]',
+                    'cursor-pointer transition-colors duration-instant focus-visible:outline-[3px] focus-visible:outline-action-focus active:bg-background-disabled',
                 disabled && 'border-border-subtle bg-background-disabled',
                 className
             )}
@@ -92,22 +92,22 @@ export const ListItem = ({
                     and truncate only ellipsizes text anyway) */}
                 <div className="flex min-w-0 flex-col gap-0.5">
                     {typeof title === 'string' ? (
-                        <span className={twMerge('text-body-m-semibold truncate', titleColor)}>{title}</span>
+                        <span className={twMerge('truncate text-body-m-semibold', titleColor)}>{title}</span>
                     ) : (
-                        <div className={twMerge('text-body-m-semibold min-w-0', titleColor)}>{title}</div>
+                        <div className={twMerge('min-w-0 text-body-m-semibold', titleColor)}>{title}</div>
                     )}
                     {body &&
                         (typeof body === 'string' ? (
                             <span
                                 className={twMerge(
                                     'text-body-s text-foreground-secondary',
-                                    bodyWrap ? 'whitespace-normal break-words' : 'truncate'
+                                    bodyWrap ? 'break-words whitespace-normal' : 'truncate'
                                 )}
                             >
                                 {body}
                             </span>
                         ) : (
-                            <div className="text-body-s text-foreground-secondary min-w-0">{body}</div>
+                            <div className="min-w-0 text-body-s text-foreground-secondary">{body}</div>
                         ))}
                 </div>
             </div>

--- a/src/components/0_Bruddle/ListItem.tsx
+++ b/src/components/0_Bruddle/ListItem.tsx
@@ -80,7 +80,7 @@ export const ListItem = ({
                 'flex items-center justify-between gap-3 p-4',
                 onClick &&
                     !disabled &&
-                    'cursor-pointer transition-colors duration-instant focus-visible:outline-[3px] focus-visible:outline-action-focus active:bg-background-disabled',
+                    'duration-instant focus-visible:outline-action-focus active:bg-background-disabled cursor-pointer transition-colors focus-visible:outline-[3px]',
                 disabled && 'border-border-subtle bg-background-disabled',
                 className
             )}
@@ -92,9 +92,9 @@ export const ListItem = ({
                     and truncate only ellipsizes text anyway) */}
                 <div className="flex min-w-0 flex-col gap-0.5">
                     {typeof title === 'string' ? (
-                        <span className={twMerge('truncate text-body-m-semibold', titleColor)}>{title}</span>
+                        <span className={twMerge('text-body-m-semibold truncate', titleColor)}>{title}</span>
                     ) : (
-                        <div className={twMerge('min-w-0 text-body-m-semibold', titleColor)}>{title}</div>
+                        <div className={twMerge('text-body-m-semibold min-w-0', titleColor)}>{title}</div>
                     )}
                     {body &&
                         (typeof body === 'string' ? (
@@ -107,7 +107,7 @@ export const ListItem = ({
                                 {body}
                             </span>
                         ) : (
-                            <div className="min-w-0 text-body-s text-foreground-secondary">{body}</div>
+                            <div className="text-body-s text-foreground-secondary min-w-0">{body}</div>
                         ))}
                 </div>
             </div>

--- a/src/components/0_Bruddle/ListItem.tsx
+++ b/src/components/0_Bruddle/ListItem.tsx
@@ -9,6 +9,8 @@ import { useAppHaptic } from '@/hooks/useAppHaptic'
 interface ListItemProps {
     title: React.ReactNode
     body?: React.ReactNode
+    /** allow a string body to wrap instead of using the default one-line ellipsis */
+    bodyWrap?: boolean
     /** leading slot: IconBubble, Icon, avatar, flag… (board leading content) */
     leading?: React.ReactNode
     /** trailing slot: value, toggle, badge… renders before the chevron */
@@ -35,6 +37,7 @@ interface ListItemProps {
 export const ListItem = ({
     title,
     body,
+    bodyWrap = false,
     leading,
     trailing,
     chevron,
@@ -95,7 +98,14 @@ export const ListItem = ({
                     )}
                     {body &&
                         (typeof body === 'string' ? (
-                            <span className="truncate text-body-s text-foreground-secondary">{body}</span>
+                            <span
+                                className={twMerge(
+                                    'text-body-s text-foreground-secondary',
+                                    bodyWrap ? 'whitespace-normal break-words' : 'truncate'
+                                )}
+                            >
+                                {body}
+                            </span>
                         ) : (
                             <div className="min-w-0 text-body-s text-foreground-secondary">{body}</div>
                         ))}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -136,7 +136,7 @@ const GettingStartedChecklist = () => {
                             chevron={tappable}
                             disabled={!tappable}
                             onClick={tappable ? item.onTap : undefined}
-                            className="bg-background-badge-success"
+                            className={item.done ? 'bg-background-badge-success' : undefined}
                         />
                     )
                 })}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -135,6 +135,7 @@ const GettingStartedChecklist = () => {
                             chevron={tappable}
                             disabled={!tappable}
                             onClick={tappable ? item.onTap : undefined}
+                            className="bg-background-badge-success"
                         />
                     )
                 })}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -28,7 +28,7 @@ interface ChecklistItem {
 // The undone marker: same 20px circle StatusPill draws for "completed",
 // outlined and empty. No status token means "not yet", so it stays local.
 const PendingMarker = () => (
-    <span aria-hidden className="flex size-5 shrink-0 rounded-full border border-border-default" />
+    <span aria-hidden className="border-border-default flex size-5 shrink-0 rounded-full border" />
 )
 
 /**

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -132,6 +132,7 @@ const GettingStartedChecklist = () => {
                             leading={item.done ? <StatusPill status="completed" /> : <PendingMarker />}
                             title={item.label}
                             body={showSub ? item.sub : undefined}
+                            bodyWrap
                             chevron={tappable}
                             disabled={!tappable}
                             onClick={tappable ? item.onTap : undefined}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -121,7 +121,7 @@ const GettingStartedChecklist = () => {
 
     return (
         <Section title={t('title')}>
-            <ListGroup>
+            <ListGroup className="bg-background-default">
                 {items.map((item) => {
                     const tappable = !item.done && !!item.onTap
                     const showSub = (item.done && item.id === 'create-account') || (!item.done && !!item.sub)
@@ -136,7 +136,7 @@ const GettingStartedChecklist = () => {
                             chevron={tappable}
                             disabled={!tappable}
                             onClick={tappable ? item.onTap : undefined}
-                            className={item.done ? 'bg-background-badge-success' : undefined}
+                            className={item.done ? 'bg-background-icon-bubble-green/10' : undefined}
                         />
                     )
                 })}

--- a/src/components/Home/GettingStartedChecklist.tsx
+++ b/src/components/Home/GettingStartedChecklist.tsx
@@ -28,7 +28,7 @@ interface ChecklistItem {
 // The undone marker: same 20px circle StatusPill draws for "completed",
 // outlined and empty. No status token means "not yet", so it stays local.
 const PendingMarker = () => (
-    <span aria-hidden className="border-border-default flex size-5 shrink-0 rounded-full border" />
+    <span aria-hidden className="flex size-5 shrink-0 rounded-full border border-border-default" />
 )
 
 /**

--- a/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
@@ -65,6 +65,13 @@ describe('GettingStartedChecklist', () => {
         }
     })
 
+    it('wraps checklist subtitles instead of truncating them', () => {
+        render()
+        const subtitle = screen.getByText('Bank transfer or crypto · bank needs a one-time ID check')
+        expect(subtitle).toHaveClass('whitespace-normal', 'break-words')
+        expect(subtitle).not.toHaveClass('truncate')
+    })
+
     // The row opens /add-money, a chooser offering bank transfer AND crypto, so
     // it no longer names one rail per residence — that promised a route the
     // chooser does not take you straight to.

--- a/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
@@ -60,7 +60,7 @@ describe('GettingStartedChecklist', () => {
 
     it('uses the light-green design-system background only for completed rows', () => {
         render()
-        expect(screen.getByTestId('checklist-create-account')).toHaveClass('bg-background-badge-success')
+        expect(screen.getByTestId('checklist-create-account')).toHaveClass('bg-background-icon-bubble-green/10')
         expect(screen.getByTestId('checklist-add-money')).toHaveClass('bg-white')
         expect(screen.getByTestId('checklist-get-card')).toHaveClass('bg-white')
     })

--- a/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
@@ -58,6 +58,13 @@ describe('GettingStartedChecklist', () => {
         expect(screen.getByText('Done. Your money has a username now')).toBeInTheDocument()
     })
 
+    it('uses the light-green design-system background for every row', () => {
+        render()
+        for (const row of screen.getAllByTestId(/^checklist-/)) {
+            expect(row).toHaveClass('bg-background-badge-success')
+        }
+    })
+
     // The row opens /add-money, a chooser offering bank transfer AND crypto, so
     // it no longer names one rail per residence — that promised a route the
     // chooser does not take you straight to.

--- a/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Home/__tests__/GettingStartedChecklist.test.tsx
@@ -58,11 +58,11 @@ describe('GettingStartedChecklist', () => {
         expect(screen.getByText('Done. Your money has a username now')).toBeInTheDocument()
     })
 
-    it('uses the light-green design-system background for every row', () => {
+    it('uses the light-green design-system background only for completed rows', () => {
         render()
-        for (const row of screen.getAllByTestId(/^checklist-/)) {
-            expect(row).toHaveClass('bg-background-badge-success')
-        }
+        expect(screen.getByTestId('checklist-create-account')).toHaveClass('bg-background-badge-success')
+        expect(screen.getByTestId('checklist-add-money')).toHaveClass('bg-white')
+        expect(screen.getByTestId('checklist-get-card')).toHaveClass('bg-white')
     })
 
     it('wraps checklist subtitles instead of truncating them', () => {


### PR DESCRIPTION
## Summary
- use the design-system light-green background for home checklist rows
- add a regression assertion for the semantic token class

## Verification
- `git diff --check` passes
- focused Jest test could not run because this checkout has no `ts-jest` dependencies