### PR TITLE
fix: Back navigation loop in Send to friend wallet flow (TASK-22424)

### DIFF
--- a/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/add-money/[country]/bank/page.tsx
@@ -46,7 +46,7 @@ import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useSafeBack } from '@/hooks/useSafeBack'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { useLocale, useTranslations } from 'next-intl'
 import { localizedCountryTitle } from '@/utils/country-name.utils'
 
@@ -503,7 +503,7 @@ function BridgeBankOnrampPage() {
                             await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                         } else {
                             await sumsubFlow.handleInitiateKyc(
-                                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                                getBankRegionIntent(selectedCountry),
                                 undefined,
                                 gate.kind === 'needs-enrollment' || undefined,
                                 selectedCountry?.id

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -1476,7 +1476,9 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
             fireEvent.click(screen.getByTestId('kyc-verify-button'))
         })
 
-        expect(handleInitiateKyc).toHaveBeenCalledWith('NA', undefined, true, 'MX')
+        // intent + crossRegion are what the BE routes on; the 4th arg (country) is
+        // dropped by useSumsubKycFlow for non-Manteca countries, so don't pin it
+        expect(handleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
     })
 
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -705,7 +705,7 @@ jest.mock('@/components/AddMoney/consts', () => ({
         { type: 'country', id: 'BR', path: 'brazil', currency: 'BRL', iso3: 'BRA' },
         { type: 'country', id: 'US', path: 'us', currency: 'USD', iso3: 'USA' },
         { type: 'country', id: 'DE', path: 'germany', currency: 'EUR', iso3: 'DEU' },
-        { type: 'country', id: 'MX', path: 'mexico', currency: 'MXN', iso3: 'MEX' },
+        { type: 'country', id: 'MX', path: 'mexico', currency: 'MXN', iso3: 'MEX', region: 'latam' },
         { type: 'country', id: 'GB', path: 'uk', currency: 'GBP', iso3: 'GBR' },
         { type: 'country', id: 'XX', path: 'unknown', currency: 'USD', iso3: 'XXX' },
     ],
@@ -1454,6 +1454,29 @@ describe('GROUP 5: Bridge Bank Onramp', () => {
 
         expect(mockRouterReplace).not.toHaveBeenCalled()
         expect(screen.getByText('How much do you want to add?')).toBeInTheDocument()
+    })
+
+    // Mexico is tagged `latam` but deposits over Bridge SPEI. A verified user with
+    // no SPEI rail (needs-enrollment) must unlock via the NA (Bridge) intent —
+    // LATAM + MX hits the Manteca path, which rejects MX and dead-ended in
+    // "contact support" (TASK-22333).
+    test('mexico needs-enrollment unlock sends the NA intent, not LATAM', async () => {
+        setParams({ country: 'mexico' })
+        setGate('needs-enrollment')
+        resetQueryState({ step: 'inputAmount', amount: '100' })
+        const handleInitiateKyc = jest.fn()
+        mockUseMultiPhaseKycFlow.mockReturnValue({ ...mockUseMultiPhaseKycFlow(), handleInitiateKyc })
+
+        renderWithProviders(<OnrampBankPage />)
+
+        await act(async () => {
+            fireEvent.click(screen.getByText('Continue'))
+        })
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('kyc-verify-button'))
+        })
+
+        expect(handleInitiateKyc).toHaveBeenCalledWith('NA', undefined, true, 'MX')
     })
 
     test('fresh user needs KYC before Bridge deposit confirmation', async () => {

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -606,7 +606,7 @@ export default function WithdrawBankPage() {
                             getBankRegionIntent(countryFromPath),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
-                            getCountryFromPath(country)?.id
+                            countryFromPath?.id
                         )
                     }
                 }}

--- a/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/[country]/bank/page.tsx
@@ -41,7 +41,7 @@ import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@
 import { useModalsContext } from '@/context/ModalsContext'
 import ExchangeRate from '@/components/ExchangeRate'
 import countryCurrencyMappings, { isNonEuroSepaCountry } from '@/constants/countryCurrencyMapping'
-import { isBridgeSupportedCountry, getRegionIntent } from '@/utils/regions.utils'
+import { isBridgeSupportedCountry, getBankRegionIntent } from '@/utils/regions.utils'
 import { PointsAction } from '@/services/services.types'
 import { usePointsCalculation } from '@/hooks/usePointsCalculation'
 import posthog from 'posthog-js'
