### PR TITLE
fix(kyc): TASK-22471 WebSDK fallback when the native Sumsub SDK cannot start

### DIFF
--- a/src/components/Kyc/SumsubNativeSdk.tsx
+++ b/src/components/Kyc/SumsubNativeSdk.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useLocale, useTranslations } from 'next-intl'
+import { useLocale } from 'next-intl'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
-import Modal from '@/components/Global/Modal'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { toSumsubLocale } from '@/i18n/app/sumsub-locale'
-import { SumsubSdkErrorView } from './SumsubSdkErrorView'
+import { SumsubWebSdkModal } from './SumsubWebSdkModal'
 import type { SumsubSdkProps } from './sumsubSdk.types'
 
 /**
@@ -21,12 +20,16 @@ const SUBMITTED_STATES = new Set(['Pending', 'TemporarilyDeclined', 'FinallyReje
 /**
  * Drives the Sumsub Cordova SDK inside the Capacitor shell.
  *
- * The native SDK owns the whole screen, so this renders nothing while it is up
- * — only the failure state gets UI. That failure state is the entire point of
- * the component: run the WebSDK in the WebView instead and a Sumsub-side init
- * failure paints *their* "Initialization error" screen inside the iframe, which
- * throws nothing we can catch and reports nothing. Here every exit path is
- * either a resolved launch or a captured exception.
+ * The native SDK owns the whole screen, so this renders nothing while it is up.
+ * When the native SDK cannot start at all (plugin missing from the binary,
+ * init throw, launch rejection — e.g. the 1.5.0+21653381 Android build that
+ * shipped without the Cordova plugin's native class), falling over to the
+ * WebSDK in the WebView beats a dead-end error screen: the WebSDK is the
+ * battle-tested PWA path and runs in the WebView. The trade-off that made
+ * native primary still stands — a Sumsub-side init failure in the web iframe
+ * is silent to our handlers — but as a fallback that risk only exists for
+ * users who otherwise could not verify at all. Every native failure is still
+ * captured to Sentry/PostHog before the fallback renders.
  */
 export const SumsubNativeSdk = ({
     visible,
@@ -38,13 +41,11 @@ export const SumsubNativeSdk = ({
     onSubmitted,
     isMultiLevel,
 }: SumsubSdkProps) => {
-    const t = useTranslations('kyc')
     const locale = useLocale()
     const [failure, setFailure] = useState<'sdk-missing' | 'launch' | null>(null)
 
     const onCloseRef = useRef(onClose)
     const onCompleteRef = useRef(onComplete)
-    const onErrorRef = useRef(onError)
     const onRefreshTokenRef = useRef(onRefreshToken)
     const accessTokenRef = useRef(accessToken)
     const isMultiLevelRef = useRef(isMultiLevel)
@@ -54,12 +55,11 @@ export const SumsubNativeSdk = ({
     useEffect(() => {
         onCloseRef.current = onClose
         onCompleteRef.current = onComplete
-        onErrorRef.current = onError
         onRefreshTokenRef.current = onRefreshToken
         accessTokenRef.current = accessToken
         isMultiLevelRef.current = isMultiLevel
         onSubmittedRef.current = onSubmitted
-    }, [onClose, onComplete, onError, onRefreshToken, accessToken, isMultiLevel, onSubmitted])
+    }, [onClose, onComplete, onRefreshToken, accessToken, isMultiLevel, onSubmitted])
 
     useEffect(() => {
         sumsubLocaleRef.current = toSumsubLocale(locale)
@@ -84,8 +84,11 @@ export const SumsubNativeSdk = ({
                 tags: { sumsub_sdk: 'native', sumsub_failure: reason },
                 extra: { detail },
             })
+            // Falling back to the WebSDK is recovery, not a terminal error, so
+            // the parent's onError stays quiet here; the web driver still calls
+            // it if the fallback itself fails.
+            posthog.capture(ANALYTICS_EVENTS.KYC_WEB_FALLBACK_USED, { platform: 'native', reason })
             setFailure(kind)
-            onErrorRef.current?.(detail)
         }
 
         const sumsub = window.SNSMobileSDK
@@ -158,22 +161,19 @@ export const SumsubNativeSdk = ({
 
     if (!visible || !failure) return null
 
+    // Native SDK could not start — hand the same session to the WebSDK. The web
+    // driver owns its own load-error UI, so a fallback that also fails still
+    // ends in an actionable error screen rather than a blank modal.
     return (
-        <Modal
-            visible
+        <SumsubWebSdkModal
+            visible={visible}
+            accessToken={accessToken}
             onClose={onClose}
-            classWrap="h-full w-full !max-w-none sm:!max-w-[600px] border-none sm:m-auto m-0"
-            classOverlay="bg-black/50"
-            video={false}
-            className="z-[100] !p-0 md:!p-6"
-            classButtonClose="hidden"
-            preventClose={true}
-            hideOverlay={false}
-        >
-            <SumsubSdkErrorView
-                onClose={onClose}
-                message={failure === 'sdk-missing' ? t('errorSdkUnavailable') : t('wrapper.loadError')}
-            />
-        </Modal>
+            onComplete={onComplete}
+            onSubmitted={onSubmitted}
+            onError={onError}
+            onRefreshToken={onRefreshToken}
+            isMultiLevel={isMultiLevel}
+        />
     )
 }

--- a/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
+++ b/src/components/Kyc/__tests__/SumsubNativeSdk.test.tsx
@@ -17,11 +17,11 @@ jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: (...a: un
 const captureException = jest.fn()
 jest.mock('@sentry/nextjs', () => ({ captureException: (...a: unknown[]) => captureException(...a) }))
 
-jest.mock('@/components/Global/Modal', () => ({
+jest.mock('../SumsubWebSdkModal', () => ({
     __esModule: true,
-    default: function MockModal({ visible, children }: { visible: boolean; children: ReactNode }) {
+    SumsubWebSdkModal: ({ visible, accessToken }: { visible: boolean; accessToken: string | null }) => {
         if (!visible) return null
-        return <div data-testid="modal">{children}</div>
+        return <div data-testid="web-fallback" data-token={accessToken ?? ''} />
     },
 }))
 
@@ -185,10 +185,11 @@ describe('SumsubNativeSdk', () => {
         }
     )
 
-    // The whole point of moving off the WebSDK: a Sumsub-side failure used to
-    // paint their "Initialization error" screen inside a cross-origin iframe and
-    // report nothing. It must now reach the user AND both reporters.
-    it('surfaces and reports a failed launch', async () => {
+    // A native SDK that cannot start must not dead-end the user: the WebSDK
+    // takes over with the same session token, and both reporters still hear
+    // about the native failure (that telemetry is how the broken 21653381
+    // Android binary was caught).
+    it('falls back to the WebSDK and reports a failed launch', async () => {
         launch.mockResolvedValue({ success: false, status: 'Failed', errorType: 'Unknown', errorMsg: 'boom' })
         const props = baseProps()
         const { rerender } = render(<SumsubNativeSdk visible={false} {...props} />)
@@ -197,12 +198,14 @@ describe('SumsubNativeSdk', () => {
             rerender(<SumsubNativeSdk visible {...props} />)
         })
 
-        expect(await screen.findByText(/failed to load verification/i)).toBeInTheDocument()
+        const fallback = await screen.findByTestId('web-fallback')
+        expect(fallback).toHaveAttribute('data-token', 'tok_abc')
         expect(capture).toHaveBeenCalledWith('kyc_sdk_init_failed', expect.objectContaining({ platform: 'native' }))
+        expect(capture).toHaveBeenCalledWith('kyc_web_fallback_used', expect.objectContaining({ reason: 'Unknown' }))
         expect(captureException).toHaveBeenCalled()
     })
 
-    it('surfaces and reports a missing plugin instead of opening nothing', async () => {
+    it('falls back to the WebSDK when the plugin is missing from the binary', async () => {
         delete (window as unknown as { SNSMobileSDK?: unknown }).SNSMobileSDK
         const props = baseProps()
 
@@ -210,11 +213,24 @@ describe('SumsubNativeSdk', () => {
             render(<SumsubNativeSdk visible {...props} />)
         })
 
-        expect(screen.getByText(/not available/i)).toBeInTheDocument()
+        expect(screen.getByTestId('web-fallback')).toBeInTheDocument()
         expect(capture).toHaveBeenCalledWith(
             'kyc_sdk_init_failed',
             expect.objectContaining({ reason: 'sdk-unavailable' })
         )
+        expect(capture).toHaveBeenCalledWith(
+            'kyc_web_fallback_used',
+            expect.objectContaining({ reason: 'sdk-unavailable' })
+        )
+    })
+
+    it('does not render the fallback while the native SDK is up', async () => {
+        const props = baseProps()
+        await act(async () => {
+            render(<SumsubNativeSdk visible {...props} />)
+        })
+        expect(launch).toHaveBeenCalledTimes(1)
+        expect(screen.queryByTestId('web-fallback')).not.toBeInTheDocument()
     })
 
     // Without this the plugin's module-level lock is never released and every

--- a/src/constants/analytics.consts.ts
+++ b/src/constants/analytics.consts.ts
@@ -192,6 +192,8 @@ export const ANALYTICS_EVENTS = {
     KYC_SDK_LAUNCHED: 'kyc_sdk_launched',
     KYC_SDK_LAUNCH_TIMEOUT: 'kyc_sdk_launch_timeout',
     KYC_SDK_INIT_FAILED: 'kyc_sdk_init_failed',
+    // native SDK failed and the WebSDK rendered in its place
+    KYC_WEB_FALLBACK_USED: 'kyc_web_fallback_used',
 
     // ── Card: acquisition funnel (Rain virtual card) ──
     // State observed on /card mount or transition. `state` matches CardTopLevelState.


### PR DESCRIPTION
## TASK-22471 · P1 · Android native KYC broken on Play binary 1.5.0+21653381

**What**: when the native Sumsub SDK cannot start (plugin missing from the binary, init throw, launch rejection), render the WebSDK in the WebView with the same session token instead of a dead-end error modal.

**Why now**: the current Play binary shipped without the Cordova plugin's native class ("Class not found" at `SumsubNativeSdk.tsx` launch). Every Android user on it — 5+ real users and climbing since the 100% pwa-sunset flip — cannot KYC at all (Sentry [PEANUT-UI-T33](https://peanut-c34d84c05.sentry.io/issues/PEANUT-UI-T33)). This change is OTA-able: merge → production OTA dispatch → installed users heal on next launch, no Play review.

**Why the fallback is safe**:
- The wrapper's own design note records that "the WebSDK does run inside the Capacitor WebView" — native was preferred only because a Sumsub-side iframe init failure is silent. As a fallback that runs *only after native failed*, the trade-off inverts: silent-failure risk applies only to users who otherwise could not verify at all, and the web driver has its own load-error UI.
- Camera: `AndroidManifest.xml` declares `CAMERA`; there is no custom `WebChromeClient`/`onPermissionRequest` override, so Capacitor's default bridge grants WebView `getUserMedia` when the app holds the permission.
- Native stays primary: iOS and a future fixed binary never see the fallback (`does not render the fallback while the native SDK is up` test).
- `onError` is not fired on fallback — recovery isn't a terminal error; the web driver still calls it for its own failures. No current caller passes `onError`.

**Telemetry**: every native failure still captures to Sentry + PostHog (`kyc_sdk_init_failed`), plus new `kyc_web_fallback_used` so fallback usage is measurable (and alertable when the fixed binary should have made it zero).

**Verification**: Kyc suites 26/26 green; full jest: only 2 pre-existing timezone-flaky suites fail locally (IST machine; date-string assertions — CI/UTC green on base). Typecheck via CI (fresh-worktree svg-types env issue locally, known phantom class).

**Follow-ups (in TASK-22471, not this PR)**: rebuild the Android binary with the plugin synced (`release-native.yml` run 34240637046 shows no cordova/cap-sync lines — the packaging root cause), and add a build assertion that the APK contains the Sumsub native class.
