### PR TITLE
fix: align navigation controls and wrap titles

### DIFF
--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -59,6 +59,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     const isHome = pathName === '/home' || pathName === '/home/'
     const isHistory = pathName === '/history'
     const isSupport = pathName === '/support'
+    const isReceipt = pathName === '/receipt' || pathName === '/receipt/'
     // The profile menu IS the full-screen menu: the bottom nav and its QR
     // button used to float over its own list of destinations. Exact match —
     // /profile/* sub-pages keep the nav.
@@ -192,6 +193,9 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
                     'pb-[calc(6rem_+_var(--safe-bottom))]',
                     isSupport && 'p-0 pb-[calc(5rem_+_var(--safe-bottom))]',
                     isHome && 'p-0',
+                    // Receipt owns its 16px page inset so the same shell also
+                    // renders correctly on the public web receipt route.
+                    isReceipt && 'p-0',
                     // the 6rem reservation exists to clear the bottom nav, so a
                     // screen without one takes the same inset as a logged-out one
                     isUserLoggedIn && !isProfileMenu

--- a/src/app/(mobile-ui)/receipt/page.tsx
+++ b/src/app/(mobile-ui)/receipt/page.tsx
@@ -47,7 +47,7 @@ export default function NativeReceiptPage() {
     const unavailable = !entryId || !kind ? 'gone' : isError && !entry ? 'loadFailed' : undefined
 
     return (
-        <PageContainer className="receipt-page flex min-h-dvh flex-col items-center justify-center p-6">
+        <PageContainer className="receipt-page flex min-h-dvh flex-col items-center justify-center p-4">
             {/* app chrome: mobile only, and never on the printed/PDF receipt */}
             <div className="md:hidden print:hidden">
                 <NavHeader titleKey="receipt" />

--- a/src/app/receipt/[entryId]/page.tsx
+++ b/src/app/receipt/[entryId]/page.tsx
@@ -155,7 +155,7 @@ export default async function ReceiptPage({
 
 function ReceiptShell({ state, children }: { state?: 'gone' | 'loadFailed'; children?: React.ReactNode }) {
     return (
-        <PageContainer className="receipt-page flex min-h-dvh flex-col items-center justify-center p-6">
+        <PageContainer className="receipt-page flex min-h-dvh flex-col items-center justify-center p-4">
             <div className="md:hidden print:hidden">
                 <NavHeader titleKey="receipt" />
             </div>

--- a/src/components/Global/AppShell/__tests__/AppShell.test.tsx
+++ b/src/components/Global/AppShell/__tests__/AppShell.test.tsx
@@ -47,4 +47,16 @@ describe('AppShell bottom nav slot', () => {
         )
         expect(screen.queryByTestId('app-shell-nav')).not.toBeInTheDocument()
     })
+
+    it('starts app content 16px below the safe-area boundary', () => {
+        const { container } = render(
+            <AppShell variant="app">
+                <div>content</div>
+            </AppShell>
+        )
+
+        const content = container.querySelector('#scrollable-content')
+        expect(content).toHaveClass('px-4', 'pt-4', 'pb-6')
+        expect(content).not.toHaveClass('py-6')
+    })
 })

--- a/src/components/Global/AppShell/index.tsx
+++ b/src/components/Global/AppShell/index.tsx
@@ -83,9 +83,11 @@ export const AppShell = ({
             {/* Scrollable content — one centered mobile column on every viewport */}
             <div
                 id="scrollable-content"
-                // spacing board 17291:2772: screen edge inset is L/16 (px-4); vertical keeps the XL/24 section rhythm
+                // Top navigation controls share the home screen's L/16 origin:
+                // the shell already starts below --safe-top, so pt-4 means 16px
+                // below the safe-area boundary. Keep the XL/24 bottom rhythm.
                 className={twMerge(
-                    'relative w-full flex-1 overflow-y-auto bg-background-page px-4 py-6',
+                    'relative w-full flex-1 overflow-y-auto bg-background-page px-4 pt-4 pb-6',
                     contentClassName
                 )}
             >

--- a/src/components/Global/NavHeader/__tests__/NavHeaderMaintenanceBanner.test.tsx
+++ b/src/components/Global/NavHeader/__tests__/NavHeaderMaintenanceBanner.test.tsx
@@ -24,10 +24,10 @@ jest.mock('@/config/underMaintenance.config', () => ({
     },
 }))
 
-const renderNavHeader = () =>
+const renderNavHeader = (title = 'Your card') =>
     render(
         <NextIntlClientProvider locale="en" messages={en}>
-            <NavHeader title="Your card" />
+            <NavHeader title={title} />
         </NextIntlClientProvider>
     )
 
@@ -55,5 +55,17 @@ describe('NavHeader maintenance banner placement', () => {
         const banner = screen.getByText(en.global.maintenanceBody)
         // DOCUMENT_POSITION_FOLLOWING: the banner comes after the header row
         expect(backButton.compareDocumentPosition(banner) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('wraps long titles in the center column without moving the side controls', () => {
+        renderNavHeader('Exchange rate & fees')
+
+        const backButton = screen.getByTestId('nav-back')
+        const row = backButton.closest('div.grid')
+        const title = screen.getByText('Exchange rate & fees')
+
+        expect(row).toHaveClass('grid-cols-[2.5rem_minmax(0,1fr)_2.5rem]', 'items-start')
+        expect(title).toHaveClass('col-start-2', 'row-start-1', 'break-words', 'whitespace-normal')
+        expect(title).not.toHaveClass('truncate')
     })
 })

--- a/src/components/Global/NavHeader/index.tsx
+++ b/src/components/Global/NavHeader/index.tsx
@@ -79,14 +79,34 @@ const NavHeader = ({
 
     return (
         <div className="w-full" ref={rootRef}>
-            <div className="relative flex w-full flex-row items-center justify-between">
-                {hideBackBtn ? (
-                    <div />
-                ) : !onPrev ? (
-                    <Link href={href ?? '/home'}>
+            {/* Fixed side columns keep both controls at the navigation origin.
+                The center column stays clear of their 40px visuals plus a 24px
+                gap, and grows DOWN for translated titles that need more than one
+                line; absolute centering made a wrapped title grow into the safe
+                area and did not contribute height to the page stack. */}
+            <div className="grid w-full grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-x-6">
+                <div className="col-start-1 row-start-1">
+                    {hideBackBtn ? null : !onPrev ? (
+                        <Link href={href ?? '/home'}>
+                            <Button
+                                variant="stroke"
+                                className={navCircleBtn}
+                                aria-label={tCommon('back')}
+                                data-testid="nav-back"
+                            >
+                                <Icon
+                                    name={icon}
+                                    size={20}
+                                    className={twMerge(icon === 'chevron-up' && '-rotate-90') || undefined}
+                                />
+                            </Button>
+                        </Link>
+                    ) : (
                         <Button
                             variant="stroke"
                             className={navCircleBtn}
+                            onClick={onPrev}
+                            disabled={disableBackBtn}
                             aria-label={tCommon('back')}
                             data-testid="nav-back"
                         >
@@ -96,23 +116,8 @@ const NavHeader = ({
                                 className={twMerge(icon === 'chevron-up' && '-rotate-90') || undefined}
                             />
                         </Button>
-                    </Link>
-                ) : (
-                    <Button
-                        variant="stroke"
-                        className={navCircleBtn}
-                        onClick={onPrev}
-                        disabled={disableBackBtn}
-                        aria-label={tCommon('back')}
-                        data-testid="nav-back"
-                    >
-                        <Icon
-                            name={icon}
-                            size={20}
-                            className={twMerge(icon === 'chevron-up' && '-rotate-90') || undefined}
-                        />
-                    </Button>
-                )}
+                    )}
+                </div>
                 {!hideLabel && (
                     <div
                         className={twMerge(
@@ -120,27 +125,26 @@ const NavHeader = ({
                             // weight pair used here happened to render the same
                             // 24/800/32, but off the token the two drift apart the
                             // moment Heading/S moves.
-                            // min-w-max let a long title run under the 40px side buttons
-                            // on 360px screens; cap it to the space between them instead
-                            'absolute top-1/2 left-1/2 max-w-[calc(100%-8rem)] -translate-x-1/2 -translate-y-1/2 transform truncate pb-1 text-heading-s',
+                            'col-start-2 row-start-1 min-w-0 pt-0.5 pb-1 text-center text-heading-s break-words whitespace-normal',
                             titleClassName
                         )}
                     >
                         {label}
                     </div>
                 )}
-
-                {rightElement}
-                {showLogoutBtn && auth && (
-                    <Button
-                        onClick={() => auth.logoutUser()}
-                        loading={auth.isLoggingOut}
-                        variant="stroke"
-                        icon="logout"
-                        aria-label={tNav('logout')}
-                        className={navCircleBtn}
-                    />
-                )}
+                <div className="col-start-3 row-start-1 flex justify-end gap-3">
+                    {rightElement}
+                    {showLogoutBtn && auth && (
+                        <Button
+                            onClick={() => auth.logoutUser()}
+                            loading={auth.isLoggingOut}
+                            variant="stroke"
+                            icon="logout"
+                            aria-label={tNav('logout')}
+                            className={navCircleBtn}
+                        />
+                    )}
+                </div>
             </div>
             {/* maintenance announcement renders below the nav header (designer
                 ruling 2026-09-03) — null outside maintenance mode. The page's

--- a/src/components/Marketing/HeroBackNav.tsx
+++ b/src/components/Marketing/HeroBackNav.tsx
@@ -23,7 +23,7 @@ export function HeroBackNav({ fallbackHref = '/' }: { fallbackHref?: string }) {
     const onBack = useSafeBack(fallbackHref)
 
     return (
-        <div className="absolute top-4 left-4 z-30">
+        <div className="absolute top-[calc(var(--safe-top)_+_1rem)] left-4 z-30">
             {/* no maintenance banner on marketing pages / shhhhh (ruled
                 2026-09-03) — and a banner inside this absolute overlay would
                 cover the hero anyway */}

--- a/src/components/Marketing/__tests__/HeroBackNav.test.tsx
+++ b/src/components/Marketing/__tests__/HeroBackNav.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { HeroBackNav } from '../HeroBackNav'
+
+jest.mock('@/hooks/useSafeBack', () => ({ useSafeBack: () => jest.fn() }))
+jest.mock('@/components/Global/NavHeader', () => ({
+    __esModule: true,
+    default: () => <button aria-label="Back" />,
+}))
+
+describe('HeroBackNav', () => {
+    it('uses the shared 16px safe-area-relative navigation origin', () => {
+        render(<HeroBackNav />)
+
+        const wrapper = screen.getByRole('button', { name: 'Back' }).parentElement
+        expect(wrapper).toHaveClass('left-4', 'top-[calc(var(--safe-top)_+_1rem)]')
+    })
+})

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -165,12 +165,11 @@ const Navigation = memo(function Navigation({
 
     // Icons inherit currentColor: the stroke button inverts on hover/active, and
     // a hard-coded fill vanished into the black background.
-    // The row's containing block is the initial one (no positioned ancestor), so a
-    // bare top-8 is 32px from the VIEWPORT — under the status bar on any device
-    // whose inset is deeper than that, and under the shell's inset cover with it.
-    // Same max() shape the QR scanner header uses.
+    // The row's containing block is the initial one (no positioned ancestor).
+    // Match app navigation at 16px from either horizontal edge and 16px below
+    // the safe-area boundary; on web --safe-top is zero.
     return (
-        <div className="absolute top-[max(2rem,calc(var(--safe-top)_+_0.5rem))] z-20 flex w-full items-center justify-between px-6">
+        <div className="absolute top-[calc(var(--safe-top)_+_1rem)] z-20 flex w-full items-center justify-between px-4">
             <div>
                 {showBackButton && (
                     <Button

--- a/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
+++ b/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
@@ -72,12 +72,16 @@ describe('SetupWrapper navigation', () => {
     })
 
     it('offsets the navigation row by the measured safe-area inset', () => {
-        // The row's containing block is the initial one, so a bare top-8 is 32px
-        // from the viewport — under the status bar (and under the shell's inset
-        // cover) on any device whose inset runs deeper than that.
         renderWrapper({ showBackButton: true, onBack: jest.fn() })
         const row = screen.getByRole('button', { name: 'Go back' }).closest('div.absolute')
-        expect(row?.className).toContain('top-[max(2rem,calc(var(--safe-top)_+_0.5rem))]')
+        expect(row).toHaveClass('top-[calc(var(--safe-top)_+_1rem)]', 'px-4')
+    })
+
+    it('keeps the trailing logout action on the same navigation row as Back', () => {
+        renderWrapper({ showBackButton: true, showLogoutButton: true, onBack: jest.fn(), onLogout: jest.fn() })
+        const back = screen.getByRole('button', { name: 'Go back' })
+        const logout = screen.getByRole('button', { name: 'Logout' })
+        expect(back.closest('div.absolute')).toBe(logout.closest('div.absolute'))
     })
 
     it('fires onBack from the back button', () => {


### PR DESCRIPTION
## Summary
- align shared app Back controls with the Home hamburger at 16px from the content-safe top and left edges
- align Setup Back and trailing actions at the same safe-area-relative Y coordinate
- make marketing and Shhhhh back navigation respect the native top safe area
- remove the Receipt route double inset so its Back control also lands at 16,16
- allow shared navigation titles to wrap in a centered column without moving the Back or trailing controls

## Measured at 393x852
- Home hamburger: 16,16
- Profile Back: 16,16
- Profile Logout: right 16, y 16
- Exchange Rates Back: 16,16
- Exchange Rates title: wraps to two centered lines; no clipping or overlap
- Receipt Back: 16,16
- Shhhhh Back on web: 16,16; native adds safeTop before the 16px inset

## Validation
- 18 focused Jest tests passed
- focused ESLint passed
- Prettier check passed
- design-system lint ratchet passed
- pnpm typecheck passed
- pnpm run build passed, including 1,105 generated pages
