### PR TITLE
fix(TASK-21087): cancel abandoned crypto withdrawal drafts

### DIFF
--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -111,7 +111,7 @@ jest.mock('@/interfaces/peanut-sdk-types', () => ({
 }))
 
 jest.mock('@/services/charges', () => ({
-    chargesApi: { create: jest.fn(), get: jest.fn() },
+    chargesApi: { create: jest.fn(), get: jest.fn(), cancel: jest.fn().mockResolvedValue(undefined) },
 }))
 
 jest.mock('@/services/requests', () => ({
@@ -122,10 +122,15 @@ jest.mock('@/services/requests', () => ({
 
 jest.mock('@/features/withdraw/views/ConfirmWithdrawView', () => ({
     __esModule: true,
-    default: (props: { onConfirm: () => void }) => (
-        <button data-testid="confirm-withdraw" onClick={props.onConfirm}>
-            Confirm
-        </button>
+    default: (props: { onConfirm: () => void; onBack: () => void }) => (
+        <>
+            <button data-testid="back-review" onClick={props.onBack}>
+                Back
+            </button>
+            <button data-testid="confirm-withdraw" onClick={props.onConfirm}>
+                Confirm
+            </button>
+        </>
     ),
 }))
 
@@ -718,7 +723,7 @@ describe('crypto withdraw — URL amount validation (Chip review round 4)', () =
         requestsApi: { create: jest.Mock }
     }
     const { chargesApi } = jest.requireMock('@/services/charges') as {
-        chargesApi: { create: jest.Mock; get: jest.Mock }
+        chargesApi: { create: jest.Mock; get: jest.Mock; cancel: jest.Mock }
     }
 
     const armHappyPersistence = () => {
@@ -761,7 +766,7 @@ describe('crypto withdraw — URL amount validation (Chip review round 4)', () =
         )
     })
 
-    test('a post-review ?amount= edit does not change the broadcast — the charge-pinned amount moves', async () => {
+    test('a post-review amount edit cancels the old draft and cannot broadcast it', async () => {
         armHappyPersistence()
         mockSendMoney.mockResolvedValue({
             txHash: '0xbetx',
@@ -779,8 +784,8 @@ describe('crypto withdraw — URL amount validation (Chip review round 4)', () =
         view.rerender(<WithdrawCryptoPage />)
         fireEvent.click(screen.getByTestId('confirm-withdraw'))
 
-        await waitFor(() => expect(mockSendMoney).toHaveBeenCalled())
-        expect(mockSendMoney).toHaveBeenCalledWith(RECIPIENT, '50', expect.anything())
+        await waitFor(() => expect(chargesApi.cancel).toHaveBeenCalledWith(CHARGE_UUID))
+        expect(mockSendMoney).not.toHaveBeenCalled()
     })
 
     test('a tampered over-balance amount at confirm never reaches sendMoney', async () => {
@@ -811,7 +816,7 @@ describe('crypto withdraw — the spend is frozen with the charge', () => {
         requestsApi: { create: jest.Mock }
     }
     const { chargesApi } = jest.requireMock('@/services/charges') as {
-        chargesApi: { create: jest.Mock; get: jest.Mock }
+        chargesApi: { create: jest.Mock; get: jest.Mock; cancel: jest.Mock }
     }
     const { parseUnits } = jest.requireActual('viem') as { parseUnits: (v: string, d: number) => bigint }
 
@@ -1022,5 +1027,96 @@ describe('crypto withdraw retry — after a route error (cross-chain cap 429, TA
             m.error = prev.error
             m.isCalculating = prev.isCalculating
         }
+    })
+})
+
+describe('unpaid withdrawal draft cleanup', () => {
+    beforeEach(() => {
+        mockStepper.step = 'recipient'
+        jest.mocked(chargesApi.create).mockResolvedValue({ data: { id: CHARGE_UUID } } as never)
+        jest.mocked(chargesApi.get).mockResolvedValue(chargeDetails as never)
+        jest.mocked(chargesApi.cancel).mockResolvedValue(undefined)
+    })
+
+    it('cancels a created charge when its detail fetch fails', async () => {
+        jest.mocked(chargesApi.get).mockRejectedValueOnce(new Error('detail fetch failed'))
+        render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.cancel).toHaveBeenCalledWith(CHARGE_UUID))
+        expect(mockSendMoney).not.toHaveBeenCalled()
+    })
+
+    it('cancels the unpaid charge on unmount', async () => {
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        view.unmount()
+        await waitFor(() => expect(chargesApi.cancel).toHaveBeenCalledWith(CHARGE_UUID))
+    })
+
+    it('cancels a charge whose create response arrives after unmount', async () => {
+        let resolveCreate!: (value: never) => void
+        jest.mocked(chargesApi.create).mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveCreate = resolve
+                })
+        )
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        view.unmount()
+        resolveCreate({ data: { id: CHARGE_UUID } } as never)
+        await waitFor(() => expect(chargesApi.cancel).toHaveBeenCalledWith(CHARGE_UUID))
+        expect(chargesApi.get).not.toHaveBeenCalled()
+    })
+
+    it('creates only one charge for two Review clicks', async () => {
+        render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        expect(chargesApi.create).toHaveBeenCalledTimes(1)
+    })
+
+    it('cancels on Back and refuses a stale Confirm handler', async () => {
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        mockStepper.step = 'review'
+        view.rerender(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('back-review'))
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        expect(chargesApi.cancel).toHaveBeenCalledTimes(1)
+        expect(mockSendMoney).not.toHaveBeenCalled()
+    })
+
+    it('allows a new Review after a signing error without cancelling the old charge', async () => {
+        mockSendMoney.mockRejectedValueOnce(new Error('signing rejected'))
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        mockStepper.step = 'review'
+        view.rerender(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockSetPaymentError).toHaveBeenCalledWith('signing rejected'))
+        fireEvent.click(screen.getByTestId('back-review'))
+        mockStepper.step = 'recipient'
+        view.rerender(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.create).toHaveBeenCalledTimes(2))
+        expect(chargesApi.cancel).not.toHaveBeenCalled()
+    })
+
+    it('never cancels after signing starts, including an ambiguous timeout', async () => {
+        mockSendMoney.mockRejectedValueOnce(new Error('network timeout'))
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        mockStepper.step = 'review'
+        view.rerender(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockSendMoney).toHaveBeenCalledTimes(1))
+        view.unmount()
+        expect(chargesApi.cancel).not.toHaveBeenCalled()
     })
 })

--- a/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/__tests__/crypto-withdraw-confirm.test.tsx
@@ -151,7 +151,12 @@ jest.mock('@/features/payments/shared/components/PaymentSuccessView', () => ({
 
 jest.mock('@/components/Global/ActionModal', () => ({
     __esModule: true,
-    default: () => null,
+    default: ({ visible, onClose }: { visible: boolean; onClose: () => void }) =>
+        visible ? (
+            <button data-testid="modal-close" onClick={onClose}>
+                Close
+            </button>
+        ) : null,
 }))
 
 jest.mock('@/components/Global/AddressLink', () => ({
@@ -314,6 +319,7 @@ const confirm = async () => {
 }
 
 beforeEach(() => {
+    mockWithdrawFlow.showCompatibilityModal = false
     jest.clearAllMocks()
     mockRecordPayment.mockResolvedValue(PAYMENT_RESULT)
     Object.assign(mockCrossChainTransfer, { isXChain: false, isDiffToken: false, quoteExpiresAt: null })
@@ -1104,6 +1110,32 @@ describe('unpaid withdrawal draft cleanup', () => {
         view.rerender(<WithdrawCryptoPage />)
         fireEvent.click(screen.getByTestId('review-cta'))
         await waitFor(() => expect(chargesApi.create).toHaveBeenCalledTimes(2))
+        expect(chargesApi.cancel).not.toHaveBeenCalled()
+    })
+
+    it('cancels and clears the charge when the compatibility modal closes', async () => {
+        mockWithdrawFlow.showCompatibilityModal = true
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        fireEvent.click(screen.getByTestId('modal-close'))
+        expect(chargesApi.cancel).toHaveBeenCalledWith(CHARGE_UUID)
+        expect(mockWithdrawFlow.setChargeDetails).toHaveBeenCalledWith(null)
+        view.unmount()
+        mockWithdrawFlow.showCompatibilityModal = false
+    })
+
+    it('broadcasts once for two Confirm clicks while the first send is pending', async () => {
+        mockSendMoney.mockImplementationOnce(() => new Promise(() => {}))
+        const view = render(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('review-cta'))
+        await waitFor(() => expect(chargesApi.get).toHaveBeenCalled())
+        mockStepper.step = 'review'
+        view.rerender(<WithdrawCryptoPage />)
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        fireEvent.click(screen.getByTestId('confirm-withdraw'))
+        await waitFor(() => expect(mockSendMoney).toHaveBeenCalledTimes(1))
+        view.unmount()
         expect(chargesApi.cancel).not.toHaveBeenCalled()
     })
 

--- a/src/app/(mobile-ui)/withdraw/crypto/page.tsx
+++ b/src/app/(mobile-ui)/withdraw/crypto/page.tsx
@@ -153,6 +153,38 @@ export default function WithdrawCryptoPage() {
     // different amount on-chain than the records say (Chip review round 4).
     const setupAmountRef = useRef<{ chargeId: string; amountUsd: string } | null>(null)
 
+    // Only drafts created by this mounted flow belong to its cleanup. Once
+    // signing starts, a transport failure is ambiguous: never cancel that charge.
+    const draftRef = useRef<{ id: string; signingStarted: boolean } | null>(null)
+    const cancelledChargeIdsRef = useRef(new Set<string>())
+    const setupGenerationRef = useRef(0)
+    const setupInFlightRef = useRef(false)
+    const executionInFlightRef = useRef(false)
+    const cancelUnpaidDraft = useCallback((id: string) => {
+        cancelledChargeIdsRef.current.add(id)
+        void chargesApi.cancel(id).catch((error: unknown) => {
+            void captureNetworkTriagedFailure(error, {
+                tags: { ...criticalFlowTags('withdraw-crypto'), withdraw_step: 'cancel-draft' },
+                extra: { chargeId: id },
+            })
+        })
+    }, [])
+    const abandonDraft = useCallback(() => {
+        ++setupGenerationRef.current
+        setIsPreparingReview(false)
+        const draft = draftRef.current
+        if (!draft || draft.signingStarted) return
+        draftRef.current = null
+        cancelUnpaidDraft(draft.id)
+    }, [cancelUnpaidDraft, setIsPreparingReview])
+
+    useEffect(() => () => abandonDraft(), [abandonDraft])
+    const previousStepRef = useRef(stepper.step)
+    useEffect(() => {
+        if (previousStepRef.current === 'review' && stepper.step !== 'review') abandonDraft()
+        previousStepRef.current = stepper.step
+    }, [stepper.step, abandonDraft])
+
     const { triggerHaptic } = useAppHaptic()
 
     // local state for transaction execution
@@ -196,10 +228,11 @@ export default function WithdrawCryptoPage() {
     // goes with them; setupAmountRef only ever resolves against the live charge)
     useEffect(() => {
         if (amountToWithdraw) {
+            abandonDraft()
             clearErrors()
             setChargeDetails(null)
         }
-    }, [amountToWithdraw, clearErrors, setChargeDetails])
+    }, [amountToWithdraw, clearErrors, setChargeDetails, abandonDraft])
 
     // propagate route/record errors
     useEffect(() => {
@@ -253,6 +286,7 @@ export default function WithdrawCryptoPage() {
 
     const handleSetupReview = useCallback(
         async (data: Omit<WithdrawData, 'amount'>) => {
+            if (setupInFlightRef.current || executionInFlightRef.current) return
             if (!amountToWithdraw) {
                 console.error('Amount to withdraw is not set or not available from context')
                 setError(t('errors.amountMissing'))
@@ -300,6 +334,9 @@ export default function WithdrawCryptoPage() {
                 }
             }
 
+            abandonDraft()
+            const generation = setupGenerationRef.current
+            setupInFlightRef.current = true
             clearErrors()
             setChargeDetails(null)
             // a NEW attempt invalidates the previous one's execution proof —
@@ -350,7 +387,13 @@ export default function WithdrawCryptoPage() {
                     throw new Error(t('errors.chargeFailed'))
                 }
 
+                if (generation !== setupGenerationRef.current) {
+                    cancelUnpaidDraft(createdCharge.data.id)
+                    return
+                }
+                draftRef.current = { id: createdCharge.data.id, signingStarted: false }
                 const fullChargeDetails = await chargesApi.get(createdCharge.data.id)
+                if (generation !== setupGenerationRef.current) return
 
                 // the confirm leg broadcasts the amount these records were
                 // created for — never re-read from the editable URL
@@ -359,11 +402,19 @@ export default function WithdrawCryptoPage() {
                 setChargeDetails(fullChargeDetails)
                 setShowCompatibilityModal(true)
             } catch (err) {
+                if (generation !== setupGenerationRef.current) return
+                const failedDraft = draftRef.current
+                draftRef.current = null
+                if (failedDraft && !failedDraft.signingStarted) cancelUnpaidDraft(failedDraft.id)
+                void captureNetworkTriagedFailure(err, {
+                    tags: { ...criticalFlowTags('withdraw-crypto'), withdraw_step: 'setup-review' },
+                })
                 console.error('Error during setup review (charge creation):', err)
                 const errorMessage = err instanceof Error && err.message ? err.message : t('errors.prepareFailed')
                 setError(errorMessage)
             } finally {
-                setIsPreparingReview(false)
+                setupInFlightRef.current = false
+                if (generation === setupGenerationRef.current) setIsPreparingReview(false)
             }
         },
         [
@@ -374,6 +425,8 @@ export default function WithdrawCryptoPage() {
             setChargeDetails,
             setTransactionHash,
             setIsPreparingReview,
+            abandonDraft,
+            cancelUnpaidDraft,
             setWithdrawData,
             setShowCompatibilityModal,
             setError,
@@ -404,12 +457,14 @@ export default function WithdrawCryptoPage() {
     }, [withdrawData, chargeDetails, isXChain, isDiffToken])
 
     const handleConfirmWithdrawal = useCallback(async () => {
+        if (executionInFlightRef.current) return
         if (!chargeDetails || !withdrawData || !amountToWithdraw || !address) {
             console.error('Withdraw data, active charge details, or amount missing for final confirmation')
             setError(t('errors.essentialInfoMissing'))
             return
         }
 
+        if (cancelledChargeIdsRef.current.has(chargeDetails.uuid)) return
         const alreadySpent = executedSpendRef.current?.chargeId === chargeDetails.uuid
         if (!alreadySpent && (!transactions || transactions.length === 0)) {
             // Nothing prepared — the route never resolved, an expiry refresh
@@ -461,6 +516,8 @@ export default function WithdrawCryptoPage() {
             broadcastAmount = amountCheck.normalized
         }
 
+        executionInFlightRef.current = true
+        if (draftRef.current?.id === chargeDetails.uuid) draftRef.current.signingStarted = true
         clearErrors()
         setIsSendingTx(true)
 
@@ -641,6 +698,7 @@ export default function WithdrawCryptoPage() {
             })
             setError(errMsg)
         } finally {
+            executionInFlightRef.current = false
             setIsSendingTx(false)
         }
     }, [
@@ -674,10 +732,11 @@ export default function WithdrawCryptoPage() {
     ])
 
     const handleBackFromConfirm = useCallback(() => {
+        abandonDraft()
         void stepper.goTo('recipient')
         clearErrors()
         setChargeDetails(null)
-    }, [stepper, clearErrors, setChargeDetails])
+    }, [stepper, clearErrors, setChargeDetails, abandonDraft])
 
     // Clear crypto-TRANSIENT flow memory when this page unmounts (charge,
     // route, recipient, token selection) — on unmount rather than in the
@@ -857,6 +916,8 @@ export default function WithdrawCryptoPage() {
                 visible={showCompatibilityModal}
                 onClose={() => {
                     if (isPreparingReview) return
+                    abandonDraft()
+                    setChargeDetails(null)
                     setShowCompatibilityModal(false)
                 }}
                 preventClose={isPreparingReview}


### PR DESCRIPTION
Crypto withdrawal Review creates a charge for Rhino's destination and withdrawal-cap checks. Leaving Review previously left that charge pending, even when setup failed before signing.

Cancel owned, unpaid drafts on Back, amount changes, compatibility dismissal, unmount, and detail-fetch failure. Cancel late creation responses after the flow exits. Once signing starts, retain the charge even after a timeout because submission may have succeeded. Prevent duplicate Review and Confirm submissions within the mounted flow.

The charge create/read contract stays intact: cross-chain quotes require its identity. The companion API change handles expiry when browser cleanup cannot run. No historical rows or staging databases were changed.

Validation: 40 withdrawal regressions; 560 suites / 6,913 tests pass (5 skips); typecheck and formatting pass; changed-file eslint has no errors. Covers late responses, failed setup, stale Confirm, single creation, and no cancellation after signing. Existing full-balance and record-only retry tests remain.

Task: https://app.notion.com/p/39d713a62ca84f7db262b5a18769a1e4


Review follow-up: added direct compatibility-modal dismissal and same-tick double-Confirm coverage. All 560 suites / 6,915 tests pass locally (5 skipped), plus typecheck and formatting. No runtime change in this follow-up.
