### PR TITLE
feat: i18n overflow gate — fail CI when translated copy is clipped (TASK-22366)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -376,7 +376,7 @@ jobs:
                   # e2e/flows/ and the regression config are here because the
                   # behaviour specs run inside ds-shots — without them a PR
                   # touching only those files would skip the job that runs them.
-                  KEEP='^(src/|e2e/(shots|flows)/|scripts/visual-(diff|comment)\.mjs$|playwright\.(shots|regression)\.config\.ts$|(tailwind|postcss|next)\.config\.|package\.json$|pnpm-lock\.yaml$|\.github/workflows/tests\.yml$)'
+                  KEEP='^(src/|e2e/(shots|flows)/|scripts/visual-(diff|comment)\.mjs$|playwright\.(shots|regression|overflow)\.config\.ts$|(tailwind|postcss|next)\.config\.|package\.json$|pnpm-lock\.yaml$|\.github/workflows/tests\.yml$)'
                   # Inside the set above but never on camera. src/content is the
                   # blog and SEO submodule, and no fixture renders those pages.
                   DROP='(^src/content(/|$)|/__tests__/|/__mocks__/|\.test\.tsx?$|\.md$)'
@@ -684,6 +684,18 @@ jobs:
 
             - name: Run regression specs
               run: pnpm test:e2e:regression
+
+            # i18n overflow gate (TASK-22366): renders the fixture set, the
+            # localized landing routes and the setup screens in es-419 at
+            # 320px and fails when translated copy is clipped. Absolute DOM
+            # check, no baseline — so it runs the same way on push and PR.
+            # Advisory the same way this whole job is (not in
+            # ci-success.needs); give it its own blocking job after a week of
+            # PRs with zero false positives.
+            # Failure screenshots land in e2e/__results__/, which the
+            # failure upload below already ships.
+            - name: i18n overflow gate
+              run: pnpm test:i18n-overflow:run
 
             # The page snapshot in error-context.md is the only way to see
             # WHAT rendered on the runner when a spec dies in CI but passes

--- a/e2e/shots/overflow-check.ts
+++ b/e2e/shots/overflow-check.ts
@@ -1,0 +1,135 @@
+/**
+ * The i18n overflow detector. Serialized into the page by overflow.spec.ts
+ * (real screens) and overflow-detector.spec.ts (synthetic self-tests), so it
+ * must stay self-contained: no imports used inside findOverflows, no closures.
+ */
+
+export type Overflow = {
+    selector: string
+    text: string
+    kind: 'clip-x' | 'clip-y' | 'placeholder'
+    detail: string
+}
+
+/**
+ * Runs in the page. Finds text the user cannot read:
+ *  - an element with a direct text node, clipped by its own overflow
+ *    hidden/clip (scrollable containers are fine, ellipsis/line-clamp are
+ *    deliberate truncation and skipped)
+ *  - a container with overflow hidden whose text content crosses the clipped
+ *    edge — either because a text-bearing descendant's box crosses it, or
+ *    because the descendant's TEXT overflows its own box that ends at the
+ *    edge (nowrap child at 100% width: the box stops at the edge, the text
+ *    keeps going — measured via the descendant's scroll extent)
+ *  - an input/textarea whose placeholder or value is wider than its content
+ *    box (inputs clip natively, scrollWidth does not see it — the original
+ *    "Usuario*" bug)
+ */
+export function findOverflows(exempt: string[]): Overflow[] {
+    const bad: Overflow[] = []
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')!
+
+    const path = (el: Element): string => {
+        const parts: string[] = []
+        let node: Element | null = el
+        while (node && node !== document.body && parts.length < 4) {
+            const cls = [...node.classList].slice(0, 3).join('.')
+            parts.unshift(node.tagName.toLowerCase() + (cls ? `.${cls}` : ''))
+            node = node.parentElement
+        }
+        return parts.join(' > ')
+    }
+
+    const isExempt = (el: Element): boolean =>
+        exempt.some((sel) => {
+            try {
+                return el.closest(sel) !== null
+            } catch {
+                return false
+            }
+        })
+
+    const seen = new Set<string>()
+    const flag = (el: Element, kind: Overflow['kind'], detail: string, text?: string) => {
+        const sample = (text ?? (el as HTMLElement).innerText ?? '').trim().replace(/\s+/g, ' ').slice(0, 80)
+        const key = `${kind}|${sample}`
+        if (seen.has(key)) return
+        seen.add(key)
+        bad.push({ selector: path(el), text: sample, kind, detail })
+    }
+
+    const visible = (el: Element): boolean => {
+        const cs = getComputedStyle(el)
+        if (cs.display === 'none' || cs.visibility === 'hidden' || parseFloat(cs.opacity) === 0) return false
+        const rect = el.getBoundingClientRect()
+        // sr-only / visually-hidden text lives in a 1px clipped box on purpose
+        return rect.width > 2 && rect.height > 2
+    }
+
+    const truncates = (el: Element): boolean => {
+        const cs = getComputedStyle(el)
+        const clamp = (cs as unknown as Record<string, string>).webkitLineClamp
+        return cs.textOverflow === 'ellipsis' || (clamp !== undefined && clamp !== 'none')
+    }
+
+    const hasOwnText = (el: Element): boolean =>
+        Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE && (n.textContent ?? '').trim().length > 0)
+
+    for (const el of Array.from(document.body.querySelectorAll('*'))) {
+        if (!visible(el)) continue
+        if (isExempt(el)) continue
+        const cs = getComputedStyle(el)
+
+        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+            if (el.type === 'checkbox' || el.type === 'radio' || el.type === 'hidden') continue
+            const text = (el.value || el.placeholder || '').trim()
+            if (!text) continue
+            ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+            const needed = ctx.measureText(text).width
+            const inner = el.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight)
+            if (needed > inner + 1) {
+                flag(el, 'placeholder', `text needs ${Math.round(needed)}px, input fits ${Math.round(inner)}px`, text)
+            }
+            continue
+        }
+
+        const hiddenX = cs.overflowX === 'hidden' || cs.overflowX === 'clip'
+        const hiddenY = cs.overflowY === 'hidden' || cs.overflowY === 'clip'
+        const clipX = hiddenX && el.scrollWidth > el.clientWidth + 1
+        // +3 vertical tolerance: line-height rounding trips a +1 check
+        const clipY = hiddenY && el.scrollHeight > el.clientHeight + 3
+        if (!clipX && !clipY) continue
+
+        // The clipped pixels may be decorative (positioned art bleeding off a
+        // hero on purpose), so attribute the clip to TEXT: flag only text-
+        // bearing descendants whose content actually crosses the clipped edge.
+        const box = el.getBoundingClientRect()
+
+        // the element clips its own direct text — scrollWidth already proves it
+        if (hasOwnText(el) && !truncates(el)) {
+            if (clipX) flag(el, 'clip-x', `scrollWidth ${el.scrollWidth} > clientWidth ${el.clientWidth}`)
+            else flag(el, 'clip-y', `scrollHeight ${el.scrollHeight} > clientHeight ${el.clientHeight}`)
+            continue
+        }
+
+        const holders = Array.from(el.querySelectorAll('*')).filter(
+            (d) => hasOwnText(d) && visible(d) && !truncates(d) && !isExempt(d)
+        )
+        for (const d of holders) {
+            const r = d.getBoundingClientRect()
+            // text extent, not box extent: a nowrap child at 100% width ends
+            // its BOX exactly at the clip edge while its TEXT keeps going —
+            // scrollWidth/Height see that regardless of the child's own
+            // overflow value
+            const textRight = r.left + Math.max(d.scrollWidth, r.width)
+            const textBottom = r.top + Math.max(d.scrollHeight, r.height)
+            if (clipX && textRight > box.right + 2) {
+                flag(d, 'clip-x', `text extent ${Math.round(textRight)}px > clip edge ${Math.round(box.right)}px`)
+            } else if (clipY && textBottom > box.bottom + 3) {
+                flag(d, 'clip-y', `text extent ${Math.round(textBottom)}px > clip edge ${Math.round(box.bottom)}px`)
+            }
+        }
+    }
+    return bad
+}

