### PR TITLE
fix: keep link cancellation responsive (TASK-22443)

### DIFF
--- a/src/components/Claim/__tests__/useClaimLink.sentry.test.tsx
+++ b/src/components/Claim/__tests__/useClaimLink.sentry.test.tsx
@@ -107,3 +107,27 @@ describe('claimLinkMutation.onError', () => {
         expect(mockCaptureException).toHaveBeenCalledTimes(1)
     })
 })
+
+test('claim success refreshes once without a background polling loop', async () => {
+    jest.useFakeTimers()
+    const client = new QueryClient()
+    const refresh = jest.spyOn(client, 'refetchQueries')
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    mockClaimResponse(200, { txHash: '0xtx' })
+    try {
+        const { result, unmount } = renderHook(() => useClaimLink(), { wrapper: Wrapper })
+        await result.current.claimLink({
+            address: '0x1111111111111111111111111111111111111111',
+            link: 'https://peanut.me/claim#p=pw',
+        })
+        expect(refresh).toHaveBeenCalledTimes(2)
+        await jest.advanceTimersByTimeAsync(11_000)
+        expect(refresh).toHaveBeenCalledTimes(2)
+        unmount()
+    } finally {
+        client.clear()
+        jest.useRealTimers()
+    }
+})

--- a/src/components/Claim/useClaimLink.tsx
+++ b/src/components/Claim/useClaimLink.tsx
@@ -311,47 +311,6 @@ const useClaimLink = () => {
                         queryKey: ['balance'],
                         type: 'active',
                     })
-
-                    // Aggressive polling: Backend might take 2-4 seconds to process
-                    // Poll every 1 second, stop early if data updates or after 10 attempts
-                    let pollCount = 0
-                    let lastTransactionCount = 0
-
-                    // Get initial transaction count
-                    const initialData = queryClient.getQueryData<unknown[]>([TRANSACTIONS])
-                    lastTransactionCount = initialData?.length || 0
-
-                    const pollInterval = setInterval(() => {
-                        pollCount++
-
-                        // Check if backend has finished processing (new transaction appeared)
-                        const currentData = queryClient.getQueryData<unknown[]>([TRANSACTIONS])
-                        const currentCount = currentData?.length || 0
-
-                        if (currentCount > lastTransactionCount) {
-                            console.log(
-                                `✅ Backend processing complete (new transaction detected), stopping poll at ${pollCount}/10`
-                            )
-                            clearInterval(pollInterval)
-                            return
-                        }
-
-                        console.log(`🔄 Polling for backend updates ${pollCount}/10`)
-
-                        queryClient.refetchQueries({
-                            queryKey: [TRANSACTIONS],
-                            type: 'active',
-                        })
-                        queryClient.refetchQueries({
-                            queryKey: ['balance'],
-                            type: 'active',
-                        })
-
-                        if (pollCount >= 10) {
-                            console.log('⏱️ Polling timeout reached (WebSocket should handle future updates)')
-                            clearInterval(pollInterval)
-                        }
-                    }, 1000)
                 }
             },
             onSettled: () => {

--- a/src/components/Send/link/views/Success.link.send.view.tsx
+++ b/src/components/Send/link/views/Success.link.send.view.tsx
@@ -127,7 +127,7 @@ const LinkSendSuccessView = () => {
                             }
 
                             // Cancel the link by claiming it back
-                            await cancelLinkAndClaim({
+                            const txHash = await cancelLinkAndClaim({
                                 link,
                                 walletAddress,
                                 userId: user?.user?.userId,
@@ -135,7 +135,7 @@ const LinkSendSuccessView = () => {
 
                             try {
                                 // Wait for transaction confirmation
-                                const isConfirmed = await pollForClaimConfirmation(link)
+                                const isConfirmed = txHash || (await pollForClaimConfirmation(link))
 
                                 if (!isConfirmed) {
                                     console.warn('Transaction confirmation timeout - proceeding with refresh')
@@ -143,7 +143,7 @@ const LinkSendSuccessView = () => {
 
                                 // Update UI and queries
                                 fetchBalance()
-                                await queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] })
+                                void queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] }).catch(captureException)
 
                                 setIsLoading(false)
                                 setShowCancelLinkDrawer(false)
@@ -176,7 +176,7 @@ const LinkSendSuccessView = () => {
                                 setCancelStatus('idle')
                                 setShowCancelLinkDrawer(false)
                                 toast.info(friendly(error))
-                                await queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] }).catch(() => undefined)
+                                void queryClient.invalidateQueries({ queryKey: [TRANSACTIONS] }).catch(() => undefined)
                                 router.push('/home')
                                 return
                             }

--- a/src/components/TransactionDetails/__tests__/useReceiptActions.test.ts
+++ b/src/components/TransactionDetails/__tests__/useReceiptActions.test.ts
@@ -84,3 +84,11 @@ describe('useReceiptActions.cancelSendLink', () => {
         expect(mockToast.success).toHaveBeenCalledWith('toast.linkCancelled')
     })
 })
+
+test('confirmed cancellation finishes while history is still pending', async () => {
+    mockCancelLinkAndClaim.mockResolvedValue('0xtx')
+    mockInvalidateQueries.mockImplementationOnce(() => new Promise(() => {}))
+    const { result } = renderHook(() => useReceiptActions(tx))
+    await expect(result.current.cancelSendLink()).resolves.toBe('cancelled')
+    expect(mockToast.success).toHaveBeenCalledWith('toast.linkCancelled')
+})