@@ -603,7 +603,7 @@ export default function WithdrawBankPage() {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(getCountryFromPath(country)?.region ?? 'rest-of-the-world'),
+                            getBankRegionIntent(countryFromPath),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             getCountryFromPath(country)?.id

--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -18,6 +18,7 @@ import { parseUnits } from 'viem'
 // next/navigation
 const mockRouterPush = jest.fn()
 const mockRouterBack = jest.fn()
+const mockRouterReplace = jest.fn()
 const mockSearchParams = new Map<string, string>()
 
 jest.mock('next/navigation', () => ({
@@ -27,7 +28,7 @@ jest.mock('next/navigation', () => ({
     useRouter: () => ({
         push: mockRouterPush,
         back: mockRouterBack,
-        replace: jest.fn(),
+        replace: mockRouterReplace,
         prefetch: jest.fn(),
     }),
     usePathname: () => '/withdraw',
@@ -225,6 +226,7 @@ jest.mock('@/components/AddWithdraw/AddWithdrawRouterView', () => ({
 
 // ---------- import component under test AFTER all mocks ----------
 import WithdrawPage from '../page'
+import { __testing as safeBackTesting } from '@/hooks/useSafeBack'
 
 // ---------- helpers ----------
 
@@ -286,6 +288,7 @@ function applyDefaults() {
 beforeEach(() => {
     jest.clearAllMocks()
     mockSearchParams.clear()
+    safeBackTesting.reset()
     applyDefaults()
     // clearAllMocks() resets call history but not implementations, so restore
     // the default country resolution here — tests that override it (GROUP 6)
@@ -340,14 +343,28 @@ describe('GROUP 1: Method Selection', () => {
         renderWithdraw({ method: 'bank', returnTo: '/profile/exchange-rate' })
 
         fireEvent.click(screen.getByTestId('router-view-back'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 
-    test('Back from bank send method selection navigates to /send', () => {
+    // Regression: this branch used to router.push('/send') over the retained
+    // /withdraw?method=bank entry, so send's safe-back popped right back into
+    // the withdraw step — Back looped instead of unwinding (TASK-22424).
+    test('Back from bank send method selection pops in-app history, not push', () => {
+        window.history.pushState({}, '', '/withdraw?method=bank')
         renderWithdraw({ method: 'bank' })
 
         fireEvent.click(screen.getByTestId('router-view-back'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    test('Back from bank send method selection replaces to /send on a cold deep link', () => {
+        renderWithdraw({ method: 'bank' })
+
+        fireEvent.click(screen.getByTestId('router-view-back'))
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 })
 
@@ -563,13 +580,29 @@ describe('GROUP 4: Limits Validation', () => {
 // GROUP 5: Navigation
 // ============================================================
 describe('GROUP 5: Navigation', () => {
-    test('Back from crypto send navigates to /send', () => {
+    // Regression: this handler used to router.push('/send') over the retained
+    // /withdraw?method=crypto entry, so send's safe-back popped right back into
+    // the amount step and ?method=crypto re-selected crypto — Back looped
+    // between Send and the amount screen forever (TASK-22424).
+    test('Back from crypto send pops in-app history, not push', () => {
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        window.history.pushState({}, '', '/withdraw?method=crypto')
+        renderWithdraw({ method: 'crypto' })
+
+        fireEvent.click(screen.getByTestId('nav-back'))
+        expect(mockSetSelectedMethod).toHaveBeenCalledWith(null)
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    test('Back from crypto send replaces to /send on a cold deep link', () => {
         mockWithdrawFlow.selectedMethod = { type: 'crypto' }
         renderWithdraw({ method: 'crypto' })
 
         fireEvent.click(screen.getByTestId('nav-back'))
         expect(mockSetSelectedMethod).toHaveBeenCalledWith(null)
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 
     test('Back from bank withdraw resets method and goes to method selection', () => {

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -12,6 +12,7 @@ import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
 import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { AccountType } from '@/interfaces/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useCallback, useContext, useEffect, useMemo, useState, useRef } from 'react'
@@ -51,6 +52,11 @@ export default function WithdrawPage() {
     // check if coming from send flow based on method query param
     const methodParam = searchParams.get('method')
     const { isFromSendFlow, isCryptoFromSend, isBankFromSend } = useSendFlowOrigin()
+
+    // back(), not push: pushing /send over /withdraw?method=… left the withdraw
+    // URL in history, and send's safe-back popped right back into it (Back loop).
+    // A cold deep link has no history to pop, so the fallback replaces instead.
+    const goBackToSend = useSafeBack('/send', { replace: true })
 
     // native app passes country as query param instead of path segment
     const countryFromQuery = searchParams.get('country')
@@ -412,7 +418,7 @@ export default function WithdrawPage() {
                         // if crypto from send, go back to send page
                         if (isCryptoFromSend) {
                             setSelectedMethod(null)
-                            router.push('/send')
+                            goBackToSend()
                         } else {
                             // otherwise go back to method selection
                             // clear amount so it doesn't carry over to a different method
@@ -483,7 +489,7 @@ export default function WithdrawPage() {
                 onBackClick={() => {
                     // if bank from send flow, go back to send page
                     if (isBankFromSend) {
-                        router.push('/send')
+                        goBackToSend()
                         return
                     }
                     // an explicit origin (e.g. the exchange-rate widget's "Try it!" CTA)

--- a/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
+++ b/src/components/AddWithdraw/AddWithdrawCountriesList.tsx
@@ -32,7 +32,7 @@ import { InitiateKycModal } from '@/components/Kyc/InitiateKycModal'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { resolveKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
 import { railJurisdictionForBank } from '@/utils/bridge.utils'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { useTosGuard } from '@/hooks/useTosGuard'
 import { BridgeTosStep } from '@/components/Kyc/BridgeTosStep'
 import ProvideEmailStep from '@/components/Kyc/ProvideEmailStep'
@@ -259,7 +259,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (!isUserKycApproved) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                getBankRegionIntent(currentCountry),
                 undefined,
                 undefined,
                 currentCountry?.id
@@ -374,7 +374,7 @@ const AddWithdrawCountriesList = ({ flow }: AddWithdrawCountriesListProps) => {
                         await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                     } else {
                         await sumsubFlow.handleInitiateKyc(
-                            getRegionIntent(currentCountry?.region ?? 'rest-of-the-world'),
+                            getBankRegionIntent(currentCountry),
                             undefined,
                             gate.kind === 'needs-enrollment' || undefined,
                             currentCountry?.id

--- a/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
+++ b/src/components/AddWithdraw/__tests__/AddWithdrawCountriesList.test.tsx
@@ -135,7 +135,7 @@ jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: str
 // under jest when consts is stubbed). The gate is mocked, so neither return value
 // affects these assertions — stub both so the real consts is never evaluated.
 jest.mock('@/utils/bridge.utils', () => ({ railJurisdictionForBank: () => 'US' }))
-jest.mock('@/utils/regions.utils', () => ({ getRegionIntent: () => 'STANDARD' }))
+jest.mock('@/utils/regions.utils', () => ({ getBankRegionIntent: () => 'STANDARD' }))
 
 jest.mock('@/components/ActionListCard', () => ({
     ActionListCard: (props: any) => (

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -15,7 +15,7 @@ import useClaimLink from '../../useClaimLink'
 import { type AddBankAccountPayload } from '@/app/actions/types/users.types'
 import { useAuth } from '@/context/authContext'
 import { type TCreateOfframpRequest, type TCreateOfframpResponse } from '@/services/services.types'
-import { getOfframpConfigFromAccount } from '@/utils/bridge.utils'
+import { getCountryFromAccount, getOfframpConfigFromAccount } from '@/utils/bridge.utils'
 import { getBridgeChainName, getBridgeTokenName } from '@/utils/bridge-accounts.utils'
 import { generateKeysFromString, getParamsFromLink } from '@/utils/peanut-link.utils'
 import { getContractAddress } from '@/utils/peanut-claim.utils'
@@ -69,6 +69,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         flowStep: claimBankFlowStep,
         setFlowStep: setClaimBankFlowStep,
         selectedCountry,
+        setSelectedCountry,
         setClaimType,
         setBankDetails,
         justCompletedKyc,
@@ -522,6 +523,10 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
 
                         setLocalBankDetails(bankDetails)
                         setBankDetails(bankDetails)
+                        // only the country list sets selectedCountry; a saved
+                        // account skips it, so the unlock CTA below derived a
+                        // rest-of-world intent. The account is the destination.
+                        setSelectedCountry(getCountryFromAccount(account) ?? null)
 
                         const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
                         const userForOfframp = isGuestFlow

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -32,7 +32,7 @@ import { bankFormActions } from '@/redux/slices/bank-form-slice'
 import { sendLinksApi } from '@/services/sendLinks'
 import { useSearchParams } from 'next/navigation'
 import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
-import { getRegionIntent } from '@/utils/regions.utils'
+import { getBankRegionIntent } from '@/utils/regions.utils'
 import { SumsubKycModals } from '@/components/Kyc/SumsubKycModals'
 import { useCapabilities } from '@/hooks/useCapabilities'
 import { getKycModalVariant, getGateUserMessage, getGateReasonCode } from '@/utils/capability-gate'
@@ -321,7 +321,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
         // name and email are now collected by sumsub sdk — no need to save them beforehand
         if (bankClaimType === BankClaimType.ReceiverKycNeeded && !justCompletedKyc) {
             await sumsubFlow.handleInitiateKyc(
-                getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                getBankRegionIntent(selectedCountry),
                 undefined,
                 undefined,
                 selectedCountry?.id
@@ -617,7 +617,7 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                                     await sumsubFlow.handleSelfHealResubmit('BRIDGE')
                                 } else {
                                     await sumsubFlow.handleInitiateKyc(
-                                        getRegionIntent(selectedCountry?.region ?? 'rest-of-the-world'),
+                                        getBankRegionIntent(selectedCountry),
                                         undefined,
                                         gate.kind === 'needs-enrollment' || undefined,
                                         selectedCountry?.id

--- a/src/components/Claim/Link/views/BankFlowManager.view.tsx
+++ b/src/components/Claim/Link/views/BankFlowManager.view.tsx
@@ -525,8 +525,12 @@ export const BankFlowManager = (props: IClaimScreenProps) => {
                         setBankDetails(bankDetails)
                         // only the country list sets selectedCountry; a saved
                         // account skips it, so the unlock CTA below derived a
-                        // rest-of-world intent. The account is the destination.
-                        setSelectedCountry(getCountryFromAccount(account) ?? null)
+                        // rest-of-world intent. The account is the destination —
+                        // but an account with no resolvable country (empty
+                        // countryCode/countryName, a known prod state) must not
+                        // clobber a country the user already picked.
+                        const accountCountry = getCountryFromAccount(account)
+                        if (accountCountry) setSelectedCountry(accountCountry)
 
                         const isGuestFlow = bankClaimType === BankClaimType.GuestBankClaim
                         const userForOfframp = isGuestFlow

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- jest.mock factories stub component props with `any`; matches the sibling add-money-states.test.tsx style. */
 /**
  * BankFlowManager — saved-account claim path (TASK-22333).
  *
@@ -169,8 +168,11 @@ const clabeAccount = (details: Record<string, string>) => ({
     details,
 })
 
+// the view reads only claimLinkData / onCustom / setTransactionHash off IClaimScreenProps
+const props: any = { claimLinkData, onCustom: jest.fn(), setTransactionHash: jest.fn() }
+
 function renderView() {
-    return render(<BankFlowManager claimLinkData={claimLinkData} onCustom={jest.fn()} setTransactionHash={jest.fn()} />)
+    return render(<BankFlowManager {...props} />)
 }
 
 beforeEach(() => {

--- a/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
+++ b/src/components/Claim/Link/views/__tests__/BankFlowManager.savedAccount.test.tsx
@@ -1,0 +1,223 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- jest.mock factories stub component props with `any`; matches the sibling add-money-states.test.tsx style. */
+/**
+ * BankFlowManager — saved-account claim path (TASK-22333).
+ *
+ * Only the country list used to set `selectedCountry`; a saved account skipped
+ * it, so the unlock CTA derived a rest-of-world intent. The account is the
+ * destination: clicking it must set the country, and the unlock CTA must send
+ * the bank intent for it (Mexico → NA, not LATAM). An account whose country
+ * cannot be resolved (empty countryCode/countryName — a known prod state) must
+ * not clobber a country the user already picked.
+ */
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { BankFlowManager } from '../BankFlowManager.view'
+import { getCountryFromPath } from '@/utils/bridge.utils'
+
+// --- stateful ClaimBankFlow context: re-renders triggered by the component's
+// own useState calls read the latest values back
+const mockSetSelectedCountry = jest.fn()
+const ctx: Record<string, any> = {}
+function resetCtx(overrides: Record<string, any> = {}) {
+    Object.keys(ctx).forEach((k) => delete ctx[k])
+    Object.assign(ctx, {
+        flowStep: 'saved-accounts-list',
+        setFlowStep: jest.fn((step: string | null) => {
+            ctx.flowStep = step
+        }),
+        selectedCountry: null,
+        setSelectedCountry: mockSetSelectedCountry,
+        setClaimType: jest.fn(),
+        setBankDetails: jest.fn(),
+        justCompletedKyc: false,
+        setJustCompletedKyc: jest.fn(),
+        setShowVerificationModal: jest.fn(),
+        ...overrides,
+    })
+}
+jest.mock('@/context/ClaimBankFlowContext', () => ({
+    ClaimBankFlowStep: {
+        SavedAccountsList: 'saved-accounts-list',
+        BankDetailsForm: 'bank-details-form',
+        BankConfirmClaim: 'bank-confirm-claim',
+        BankCountryList: 'bank-country-list',
+    },
+    useClaimBankFlow: () => ctx,
+}))
+
+// --- the account under test is injected through the saved-accounts hook
+let mockSavedAccounts: any[] = []
+jest.mock('@/hooks/useSavedAccounts', () => ({ __esModule: true, default: () => mockSavedAccounts }))
+jest.mock('@/components/Common/SavedAccountsView', () => ({
+    __esModule: true,
+    default: (props: any) => (
+        <div data-testid="saved-accounts">
+            {props.savedAccounts.map((account: any) => (
+                <button
+                    key={account.id}
+                    data-testid={`account-${account.id}`}
+                    onClick={() => props.onAccountClick(account, '')}
+                >
+                    {account.id}
+                </button>
+            ))}
+        </div>
+    ),
+}))
+
+// --- KYC plumbing
+const mockHandleInitiateKyc = jest.fn()
+jest.mock('@/hooks/useMultiPhaseKycFlow', () => ({
+    useMultiPhaseKycFlow: () => ({
+        handleInitiateKyc: mockHandleInitiateKyc,
+        handleRestartIdentity: jest.fn(),
+        handleSelfHealResubmit: jest.fn(),
+        showWrapper: false,
+        isLoading: false,
+        error: null,
+    }),
+}))
+jest.mock('@/hooks/useCapabilities', () => ({
+    useCapabilities: () => ({ gateFor: () => ({ kind: 'needs-enrollment' }) }),
+}))
+jest.mock('@/utils/capability-gate', () => ({
+    getKycModalVariant: () => 'needs_kyc',
+    getGateUserMessage: () => undefined,
+    getGateReasonCode: () => undefined,
+}))
+jest.mock('@/hooks/useTosGuard', () => ({
+    useTosGuard: () => ({ guardWithTos: jest.fn(), showBridgeTos: false, hideTos: jest.fn() }),
+}))
+jest.mock('@/components/Kyc/InitiateKycModal', () => ({
+    InitiateKycModal: (props: any) =>
+        props.visible ? (
+            <button data-testid="kyc-verify-button" onClick={props.onVerify}>
+                Verify
+            </button>
+        ) : null,
+}))
+jest.mock('@/components/Kyc/SumsubKycModals', () => ({ SumsubKycModals: () => null }))
+jest.mock('@/components/Kyc/BridgeTosStep', () => ({ BridgeTosStep: () => null }))
+jest.mock('@/components/Claim/Link/views/Confirm.bank-claim.view', () => ({
+    ConfirmBankClaimView: (props: any) => (
+        <button data-testid="confirm-claim" onClick={props.onConfirm}>
+            Confirm
+        </button>
+    ),
+}))
+
+// --- everything else the view imports but this path never exercises
+jest.mock('@/hooks/useDetermineBankClaimType', () => ({
+    BankClaimType: {
+        GuestBankClaim: 'guest-bank-claim',
+        UserBankClaim: 'user-bank-claim',
+        ReceiverKycNeeded: 'receiver-kyc-needed',
+        GuestKycNeeded: 'guest-kyc-needed',
+    },
+    useDetermineBankClaimType: () => ({ claimType: 'user-bank-claim' }),
+}))
+jest.mock('@/context/authContext', () => ({
+    useAuth: () => ({ user: { user: { fullName: 'Ana Perez', email: 'ana@example.com' } }, fetchUser: jest.fn() }),
+}))
+jest.mock('@/context/loadingStates.context', () => {
+    const { createContext } = jest.requireActual('react')
+    return { loadingStateContext: createContext({ isLoading: false, setLoadingState: jest.fn() }) }
+})
+jest.mock('@/context/ModalsContext', () => ({ useModalsContext: () => ({ setIsSupportModalOpen: jest.fn() }) }))
+jest.mock('@/components/Claim/useClaimLink', () => ({ __esModule: true, default: () => ({ claimLink: jest.fn() }) }))
+jest.mock('@/hooks/useFriendlyError', () => ({ useFriendlyError: () => (e: unknown) => String(e) }))
+jest.mock('@/app/actions/external-accounts', () => ({ createBridgeExternalAccountForGuest: jest.fn() }))
+jest.mock('@/app/actions/offramp', () => ({
+    confirmOfframp: jest.fn(),
+    createOfframp: jest.fn(),
+    createOfframpForGuest: jest.fn(),
+}))
+jest.mock('@/app/actions/users', () => ({ addBankAccount: jest.fn(), getUserById: jest.fn() }))
+jest.mock('@/utils/general.utils', () => ({ formatTokenAmount: (n: number) => String(n) }))
+jest.mock('@/utils/bridge-accounts.utils', () => ({
+    getBridgeChainName: () => 'arbitrum',
+    getBridgeTokenName: () => 'usdc',
+}))
+jest.mock('@/utils/peanut-link.utils', () => ({ generateKeysFromString: jest.fn(), getParamsFromLink: jest.fn() }))
+jest.mock('@/utils/peanut-claim.utils', () => ({ getContractAddress: () => '0x0' }))
+jest.mock('@/utils/withdraw.utils', () => ({ getCountryCodeForWithdraw: (id: string) => id }))
+jest.mock('@/components/AddWithdraw/DynamicBankAccountForm', () => ({ DynamicBankAccountForm: () => null }))
+jest.mock('@/components/Common/CountryListRouter', () => ({ CountryListRouter: () => null }))
+jest.mock('@/components/Global/NavHeader', () => ({ __esModule: true, default: () => null }))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({ badgeCampaignForLegacyWire: () => undefined }))
+jest.mock('@/redux/hooks', () => ({ useAppDispatch: () => jest.fn() }))
+jest.mock('@/redux/slices/bank-form-slice', () => ({ bankFormActions: {} }))
+jest.mock('@/services/sendLinks', () => ({ sendLinksApi: {} }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
+jest.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }))
+jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+const claimLinkData: any = {
+    sender: { userId: 'sender-1' },
+    senderAddress: '0xsender',
+    amount: 1000000n,
+    tokenDecimals: 6,
+    tokenSymbol: 'USDC',
+    chainId: '42161',
+    contractVersion: 'v4.3',
+}
+const clabeAccount = (details: Record<string, string>) => ({
+    id: 'acc-mx',
+    type: 'clabe',
+    identifier: '002010077777777771',
+    bridgeAccountId: 'bridge-acc-1',
+    details,
+})
+
+function renderView() {
+    return render(<BankFlowManager claimLinkData={claimLinkData} onCustom={jest.fn()} setTransactionHash={jest.fn()} />)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    resetCtx()
+})
+
+test('clicking a saved Mexico CLABE account sets selectedCountry to Mexico', async () => {
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).toHaveBeenCalledWith(expect.objectContaining({ id: 'MX', region: 'latam' }))
+})
+
+test('a saved account with no resolvable country does not clobber the country already picked', async () => {
+    resetCtx({ selectedCountry: getCountryFromPath('germany') })
+    mockSavedAccounts = [clabeAccount({ countryCode: '', countryName: '', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+
+    expect(mockSetSelectedCountry).not.toHaveBeenCalled()
+})
+
+test('unlock CTA after a saved Mexico account sends the NA intent, not LATAM', async () => {
+    // the real context would now hold Mexico (previous test); mirror that here
+    resetCtx({ selectedCountry: getCountryFromPath('mexico') })
+    mockSavedAccounts = [clabeAccount({ countryCode: 'MEX', countryName: 'mexico', accountOwnerName: 'Ana Perez' })]
+    renderView()
+
+    // saved account → confirm step (localBankDetails set) → confirm → gate is
+    // needs-enrollment → KYC modal → verify
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('account-acc-mx'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('confirm-claim'))
+    })
+    await act(async () => {
+        fireEvent.click(screen.getByTestId('kyc-verify-button'))
+    })
+
+    expect(mockHandleInitiateKyc.mock.calls[0].slice(0, 3)).toEqual(['NA', undefined, true])
+})

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -15,6 +15,7 @@ import underMaintenanceConfig from '@/config/underMaintenance.config'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
 import StoreBadges from '@/components/Migration/StoreBadges'
+import { Button } from '@/components/0_Bruddle/Button'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
 import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
@@ -28,6 +29,9 @@ import type { LandingContentHrefs } from './landingContentHrefs'
 // SSR stays on so crawlers still see the tweets; only the client bundle moves
 // off the critical path.
 const TweetCarousel = dynamic(() => import('@/components/LandingPage/TweetCarousel'))
+
+// desktop-only, opened on demand — keep the QR modal off the landing critical path
+const ScanToDownloadModal = dynamic(() => import('@/components/Migration/ScanToDownloadModal'))
 
 type LandingPageClientProps = {
     heroConfig: {
@@ -79,10 +83,12 @@ export function LandingPageClient({
     const doorFoldOn = !underMaintenanceConfig.disableLandingCardFold
 
     // pwa-sunset hero CTAs are device-based: phones get one "Download now"
-    // with their store's mark deep-linking to it; desktop drops the primary
-    // and shows the equal store-button pair instead (customCta below).
+    // with their store's mark deep-linking to it; desktop gets "Download now"
+    // opening the scan-to-download QR modal (the rule every other desktop
+    // download surface follows) plus the store-link pair (customCta below).
     // the permanent flag-off CTA change goes through the content system
     // post-cutover (TASK-20600).
+    const [qrModalOpen, setQrModalOpen] = useState(false)
     const primaryCta = useMemo((): CTAButton | undefined => {
         if (!migrationOn) return heroConfig.primaryCta
         if (isDesktop) return undefined
@@ -280,10 +286,18 @@ export function LandingPageClient({
                 locale={locale}
                 customCta={
                     migrationOn && isDesktop ? (
-                        <div className="flex flex-col items-center">
+                        <div className="flex flex-col items-center gap-4">
+                            <Button
+                                shadowSize="4"
+                                icon="qr-code"
+                                className="bg-white px-7 py-3 text-base font-extrabold hover:bg-white/90 md:px-9 md:py-8 md:text-xl"
+                                onClick={() => setQrModalOpen(true)}
+                            >
+                                {tMigration('downloadNow')}
+                            </Button>
                             <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
                             {heroConfig.primaryCta.subtext && (
-                                <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">
+                                <span className="block text-center text-sm italic text-n-1 md:text-base">
                                     {heroConfig.primaryCta.subtext}
                                 </span>
                             )}
@@ -291,6 +305,13 @@ export function LandingPageClient({
                     ) : undefined
                 }
             />
+            {qrModalOpen && (
+                <ScanToDownloadModal
+                    visible
+                    onClose={() => setQrModalOpen(false)}
+                    surface={MIGRATION_SURFACES.LANDING_HERO}
+                />
+            )}
             <Marquee {...marqueeProps} />
             {doorFoldOn && (
                 <>

--- a/src/components/LandingPage/LandingPageClient.tsx
+++ b/src/components/LandingPage/LandingPageClient.tsx
@@ -14,7 +14,6 @@ import { StickyMobileCTA } from '@/components/LandingPage/StickyMobileCTA'
 import underMaintenanceConfig from '@/config/underMaintenance.config'
 import type { LandingStrings } from './landingStrings'
 import type { Locale } from '@/i18n/types'
-import StoreBadges from '@/components/Migration/StoreBadges'
 import { Button } from '@/components/0_Bruddle/Button'
 import { type CTAButton } from '@/components/LandingPage/landing.types'
 import { MIGRATION_SURFACES } from '@/constants/migration.consts'
@@ -83,9 +82,9 @@ export function LandingPageClient({
     const doorFoldOn = !underMaintenanceConfig.disableLandingCardFold
 
     // pwa-sunset hero CTAs are device-based: phones get one "Download now"
-    // with their store's mark deep-linking to it; desktop gets "Download now"
-    // opening the scan-to-download QR modal (the rule every other desktop
-    // download surface follows) plus the store-link pair (customCta below).
+    // with their store's mark deep-linking to it; desktop gets one "Download
+    // now" opening the scan-to-download QR modal (the rule every other desktop
+    // download surface follows) — the store pair lives inside the modal.
     // the permanent flag-off CTA change goes through the content system
     // post-cutover (TASK-20600).
     const [qrModalOpen, setQrModalOpen] = useState(false)
@@ -286,7 +285,7 @@ export function LandingPageClient({
                 locale={locale}
                 customCta={
                     migrationOn && isDesktop ? (
-                        <div className="flex flex-col items-center gap-4">
+                        <div className="flex flex-col items-center">
                             <Button
                                 shadowSize="4"
                                 icon="qr-code"
@@ -295,9 +294,8 @@ export function LandingPageClient({
                             >
                                 {tMigration('downloadNow')}
                             </Button>
-                            <StoreBadges surface={MIGRATION_SURFACES.LANDING_HERO} appearance="hero" />
                             {heroConfig.primaryCta.subtext && (
-                                <span className="block text-center text-sm italic text-n-1 md:text-base">
+                                <span className="mt-2 block text-center text-sm italic text-n-1 md:text-base">
                                     {heroConfig.primaryCta.subtext}
                                 </span>
                             )}

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -26,9 +26,9 @@ export const MIGRATION_URGENCY_THRESHOLD_DAYS = 14
 export const NOTIF_PROMPT_SNOOZE_DAYS = 14
 
 // store review deep links ("Love it" on the review prompt). the ios
-// write-review action needs the real numeric app id — placeholder until launch.
+// write-review action needs the real numeric app id.
 export const REVIEW_URL = {
-    ios: 'https://apps.apple.com/app/peanut?action=write-review',
+    ios: 'https://apps.apple.com/us/app/id6786373552?action=write-review',
     android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
 } as const
 
@@ -40,10 +40,9 @@ export const KEEP_WEB_COOKIE = 'keep-web'
 export const KEEP_WEB_TOKEN = 'walnut-still-cracks'
 export const KEEP_WEB_COOKIE_DAYS = 90
 
-// placeholder store URLs — real App Store numeric id + Play listing must be
-// confirmed before flag-on (also needed for the review deep link).
+// real store listings (App Store Connect app 6786373552, Play me.peanut.wallet)
 export const STORE_URL = {
-    ios: 'https://apps.apple.com/app/peanut',
+    ios: 'https://apps.apple.com/us/app/id6786373552',
     android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
 } as const
 

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -1,4 +1,9 @@
-import { getRegionIntent, pendingBankRailRegionPaths, providerForRegionIntent } from '../regions.utils'
+import {
+    getBankRegionIntent,
+    getRegionIntent,
+    pendingBankRailRegionPaths,
+    providerForRegionIntent,
+} from '../regions.utils'
 import { type RailCapability } from '@/types/capabilities'
 
 describe('getRegionIntent', () => {
@@ -18,6 +23,23 @@ describe('getRegionIntent', () => {
 // Mirrors the BE registry (crossRegionProvider in peanut-api-ts
 // src/kyc/level-registry.ts) — if these expectations change, the BE
 // registry changed and both sides must move together.
+describe('getBankRegionIntent', () => {
+    // Mexico is a `latam` picker region but deposits/withdraws over Bridge SPEI —
+    // LATAM + MX hits the Manteca path, which rejects MX (TASK-22333)
+    it('routes Mexico bank flows as NA (Bridge), not LATAM', () => {
+        expect(getBankRegionIntent({ id: 'MX', region: 'latam' })).toBe('NA')
+    })
+
+    it('falls back to the region intent for every other country', () => {
+        expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
+        expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
+        expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')
+        expect(getBankRegionIntent({ id: 'XX' })).toBe('ROW')
+        expect(getBankRegionIntent(undefined)).toBe('ROW')
+    })
+})
+
 describe('providerForRegionIntent', () => {
     it('maps Bridge intents (EU / NA + legacy STANDARD) to bridge', () => {
         expect(providerForRegionIntent('EU')).toBe('bridge')

--- a/src/utils/__tests__/regions.utils.test.ts
+++ b/src/utils/__tests__/regions.utils.test.ts
@@ -32,6 +32,9 @@ describe('getBankRegionIntent', () => {
 
     it('falls back to the region intent for every other country', () => {
         expect(getBankRegionIntent({ id: 'AR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'BR', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'CO', region: 'latam' })).toBe('LATAM')
+        expect(getBankRegionIntent({ id: 'GB', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'US', region: 'north-america' })).toBe('NA')
         expect(getBankRegionIntent({ id: 'DE', region: 'europe' })).toBe('EU')
         expect(getBankRegionIntent({ id: 'NG', region: 'rest-of-the-world' })).toBe('ROW')

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -114,13 +114,16 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
 
 /**
  * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
- * Mexico is `region: 'latam'` for the region picker, but its bank rail (SPEI)
- * is a Bridge rail. Sending LATAM + MX asks the Manteca path for a country it
- * does not serve; the BE rejects it and the UI collapsed that into "contact
- * support" (TASK-22333). Route it as NA (Bridge), like the US.
+ * A `latam` picker country whose bank rail is Bridge (today: Mexico / SPEI)
+ * must unlock as NA (Bridge), like the US. Sending LATAM + MX asks the Manteca
+ * path for a country it does not serve; the BE rejects it and the UI collapsed
+ * that into "contact support" (TASK-22333). Every other country keeps the
+ * picker-region intent.
  */
 export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
-    country?.id === 'MX' ? 'NA' : getRegionIntent(country?.region ?? 'rest-of-the-world')
+    country?.region === 'latam' && isBridgeSupportedCountry(country.id)
+        ? 'NA'
+        : getRegionIntent(country?.region ?? 'rest-of-the-world')
 
 /**
  * Which provider serves a region intent — an exact FE mirror of the BE registry

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -2,7 +2,7 @@ import { EUROPE_GLOBE_ICON, LATAM_GLOBE_ICON, NORTH_AMERICA_GLOBE_ICON, REST_OF_
 import { getFlagUrl } from '@/constants/countryCurrencyMapping'
 import { type KYCRegionIntent } from '@/app/actions/types/sumsub.types'
 import { type RailCapability } from '@/types/capabilities'
-import { BRIDGE_ALPHA3_TO_ALPHA2 } from '@/components/AddMoney/consts'
+import { BRIDGE_ALPHA3_TO_ALPHA2, type CountryData } from '@/components/AddMoney/consts'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import type { StaticImageData } from 'next/image'
 
@@ -111,6 +111,16 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
             return 'ROW'
     }
 }
+
+/**
+ * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
+ * Mexico is `region: 'latam'` for the region picker, but its bank rail (SPEI)
+ * is a Bridge rail. Sending LATAM + MX asks the Manteca path for a country it
+ * does not serve; the BE rejects it and the UI collapsed that into "contact
+ * support" (TASK-22333). Route it as NA (Bridge), like the US.
+ */
+export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
+    country?.id === 'MX' ? 'NA' : getRegionIntent(country?.region ?? 'rest-of-the-world')
 
 /**
  * Which provider serves a region intent — an exact FE mirror of the BE registry

--- a/src/utils/regions.utils.ts
+++ b/src/utils/regions.utils.ts
@@ -113,19 +113,6 @@ export const getRegionIntent = (regionPath: string): KYCRegionIntent => {
 }
 
 /**
- * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
- * A `latam` picker country whose bank rail is Bridge (today: Mexico / SPEI)
- * must unlock as NA (Bridge), like the US. Sending LATAM + MX asks the Manteca
- * path for a country it does not serve; the BE rejects it and the UI collapsed
- * that into "contact support" (TASK-22333). Every other country keeps the
- * picker-region intent.
- */
-export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
-    country?.region === 'latam' && isBridgeSupportedCountry(country.id)
-        ? 'NA'
-        : getRegionIntent(country?.region ?? 'rest-of-the-world')
-
-/**
  * Which provider serves a region intent — an exact FE mirror of the BE registry
  * (`crossRegionProvider` in peanut-api-ts `src/kyc/level-registry.ts`). Used for
  * DISPLAY only (which provider rail backs a clicked region); the BE stays the
@@ -226,6 +213,18 @@ const RAIL_COUNTRY_TO_REGION_PATH: Record<string, string> = {
     BR: 'latam',
     CO: 'latam',
 }
+
+/**
+ * Region intent for a BANK flow (Bridge bank deposit / withdraw, bank claim).
+ * The picker region is not the rail jurisdiction: Mexico is `region: 'latam'`
+ * for the picker, but its bank rail (SPEI) is Bridge, and the jurisdiction
+ * table above says `north-america`. Sending LATAM + MX asked the Manteca path
+ * for a country it does not serve; the BE rejects it and the UI collapsed that
+ * into "contact support" (TASK-22333). Countries with no rail entry keep the
+ * picker region.
+ */
+export const getBankRegionIntent = (country: Pick<CountryData, 'id' | 'region'> | null | undefined): KYCRegionIntent =>
+    getRegionIntent(RAIL_COUNTRY_TO_REGION_PATH[country?.id ?? ''] ?? country?.region ?? 'rest-of-the-world')
 
 /**
  * Region picker paths with a mid-flight bank rail (`pending` = BE provisioning,


### PR DESCRIPTION
## Summary

Back in Send → Send to friend → Exchange or wallet (or bank) trapped users in a loop. The send-origin back handlers in `withdraw/page.tsx` pushed `/send` on top of the retained `/withdraw?method=…` history entry. Send's safe-back then popped straight back into the withdraw step, and `?method=crypto` re-selected crypto — Back never reached Home. One production reporter with a deterministic video; the monitor sweep confirmed the trace.

Fix: use the shared `useSafeBack('/send', { replace: true })` in both send-origin back handlers (crypto amount step, bank method-selection step). With in-app history it pops the withdraw entry off the stack; on a cold deep link it replaces to `/send` instead of minting an entry that Send's own safe-back would walk back into. Same pattern SendRouter already uses for its link/contacts subviews. `?method=…` stays on the URL — `useSendFlowOrigin` needs the marker to survive every hop.

## Task

[TASK-22424 — Fix Back navigation loop in Send to friend wallet flow](https://app.notion.com/p/3d583811757981999640edfb2abd3518) (P2, PRODUCTION). [TASK-22420](https://app.notion.com/p/Stop-Back-navigation-from-looping-between-Send-and-crypto-withdrawal-amount-3d583811757981fa86e8c7e326fbf71e) is the monitor's card for the same defect — close as duplicate when this merges.

## Risks / breaking changes

- FE only, no cross-repo impact. Blast radius is the two send-origin back handlers; non-send withdraw back paths are untouched.
- Base is `main` (production bug) — creates main→dev back-merge debt.

## QA

- 5 regression tests fail on the old code and pass on the fix (in-app pop + cold-deep-link replace, for both crypto and bank paths).
- Full local gate green: prettier, typecheck, all 347 jest suites (4270 tests), production build.
- Manual path to verify: Home → Send → Send to friend → Exchange or wallet → Amount → Back → Send → Back → Home. Also cold-load `/withdraw?method=crypto` → Back → Send → Back → Home.

Screenshots: N/A (no visible change — screens render the same; only where Back lands changes).

## Design notes / accepted trade-offs

- Send and withdraw step state stays out of the URL and off nuqs (both files parse query params by hand, against the repo's URL-as-state rule). Pre-existing, out of this PR's blast radius — noted as a follow-up refactor opportunity, not done here.
