### PR TITLE
TASK-22425 feat: enable send -> bank -> Brazil -> Pix key sends

### DIFF
--- a/src/components/AddWithdraw/AddWithdrawRouterView.tsx
+++ b/src/components/AddWithdraw/AddWithdrawRouterView.tsx
@@ -380,7 +380,11 @@ export const AddWithdrawRouterView: FC<AddWithdrawRouterViewProps> = ({
                     // from send flow (bank): set method in context and stay on /withdraw?method=bank
                     if (flow === 'withdraw' && isBankFromSend) {
                         if (isMantecaCountry(country.path)) {
-                            const route = `/withdraw/manteca?method=bank-transfer&country=${country.path}`
+                            // Brazil from send = pay another person's PIX key: method=pix
+                            // delegates to PixKeySendView (Manteca QR-payment endpoint).
+                            // bank-transfer is the own-account offramp and stays for the rest.
+                            const mantecaMethod = country.path === 'brazil' ? 'pix' : 'bank-transfer'
+                            const route = `/withdraw/manteca?method=${mantecaMethod}&country=${country.path}`
                             startTransition(() => {
                                 router.push(route)
                             })

--- a/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawRouterView.test.tsx
@@ -16,9 +16,10 @@ import { render as rtlRender, screen, fireEvent, cleanup } from '@testing-librar
 import { IntlWrapper } from '@/test-utils/intl'
 
 const mockRouterPush = jest.fn()
+let mockSearchParams: Record<string, string> = {}
 jest.mock('next/navigation', () => ({
     useRouter: () => ({ push: mockRouterPush, back: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
-    useSearchParams: () => ({ get: () => null }),
+    useSearchParams: () => ({ get: (key: string) => mockSearchParams[key] ?? null }),
     usePathname: () => '/withdraw',
 }))
 
@@ -93,10 +94,24 @@ jest.mock('@/components/Profile/AvatarWithBadge', () => ({
 }))
 
 jest.mock('../../Common/CountryList', () => ({
-    CountryList: (props: { onCryptoClick?: () => void }) => (
+    CountryList: (props: { onCryptoClick?: () => void; onCountryClick?: (country: unknown) => void }) => (
         <div data-testid="country-list">
             <button data-testid="crypto-option" onClick={props.onCryptoClick}>
                 Crypto
+            </button>
+            <button
+                data-testid="brazil-option"
+                onClick={() =>
+                    props.onCountryClick?.({
+                        id: 'BRA',
+                        type: 'country',
+                        title: 'Brazil',
+                        currency: 'BRL',
+                        path: 'brazil',
+                    })
+                }
+            >
+                Brazil
             </button>
         </div>
     ),
@@ -168,6 +183,9 @@ describe('AddWithdrawRouterView — withdraw method selection', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockRestrictions = { banking: false, card: false }
+        mockSearchParams = {}
+        const { isMantecaCountry } = jest.requireMock('@/constants/manteca.consts')
+        isMantecaCountry.mockImplementation(() => false)
     })
 
     // Every country on the list dead-ends for these residents; say so once here
@@ -198,6 +216,20 @@ describe('AddWithdrawRouterView — withdraw method selection', () => {
             expect.objectContaining({ type: 'crypto', title: 'Crypto' })
         )
         expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    // send -> bank -> Brazil pays another person's PIX key: the route must be
+    // method=pix (delegates to PixKeySendView), never the bank-transfer offramp.
+    test('send→bank: clicking Brazil routes to the PIX-key send flow', () => {
+        mockSearchParams = { method: 'bank' }
+        const { isMantecaCountry } = jest.requireMock('@/constants/manteca.consts')
+        isMantecaCountry.mockImplementation((path: string) => path === 'brazil' || path === 'argentina')
+
+        render(<Harness user={makeUser()} />)
+        fireEvent.click(screen.getByTestId('select-new-method'))
+        fireEvent.click(screen.getByTestId('brazil-option'))
+
+        expect(mockRouterPush).toHaveBeenCalledWith('/withdraw/manteca?method=pix&country=brazil')
     })
 
     test('a user refetch (new object identity) does not bounce the country list back to saved accounts', () => {

--- a/src/components/Common/CountryList.tsx
+++ b/src/components/Common/CountryList.tsx
@@ -198,9 +198,13 @@ export const CountryList = ({
                             let isSupported = false
 
                             if (viewMode === 'add-withdraw') {
-                                // for send->bank flow, enforce only bridge or manteca supported countries
+                                // send->bank flow: bridge countries, plus Brazil — a PIX send to a
+                                // third-party key rides the Manteca QR-payment endpoint (see the
+                                // method=pix delegation in /withdraw/manteca). Argentina stays
+                                // gated: its Manteca rails here are own-account offramps, same
+                                // ruling that keeps Mercado Pago off the send list (PR #2813).
                                 if (enforceSupportedCountries) {
-                                    isSupported = isBridgeSupportedCountryResult
+                                    isSupported = isBridgeSupportedCountryResult || country.path === 'brazil'
                                 } else {
                                     // otherwise allow all countries
                                     isSupported = true

--- a/src/components/Common/__tests__/CountryList.test.tsx
+++ b/src/components/Common/__tests__/CountryList.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * CountryList — the send->bank supported-country gate (enforceSupportedCountries).
+ *
+ * The send flow reuses the withdraw country list, gated so users cannot pick a
+ * country with no send rail. Pinned here:
+ * 1. Brazil is selectable — a PIX send to a third-party key rides the Manteca
+ *    QR-payment endpoint, so the send->bank flow must let users reach it.
+ * 2. Argentina stays disabled — its Manteca rails in this flow are own-account
+ *    offramps (same ruling that keeps Mercado Pago off the send list, PR #2813).
+ * 3. Bridge countries (e.g. Germany) stay selectable.
+ */
+import React from 'react'
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react'
+import { IntlWrapper } from '@/test-utils/intl'
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: () => ({ get: () => null }),
+}))
+
+// next/image — render a plain <img>
+jest.mock('next/image', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        const { priority, layout, objectFit, fill, loading, onError, ...rest } = props
+        return <img {...rest} />
+    },
+}))
+
+jest.mock('@/hooks/useGeoLocation', () => ({
+    useGeoLocation: () => ({ countryCode: null, isLoading: false }),
+}))
+
+jest.mock('@/components/Global/EasterEggModal', () => ({
+    __esModule: true,
+    default: () => null,
+    EASTER_EGG_COUNTRIES: {},
+}))
+
+import { CountryList } from '../CountryList'
+
+const render = (ui: Parameters<typeof rtlRender>[0]) => rtlRender(ui, { wrapper: IntlWrapper })
+
+const row = (name: string) => {
+    const title = screen.getByText(name)
+    const card = title.closest('[role="button"]')
+    expect(card).not.toBeNull()
+    return card as HTMLElement
+}
+
+describe('CountryList — enforceSupportedCountries (send->bank flow)', () => {
+    const onCountryClick = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        render(
+            <CountryList
+                inputTitle="How?"
+                viewMode="add-withdraw"
+                flow="withdraw"
+                enforceSupportedCountries
+                onCountryClick={onCountryClick}
+                showLoadingState={false}
+            />
+        )
+    })
+
+    test('Brazil is selectable and clicking it selects the country', () => {
+        const brazil = row('Brazil')
+        expect(brazil).not.toHaveAttribute('aria-disabled')
+        fireEvent.click(brazil)
+        expect(onCountryClick).toHaveBeenCalledWith(expect.objectContaining({ path: 'brazil' }))
+    })
+
+    test('Argentina stays disabled (own-account rails only)', () => {
+        const argentina = row('Argentina')
+        expect(argentina).toHaveAttribute('aria-disabled', 'true')
+        fireEvent.click(argentina)
+        expect(onCountryClick).not.toHaveBeenCalled()
+    })
+
+    test('a bridge country stays selectable', () => {
+        const germany = row('Germany')
+        expect(germany).not.toHaveAttribute('aria-disabled')
+        fireEvent.click(germany)
+        expect(onCountryClick).toHaveBeenCalledWith(expect.objectContaining({ path: 'germany' }))
+    })
+})


### PR DESCRIPTION
## Summary

Send → Send to friends → Bank showed Brazil disabled behind a "soon" badge: the country list's `enforceSupportedCountries` gate only accepted Bridge countries. The Pix-key send flow already pays any third-party Pix key (Manteca QR-payment endpoint, `PixKeySendView`), so the gate blocked a path the product supports. This PR enables Brazil in that list and routes it to `method=pix`.

- `CountryList.tsx`: the send→bank gate now accepts Bridge countries plus Brazil. Argentina stays disabled — its Manteca rails in this flow are own-account offramps, same ruling that keeps Mercado Pago off the send list (#2813).
- `AddWithdrawRouterView.tsx`: the send→bank Manteca branch routes Brazil to `/withdraw/manteca?method=pix&country=brazil` (delegates to `PixKeySendView`); `bank-transfer` stays for the rest.

## Task

TASK-22425

## Risks / breaking changes

- Frontend-only routing/gating change; no backend or contract changes.
- The Pix-key flow itself is untouched. The capability gate (`canDo('pay', { provider: 'manteca' })`) is enforced downstream in `/qr-pay`, same as the existing Brazil-geo entry points.
- The send-origin `?method=bank` marker is dropped on the Brazil hop, same as the existing Manteca `bank-transfer` hop; `PixKeySendView`'s back navigation targets `/send` already.

## QA

- `npm test` — 524 suites green, incl. new tests:
  - `CountryList.test.tsx`: under `enforceSupportedCountries`, Brazil selectable, Argentina disabled, Bridge country (Germany) selectable.
  - `AddWithdrawRouterView.test.tsx`: send→bank Brazil click pushes `/withdraw/manteca?method=pix&country=brazil`.
- Manual: /send → Bank → country list → Brazil → Pix-key entry → BR Code handoff to /qr-pay (sandbox).

## Design notes / accepted trade-offs

- The `'brazil'` literal appears twice (the CountryList gate and the AddWithdrawRouterView route). The two sites encode different decisions — which countries the send→bank list offers vs which Manteca method a country routes to — so a shared constant would couple them without making either clearer. If a second Manteca send country lands, promote a map in `manteca.consts` then.
- Smells: adds none beyond the above; reveals none. The stale comment in CountryList ("bridge or manteca supported countries" over bridge-only code) is replaced by an accurate one.

## Screenshots

375×667, dev build with the `withdraw` fixture (API faked). Assets branch `pr-assets-3055` is deleted post-merge.

| Send → Bank country list | Brazil — now selectable | Argentina — stays "Soon" | Brazil → Pix key entry |
|---|---|---|---|
| ![country list](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3055/1-country-list.png) | ![brazil enabled](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3055/2-brazil-enabled.png) | ![argentina soon](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3055/3-argentina-still-soon.png) | ![pix key send](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3055/4-pix-key-send.png) |

Click-through verified live: tapping Brazil lands on `/withdraw/manteca?method=pix&country=brazil` (the "Send with Pix" key-entry screen).
