### PR TITLE
fix: Back navigation loop in Send to friend wallet flow (TASK-22424)

### DIFF
--- a/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/__tests__/withdraw-states.test.tsx
@@ -18,6 +18,7 @@ import { parseUnits } from 'viem'
 // next/navigation
 const mockRouterPush = jest.fn()
 const mockRouterBack = jest.fn()
+const mockRouterReplace = jest.fn()
 const mockSearchParams = new Map<string, string>()
 
 jest.mock('next/navigation', () => ({
@@ -27,7 +28,7 @@ jest.mock('next/navigation', () => ({
     useRouter: () => ({
         push: mockRouterPush,
         back: mockRouterBack,
-        replace: jest.fn(),
+        replace: mockRouterReplace,
         prefetch: jest.fn(),
     }),
     usePathname: () => '/withdraw',
@@ -233,6 +234,7 @@ jest.mock('@/components/AddWithdraw/AddWithdrawRouterView', () => ({
 
 // ---------- import component under test AFTER all mocks ----------
 import WithdrawPage from '../page'
+import { __testing as safeBackTesting } from '@/hooks/useSafeBack'
 
 // ---------- helpers ----------
 
@@ -294,6 +296,7 @@ function applyDefaults() {
 beforeEach(() => {
     jest.clearAllMocks()
     mockSearchParams.clear()
+    safeBackTesting.reset()
     applyDefaults()
     // clearAllMocks() resets call history but not implementations, so restore
     // the default country resolution here — tests that override it (GROUP 6)
@@ -348,14 +351,28 @@ describe('GROUP 1: Method Selection', () => {
         renderWithdraw({ method: 'bank', returnTo: '/profile/exchange-rate' })
 
         fireEvent.click(screen.getByTestId('router-view-back'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 
-    test('Back from bank send method selection navigates to /send', () => {
+    // Regression: this branch used to router.push('/send') over the retained
+    // /withdraw?method=bank entry, so send's safe-back popped right back into
+    // the withdraw step — Back looped instead of unwinding (TASK-22424).
+    test('Back from bank send method selection pops in-app history, not push', () => {
+        window.history.pushState({}, '', '/withdraw?method=bank')
         renderWithdraw({ method: 'bank' })
 
         fireEvent.click(screen.getByTestId('router-view-back'))
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    test('Back from bank send method selection replaces to /send on a cold deep link', () => {
+        renderWithdraw({ method: 'bank' })
+
+        fireEvent.click(screen.getByTestId('router-view-back'))
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 })
 
@@ -654,13 +671,29 @@ describe('GROUP 4: Limits Validation', () => {
 // GROUP 5: Navigation
 // ============================================================
 describe('GROUP 5: Navigation', () => {
-    test('Back from crypto send navigates to /send', () => {
+    // Regression: this handler used to router.push('/send') over the retained
+    // /withdraw?method=crypto entry, so send's safe-back popped right back into
+    // the amount step and ?method=crypto re-selected crypto — Back looped
+    // between Send and the amount screen forever (TASK-22424).
+    test('Back from crypto send pops in-app history, not push', () => {
+        mockWithdrawFlow.selectedMethod = { type: 'crypto' }
+        window.history.pushState({}, '', '/withdraw?method=crypto')
+        renderWithdraw({ method: 'crypto' })
+
+        fireEvent.click(screen.getByTestId('nav-back'))
+        expect(mockSetSelectedMethod).toHaveBeenCalledWith(null)
+        expect(mockRouterBack).toHaveBeenCalledTimes(1)
+        expect(mockRouterPush).not.toHaveBeenCalled()
+    })
+
+    test('Back from crypto send replaces to /send on a cold deep link', () => {
         mockWithdrawFlow.selectedMethod = { type: 'crypto' }
         renderWithdraw({ method: 'crypto' })
 
         fireEvent.click(screen.getByTestId('nav-back'))
         expect(mockSetSelectedMethod).toHaveBeenCalledWith(null)
-        expect(mockRouterPush).toHaveBeenCalledWith('/send')
+        expect(mockRouterReplace).toHaveBeenCalledWith('/send')
+        expect(mockRouterPush).not.toHaveBeenCalled()
     })
 
     test('Back from a selected bank country returns to the country list', () => {

--- a/src/app/(mobile-ui)/withdraw/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/page.tsx
@@ -13,6 +13,7 @@ import { tokenSelectorContext } from '@/context/tokenSelector.context'
 import { getCountryFromAccount, getCountryFromPath, getMinimumAmount } from '@/utils/bridge.utils'
 import useGetExchangeRate from '@/hooks/useGetExchangeRate'
 import { useSendFlowOrigin } from '@/hooks/useSendFlowOrigin'
+import { useSafeBack } from '@/hooks/useSafeBack'
 import { AccountType } from '@/interfaces/interfaces'
 import { useRouter, useSearchParams } from 'next/navigation'
 import React, { useCallback, useContext, useEffect, useMemo, useState, useRef } from 'react'
@@ -52,6 +53,11 @@ export default function WithdrawPage() {
     // check if coming from send flow based on method query param
     const methodParam = searchParams.get('method')
     const { isFromSendFlow, isCryptoFromSend, isBankFromSend } = useSendFlowOrigin()
+
+    // back(), not push: pushing /send over /withdraw?method=… left the withdraw
+    // URL in history, and send's safe-back popped right back into it (Back loop).
+    // A cold deep link has no history to pop, so the fallback replaces instead.
+    const goBackToSend = useSafeBack('/send', { replace: true })
 
     // native app passes country as query param instead of path segment
     const countryFromQuery = searchParams.get('country')
@@ -434,7 +440,7 @@ export default function WithdrawPage() {
                         // if crypto from send, go back to send page
                         if (isCryptoFromSend) {
                             setSelectedMethod(null)
-                            router.push('/send')
+                            goBackToSend()
                         } else {
                             if (selectedMethod?.type === 'bridge' && !selectedBankAccount) {
                                 setShowAllWithdrawMethods(true)
@@ -516,7 +522,7 @@ export default function WithdrawPage() {
                 onBackClick={() => {
                     // if bank from send flow, go back to send page
                     if (isBankFromSend) {
-                        router.push('/send')
+                        goBackToSend()
                         return
                     }
                     // an explicit origin (e.g. the exchange-rate widget's "Try it!" CTA)


### PR DESCRIPTION
## Summary

Back in Send → Send to friend → Exchange or wallet (or bank) trapped users in a loop. The send-origin back handlers in `withdraw/page.tsx` pushed `/send` on top of the retained `/withdraw?method=…` history entry. Send's safe-back then popped straight back into the withdraw step, and `?method=crypto` re-selected crypto — Back never reached Home. One production reporter with a deterministic video; the monitor sweep confirmed the trace.

Fix: use the shared `useSafeBack('/send', { replace: true })` in both send-origin back handlers (crypto amount step, bank method-selection step). With in-app history it pops the withdraw entry off the stack; on a cold deep link it replaces to `/send` instead of minting an entry that Send's own safe-back would walk back into. Same pattern SendRouter already uses for its link/contacts subviews. `?method=…` stays on the URL — `useSendFlowOrigin` needs the marker to survive every hop.

## Task

[TASK-22424 — Fix Back navigation loop in Send to friend wallet flow](https://app.notion.com/p/3d583811757981999640edfb2abd3518) (P2, PRODUCTION). [TASK-22420](https://app.notion.com/p/Stop-Back-navigation-from-looping-between-Send-and-crypto-withdrawal-amount-3d583811757981fa86e8c7e326fbf71e) is the monitor's card for the same defect — close as duplicate when this merges.

## Risks / breaking changes

- FE only, no cross-repo impact. Blast radius is the two send-origin back handlers; non-send withdraw back paths are untouched.
- Supersedes #3057 (same fix, was based on `main`; repointed to `dev` and closed because the branch history carried 13 main-only commits).

## QA

- 5 regression tests fail on the old code and pass on the fix (in-app pop + cold-deep-link replace, for both crypto and bank paths).
- Full local gate green: prettier, typecheck, all 347 jest suites (4270 tests), production build.
- Manual path to verify: Home → Send → Send to friend → Exchange or wallet → Amount → Back → Send → Back → Home. Also cold-load `/withdraw?method=crypto` → Back → Send → Back → Home.

Screenshots: N/A (no visible change — screens render the same; only where Back lands changes).

## Design notes / accepted trade-offs

- Send and withdraw step state stays out of the URL and off nuqs (both files parse query params by hand, against the repo's URL-as-state rule). Pre-existing, out of this PR's blast radius — noted as a follow-up refactor opportunity, not done here.
