### PR TITLE
fix: bug-bounty CTA rewards valid bugs only, not 'no questions asked' (TASK-22426)

### DIFF
--- a/src/app/(mobile-ui)/dev/home-ctas/page.tsx
+++ b/src/app/(mobile-ui)/dev/home-ctas/page.tsx
@@ -142,7 +142,7 @@ const CAROUSEL_PREVIEWS: CarouselPreview[] = [
                 Help us improve and <b>get $5!</b>
             </span>
         ),
-        description: 'Be the first to report a valid bug. Get rewarded!',
+        description: 'Be the first to report a bug. Get rewarded!',
     },
     {
         id: 'notification-prompt',

--- a/src/app/(mobile-ui)/dev/home-ctas/page.tsx
+++ b/src/app/(mobile-ui)/dev/home-ctas/page.tsx
@@ -142,7 +142,7 @@ const CAROUSEL_PREVIEWS: CarouselPreview[] = [
                 Help us improve and <b>get $5!</b>
             </span>
         ),
-        description: 'Report a bug. Get rewarded! No questions asked.',
+        description: 'Be the first to report a valid bug. Get rewarded!',
     },
     {
         id: 'notification-prompt',

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Help us improve and <b>get $5!</b>",
-                "description": "Report a bug. Get rewarded! No questions asked."
+                "description": "Be the first to report a valid bug. Get rewarded!"
             },
             "userInterview": {
                 "title": "Help shape Peanut",

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Help us improve and <b>get $5!</b>",
-                "description": "Be the first to report a valid bug. Get rewarded!"
+                "description": "Be the first to report a bug. Get rewarded!"
             },
             "userInterview": {
                 "title": "Help shape Peanut",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Ayúdanos a mejorar y <b>¡gana $5!</b>",
-                "description": "Sé el primero en reportar un error válido. ¡Recibe una recompensa!"
+                "description": "Sé el primero en reportar un error. ¡Recibe una recompensa!"
             },
             "userInterview": {
                 "title": "Ayúdanos a construir Peanut",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Ayúdanos a mejorar y <b>¡gana $5!</b>",
-                "description": "Reporta un error. ¡Recibe una recompensa! Sin preguntas."
+                "description": "Sé el primero en reportar un error válido. ¡Recibe una recompensa!"
             },
             "userInterview": {
                 "title": "Ayúdanos a construir Peanut",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -114,7 +114,7 @@
             },
             "bugBounty": {
                 "title": "Ayudanos a mejorar y <b>¡ganá $5!</b>",
-                "description": "Sé el primero en reportar un error válido. ¡Recibí una recompensa!"
+                "description": "Sé el primero en reportar un error. ¡Recibí una recompensa!"
             },
             "userInterview": {
                 "title": "Ayudanos a construir Peanut",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -114,7 +114,7 @@
             },
             "bugBounty": {
                 "title": "Ayudanos a mejorar y <b>¡ganá $5!</b>",
-                "description": "Reportá un error. ¡Recibí una recompensa! Sin preguntas."
+                "description": "Sé el primero en reportar un error válido. ¡Recibí una recompensa!"
             },
             "userInterview": {
                 "title": "Ayudanos a construir Peanut",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Ajude a gente a melhorar e <b>ganhe $5!</b>",
-                "description": "Relate um bug. Ganhe uma recompensa! Sem perguntas."
+                "description": "Seja o primeiro a relatar um bug válido. Ganhe uma recompensa!"
             },
             "userInterview": {
                 "title": "Ajude a construir Peanut",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -243,7 +243,7 @@
             },
             "bugBounty": {
                 "title": "Ajude a gente a melhorar e <b>ganhe $5!</b>",
-                "description": "Seja o primeiro a relatar um bug válido. Ganhe uma recompensa!"
+                "description": "Seja o primeiro a relatar um bug. Ganhe uma recompensa!"
             },
             "userInterview": {
                 "title": "Ajude a construir Peanut",


### PR DESCRIPTION
## Summary

The home carousel bug-bounty card said "Report a bug. Get rewarded! No questions asked." We do ask questions: we reward reports at our discretion — the bar is a bug that is new to us and actionable, and "be the first" carries that expectation without sounding like fine print. The old copy over-promised and invited low-quality reports. New copy in all 4 locales:

| Locale | Before | After |
|---|---|---|
| en | Report a bug. Get rewarded! No questions asked. | Be the first to report a bug. Get rewarded! |
| es-419 | Reporta un error. ¡Recibe una recompensa! Sin preguntas. | Sé el primero en reportar un error. ¡Recibe una recompensa! |
| es-AR | Reportá un error. ¡Recibí una recompensa! Sin preguntas. | Sé el primero en reportar un error. ¡Recibí una recompensa! |
| pt-BR | Relate um bug. Ganhe uma recompensa! Sem perguntas. | Seja o primeiro a relatar um bug. Ganhe uma recompensa! |

The dev showcase page (`/dev/home-ctas`) hardcodes the same string; kept in sync.

## Task

TASK-22426 — https://app.notion.com/p/3d5838117579813498d2df9c8711a2d3

## Risks / breaking changes

None. Copy-only, no keys added or removed, no logic touched, no cross-repo impact.

## QA

- `npm test` (523 suites), `npm run typecheck`, prettier — all green locally.
- Visual: the `home` fixture is ds-shots-covered; screenshots of the updated card below.

## Screenshots

Captured on `/dev/home-ctas` (the CTA showcase, updated in this PR — same string as the `home.carousel.bugBounty` key), 375px viewport. Assets live on branch `pr-assets-3056`, deleted post-merge.

| Card (new copy) | In page context |
|---|---|
| ![bug-bounty card](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3056/bug-bounty-cta.png) | ![showcase page](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3056/bug-bounty-cta-viewport.png) |
