### PR TITLE
ci: register App Staging OTA on main

### DIFF
--- a/.github/workflows/staging-ota.yml
+++ b/.github/workflows/staging-ota.yml
@@ -1,0 +1,158 @@
+name: App Staging OTA
+
+# Manual staging publication for beta testers. This is deliberately separate from
+# App Release OTA: the dispatcher defaults to the `dev` source ref, uses the staging
+# version band, and never writes a production bundle or release tag. Keep this file
+# on the repository default branch too: GitHub only registers workflow_dispatch for
+# workflow files present there.
+
+on:
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: 'Source ref to publish (staging must come from dev)'
+                required: true
+                default: 'dev'
+                type: string
+
+permissions:
+    contents: read
+
+concurrency:
+    group: staging-ota
+    cancel-in-progress: false
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Guard staging ref
+              env:
+                  SOURCE_REF: ${{ inputs.ref || 'dev' }}
+              run: |
+                  if [ "$SOURCE_REF" != "dev" ]; then
+                      echo "::error::staging OTAs are published from dev, not $SOURCE_REF" >&2
+                      exit 1
+                  fi
+                  echo "Publishing staging OTA from $SOURCE_REF"
+
+            - uses: actions/checkout@v7
+              with:
+                  submodules: true
+                  token: ${{ secrets.SUBMODULE_TOKEN }}
+                  fetch-depth: 0
+                  ref: ${{ inputs.ref || 'dev' }}
+
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '22'
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Resolve staging bundle version
+              id: version
+              run: |
+                  VERSION="$(node scripts/release-version.mjs staging)"
+                  echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "Staging bundle version $VERSION"
+
+            # NEXT_PUBLIC_* values are baked into the static export at build time.
+            # rpId MUST be peanut.me (passkeys + assetlinks/AASA). CAPACITOR_BUILD /
+            # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
+            # Delimiter is quoted: a secret holding $ or a backtick must land in the
+            # file verbatim, not be expanded — or executed — by the shell.
+            - name: Bake staging NEXT_PUBLIC_* into the static export
+              run: |
+                  cat > .env.production.local <<'EOF'
+                  NEXT_PUBLIC_BASE_URL=https://peanut.me
+                  NEXT_PUBLIC_PEANUT_API_URL=${{ vars.NEXT_PUBLIC_PEANUT_API_URL }}
+                  NEXT_PUBLIC_NATIVE_RP_ID=peanut.me
+                  NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_BUNDLER_URL }}
+                  NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_PAYMASTER_URL }}
+                  NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_ZERO_DEV_PASSKEY_PROJECT_ID }}
+                  NEXT_PUBLIC_ZERO_DEV_RECOVERY_BUNDLER_URL=${{ secrets.NEXT_PUBLIC_ZERO_DEV_RECOVERY_BUNDLER_URL }}
+                  NEXT_PUBLIC_JUSTANAME_ENS_DOMAIN=peanut.me
+                  NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+                  NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+                  NEXT_PUBLIC_POSTHOG_HOST=${{ vars.NEXT_PUBLIC_POSTHOG_HOST }}
+                  NEXT_PUBLIC_GA_KEY=${{ vars.NEXT_PUBLIC_GA_KEY }}
+                  NEXT_PUBLIC_ONESIGNAL_APP_ID=${{ secrets.NEXT_PUBLIC_ONESIGNAL_APP_ID }}
+                  NEXT_PUBLIC_SAFARI_WEB_ID=${{ vars.NEXT_PUBLIC_SAFARI_WEB_ID }}
+                  NEXT_PUBLIC_ONESIGNAL_WEBHOOK=${{ vars.NEXT_PUBLIC_ONESIGNAL_WEBHOOK }}
+                  EOF
+
+            - name: Build native static export
+              run: node scripts/native-build.js
+
+            - name: Verify build output
+              run: |
+                  test -d out && test -f out/index.html || (echo "ERROR: out/ directory missing or incomplete" && exit 1)
+                  echo "Bundle ready. File count: $(find out -type f | wc -l)"
+
+            # Staging still needs the same native floor and surface guard as
+            # production: beta testers must not receive JS that their shell cannot run.
+            - name: Resolve native floor
+              id: native_floor
+              run: |
+                  FLOOR="$(node scripts/release-version.mjs native-floor)"
+                  echo "name=$FLOOR" >> "$GITHUB_OUTPUT"
+                  echo "Bundle requires native $FLOOR or newer"
+
+            - name: Check the native surface still matches that binary
+              env:
+                  FLOOR: ${{ steps.native_floor.outputs.name }}
+              run: |
+                  if ! git rev-parse -q --verify "refs/tags/v$FLOOR" >/dev/null; then
+                      echo "::error::no v$FLOOR tag in this checkout — cannot prove the bundle fits the binary it targets" >&2
+                      exit 1
+                  fi
+                  node scripts/check-native-capabilities.mjs "v$FLOOR"
+                  node scripts/check-native-ota-surface.mjs "v$FLOOR" --platform android
+
+            - name: Upload bundle to Capgo staging
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
+                  CHANNEL: staging
+                  VERSION: ${{ steps.version.outputs.name }}
+                  NATIVE_FLOOR: ${{ steps.native_floor.outputs.name }}
+              run: |
+                  echo "Uploading bundle $VERSION to channel $CHANNEL"
+                  BUILD_SHA="$(git rev-parse --short=7 HEAD)"
+                  npx @capgo/cli@8.42.4 bundle upload \
+                    --channel "$CHANNEL" \
+                    --apikey "$CAPGO_API_KEY" \
+                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
+                    --path ./out \
+                    --bundle "$VERSION" \
+                    --min-update-version "$NATIVE_FLOOR" \
+                    --version-exists-ok \
+                    --comment "$BUILD_SHA — manual staging deploy"
+
+            - name: Verify staging channel serves the new bundle
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  CHANNEL: staging
+                  EXPECTED: ${{ steps.version.outputs.name }}
+              run: |
+                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle "$CHANNEL" \
+                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
+                  if [ "$CURRENT" != "$EXPECTED" ]; then
+                    echo "ERROR: channel $CHANNEL serves '${CURRENT:-<none>}', expected $EXPECTED — nothing shipped" >&2
+                    exit 1
+                  fi
+                  echo "Channel $CHANNEL now serves $EXPECTED"
+
+            - name: Deployment summary
+              run: |
+                  {
+                    echo "## Staging OTA"
+                    echo "- **Channel:** staging"
+                    echo "- **Bundle version:** ${{ steps.version.outputs.name }}"
+                    echo "- **Commit:** $(git rev-parse HEAD)"
+                    echo "- **Branch:** ${{ inputs.ref || 'dev' }}"
+                  } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- register the manual App Staging OTA workflow on the repository default branch
- default the selected source ref to `dev` and reject any other ref
- publish only to Capgo `staging` with native compatibility checks

This PR must land before PR #3058 removes the registered `capgo-deploy.yml` path from `dev`. The staging source remains `dev`; `main` is only the workflow registration branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for publishing staging over-the-air updates.
  * Added validation checks for the source branch, build output, version, and native compatibility.
  * Added post-deployment verification to confirm the staging channel serves the new bundle.
  * Added a deployment summary with build and release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->