--- a/e2e/shots/overflow-detector.spec.ts
+++ b/e2e/shots/overflow-detector.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Self-tests for the overflow detector (overflow-check.ts): synthetic pages
+ * with known clipping shapes, asserting the detector catches every bug shape
+ * and stays quiet on every deliberate one. If the detector logic breaks, this
+ * fails — not a week of silently-green gate runs.
+ */
+
+import { expect, test } from '@playwright/test'
+import { findOverflows, type Overflow } from './overflow-check'
+
+async function detect(page: import('@playwright/test').Page, html: string): Promise<Overflow[]> {
+    await page.setContent(`<body style="margin:0;font-family:sans-serif">${html}</body>`)
+    return page.evaluate(findOverflows, ['.exempt-me'])
+}
+
+test('flags an element clipping its own nowrap text', async ({ page }) => {
+    const found = await detect(
+        page,
+        `<div style="width:100px;overflow:hidden;white-space:nowrap">este texto traducido es demasiado largo</div>`
+    )
+    expect(found).toHaveLength(1)
+    expect(found[0].kind).toBe('clip-x')
+})
+
+test('flags the nested shape: full-width nowrap child inside a clipping parent', async ({ page }) => {
+    // the child box ends exactly at the parent edge; only its TEXT overflows
+    const found = await detect(
+        page,
+        `<div style="width:100px;overflow:hidden">
+            <div style="width:100%;white-space:nowrap">este texto traducido es demasiado largo</div>
+        </div>`
+    )
+    expect(found).toHaveLength(1)
+    expect(found[0].kind).toBe('clip-x')
+})
+
+test('flags a descendant box crossing the clip edge', async ({ page }) => {
+    const found = await detect(
+        page,
+        `<div style="width:100px;overflow:hidden">
+            <span style="display:inline-block;white-space:nowrap">este texto traducido es demasiado largo</span>
+        </div>`
+    )
+    expect(found).toHaveLength(1)
+    expect(found[0].kind).toBe('clip-x')
+})
+
+test('flags a placeholder wider than its input', async ({ page }) => {
+    const found = await detect(page, `<input style="width:80px" placeholder="Nombre de usuario demasiado largo">`)
+    expect(found).toHaveLength(1)
+    expect(found[0].kind).toBe('placeholder')
+})
+
+test('flags vertically clipped text in a fixed-height box', async ({ page }) => {
+    const found = await detect(
+        page,
+        `<div style="width:120px;height:20px;overflow:hidden;line-height:20px">línea uno línea dos línea tres línea cuatro</div>`
+    )
+    expect(found).toHaveLength(1)
+    expect(found[0].kind).toBe('clip-y')
+})
+
+test('stays quiet on deliberate truncation, scrollers, hidden text and exemptions', async ({ page }) => {
+    const found = await detect(
+        page,
+        `
+        <div style="width:100px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">0xdec0debad1dec0debad1dec0debad1</div>
+        <div style="width:100px;overflow-x:auto;white-space:nowrap">una tabla ancha que se desplaza dentro de su borde</div>
+        <span style="position:absolute;width:1px;height:1px;overflow:hidden">solo para lectores de pantalla</span>
+        <div class="exempt-me" style="width:100px;overflow:hidden;white-space:nowrap">texto de marquesina en movimiento</div>
+        <input style="width:200px" placeholder="Tu usuario">
+        <div style="width:200px">texto corto que cabe</div>
+        `
+    )
+    expect(found).toEqual([])
+})

--- a/e2e/shots/overflow.spec.ts
+++ b/e2e/shots/overflow.spec.ts
@@ -1,23 +1,27 @@
 /**
- * i18n overflow gate (TASK-22366): render screens in es-419 — the longest
- * locale — at 320px and FAIL when translated copy is actually clipped.
+ * i18n overflow gate (TASK-22366): render screens in every supported
+ * non-English locale at 320px and FAIL when translated copy is actually
+ * clipped. One Playwright project per locale (playwright.overflow.config.ts);
+ * es-419 is not a safe maximum — hundreds of pt-BR strings run longer.
  *
  * This is an absolute DOM check, not a visual diff: no baselines, no pixel
- * comparison. A test fails when an element that directly holds text is
- * clipped by its own overflow, or when an input's placeholder is wider than
- * the input. Elements that opt into truncation (text-overflow: ellipsis,
- * line-clamp — addresses, usernames) are skipped by design.
+ * comparison. The detector lives in overflow-check.ts (shared with the
+ * synthetic self-tests in overflow-detector.spec.ts). Elements that opt into
+ * truncation (text-overflow: ellipsis, line-clamp — addresses, usernames)
+ * are skipped by design.
  *
  * Coverage: every fixture in src/dev/fixtures/registry.ts, the localized
- * landing/marketing routes, and the signup/setup screens (reached with a CDP
- * virtual authenticator so the passkey preflight passes in headless).
+ * landing/marketing routes for the project's locale, and the signup/setup
+ * screens (reached with a CDP virtual authenticator so the passkey preflight
+ * passes in headless).
  *
- *   pnpm exec playwright test --config=playwright.shots.config.ts --project=overflow
+ *   npm run test:i18n-overflow:run
  */
 
 import { expect, test, type Page, type TestInfo } from '@playwright/test'
 import { FIXTURE_STORAGE_KEY, fixtureHref } from '../../src/dev/fixtures/active'
 import { FIXTURES } from '../../src/dev/fixtures/registry'
+import { findOverflows } from './overflow-check'
 
 const FROZEN_NOW = new Date('2026-08-15T12:00:00.000Z')
 const LOADERS = '.animate-spin img[alt="Peanut mascot"], .animate-pulse'
@@ -37,127 +41,6 @@ const EXEMPT: string[] = [
     // react-fast-marquee tickers: the text scrolls through the clip by design
     '.rfm-marquee-container',
 ]
