### PR TITLE
test: cover confirmed link cancellation during slow history (TASK-22443)

### DIFF
--- a/src/components/Send/link/views/__tests__/Success.link.send.view.cancel.test.tsx
+++ b/src/components/Send/link/views/__tests__/Success.link.send.view.cancel.test.tsx
@@ -11,6 +11,7 @@ import { TRANSACTIONS } from '@/constants/query.consts'
 
 const mockPush = jest.fn()
 const mockCancelLinkAndClaim = jest.fn()
+const mockPollForClaimConfirmation = jest.fn(async () => true)
 const mockInvalidateQueries = jest.fn(async () => undefined)
 const mockToast = { success: jest.fn(), error: jest.fn(), info: jest.fn(), warning: jest.fn() }
 const mockCaptureException = jest.fn()
@@ -40,7 +41,7 @@ jest.mock('@/components/Claim/useClaimLink', () => ({
     __esModule: true,
     default: () => ({
         cancelLinkAndClaim: mockCancelLinkAndClaim,
-        pollForClaimConfirmation: jest.fn(async () => true),
+        pollForClaimConfirmation: mockPollForClaimConfirmation,
     }),
 }))
 jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => mockToast }))
@@ -123,4 +124,17 @@ describe('LinkSendSuccessView — cancel on an already-claimed link', () => {
         expect(mockPush).not.toHaveBeenCalled()
         expect(mockInvalidateQueries).not.toHaveBeenCalled()
     })
+})
+
+test('confirmed cancellation leaves for home while history is still pending', async () => {
+    mockCancelLinkAndClaim.mockResolvedValue('0xtx')
+    mockInvalidateQueries.mockImplementationOnce(() => new Promise(() => {}))
+
+    await cancelFromView()
+
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith('link.cancelSuccess'))
+    expect(mockPollForClaimConfirmation).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('confirm-cancel')).toBeNull()
+    expect(mockToast.error).not.toHaveBeenCalled()
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/home'), { timeout: 3000 })
 })


### PR DESCRIPTION
Add the success-screen regression requested in the review of #3071 (TASK-22443). The fix merged while this test completed its full-suite run.

The test proves that a confirmed cancellation skips confirmation polling, closes the drawer, shows success, and returns home while history remains pending. No production code changes.

Validation: 560 suites passed; 6,921 tests passed, five skipped. TypeScript and changed-file ESLint passed.

Task: https://app.notion.com/3d683811757981778290e93c72f2a8a4
Screenshots: N/A (test only). Docs/legal: none.