--- a/src/components/TransactionDetails/useReceiptActions.ts
+++ b/src/components/TransactionDetails/useReceiptActions.ts
@@ -85,19 +85,19 @@ export function useReceiptActions(transaction: TransactionDetails | null) {
                 throw new Error('No link found for cancellation')
             }
 
-            await cancelLinkAndClaim({
+            const txHash = await cancelLinkAndClaim({
                 link: transaction.extraDataForDrawer.link,
                 walletAddress,
                 userId: user?.user?.userId,
             })
 
             try {
-                const isConfirmed = await pollForClaimConfirmation(transaction.extraDataForDrawer.link)
+                const isConfirmed = txHash || (await pollForClaimConfirmation(transaction.extraDataForDrawer.link))
                 if (!isConfirmed) {
                     console.warn('Transaction confirmation timeout - proceeding with refresh')
                 }
                 fetchBalance()
-                await invalidateTransactions()
+                void invalidateTransactions().catch((error) => captureException(error))
                 toast.success(t('toast.linkCancelled'))
             } catch (invalidateError) {
                 console.error('Failed to update after claim:', invalidateError)
@@ -112,7 +112,7 @@ export function useReceiptActions(transaction: TransactionDetails | null) {
             if (wireErrorCode(error) === API_ERROR_CODES.LINK_ALREADY_CLAIMED) {
                 // refetch so the entry re-renders as claimed; a refetch failure is
                 // not a cancel failure (same rule as the success path above)
-                await invalidateTransactions().catch(() => undefined)
+                void invalidateTransactions().catch(() => undefined)
                 toast.info(friendly(error))
                 return 'already-claimed'
             }

--- a/src/hooks/query/__tests__/user.test.tsx
+++ b/src/hooks/query/__tests__/user.test.tsx
@@ -216,3 +216,19 @@ describe('useUserQuery — demo mode', () => {
         expect(data?.user.avatarKey).toBe('basic.frog')
     })
 })
+
+describe('useUserQuery transient failures', () => {
+    it.each([429, 408, 503])('keeps the cached session after HTTP %s', async (status) => {
+        const profile = { user: { userId: 'u1', username: 'alice' } }
+        mockApiFetch.mockReset()
+        mockClearAuthToken.mockClear()
+        mockApiFetch.mockResolvedValueOnce(mockResponse(200, profile))
+        const { result } = renderHook(() => useUserQuery(), { wrapper: makeWrapper() })
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+        mockApiFetch.mockResolvedValue(mockResponse(status, {}))
+        const refreshed = await result.current.refetch()
+        expect(refreshed.data).toEqual(profile)
+        expect(refreshed.isError).toBe(true)
+        expect(mockClearAuthToken).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/query/user.ts
+++ b/src/hooks/query/user.ts
@@ -78,8 +78,8 @@ export const useUserQuery = (dependsOn: boolean = true) => {
             return payload
         }
 
-        // 5xx = backend error, throw so tanstack retries
-        if (userResponse.status >= 500) {
+        // Temporary failures must preserve the cached session.
+        if (userResponse.status >= 500 || userResponse.status === 429 || userResponse.status === 408) {
             console.error('Backend error fetching user:', userResponse.status)
             throw new BackendError('Backend error fetching user', userResponse.status)
         }
@@ -110,7 +110,9 @@ export const useUserQuery = (dependsOn: boolean = true) => {
     return useQuery({
         queryKey: [USER],
         queryFn: fetchUser,
-        retry: (failureCount, _error) => {
+        retry: (failureCount, error) => {
+            // Retrying immediately would extend the rate-limit incident.
+            if (error instanceof BackendError && error.status === 429) return false
             // retry all errors (5xx, network timeouts, connection failures) up to 2 times
             // previously only BackendError (5xx) was retried, meaning a single network
             // blip would instantly show the BackendErrorScreen with zero retries


### PR DESCRIPTION
## Summary
Cancelling a send link could finish on-chain while the drawer waited for slow history requests. Rate-limited profile requests then looked like a logout.

Confirmed cancellations now finish without waiting for history. Temporary profile errors preserve the cached session, and 429 responses do not trigger immediate retries. Remove the one-second post-claim refresh loop, whose completion check used an obsolete query key.

Task: [TASK-22443](https://app.notion.com/3d683811757981778290e93c72f2a8a4)

## Validation
Local checks: 560 suites passed (6,920 tests; five skipped), TypeScript passed, repository formatting passed, and changed-file ESLint passed. The production build passed.

Regression tests cover a pending history refresh, cached sessions after 408/429/503, and no additional claim refresh calls after 11 seconds. Existing claim failures and already-claimed behavior remain covered.

Screenshots: N/A (no layout or copy changes).

## Risk and follow-up
Claim submission and backend accounting are unchanged. History can briefly lag the confirmed cancellation while it refreshes in the background. The asynchronous claim path still polls for confirmation.

This removes a confirmed source of excess refreshes. It does not establish that this loop alone caused the entire observed request burst; verify request volume on staging after deployment. Missing asset decimals are a separate backend issue.

Docs and legal: no changes required. No cross-repo deployment dependency.