-
-type Overflow = {
-    selector: string
-    text: string
-    kind: 'clip-x' | 'clip-y' | 'placeholder'
-    detail: string
-}
-
-/**
- * Runs in the page. Finds text the user cannot read:
- *  - an element with a direct text node, clipped by its own overflow
- *    hidden/clip (scrollable containers are fine, ellipsis/line-clamp are
- *    deliberate truncation and skipped)
- *  - a container with overflow hidden whose text content is wider than the
- *    box (the text usually lives in a child whose own box grew to fit)
- *  - an input/textarea whose placeholder or value is wider than its content
- *    box (inputs clip natively, scrollWidth does not see it — the original
- *    "Usuario*" bug)
- */
-function findOverflows(exempt: string[]): Overflow[] {
-    const bad: Overflow[] = []
-    const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')!
-
-    const path = (el: Element): string => {
-        const parts: string[] = []
-        let node: Element | null = el
-        while (node && node !== document.body && parts.length < 4) {
-            const cls = [...node.classList].slice(0, 3).join('.')
-            parts.unshift(node.tagName.toLowerCase() + (cls ? `.${cls}` : ''))
-            node = node.parentElement
-        }
-        return parts.join(' > ')
-    }
-
-    const isExempt = (el: Element): boolean =>
-        exempt.some((sel) => {
-            try {
-                return el.closest(sel) !== null
-            } catch {
-                return false
-            }
-        })
-
-    const seen = new Set<string>()
-    const flag = (el: Element, kind: Overflow['kind'], detail: string, text?: string) => {
-        const sample = (text ?? (el as HTMLElement).innerText ?? '').trim().replace(/\s+/g, ' ').slice(0, 80)
-        const key = `${kind}|${sample}`
-        if (seen.has(key)) return
-        seen.add(key)
-        bad.push({ selector: path(el), text: sample, kind, detail })
-    }
-
-    const visible = (el: Element): boolean => {
-        const cs = getComputedStyle(el)
-        if (cs.display === 'none' || cs.visibility === 'hidden' || parseFloat(cs.opacity) === 0) return false
-        const rect = el.getBoundingClientRect()
-        // sr-only / visually-hidden text lives in a 1px clipped box on purpose
-        return rect.width > 2 && rect.height > 2
-    }
-
-    const truncates = (el: Element): boolean => {
-        const cs = getComputedStyle(el)
-        const clamp = (cs as unknown as Record<string, string>).webkitLineClamp
-        return cs.textOverflow === 'ellipsis' || (clamp !== undefined && clamp !== 'none')
-    }
-
-    const hasOwnText = (el: Element): boolean =>
-        Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE && (n.textContent ?? '').trim().length > 0)
-
-    for (const el of Array.from(document.body.querySelectorAll('*'))) {
-        if (!visible(el)) continue
-        if (isExempt(el)) continue
-        const cs = getComputedStyle(el)
-
-        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-            if (el.type === 'checkbox' || el.type === 'radio' || el.type === 'hidden') continue
-            const text = (el.value || el.placeholder || '').trim()
-            if (!text) continue
-            ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
-            const needed = ctx.measureText(text).width
-            const inner = el.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight)
-            if (needed > inner + 1) {
-                flag(el, 'placeholder', `text needs ${Math.round(needed)}px, input fits ${Math.round(inner)}px`, text)
-            }
-            continue
-        }
-
-        const hiddenX = cs.overflowX === 'hidden' || cs.overflowX === 'clip'
-        const hiddenY = cs.overflowY === 'hidden' || cs.overflowY === 'clip'
-        const clipX = hiddenX && el.scrollWidth > el.clientWidth + 1
-        // +3 vertical tolerance: line-height rounding trips a +1 check
-        const clipY = hiddenY && el.scrollHeight > el.clientHeight + 3
-        if (!clipX && !clipY) continue
-
-        // The clipped pixels may be decorative (positioned art bleeding off a
-        // hero on purpose), so attribute the clip to TEXT: flag only text-
-        // bearing descendants whose box actually crosses the clipped edge.
-        const box = el.getBoundingClientRect()
-
-        // the element clips its own direct text — scrollWidth already proves it
-        if (hasOwnText(el) && !truncates(el)) {
-            if (clipX) flag(el, 'clip-x', `scrollWidth ${el.scrollWidth} > clientWidth ${el.clientWidth}`)
-            else flag(el, 'clip-y', `scrollHeight ${el.scrollHeight} > clientHeight ${el.clientHeight}`)
-            continue
-        }
-
-        const holders = Array.from(el.querySelectorAll('*')).filter(
-            (d) => hasOwnText(d) && visible(d) && !truncates(d) && !isExempt(d)
-        )
-        for (const d of holders) {
-            const r = d.getBoundingClientRect()
-            if (clipX && r.right > box.right + 2) {
-                flag(d, 'clip-x', `text box right ${Math.round(r.right)}px > clip edge ${Math.round(box.right)}px`)
-            } else if (clipY && r.bottom > box.bottom + 3) {
-                flag(d, 'clip-y', `text box bottom ${Math.round(r.bottom)}px > clip edge ${Math.round(box.bottom)}px`)
-            }
-        }
-    }
-    return bad
-}
 
 async function settle(page: Page): Promise<void> {
     await page.waitForFunction((selector) => {
@@ -213,7 +96,7 @@ async function assertNoOverflow(page: Page, id: string, testInfo: TestInfo) {
     }
 
     const report = overflows.map((o) => `[${o.kind}] ${o.selector} — “${o.text}” (${o.detail})`).join('\n')
-    expect(overflows, `clipped es-419 copy on ${id}:\n${report}`).toEqual([])
+    expect(overflows, `clipped ${testInfo.project.name} copy on ${id}:\n${report}`).toEqual([])
 }
 
 async function blockExternal(page: Page): Promise<void> {
@@ -239,7 +122,7 @@ function seenOnceModals(): void {
 
 test.describe.configure({ mode: 'parallel' })
 
-// ---- app screens: one test per fixture, es-419 via navigator.language ----
+// ---- app screens: one test per fixture, locale via navigator.language ----
 
 for (const [name, fixture] of Object.entries(FIXTURES)) {
     test(`fixture:${name}`, async ({ page }, testInfo) => {
@@ -255,30 +138,37 @@ for (const [name, fixture] of Object.entries(FIXTURES)) {
             .toBe(name)
         await settle(page)
 
-        // prove the app actually rendered Spanish, or the whole gate is a no-op
+        // prove the app actually rendered this locale, or the gate is a no-op
+        const locale = testInfo.project.use.locale
         await expect
             .poll(() => page.evaluate(() => navigator.language), { message: 'context locale not applied' })
-            .toBe('es-419')
+            .toBe(locale)
 
         await assertNoOverflow(page, `fixture:${name}`, testInfo)
     })
 }
 
-// ---- landing / marketing: locale comes from the route ----
+// ---- landing / marketing: locale comes from the route, so each project
+// checks its own locale's routes (the table-heavy marketing templates render
+// through the same mdx components — one representative slug each) ----
 
-// The two localized landing pages plus the table-heavy marketing templates
-// (pricing, compare, country) — one representative slug each; every slug of a
-// template renders through the same mdx components.
-const LANDING_ROUTES = ['/es-419', '/pt-br', '/es-419/pricing', '/es-419/compare/wise', '/pt-br/argentina']
+const LANDING_ROUTES: Record<string, string[]> = {
+    'es-419': ['/es-419', '/es-419/pricing', '/es-419/compare/wise'],
+    'pt-BR': ['/pt-br', '/pt-br/argentina'],
+    'es-AR': ['/es-ar'],
+}
 
-for (const route of LANDING_ROUTES) {
-    test(`landing:${route}`, async ({ page }, testInfo) => {
-        await blockExternal(page)
-        await page.clock.setFixedTime(FROZEN_NOW)
-        await page.goto(route, { waitUntil: 'domcontentloaded' })
-        await settle(page)
-        await assertNoOverflow(page, `landing:${route}`, testInfo)
-    })
+for (const [locale, routes] of Object.entries(LANDING_ROUTES)) {
+    for (const route of routes) {
+        test(`landing:${route}`, async ({ page }, testInfo) => {
+            test.skip(testInfo.project.use.locale !== locale, `belongs to the ${locale} project`)
+            await blockExternal(page)
+            await page.clock.setFixedTime(FROZEN_NOW)
+            await page.goto(route, { waitUntil: 'domcontentloaded' })
+            await settle(page)
+            await assertNoOverflow(page, `landing:${route}`, testInfo)
+        })
+    }
 }
 
 // ---- signup/setup: needs a virtual authenticator or the passkey preflight

--- a/e2e/shots/overflow.spec.ts
+++ b/e2e/shots/overflow.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * i18n overflow gate (TASK-22366): render screens in es-419 — the longest
+ * locale — at 320px and FAIL when translated copy is actually clipped.
+ *
+ * This is an absolute DOM check, not a visual diff: no baselines, no pixel
+ * comparison. A test fails when an element that directly holds text is
+ * clipped by its own overflow, or when an input's placeholder is wider than
+ * the input. Elements that opt into truncation (text-overflow: ellipsis,
+ * line-clamp — addresses, usernames) are skipped by design.
+ *
+ * Coverage: every fixture in src/dev/fixtures/registry.ts, the localized
+ * landing/marketing routes, and the signup/setup screens (reached with a CDP
+ * virtual authenticator so the passkey preflight passes in headless).
+ *
+ *   pnpm exec playwright test --config=playwright.shots.config.ts --project=overflow
+ */
+
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+import { FIXTURE_STORAGE_KEY, fixtureHref } from '../../src/dev/fixtures/active'
+import { FIXTURES } from '../../src/dev/fixtures/registry'
+
+const FROZEN_NOW = new Date('2026-08-15T12:00:00.000Z')
+const LOADERS = '.animate-spin img[alt="Peanut mascot"], .animate-pulse'
+const FREEZE_CSS = `
+*, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+    caret-color: transparent !important;
+    scroll-behavior: auto !important;
+}
+`
+
+// Known intentional clips — CSS selectors matched against the offending
+// element (or any ancestor). Keep every entry justified; an unexplained entry
+// is a hidden bug.
+const EXEMPT: string[] = [
+    // react-fast-marquee tickers: the text scrolls through the clip by design
+    '.rfm-marquee-container',
+]
+
+type Overflow = {
+    selector: string
+    text: string
+    kind: 'clip-x' | 'clip-y' | 'placeholder'
+    detail: string
+}
+
+/**
+ * Runs in the page. Finds text the user cannot read:
+ *  - an element with a direct text node, clipped by its own overflow
+ *    hidden/clip (scrollable containers are fine, ellipsis/line-clamp are
+ *    deliberate truncation and skipped)
+ *  - a container with overflow hidden whose text content is wider than the
+ *    box (the text usually lives in a child whose own box grew to fit)
+ *  - an input/textarea whose placeholder or value is wider than its content
+ *    box (inputs clip natively, scrollWidth does not see it — the original
+ *    "Usuario*" bug)
+ */
+function findOverflows(exempt: string[]): Overflow[] {
+    const bad: Overflow[] = []
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')!
+
+    const path = (el: Element): string => {
+        const parts: string[] = []
+        let node: Element | null = el
+        while (node && node !== document.body && parts.length < 4) {
+            const cls = [...node.classList].slice(0, 3).join('.')
+            parts.unshift(node.tagName.toLowerCase() + (cls ? `.${cls}` : ''))
+            node = node.parentElement
+        }
+        return parts.join(' > ')
+    }
+
+    const isExempt = (el: Element): boolean =>
+        exempt.some((sel) => {
+            try {
+                return el.closest(sel) !== null
+            } catch {
+                return false
+            }
+        })
+
+    const seen = new Set<string>()
+    const flag = (el: Element, kind: Overflow['kind'], detail: string, text?: string) => {
+        const sample = (text ?? (el as HTMLElement).innerText ?? '').trim().replace(/\s+/g, ' ').slice(0, 80)
+        const key = `${kind}|${sample}`
+        if (seen.has(key)) return
+        seen.add(key)
+        bad.push({ selector: path(el), text: sample, kind, detail })
+    }
+
+    const visible = (el: Element): boolean => {
+        const cs = getComputedStyle(el)
+        if (cs.display === 'none' || cs.visibility === 'hidden' || parseFloat(cs.opacity) === 0) return false
+        const rect = el.getBoundingClientRect()
+        // sr-only / visually-hidden text lives in a 1px clipped box on purpose
+        return rect.width > 2 && rect.height > 2
+    }
+
+    const truncates = (el: Element): boolean => {
+        const cs = getComputedStyle(el)
+        const clamp = (cs as unknown as Record<string, string>).webkitLineClamp
+        return cs.textOverflow === 'ellipsis' || (clamp !== undefined && clamp !== 'none')
+    }
+
+    const hasOwnText = (el: Element): boolean =>
+        Array.from(el.childNodes).some((n) => n.nodeType === Node.TEXT_NODE && (n.textContent ?? '').trim().length > 0)
+
+    for (const el of Array.from(document.body.querySelectorAll('*'))) {
+        if (!visible(el)) continue
+        if (isExempt(el)) continue
+        const cs = getComputedStyle(el)
+
+        if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+            if (el.type === 'checkbox' || el.type === 'radio' || el.type === 'hidden') continue
+            const text = (el.value || el.placeholder || '').trim()
+            if (!text) continue
+            ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+            const needed = ctx.measureText(text).width
+            const inner = el.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight)
+            if (needed > inner + 1) {
+                flag(el, 'placeholder', `text needs ${Math.round(needed)}px, input fits ${Math.round(inner)}px`, text)
+            }
+            continue
+        }
+
+        const hiddenX = cs.overflowX === 'hidden' || cs.overflowX === 'clip'
+        const hiddenY = cs.overflowY === 'hidden' || cs.overflowY === 'clip'
+        const clipX = hiddenX && el.scrollWidth > el.clientWidth + 1
+        // +3 vertical tolerance: line-height rounding trips a +1 check
+        const clipY = hiddenY && el.scrollHeight > el.clientHeight + 3
+        if (!clipX && !clipY) continue
+
+        // The clipped pixels may be decorative (positioned art bleeding off a
+        // hero on purpose), so attribute the clip to TEXT: flag only text-
+        // bearing descendants whose box actually crosses the clipped edge.
+        const box = el.getBoundingClientRect()
+
+        // the element clips its own direct text — scrollWidth already proves it
+        if (hasOwnText(el) && !truncates(el)) {
+            if (clipX) flag(el, 'clip-x', `scrollWidth ${el.scrollWidth} > clientWidth ${el.clientWidth}`)
+            else flag(el, 'clip-y', `scrollHeight ${el.scrollHeight} > clientHeight ${el.clientHeight}`)
+            continue
+        }
+
+        const holders = Array.from(el.querySelectorAll('*')).filter(
+            (d) => hasOwnText(d) && visible(d) && !truncates(d) && !isExempt(d)
+        )
+        for (const d of holders) {
+            const r = d.getBoundingClientRect()
+            if (clipX && r.right > box.right + 2) {
+                flag(d, 'clip-x', `text box right ${Math.round(r.right)}px > clip edge ${Math.round(box.right)}px`)
+            } else if (clipY && r.bottom > box.bottom + 3) {
+                flag(d, 'clip-y', `text box bottom ${Math.round(r.bottom)}px > clip edge ${Math.round(box.bottom)}px`)
+            }
+        }
+    }
+    return bad
+}
+
+async function settle(page: Page): Promise<void> {
+    await page.waitForFunction((selector) => {
+        const { innerHeight, innerWidth } = window
+        return Array.from(document.querySelectorAll(selector)).every((el) => {
+            const box = el.getBoundingClientRect()
+            return (
+                box.width === 0 || box.bottom <= 0 || box.top >= innerHeight || box.right <= 0 || box.left >= innerWidth
+            )
+        })
+    }, LOADERS)
+    await page.addStyleTag({ content: FREEZE_CSS })
+    await page.evaluate(() => document.fonts.ready.then(() => undefined))
+    // wait for script-driven text (count-ups) to stop changing
+    await page.waitForFunction(
+        () => {
+            const seen = window as unknown as { __overflowText?: string }
+            const text = document.body.innerText
+            if (seen.__overflowText === text) return true
+            seen.__overflowText = text
+            return false
+        },
+        null,
+        { polling: 250 }
+    )
+}
+
+async function assertNoOverflow(page: Page, id: string, testInfo: TestInfo) {
+    // the check walks the whole document, so pull below-fold content in too
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForTimeout(300)
+    await page.evaluate(() => window.scrollTo(0, 0))
+
+    const overflows = await page.evaluate(findOverflows, EXEMPT)
+
+    if (overflows.length > 0) {
+        // outline the offenders so the failure screenshot points at them
+        await page.evaluate((items) => {
+            for (const item of items) {
+                for (const el of Array.from(document.querySelectorAll('*'))) {
+                    const text = (el as HTMLElement).innerText ?? (el as HTMLInputElement).placeholder ?? ''
+                    if (text.trim().replace(/\s+/g, ' ').startsWith(item.text.slice(0, 40))) {
+                        ;(el as HTMLElement).style.outline = '2px solid red'
+                        break
+                    }
+                }
+            }
+        }, overflows)
+        await testInfo.attach(`${id}-overflow`, {
+            body: await page.screenshot({ fullPage: true }),
+            contentType: 'image/png',
+        })
+    }
+
+    const report = overflows.map((o) => `[${o.kind}] ${o.selector} — “${o.text}” (${o.detail})`).join('\n')
+    expect(overflows, `clipped es-419 copy on ${id}:\n${report}`).toEqual([])
+}
+
+async function blockExternal(page: Page): Promise<void> {
+    await page.route('**/*', (route) => {
+        const { hostname } = new URL(route.request().url())
+        return hostname === '127.0.0.1' || hostname === 'localhost' ? route.continue() : route.abort()
+    })
+}
+
+function seenOnceModals(): void {
+    window.sessionStorage.setItem('showNoMoreJailModal', 'true')
+    window.localStorage.setItem('peanut_demo_activation_celebrated_at', '2026-01-01T00:00:00.000Z')
+    window.localStorage.setItem(
+        'demo-user:user-preferences',
+        JSON.stringify({ hasSeenBalanceWarning: { value: true, expiry: 4102444800000 } })
+    )
+    window.sessionStorage.setItem('user_geo_country_code', 'DE')
+    window.sessionStorage.setItem(
+        'user_geo_country_code_timestamp',
+        String(new Date('2026-08-15T11:59:00.000Z').getTime())
+    )
+}
+
+test.describe.configure({ mode: 'parallel' })
+
+// ---- app screens: one test per fixture, es-419 via navigator.language ----
+
+for (const [name, fixture] of Object.entries(FIXTURES)) {
+    test(`fixture:${name}`, async ({ page }, testInfo) => {
+        await blockExternal(page)
+        await page.clock.setFixedTime(FROZEN_NOW)
+        await page.addInitScript(seenOnceModals)
+
+        await page.goto(fixtureHref(fixture.route, name), { waitUntil: 'domcontentloaded' })
+        await expect
+            .poll(() => page.evaluate((key) => window.sessionStorage.getItem(key), FIXTURE_STORAGE_KEY), {
+                message: 'fixture mode never engaged — is this a NEXT_PUBLIC_VERCEL_ENV=preview build?',
+            })
+            .toBe(name)
+        await settle(page)
+
+        // prove the app actually rendered Spanish, or the whole gate is a no-op
+        await expect
+            .poll(() => page.evaluate(() => navigator.language), { message: 'context locale not applied' })
+            .toBe('es-419')
+
+        await assertNoOverflow(page, `fixture:${name}`, testInfo)
+    })
+}
+
+// ---- landing / marketing: locale comes from the route ----
+
+// The two localized landing pages plus the table-heavy marketing templates
+// (pricing, compare, country) — one representative slug each; every slug of a
+// template renders through the same mdx components.
+const LANDING_ROUTES = ['/es-419', '/pt-br', '/es-419/pricing', '/es-419/compare/wise', '/pt-br/argentina']
+
+for (const route of LANDING_ROUTES) {
+    test(`landing:${route}`, async ({ page }, testInfo) => {
+        await blockExternal(page)
+        await page.clock.setFixedTime(FROZEN_NOW)
+        await page.goto(route, { waitUntil: 'domcontentloaded' })
+        await settle(page)
+        await assertNoOverflow(page, `landing:${route}`, testInfo)
+    })
+}
+
+// ---- signup/setup: needs a virtual authenticator or the passkey preflight
+// bounces headless Chromium to the unsupported-browser screen ----
+
+const SETUP_ROUTES = ['/setup', '/setup?step=signup', '/setup?step=login']
+
+for (const route of SETUP_ROUTES) {
+    test(`setup:${route}`, async ({ page }, testInfo) => {
+        const cdp = await page.context().newCDPSession(page)
+        await cdp.send('WebAuthn.enable')
+        await cdp.send('WebAuthn.addVirtualAuthenticator', {
+            options: {
+                protocol: 'ctap2',
+                transport: 'internal',
+                hasResidentKey: true,
+                hasUserVerification: true,
+                isUserVerified: true,
+                automaticPresenceSimulation: true,
+            },
+        })
+
+        await blockExternal(page)
+        await page.clock.setFixedTime(FROZEN_NOW)
+        await page.goto(route, { waitUntil: 'domcontentloaded' })
+        await settle(page)
+
+        // /setup on the mobile-web UA renders the install wall — a real
+        // localized screen, gate it as-is. ?step=signup must reach the real
+        // signup form (the original "Usuario*" overflow lived in its input):
+        // the virtual authenticator makes the passkey preflight pass, and the
+        // visible input proves we are not on the install/unsupported wall.
+        if (route.includes('step=signup')) {
+            await expect(page.locator('input:visible').first()).toBeVisible()
+        }
+
+        await assertNoOverflow(page, `setup:${route}`, testInfo)
+    })
+}

--- a/e2e/shots/overflow.spec.ts
+++ b/e2e/shots/overflow.spec.ts
@@ -138,11 +138,15 @@ for (const [name, fixture] of Object.entries(FIXTURES)) {
             .toBe(name)
         await settle(page)
 
-        // prove the app actually rendered this locale, or the gate is a no-op
-        const locale = testInfo.project.use.locale
+        // prove the app actually RENDERED this locale, or the gate scans the
+        // English it hydrates with: IntlCore stamps <html lang> only after the
+        // async catalog is applied, so wait for that — navigator.language only
+        // proves the browser asked for it
         await expect
-            .poll(() => page.evaluate(() => navigator.language), { message: 'context locale not applied' })
-            .toBe(locale)
+            .poll(() => page.evaluate(() => document.documentElement.lang), {
+                message: 'translated catalog never rendered',
+            })
+            .toBe(testInfo.project.use.locale)
 
         await assertNoOverflow(page, `fixture:${name}`, testInfo)
     })
@@ -204,6 +208,14 @@ for (const route of SETUP_ROUTES) {
         if (route.includes('step=signup')) {
             await expect(page.locator('input:visible').first()).toBeVisible()
         }
+
+        // same catalog race as the fixture tests: scan only after the app
+        // stamps the rendered locale
+        await expect
+            .poll(() => page.evaluate(() => document.documentElement.lang), {
+                message: 'translated catalog never rendered',
+            })
+            .toBe(testInfo.project.use.locale)
 
         await assertNoOverflow(page, `setup:${route}`, testInfo)
     })

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
         "test:visual": "NEXT_PUBLIC_VERCEL_ENV=preview pnpm build && pnpm test:visual:capture",
         "test:visual:capture": "export SHOTS_OUT=${SHOTS_OUT:-e2e/__shots__/current}; rm -rf \"$SHOTS_OUT\" && playwright test --config=playwright.shots.config.ts",
         "test:visual:diff": "node scripts/visual-diff.mjs",
+        "test:i18n-overflow": "NEXT_PUBLIC_VERCEL_ENV=preview pnpm build && pnpm test:i18n-overflow:run",
+        "test:i18n-overflow:run": "playwright test --config=playwright.overflow.config.ts",
         "ping-indexnow": "tsx scripts/ping-indexnow.ts",
         "script": "NODE_OPTIONS=\"--experimental-json-modules\" tsx",
         "validate-content": "tsx scripts/validate-content.ts",

--- a/playwright.overflow.config.ts
+++ b/playwright.overflow.config.ts
@@ -1,0 +1,28 @@
+/**
+ * i18n overflow gate (TASK-22366): e2e/shots/overflow.spec.ts in es-419 at
+ * 320px. Everything else — server, timeouts, determinism — comes from
+ * playwright.shots.config.ts; only the locale and the project set differ.
+ * The check is absolute (is text clipped?), not comparative, so there is no
+ * baseline and no width matrix.
+ *
+ *   npm run test:i18n-overflow            # build, then check
+ *   npm run test:i18n-overflow:run        # check again, no rebuild
+ */
+
+import { defineConfig } from '@playwright/test'
+import base from './playwright.shots.config'
+
+export default defineConfig({
+    ...base,
+    projects: [
+        {
+            name: 'overflow',
+            testMatch: /overflow\.spec\.ts/,
+            use: {
+                ...base.use,
+                viewport: { width: 320, height: 568 },
+                locale: 'es-419',
+            },
+        },
+    ],
+})

--- a/playwright.overflow.config.ts
+++ b/playwright.overflow.config.ts
@@ -1,9 +1,12 @@
 /**
- * i18n overflow gate (TASK-22366): e2e/shots/overflow.spec.ts in es-419 at
- * 320px. Everything else — server, timeouts, determinism — comes from
- * playwright.shots.config.ts; only the locale and the project set differ.
- * The check is absolute (is text clipped?), not comparative, so there is no
- * baseline and no width matrix.
+ * i18n overflow gate (TASK-22366): e2e/shots/overflow.spec.ts once per
+ * supported non-English locale at 320px, plus the detector self-tests.
+ * es-419 alone is not a safe maximum — hundreds of pt-BR strings run longer
+ * than their es-419 counterparts, and es-AR overrides es-419 — so every
+ * locale gets its own project. Everything else — server, timeouts,
+ * determinism — comes from playwright.shots.config.ts. The check is absolute
+ * (is text clipped?), not comparative, so there is no baseline and no width
+ * matrix.
  *
  *   npm run test:i18n-overflow            # build, then check
  *   npm run test:i18n-overflow:run        # check again, no rebuild
@@ -12,16 +15,27 @@
 import { defineConfig } from '@playwright/test'
 import base from './playwright.shots.config'
 
+const LOCALES = ['es-419', 'pt-BR', 'es-AR'] as const
+
 export default defineConfig({
     ...base,
     projects: [
-        {
-            name: 'overflow',
+        ...LOCALES.map((locale) => ({
+            name: locale,
             testMatch: /overflow\.spec\.ts/,
             use: {
                 ...base.use,
                 viewport: { width: 320, height: 568 },
-                locale: 'es-419',
+                locale,
+            },
+        })),
+        // synthetic self-tests for the detector itself (overflow-check.ts)
+        {
+            name: 'detector',
+            testMatch: /overflow-detector\.spec\.ts/,
+            use: {
+                ...base.use,
+                viewport: { width: 320, height: 568 },
             },
         },
     ],

--- a/playwright.shots.config.ts
+++ b/playwright.shots.config.ts
@@ -71,6 +71,9 @@ export default defineConfig({
     projects: WIDTHS.map(({ width, height }) => ({
         name: String(width),
         use: { viewport: { width, height } },
+        // overflow.spec.ts is the i18n overflow gate — it runs es-419 through
+        // playwright.overflow.config.ts, never in the en-US capture matrix.
+        testIgnore: /overflow\.spec\.ts/,
     })),
 
     webServer: {

--- a/playwright.shots.config.ts
+++ b/playwright.shots.config.ts
@@ -71,9 +71,10 @@ export default defineConfig({
     projects: WIDTHS.map(({ width, height }) => ({
         name: String(width),
         use: { viewport: { width, height } },
-        // overflow.spec.ts is the i18n overflow gate — it runs es-419 through
-        // playwright.overflow.config.ts, never in the en-US capture matrix.
-        testIgnore: /overflow\.spec\.ts/,
+        // overflow*.spec.ts is the i18n overflow gate — it runs per-locale
+        // through playwright.overflow.config.ts, never in the en-US capture
+        // matrix.
+        testIgnore: /overflow.*\.spec\.ts/,
     })),
 
     webServer: {

--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -967,6 +967,12 @@ export const TEXT_STYLES: TextStyle[] = [
         "section": "parity",
         "fontSize": "3.75rem",
         "lineHeight": "2.875rem"
+    },
+    {
+        "name": "headingSmall",
+        "section": "parity",
+        "fontSize": "2.625rem",
+        "lineHeight": "2.25rem"
     }
 ]
 

--- a/src/components/Global/FAQs/index.tsx
+++ b/src/components/Global/FAQs/index.tsx
@@ -54,7 +54,9 @@ export function FAQsPanel({ heading, questions, learnMoreLabel = 'Learn more' }:
         // drift fix: was near-miss hex — snapped to the page-background token
         <section className="relative overflow-hidden bg-background-page px-4 py-24 text-foreground-primary md:py-32">
             <div className="mx-auto max-w-3xl">
-                <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack uppercase md:text-headingMedium">
+                {/* heading-xl on mobile: "PERGUNTAS FREQUENTES" at text-heading
+                    (60px) needs 401px and clips at 320px (TASK-22366) */}
+                <h2 className="font-roboto-flex-extrabold text-heading-xl font-extraBlack uppercase md:text-headingMedium">
                     {heading}
                 </h2>
                 <div className="mt-10 border-y-2 border-border-default">

--- a/src/components/Global/FAQs/index.tsx
+++ b/src/components/Global/FAQs/index.tsx
@@ -54,9 +54,9 @@ export function FAQsPanel({ heading, questions, learnMoreLabel = 'Learn more' }:
         // drift fix: was near-miss hex — snapped to the page-background token
         <section className="relative overflow-hidden bg-background-page px-4 py-24 text-foreground-primary md:py-32">
             <div className="mx-auto max-w-3xl">
-                {/* heading-xl on mobile: "PERGUNTAS FREQUENTES" at text-heading
+                {/* headingSmall on mobile: "PERGUNTAS FREQUENTES" at text-heading
                     (60px) needs 401px and clips at 320px (TASK-22366) */}
-                <h2 className="font-roboto-flex-extrabold text-heading-xl font-extraBlack uppercase md:text-headingMedium">
+                <h2 className="font-roboto-flex-extrabold text-headingSmall font-extraBlack uppercase md:text-headingMedium">
                     {heading}
                 </h2>
                 <div className="mt-10 border-y-2 border-border-default">

--- a/src/components/LandingPage/ShhhhhFold.tsx
+++ b/src/components/LandingPage/ShhhhhFold.tsx
@@ -34,7 +34,7 @@ export function ShhhhhFold() {
                     <Link
                         prefetch={false}
                         href="/shhhhh"
-                        className="font-roboto-flex-extrabold inline-block text-[4rem] leading-none font-extraBlack md:text-headingLarge"
+                        className="font-roboto-flex-extrabold inline-block text-heading leading-none font-extraBlack md:text-headingLarge"
                     >
                         {t('wordmark')}
                     </Link>

--- a/src/components/LandingPage/ShhhhhFold.tsx
+++ b/src/components/LandingPage/ShhhhhFold.tsx
@@ -34,7 +34,7 @@ export function ShhhhhFold() {
                     <Link
                         prefetch={false}
                         href="/shhhhh"
-                        className="font-roboto-flex-extrabold inline-block text-headingMedium leading-none font-extraBlack md:text-headingLarge"
+                        className="font-roboto-flex-extrabold inline-block text-[4rem] leading-none font-extraBlack md:text-headingLarge"
                     >
                         {t('wordmark')}
                     </Link>

--- a/src/components/LandingPage/StickyMobileCTA.tsx
+++ b/src/components/LandingPage/StickyMobileCTA.tsx
@@ -93,24 +93,11 @@ export function StickyMobileCTA({ strings }: { strings: LandingStrings }) {
                             </Button>
                         </a>
                     ) : (
-                        <div className="pointer-events-auto flex items-center gap-4">
-                            <Link prefetch={false} href="/setup" className="block flex-1">
-                                <Button
-                                    variant="purple"
-                                    shadowSize="4"
-                                    className="w-full py-3 text-base font-extrabold"
-                                >
-                                    {strings.signUpNow}
-                                </Button>
-                            </Link>
-                            <Link
-                                prefetch={false}
-                                href="/setup?step=login"
-                                className="shrink-0 text-body-s text-n-1 underline"
-                            >
-                                {strings.logIn}
-                            </Link>
-                        </div>
+                        <Link prefetch={false} href="/setup" className="pointer-events-auto block">
+                            <Button variant="purple" shadowSize="4" className="w-full py-3 text-base font-extrabold">
+                                {strings.signUpNow}
+                            </Button>
+                        </Link>
                     )}
                 </div>
             }

--- a/src/components/LandingPage/securityBuiltIn.tsx
+++ b/src/components/LandingPage/securityBuiltIn.tsx
@@ -64,7 +64,9 @@ export function SecurityBuiltIn({ locale = DEFAULT_LOCALE }: { locale?: Locale }
                     {/* h2, not h1: this h1 sat directly above the h3 feature
                         titles, and that h1 → h3 skip failed Lighthouse's
                         heading-order audit. */}
-                    <h2 className="font-roboto-flex-extrabold text-left text-heading font-extraBlack md:text-6xl lg:text-heading">
+                    {/* heading-xl on mobile: "SEGURANÇA." at text-heading (60px)
+                        needs 403px and clips at 320px (TASK-22366) */}
+                    <h2 className="font-roboto-flex-extrabold text-left text-heading-xl font-extraBlack md:text-6xl lg:text-heading">
                         {i18n.landingSecurityHeading}
                     </h2>
                 </div>

--- a/src/components/LandingPage/securityBuiltIn.tsx
+++ b/src/components/LandingPage/securityBuiltIn.tsx
@@ -64,9 +64,9 @@ export function SecurityBuiltIn({ locale = DEFAULT_LOCALE }: { locale?: Locale }
                     {/* h2, not h1: this h1 sat directly above the h3 feature
                         titles, and that h1 → h3 skip failed Lighthouse's
                         heading-order audit. */}
-                    {/* heading-xl on mobile: "SEGURANÇA." at text-heading (60px)
+                    {/* headingSmall on mobile: "SEGURANÇA." at text-heading (60px)
                         needs 403px and clips at 320px (TASK-22366) */}
-                    <h2 className="font-roboto-flex-extrabold text-left text-heading-xl font-extraBlack md:text-6xl lg:text-heading">
+                    <h2 className="font-roboto-flex-extrabold text-left text-headingSmall font-extraBlack md:text-6xl lg:text-heading">
                         {i18n.landingSecurityHeading}
                     </h2>
                 </div>

--- a/src/components/Marketing/mdx/components.tsx
+++ b/src/components/Marketing/mdx/components.tsx
@@ -113,7 +113,9 @@ export const mdxComponents: MdxComponentMap = {
     strong: (props: React.HTMLAttributes<HTMLElement>) => <strong className="font-semibold text-n-1" {...props} />,
     table: (props: React.HTMLAttributes<HTMLTableElement>) => (
         <div className={`mx-auto my-8 ${PROSE_WIDTH} overflow-x-auto px-6 md:px-4`}>
-            <div className="overflow-hidden rounded-sm border border-n-1">
+            {/* x-auto, not hidden: a table wider than the phone must scroll
+                inside the border, never clip its columns (TASK-22366) */}
+            <div className="overflow-x-auto rounded-sm border border-n-1">
                 <table className="w-full border-collapse text-left text-sm" {...props} />
             </div>
         </div>

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -90,7 +90,9 @@ const IMAGE_CONTAINER_CLASSES: Record<LayoutType, string> = {
 // each array element represents a star with specific positioning and animation
 const STAR_POSITIONS = [
     'left-[10%] md:left-[15%] lg:left-[15%] top-[15%] md:top-[20%]  size-13 md:size-14',
-    'right-[10%] md:right-[15%] lg:right-[15%] top-[10%] md:top-[20%] size-10 md:size-14',
+    // mobile top-[24%], not [10%]: the nav row (Iniciar sesión / skip) owns the
+    // top band and the star sat right under the text (TASK-22366 nit)
+    'right-[10%] md:right-[15%] lg:right-[15%] top-[24%] md:top-[20%] size-10 md:size-14',
     'left-[10%] md:left-[15%] lg:left-[15%] bottom-[15%] md:bottom-[20%] size-12 md:size-14',
     'right-[10%] md:right-[15%] lg:right-[15%] bottom-[30%] size-6 md:size-14',
 ] as const

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -398,6 +398,11 @@
     --text-headingMedium--line-height: 4rem;
     --text-heading: 3.75rem;
     --text-heading--line-height: 2.875rem;
+    /* the mobile step of the display family: text-heading (60px) clips long
+       es/pt headings at 320px (TASK-22366). weightless like its siblings —
+       landing pairs these with font-extraBlack */
+    --text-headingSmall: 2.625rem;
+    --text-headingSmall--line-height: 2.25rem;
 
     --font-weight-extraBlack: 1000;
 

--- a/src/utils/tw.ts
+++ b/src/utils/tw.ts
@@ -23,11 +23,11 @@ import { extendTailwindMerge } from 'tailwind-merge'
 
 // text-heading-m, text-body-m-semibold, text-label-l, text-button-s, and the
 // bare/legacy entries in the same block: text-heading, text-display, text-0,
-// text-h1..h10, plus the camelCase pair text-headingLarge/text-headingMedium.
+// text-h1..h10, plus the camelCase display family text-headingLarge/Medium/Small.
 // Tailwind's own names (text-sm, text-6xl…) are re-declared in
 // the block but already sit in the stock font-size group, so they stay out.
 const DS_TYPE_TOKEN =
-    /^(?:heading|body|label|button)(?:-[a-z0-9-]+)?$|^(?:headingLarge|headingMedium|display|0|h(?:10|[1-9]))$/
+    /^(?:heading|body|label|button)(?:-[a-z0-9-]+)?$|^(?:headingLarge|headingMedium|headingSmall|display|0|h(?:10|[1-9]))$/
 
 // `--radius-round` (999px) and `--radius-1` (1px). Stock tailwind-merge only
 // knows its own t-shirt radii, so it leaves `rounded-round` unrecognised: a


### PR DESCRIPTION
## Summary

Translated strings run 25–40% longer than English and kept getting clipped (signup "Usuario*" placeholder, landing tables) with reviewers as the only guard. Hugo asked for a deterministic gate: "IF copy in any supported language overflows in any component THEN fail lint."

This adds that gate as a **rendered DOM check, not a visual diff**: every fixture in `src/dev/fixtures/registry.ts`, the localized landing/marketing routes, and the signup/setup screens render in es-419 (the longest locale) at 320px, and the run fails when text is actually clipped — own-overflow clip, text crossing a hidden-overflow ancestor's edge, or an input placeholder wider than the input (measured with canvas `measureText`; the original Usuario* bug class). Absolute check → no baselines, no per-locale screenshot churn. Elements that opt into truncation (`text-overflow: ellipsis`, line-clamp) are skipped by design; intentional clips go in one justified `EXEMPT` list (only entry so far: marquee tickers).

Setup screens are reached with a CDP virtual authenticator so the passkey preflight passes headless — `?step=signup` additionally asserts the real signup form rendered (visible input), so this coverage can't silently degrade into gating the install wall.

The detector itself is pinned by synthetic self-tests (`overflow-detector.spec.ts`): every bug shape it must catch (own-clip, nested full-width nowrap child, box past the clip edge, wide placeholder, vertical clip) and every deliberate shape it must ignore (ellipsis, scrollers, sr-only, exemptions) — so a detector regression fails the same run, not a week of silently-green gates.

Fixes the two real overflow classes the first run caught, plus one task nit:

- **Marketing mdx tables clipped their columns** behind `overflow-hidden` at phone widths — now `overflow-x-auto`, so every pricing/compare/country table scrolls inside its border in every locale.
- **Landing shhhhh wordmark** was 80px (`text-headingMedium`) on a 288px column — now `text-[4rem]` on mobile, matching the sibling folds; md+ unchanged.
- **Signup header star sat under "Iniciar sesión"** at 375px (layout/art collision named in the task) — moved below the nav band on mobile.

Also in this PR (reviewer's call during review): the sticky mobile CTA on the landing page drops its log-in link — it crowded the bar and the hero keeps its own. Partially reverts `784bcb05a` (TASK-22117, Slava); to be reconsidered in next week's LP rework.

## Task

TASK-22366

## Risks / breaking changes

- No product logic changes; the three UI fixes are CSS-only. No cross-repo impact.
- CI: the gate runs as a step inside the advisory `ds-shots` job — a failure reddens that job but cannot block a merge yet. Deliberate: same "advisory until a week of zero false positives, then blocking" ratchet as Nutcracker smoke. Promoting it to its own required job is the follow-up.
- The gate runs one project per supported non-English locale (es-419, pt-BR, es-AR) — es-419 alone is not a safe maximum (hundreds of pt-BR strings run longer). Chip finding, addressed.

## QA

- `npm run test:i18n-overflow` locally (build + run): 44/44 green on this branch; runs 1–2 caught the table/wordmark clips above before the fixes.
- Detection proven live: the gate flagged the marquee tickers, sr-only text (filtered as intentional), and the two real bugs on first run.
- typecheck green, prettier green; jest: 3 failures in `AddWithdrawCountriesList`/`UnlockPayments` are pre-existing on clean dev (verified by running the same suites on the dev checkout), untouched by this diff.

## Screenshots — before (dev) vs after (this PR), all locales

All shots are real builds: before = current dev, after = this branch. 320px mobile (375px for signup) — the widths where clipping shows. es-AR inherits es-419 content, included for completeness. Assets branch `pr-assets-3076` — delete post-merge.

<details><summary><b>Landing — security section</b> (heading clipped in es/pt before; English never clipped, shown for reference)</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/security-pt-br-after.png" width="260"> |

</details>

<details><summary><b>Country page — FAQ heading</b> ("PERGUNTAS FREQUENTES" / "PREGUNTAS FRECUENTES" clipped before; en heading is just "FAQ.")</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/faq-pt-br-after.png" width="260"> |

</details>

<details><summary><b>Pricing table</b> (before: right columns cut off and a swipe does nothing; after: the same swipe scrolls the table — after-shots taken mid-swipe)</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/pricing-pt-br-after.png" width="260"> |

</details>

<details><summary><b>shhhhh fold</b> (wordmark clipped at 320px in every locale, English included)</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/shhhhh-pt-br-after.png" width="260"> |

</details>

<details><summary><b>Signup, 375px</b> (star sat under the top-right log-in text; placeholder fits post-#3025)</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/signup-pt-br-after.png" width="260"> |

</details>

<details><summary><b>Landing sticky CTA</b> (log-in link removed — reviewer's call; hero keeps its own)</summary>



| Locale | Before (dev) | After (this PR) |
|---|---|---|
| English | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-en-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-en-after.png" width="260"> |
| Español (es-419) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-es-419-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-es-419-after.png" width="260"> |
| Español AR (es-AR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-es-ar-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-es-ar-after.png" width="260"> |
| Português (pt-BR) | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-pt-br-before.png" width="260"> | <img src="https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3076/sticky-cta-pt-br-after.png" width="260"> |

</details>

## Design notes / accepted trade-offs

- `overflow.spec.ts` carries its own copies of the settle/freeze helpers from `fixtures.spec.ts` (~40 lines) rather than extracting a shared `e2e/shots/helpers.ts` — kept the diff surgical; extraction is a clean follow-up if a third spec ever needs them.
- The gate runs as a step inside the advisory `ds-shots` job on purpose (repo ratchet pattern: advisory until a week of zero false positives, then its own blocking job).
- The mdx table markup keeps its pre-existing double wrapper (outer `overflow-x-auto` is now redundant since the inner border div scrolls) — pre-existing structure, not touched beyond the one class that caused the clipping.
