### PR TITLE
fix(ci): TASK-22471 grant the android release call the write its tag job needs

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -88,6 +88,11 @@ jobs:
     android:
         needs: resolve
         uses: ./.github/workflows/android-release.yml
+        # the called workflow's record-replacement-baseline job writes one
+        # annotated tag; a caller must grant what its callee's jobs request or
+        # the whole workflow fails validation at dispatch (TASK-22471).
+        permissions:
+            contents: write
         secrets: inherit
         with:
             versionName: ${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
## Summary

Tonight's `release-native.yml` dispatch from `release/android-kyc` failed **workflow validation** before any job ran:

> The nested job 'record-replacement-baseline' is requesting 'contents: write', but is only allowed 'contents: read'.

`release-native.yml` pins `permissions: contents: read` at workflow level, and `android-release.yml` — which it calls — now carries the `record-replacement-baseline` job (added after the last successful coordinated release) that requests `contents: write` for its one annotated tag. A called workflow's jobs cannot exceed the caller's grant, so the whole dispatch dies at validation — even though the job itself is `if`-gated off for coordinated releases.

Fix: grant `contents: write` on the `android` **caller job only**. iOS stays read-only (verified: `ios-release.yml` declares `contents: read`). The called workflow's other jobs keep their own declared permissions.

Unblocks the TASK-22471 binary release. Dev's `release-native.yml` has the same latent bug — included in the dev port follow-up.

## Task

TASK-22471 — https://app.notion.com/p/3d6838117579812fb7fcc9b6dda06dfb

## Risks

One caller-job permission widened to what the callee's tag job already declares; no behavior change for any other job.

## QA

prettier ✅ · yaml-only; validation error is reproduced/verified from run annotations (the failed dispatch). CI suite doesn't run on this base.

Screenshots: N/A (CI fix)
