### PR TITLE
fix(ota): refuse a bundle built for a newer binary, and point at the store instead

### DIFF
--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -436,8 +436,16 @@ own `out/` under the binary's versionName, then assert the channel serves it.
   `<major>.<build>.<ota>` scheme a bundle's first two segments name the binary it was built
   against, so a bundle whose `<major>.<build>` outranks `App.getInfo().version` is never
   downloaded, never staged, and reported as store-update-required instead. A bundle already
-  sitting in the plugin's queue is unstaged rather than hidden — `installNext()` runs from
+  sitting in the plugin's queue is *disarmed* rather than hidden — `installNext()` runs from
   `appMovedToBackground()` with no JS involved, so hiding it would not stop it installing.
+  The disarm points `next` back at the running bundle, which is the entry `installNext()`
+  skips (there is no JS-reachable clear-next, and `setBundleError` needs a config flag no
+  shipped binary sets); `builtin` is the fallback when the running bundle's id cannot be
+  read. It is verified by re-reading the queue, and an unconfirmed disarm is reported at
+  error level under `[capgo-apply]`, because a rewrite that silently failed leaves the
+  unsafe bundle installing on the next background. The sentinel it leaves behind persists —
+  `NEXT_VERSION` is cleared only when a *different* bundle installs — so a queue entry
+  naming the running bundle is never read back as an update.
   It fails **open** on a version either side cannot parse: refusing every update on an
   off-scheme version is the worse of the two failures.
 - **Native fingerprint (the check behind that rule):** `scripts/native-fingerprint.mjs`

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -412,10 +412,34 @@ own `out/` under the binary's versionName, then assert the channel serves it.
   tag (`scripts/release-version.mjs native-floor`) and fails if none is visible. It replaced
   `--auto-min-update-version`, which only copies the previous bundle's floor forward — with no
   native version stamped on the `dev` checkout (package.json says 1.0.53) the floor never
-  rose past the first upload, and the CLI refuses the two flags together. Capgo only enforces
-  the floor when the channel's "disable auto update" strategy is set to *version number*.
+  rose past the first upload, and the CLI refuses the two flags together.
   **Bump the native version whenever you change plugins/native code**, then ship that via
   Play — OTA can't.
+
+  Capgo enforces that floor only under the channel's `metadata` "disable auto update"
+  strategy. The production channel was not on it, and the default (`major`) reads a
+  `<major>.<build>` bump as a permitted minor: a v1.6.0 native release auto-published its
+  matching 1.6.0 bundle and every install on the 1.5.0 binary downloaded it, staged it and
+  offered a restart — a restart that installs JS built against the newer binary's native
+  surface. Set it once, per channel, with repo-admin Capgo credentials:
+
+  ```
+  npx @capgo/cli@8.42.4 channel set production --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
+  npx @capgo/cli@8.42.4 channel set staging --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
+  ```
+
+  Deliberately not written by CI: the strategy is one fleet-wide switch, and a wrong value
+  takes OTA out for everyone — the TASK-21793 shape. It is an operator decision, made once.
+- **Native-version gating, on the device:** `src/utils/ota-native-gate.ts` re-derives the
+  same rule client-side, because the dashboard strategy above is invisible to both CI and
+  the app and nothing on the device noticed when it was wrong. Under the
+  `<major>.<build>.<ota>` scheme a bundle's first two segments name the binary it was built
+  against, so a bundle whose `<major>.<build>` outranks `App.getInfo().version` is never
+  downloaded, never staged, and reported as store-update-required instead. A bundle already
+  sitting in the plugin's queue is unstaged rather than hidden — `installNext()` runs from
+  `appMovedToBackground()` with no JS involved, so hiding it would not stop it installing.
+  It fails **open** on a version either side cannot parse: refusing every update on an
+  off-scheme version is the worse of the two failures.
 - **Native fingerprint (the check behind that rule):** `scripts/native-fingerprint.mjs`
   hashes the JS↔native contract in three parts: the **config** (Capacitor's two generated
   plugin manifests, `capacitor.config.ts`, the gradle files, `AndroidManifest.xml`,

--- a/src/components/Profile/components/StoreUpdateModal.tsx
+++ b/src/components/Profile/components/StoreUpdateModal.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import ActionModal from '@/components/Global/ActionModal'
+import { STORE_NAME, MIGRATION_SURFACES } from '@/constants/migration.consts'
+import { isIOSNative } from '@/utils/capacitor'
+import { openStore } from '@/utils/migration.utils'
+import { useTranslations } from 'next-intl'
+
+/**
+ * The store-only half of the update prompt. A bundle built for a newer binary
+ * cannot be installed over the air at all (see utils/ota-native-gate), so this
+ * must never offer a restart — the restart would reload the same JS and read as
+ * an update that silently did nothing.
+ */
+const StoreUpdateModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
+    const t = useTranslations('profile.storeUpdate')
+    const tUpdate = useTranslations('profile.update')
+    const store = isIOSNative() ? 'ios' : 'android'
+
+    return (
+        <ActionModal
+            visible={visible}
+            onClose={onClose}
+            tone="info"
+            icon="download"
+            title={t('title', { store: STORE_NAME[store] })}
+            description={t('description', { store: STORE_NAME[store] })}
+            ctas={[
+                {
+                    text: t('openStore', { store: STORE_NAME[store] }),
+                    shadowSize: '4',
+                    onClick: () => {
+                        openStore(store, MIGRATION_SURFACES.PROFILE_UPDATE)
+                        onClose()
+                    },
+                },
+                { text: tUpdate('notNow'), variant: 'stroke', onClick: onClose },
+            ]}
+        />
+    )
+}
+
+export default StoreUpdateModal

--- a/src/components/Profile/components/__tests__/StoreUpdateModal.test.tsx
+++ b/src/components/Profile/components/__tests__/StoreUpdateModal.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * StoreUpdateModal — the prompt for an update only the store can deliver.
+ * It must never offer a restart: the JS is not on the device, so restarting
+ * would reload the same bundle and read as an update that did nothing.
+ */
+import React from 'react'
+import { renderWithIntl } from '@/test-utils/intl'
+import { fireEvent, screen } from '@testing-library/react'
+import StoreUpdateModal from '@/components/Profile/components/StoreUpdateModal'
+
+const mockOpenStore = jest.fn()
+const platform = { ios: false }
+
+jest.mock('@/utils/migration.utils', () => ({ openStore: (...args: unknown[]) => mockOpenStore(...args) }))
+jest.mock('@/utils/capacitor', () => ({
+    ...jest.requireActual('@/utils/capacitor'),
+    isIOSNative: () => platform.ios,
+}))
+
+beforeEach(() => {
+    mockOpenStore.mockClear()
+    platform.ios = false
+})
+
+it('names the store the update has to come from', () => {
+    renderWithIntl(<StoreUpdateModal visible onClose={jest.fn()} />)
+    expect(screen.getByText('Update in Google Play')).toBeInTheDocument()
+    expect(screen.queryByText(/restart/i)).not.toBeInTheDocument()
+})
+
+it('names the App Store on iOS', () => {
+    platform.ios = true
+    renderWithIntl(<StoreUpdateModal visible onClose={jest.fn()} />)
+    expect(screen.getByText('Update in App Store')).toBeInTheDocument()
+})
+
+it('sends the user to the store and closes', () => {
+    const onClose = jest.fn()
+    renderWithIntl(<StoreUpdateModal visible onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open Google Play' }))
+
+    expect(mockOpenStore).toHaveBeenCalledWith('android', 'profile_update')
+    expect(onClose).toHaveBeenCalled()
+})

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -23,8 +23,8 @@ import { AvatarPicker } from '@/components/Avatar/AvatarPicker'
 import { AVATAR_PICKER_PARAM, avatarPickerParser } from '@/components/Avatar/avatar.consts'
 import { useOtaUpdate } from '@/context/OtaUpdateContext'
 import OtaUpdateModal from './components/OtaUpdateModal'
-import { openStore } from '@/utils/migration.utils'
-import { IOS_APP_STORE_LISTING_LIVE, MIGRATION_SURFACES } from '@/constants/migration.consts'
+import StoreUpdateModal from './components/StoreUpdateModal'
+import { IOS_APP_STORE_LISTING_LIVE } from '@/constants/migration.consts'
 import { isIOSNative } from '@/utils/capacitor'
 
 export const Profile = () => {
@@ -44,11 +44,14 @@ export const Profile = () => {
     const { locale } = useAppLocale()
     const { pendingBundle, storeUpdateRequired } = useOtaUpdate()
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false)
+    const [isStoreUpdateModalOpen, setIsStoreUpdateModalOpen] = useState(false)
     const storeUpdateOffered = storeUpdateRequired && (!isIOSNative() || IOS_APP_STORE_LISTING_LIVE)
-    // a staged OTA bundle wins over the store hint: it is already on the device
+    // A staged OTA bundle wins over the store hint: it is already on the device,
+    // and the gate only ever stages one this binary can run. Store updates get
+    // their own modal — offering a restart for one would reload the same JS.
     const onUpdateTap = () => {
         if (pendingBundle) setIsUpdateModalOpen(true)
-        else openStore(isIOSNative() ? 'ios' : 'android', MIGRATION_SURFACES.PROFILE_UPDATE)
+        else setIsStoreUpdateModalOpen(true)
     }
 
     const logout = async () => {
@@ -190,6 +193,7 @@ export const Profile = () => {
                 source="profile"
             />
             <OtaUpdateModal visible={isUpdateModalOpen} onClose={() => setIsUpdateModalOpen(false)} />
+            <StoreUpdateModal visible={isStoreUpdateModalOpen} onClose={() => setIsStoreUpdateModalOpen(false)} />
         </div>
     )
 }

--- a/src/context/OtaUpdateContext.tsx
+++ b/src/context/OtaUpdateContext.tsx
@@ -60,9 +60,10 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
         let disposed = false
         let cleanup: (() => void) | undefined
 
-        // a bundle staged on an earlier launch is still queued in the plugin
-        importWithChunkRetry(() => import('@capgo/capacitor-updater'))
-            .then(({ CapacitorUpdater }) => CapacitorUpdater.getNextBundle())
+        // a bundle staged on an earlier launch is still queued in the plugin —
+        // read through the gate, which drops one built for a newer binary
+        importWithChunkRetry(() => import('@/utils/capgo-updater'))
+            .then((updater) => updater.readStagedBundle({ onStoreUpdateRequired: () => setStoreUpdateRequired(true) }))
             .then((bundle) => {
                 if (!disposed && bundle) setPendingBundle((current) => current ?? bundle)
             })

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -119,13 +119,30 @@ it('flags a store update when the served bundle needs a newer binary', async () 
 // appMovedToBackground() with no JS involved.
 it('never offers a restart for a queued bundle that needs a newer binary', async () => {
     platform.binaryVersion = '1.1.0'
-    mockUpdater.getNextBundle.mockResolvedValue({ ...STAGED, version: '1.2.0' })
+    // The disarm re-reads the queue to prove the entry is gone; the second read
+    // is the one that answers for the rewritten queue.
+    mockUpdater.getNextBundle.mockResolvedValueOnce({ ...STAGED, version: '1.2.0' }).mockResolvedValue(null)
     const { result } = setup()
 
     await waitFor(() => expect(result.current.storeUpdateRequired).toBe(true))
     expect(result.current.pendingBundle).toBeNull()
+    expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'builtin' })
     expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-2' })
     expect(mockUpdater.set).not.toHaveBeenCalled()
+})
+
+// The sentinel that disarm leaves in the queue persists — installNext() clears
+// NEXT_VERSION only when it installs a different bundle — so a later launch
+// must not read it back as an update waiting to be applied.
+it('does not turn the disarm sentinel into a standing update offer', async () => {
+    mockUpdater.current.mockResolvedValue({ bundle: { id: 'b-2', version: '1.2.0' } })
+    mockUpdater.getNextBundle.mockResolvedValue(STAGED)
+    const { result } = setup()
+
+    await act(async () => {
+        await jest.advanceTimersByTimeAsync(5_000)
+    })
+    expect(result.current.pendingBundle).toBeNull()
 })
 
 it('still offers a restart for a queued bundle the running binary can run', async () => {

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -23,12 +23,13 @@ const mockUpdater = {
     getNextBundle: jest.fn(),
     getPluginVersion: jest.fn(),
     getFailedUpdate: jest.fn().mockResolvedValue(null),
+    delete: jest.fn().mockResolvedValue(undefined),
 }
 const mockExitApp = jest.fn().mockResolvedValue(undefined)
 // splashVisible false by default: these cases are about a bundle staged while
 // the user is already in the app, where the launch apply deliberately stands
 // down. The behind-the-splash window has its own describe block.
-const platform = { android: true, capacitor: true, splashVisible: false }
+const platform = { android: true, capacitor: true, splashVisible: false, binaryVersion: null as string | null }
 
 jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
 jest.mock('@capacitor/app', () => ({ App: { exitApp: () => mockExitApp() } }))
@@ -38,6 +39,12 @@ jest.mock('@/utils/capacitor', () => ({
     isAndroidNativeBridge: () => platform.android,
 }))
 jest.mock('@/hooks/useSplashGate', () => ({ isSplashVisible: () => platform.splashVisible }))
+// Null by default so the store-update gate fails open and the cases below are
+// about restart mechanics rather than binary compatibility; the one case that
+// is about compatibility names a version.
+jest.mock('@/utils/app-version', () => ({
+    getBinaryInfo: async () => (platform.binaryVersion ? { appVersion: platform.binaryVersion, appBuild: '1' } : null),
+}))
 
 import { OtaUpdateProvider, useOtaUpdate } from '../OtaUpdateContext'
 
@@ -55,6 +62,8 @@ beforeEach(() => {
     platform.android = true
     platform.capacitor = true
     platform.splashVisible = false
+    platform.binaryVersion = null
+    mockUpdater.delete.mockReset().mockResolvedValue(undefined)
     mockUpdater.getFailedUpdate.mockReset().mockResolvedValue(null)
     mockExitApp.mockClear()
     mockUpdater.set.mockReset().mockReturnValue(new Promise(() => {}))
@@ -100,6 +109,31 @@ it('flags a store update when the served bundle needs a newer binary', async () 
     })
     expect(result.current.storeUpdateRequired).toBe(true)
     expect(window.localStorage.getItem('capgoUpdateFailureStreak')).toBeNull()
+})
+
+// A native release publishes a bundle carrying its own version, and a device on
+// the older binary used to download it, stage it and offer a restart — which
+// installed JS built against native code that install does not have. The queue
+// outlives the JS that filled it, so a bundle staged before this gate existed
+// has to be unstaged rather than merely hidden: installNext() runs from
+// appMovedToBackground() with no JS involved.
+it('never offers a restart for a queued bundle that needs a newer binary', async () => {
+    platform.binaryVersion = '1.1.0'
+    mockUpdater.getNextBundle.mockResolvedValue({ ...STAGED, version: '1.2.0' })
+    const { result } = setup()
+
+    await waitFor(() => expect(result.current.storeUpdateRequired).toBe(true))
+    expect(result.current.pendingBundle).toBeNull()
+    expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-2' })
+    expect(mockUpdater.set).not.toHaveBeenCalled()
+})
+
+it('still offers a restart for a queued bundle the running binary can run', async () => {
+    platform.binaryVersion = '1.2.0'
+    const { result } = await withStagedBundle()
+
+    expect(result.current.storeUpdateRequired).toBe(false)
+    expect(mockUpdater.delete).not.toHaveBeenCalled()
 })
 
 it('applyNow records the marker and hands the bundle to set()', async () => {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -548,6 +548,11 @@
             "manualRestart": "Close Peanut from the app switcher and open it again to finish the update.",
             "applyFailed": "The update couldn't be applied. Check your connection and try again — Peanut is still running the version you started with."
         },
+        "storeUpdate": {
+            "title": "Update in {store}",
+            "description": "This version includes changes Peanut can't install by itself. Get it from {store} to finish updating.",
+            "openStore": "Open {store}"
+        },
         "about": {
             "title": "About Peanut",
             "intro": "Peanut makes dollars easy: hold your balance, send to any @username, and use local bank transfers after one ID check. Built by Squirrel Labs.",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -548,6 +548,11 @@
             "manualRestart": "Cierra Peanut desde el selector de apps y vuelve a abrirla para terminar la actualización.",
             "applyFailed": "No se pudo aplicar la actualización. Revisa tu conexión e inténtalo de nuevo: Peanut sigue con la versión con la que iniciaste."
         },
+        "storeUpdate": {
+            "title": "Actualiza en {store}",
+            "description": "Esta versión incluye cambios que Peanut no puede instalar por su cuenta. Descárgala en {store} para terminar de actualizar.",
+            "openStore": "Abrir {store}"
+        },
         "about": {
             "title": "Acerca de Peanut",
             "intro": "Peanut hace fáciles los dólares: guarda tu saldo, envía a cualquier @usuario y mueve dinero por rieles locales después de una sola verificación de identidad. Creado por Squirrel Labs.",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -548,6 +548,11 @@
             "manualRestart": "Feche o Peanut pelo seletor de apps e abra de novo para concluir a atualização.",
             "applyFailed": "Não foi possível aplicar a atualização. Verifique sua conexão e tente novamente — o Peanut continua na versão com que você abriu."
         },
+        "storeUpdate": {
+            "title": "Atualize na {store}",
+            "description": "Esta versão inclui mudanças que o Peanut não consegue instalar sozinho. Baixe na {store} para concluir a atualização.",
+            "openStore": "Abrir {store}"
+        },
         "about": {
             "title": "Sobre o Peanut",
             "intro": "O Peanut torna os dólares fáceis: guarde seu saldo, envie para qualquer @usuário e mova dinheiro pelos trilhos locais após uma única verificação de identidade. Criado pela Squirrel Labs.",

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -17,8 +17,10 @@ const mockUpdater = {
     reset: jest.fn().mockResolvedValue(undefined),
     getPluginVersion: jest.fn(),
     getFailedUpdate: jest.fn().mockResolvedValue(null),
+    getNextBundle: jest.fn(),
+    delete: jest.fn().mockResolvedValue(undefined),
 }
-const mockPlatform = { android: true }
+const mockPlatform = { android: true, binaryVersion: '1.5.0' as string | null }
 
 jest.mock('@capgo/capacitor-updater', () => ({ CapacitorUpdater: mockUpdater }))
 jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
@@ -26,8 +28,14 @@ jest.mock('@/utils/capacitor', () => ({
     ...jest.requireActual('@/utils/capacitor'),
     isAndroidNativeBridge: () => mockPlatform.android,
 }))
+// The gate asks the binary for its version; jsdom is not Capacitor, so the real
+// getBinaryInfo would answer null and fail the gate open in every case below.
+jest.mock('@/utils/app-version', () => ({
+    getBinaryInfo: async () =>
+        mockPlatform.binaryVersion ? { appVersion: mockPlatform.binaryVersion, appBuild: '1' } : null,
+}))
 
-import { canRestartInPlace, initCapgoUpdater } from '../capgo-updater'
+import { canRestartInPlace, initCapgoUpdater, readStagedBundle } from '../capgo-updater'
 
 let info: jest.SpyInstance
 let error: jest.SpyInstance
@@ -36,6 +44,12 @@ beforeEach(() => {
     jest.useFakeTimers()
     window.localStorage.clear()
     mockPlatform.android = true
+    mockPlatform.binaryVersion = '1.5.0'
+    mockUpdater.download.mockReset().mockResolvedValue({ id: 'b-1', version: '1.5.4' })
+    mockUpdater.current.mockReset().mockResolvedValue({ bundle: { id: 'builtin', version: '1.5.0' } })
+    mockUpdater.getNextBundle.mockReset().mockResolvedValue(null)
+    mockUpdater.delete.mockReset().mockResolvedValue(undefined)
+    mockUpdater.next.mockReset().mockResolvedValue(undefined)
     mockUpdater.getPluginVersion.mockReset()
     mockUpdater.getFailedUpdate.mockReset().mockResolvedValue(null)
     info = jest.spyOn(console, 'info').mockImplementation(() => {})
@@ -419,5 +433,86 @@ describe('canRestartInPlace', () => {
         mockPlatform.android = false
         await expect(canRestartInPlace()).resolves.toBe(true)
         expect(mockUpdater.getPluginVersion).not.toHaveBeenCalled()
+    })
+})
+
+/**
+ * A native release auto-publishes a bundle carrying its own `<major>.<build>.0`
+ * version, built from the same commit as the binary. Nothing on the device
+ * stopped that bundle from landing on an older shell: Capgo's `min_update_version`
+ * is enforced only under one channel strategy, configured in a dashboard the app
+ * cannot read. So the client refuses it too.
+ */
+describe('store-update gate', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockUpdater.notifyAppReady.mockResolvedValue(undefined)
+        mockUpdater.addListener.mockResolvedValue({ remove: jest.fn() })
+        mockUpdater.getFailedUpdate.mockResolvedValue(null)
+        mockUpdater.current.mockResolvedValue({ bundle: { id: 'builtin', version: '1.5.0' } })
+        mockUpdater.getNextBundle.mockResolvedValue(null)
+    })
+
+    it('never downloads a bundle built for a newer binary', async () => {
+        mockUpdater.getLatest.mockResolvedValue({ url: 'https://cdn.test/1.6.0.zip', version: '1.6.0' })
+        const onStoreUpdateRequired = jest.fn()
+        await initCapgoUpdater({ onStoreUpdateRequired })
+        await jest.advanceTimersByTimeAsync(5_000)
+
+        expect(mockUpdater.download).not.toHaveBeenCalled()
+        expect(mockUpdater.next).not.toHaveBeenCalled()
+        expect(onStoreUpdateRequired).toHaveBeenCalled()
+        expect(error).not.toHaveBeenCalled()
+    })
+
+    it('still stages an OTA inside the running binary build', async () => {
+        mockUpdater.getLatest.mockResolvedValue({ url: 'https://cdn.test/1.5.4.zip', version: '1.5.4' })
+        mockUpdater.download.mockResolvedValue({ id: 'b-4', version: '1.5.4' })
+        const onUpdateAvailable = jest.fn()
+        await initCapgoUpdater({ onUpdateAvailable })
+        await jest.advanceTimersByTimeAsync(5_000)
+
+        expect(mockUpdater.download).toHaveBeenCalled()
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'b-4' })
+        expect(onUpdateAvailable).toHaveBeenCalledWith({ id: 'b-4', version: '1.5.4' })
+    })
+
+    // The plugin's queue outlives the JS that filled it, and installNext() runs
+    // from appMovedToBackground() with no JS involved — hiding the entry would
+    // not stop it being installed.
+    it('unstages a queued bundle that needs a newer binary', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'builtin' })
+        expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-6' })
+    })
+
+    it('reports a queued bundle this binary can run', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-4', version: '1.5.4' })
+
+        await expect(readStagedBundle()).resolves.toEqual({ id: 'b-4', version: '1.5.4' })
+        expect(mockUpdater.next).not.toHaveBeenCalled()
+        expect(mockUpdater.delete).not.toHaveBeenCalled()
+    })
+
+    // A queue that refuses to be rewritten still must not be offered as a
+    // restart — the restart would reload JS this binary cannot run.
+    it('withholds an incompatible bundle even when the unstage fails', async () => {
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
+        mockUpdater.next.mockRejectedValue(new Error('bundle not found'))
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.delete).not.toHaveBeenCalled()
+    })
+
+    it('lets the update through when the binary version cannot be read', async () => {
+        mockPlatform.binaryVersion = null
+        mockUpdater.getLatest.mockResolvedValue({ url: 'https://cdn.test/1.6.0.zip', version: '1.6.0' })
+        mockUpdater.download.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
+        await initCapgoUpdater()
+        await jest.advanceTimersByTimeAsync(5_000)
+
+        expect(mockUpdater.download).toHaveBeenCalled()
     })
 })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -479,13 +479,16 @@ describe('store-update gate', () => {
 
     // The plugin's queue outlives the JS that filled it, and installNext() runs
     // from appMovedToBackground() with no JS involved — hiding the entry would
-    // not stop it being installed.
-    it('unstages a queued bundle that needs a newer binary', async () => {
-        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
+    // not stop it being installed. installNext() skips an entry whose id equals
+    // the running bundle's, which is what pointing `next` there achieves.
+    it('disarms a queued bundle that needs a newer binary', async () => {
+        mockUpdater.current.mockResolvedValue({ bundle: { id: 'b-3', version: '1.5.2' } })
+        mockUpdater.getNextBundle.mockResolvedValueOnce({ id: 'b-6', version: '1.6.0' }).mockResolvedValue(null)
 
         await expect(readStagedBundle()).resolves.toBeNull()
-        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'builtin' })
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'b-3' })
         expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-6' })
+        expect(error).not.toHaveBeenCalled()
     })
 
     it('reports a queued bundle this binary can run', async () => {
@@ -496,9 +499,63 @@ describe('store-update gate', () => {
         expect(mockUpdater.delete).not.toHaveBeenCalled()
     })
 
+    // The sentinel the disarm leaves behind outlives it: installNext() clears
+    // NEXT_VERSION only when it installs a DIFFERENT bundle. Reported, it would
+    // put "Update available" in the profile for good, behind a restart onto the
+    // version already running.
+    it('does not report the running bundle as an update', async () => {
+        mockUpdater.current.mockResolvedValue({ bundle: { id: 'b-3', version: '1.5.2' } })
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-3', version: '1.5.2' })
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.next).not.toHaveBeenCalled()
+    })
+
+    // next() resolving says nothing about the queue: setNextBundle returns false
+    // for a bundle it will not arm, and the wrapper still resolves. Only a re-read
+    // proves the entry is gone.
+    it('falls back to builtin when the running bundle does not take the queue', async () => {
+        mockUpdater.current.mockResolvedValue({ bundle: { id: 'b-3', version: '1.5.2' } })
+        mockUpdater.getNextBundle
+            .mockResolvedValueOnce({ id: 'b-6', version: '1.6.0' })
+            .mockResolvedValueOnce({ id: 'b-6', version: '1.6.0' })
+            .mockResolvedValue(null)
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.next).toHaveBeenNthCalledWith(1, { id: 'b-3' })
+        expect(mockUpdater.next).toHaveBeenNthCalledWith(2, { id: 'builtin' })
+        expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-6' })
+        expect(error).not.toHaveBeenCalled()
+    })
+
+    // The binary's own JS always fits the binary; the queued bundle does not.
+    it('arms builtin when the running bundle id cannot be read', async () => {
+        mockUpdater.current.mockRejectedValue(new Error('no current bundle'))
+        mockUpdater.getNextBundle.mockResolvedValueOnce({ id: 'b-6', version: '1.6.0' }).mockResolvedValue(null)
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'builtin' })
+        expect(mockUpdater.next).toHaveBeenCalledTimes(1)
+    })
+
+    // An unconfirmed disarm leaves the unsafe bundle installing on the next
+    // background — the one thing this exists to prevent, so Sentry hears about
+    // it under a prefix it keeps.
+    it('reports at error level when the queue cannot be rewritten', async () => {
+        mockUpdater.current.mockResolvedValue({ bundle: { id: 'b-3', version: '1.5.2' } })
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
+        mockUpdater.next.mockRejectedValue(new Error('bundle does not exist'))
+
+        await expect(readStagedBundle()).resolves.toBeNull()
+        expect(mockUpdater.delete).not.toHaveBeenCalled()
+        expect(error).toHaveBeenCalledWith(
+            '[capgo-apply] could not disarm staged bundle 1.6.0 (b-6); the plugin may still install it'
+        )
+    })
+
     // A queue that refuses to be rewritten still must not be offered as a
     // restart — the restart would reload JS this binary cannot run.
-    it('withholds an incompatible bundle even when the unstage fails', async () => {
+    it('withholds an incompatible bundle even when the disarm fails', async () => {
         mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-6', version: '1.6.0' })
         mockUpdater.next.mockRejectedValue(new Error('bundle not found'))
 

--- a/src/utils/__tests__/ota-native-gate.test.ts
+++ b/src/utils/__tests__/ota-native-gate.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Which bundles a given binary is allowed to run. The version scheme is
+ * `<major>.<build>.<ota>` (scripts/release-version.mjs), so `<major>.<build>`
+ * is the binary a bundle was built against and the `<ota>` segment carries no
+ * compatibility information at all.
+ */
+import { bundleNeedsNewerBinary, nativeLine } from '../ota-native-gate'
+
+describe('nativeLine', () => {
+    it('reads the binary half of a release version', () => {
+        expect(nativeLine('1.6.0')).toEqual([1, 6])
+        expect(nativeLine('1.5.3')).toEqual([1, 5])
+        // staging bundles carry the commit count as their ota segment
+        expect(nativeLine('1.6.10482')).toEqual([1, 6])
+        // a bare native version, as App.getInfo() can report it
+        expect(nativeLine('1.6')).toEqual([1, 6])
+    })
+
+    it('rejects anything off-scheme', () => {
+        expect(nativeLine('builtin')).toBeNull()
+        expect(nativeLine('')).toBeNull()
+        expect(nativeLine('v1.6.0')).toBeNull()
+    })
+})
+
+describe('bundleNeedsNewerBinary', () => {
+    it('blocks a bundle built for a newer native build', () => {
+        // the case that shipped: an install reading 1.5.3 is still the 1.5.0 binary
+        expect(bundleNeedsNewerBinary('1.6.0', '1.5.0')).toBe(true)
+        expect(bundleNeedsNewerBinary('2.0.0', '1.9.0')).toBe(true)
+    })
+
+    it('allows every OTA inside the running binary build', () => {
+        expect(bundleNeedsNewerBinary('1.5.4', '1.5.0')).toBe(false)
+        expect(bundleNeedsNewerBinary('1.5.0', '1.5.0')).toBe(false)
+        // staging's commit-count band sits far above production's, and still
+        // targets the same binary
+        expect(bundleNeedsNewerBinary('1.5.10482', '1.5.0')).toBe(false)
+    })
+
+    it('leaves the below-native direction to Capgo', () => {
+        expect(bundleNeedsNewerBinary('1.4.9', '1.5.0')).toBe(false)
+    })
+
+    it('fails open on a version it cannot read', () => {
+        // refusing every update on an unparseable version is the failure that
+        // killed OTA for the fleet for a month (TASK-21793)
+        expect(bundleNeedsNewerBinary('builtin', '1.5.0')).toBe(false)
+        expect(bundleNeedsNewerBinary('1.6.0', '')).toBe(false)
+    })
+})

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -329,20 +329,26 @@ async function reportFailedUpdate(updater: Pick<CapacitorUpdaterPlugin, 'getFail
     )
 }
 
+// Capgo's id for the JS baked into the binary. Both native implementations
+// exempt it from setNextBundle's "does this bundle exist" check, so it is the
+// one queue entry that can always be armed.
+const BUILTIN_BUNDLE_ID = 'builtin'
+
 /**
  * The bundle the plugin has queued for the next restart, or null when there is
  * none this binary may run.
  *
  * The queue outlives the JS that filled it: a bundle staged before the
- * store-update gate existed is still sitting there, and the plugin's own
- * background apply will install it from appMovedToBackground() with no JS
- * involved. So an incompatible entry is not merely hidden — `next` is pointed
- * back at the running bundle, which is what installNext() consumes, and the
- * download is deleted. Best effort in both steps: a queue that refuses to be
- * rewritten must still not be offered as a restart.
+ * store-update gate existed is still sitting there, and the plugin installs it
+ * from appMovedToBackground() with no JS involved — so an incompatible entry
+ * has to be disarmed (see disarmStagedBundle), not merely withheld.
  *
- * Queued with the checks so the rewrite cannot land between a check's download
- * and the next() that stages it.
+ * A queue entry naming the RUNNING bundle is not an update, and reporting one
+ * would be self-inflicted: installNext() clears NEXT_VERSION only when it
+ * installs a different bundle, so the sentinel disarmStagedBundle leaves behind
+ * persists across launches. Returning it would put "Update available" in the
+ * profile permanently, behind a restart that reloads the version already
+ * running.
  */
 export async function readStagedBundle(
     callbacks: Pick<OtaUpdateCallbacks, 'onStoreUpdateRequired'> = {}
@@ -352,27 +358,74 @@ export async function readStagedBundle(
         CapacitorUpdater.getNextBundle().catch(() => null),
         CapacitorUpdater.current().catch(() => null),
     ])
-    if (!next?.version || next.id === current?.bundle?.id) return next ?? null
+    if (!next?.version || next.id === current?.bundle?.id) return null
     if (!(await needsStoreUpdate(next.version))) return next
 
     // Say so, rather than letting the update row vanish: the launch check would
     // reach the same verdict, but only once it has reached the network.
     callbacks.onStoreUpdateRequired?.()
+    // Queued with the checks so the rewrite cannot land between a check's
+    // download and the next() that stages it.
+    return queueOtaWork(() => disarmStagedBundle(CapacitorUpdater, next, current?.bundle?.id))
+}
 
-    console.info(`[capgo] dropping staged bundle ${next.version} — it needs a newer binary`)
-    return queueOtaWork(async () => {
-        const runningId = current?.bundle?.id
+/**
+ * Stop the plugin installing a queued bundle this binary must not run.
+ *
+ * installNext() skips a queue entry whose id equals the running bundle's
+ * (verified in both native implementations), so pointing `next` back at the
+ * running bundle is what actually disarms the background apply. There is no
+ * JS-reachable clear-next — `next()` rejects without an id — and setBundleError
+ * needs an `allowManualBundleError` config flag no shipped binary sets.
+ *
+ * `builtin` is the fallback for a running bundle whose id cannot be read, not
+ * the first choice: arming it while a good OTA is running would install the
+ * binary's older JS on the next background. As a fallback it is still the safe
+ * side of the trade — the binary's own JS is by definition JS the binary can
+ * run, and the queued bundle is not.
+ *
+ * The rewrite is verified rather than assumed. A next() that resolved against a
+ * queue it did not change, or one that rejected, leaves the unsafe bundle
+ * installing on the next background — the whole thing this exists to prevent —
+ * so an unconfirmed disarm is reported at error level under a prefix Sentry
+ * keeps (`[capgo]` is dropped as updater noise, see sentry.utils.ts).
+ */
+async function disarmStagedBundle(
+    updater: Pick<CapacitorUpdaterPlugin, 'next' | 'delete' | 'getNextBundle'>,
+    staged: BundleInfo,
+    runningId: string | undefined
+): Promise<null> {
+    console.info(`[capgo] dropping staged bundle ${staged.version} — it needs a newer binary`)
+    const sentinels =
+        runningId && runningId !== BUILTIN_BUNDLE_ID ? [runningId, BUILTIN_BUNDLE_ID] : [BUILTIN_BUNDLE_ID]
+
+    for (const id of sentinels) {
         try {
-            // Pointing `next` at the running bundle is what neutralises the
-            // background apply; delete() refuses while the bundle is still
-            // queued, so the order matters.
-            if (runningId) await CapacitorUpdater.next({ id: runningId })
-            await CapacitorUpdater.delete({ id: next.id })
+            await updater.next({ id })
         } catch (err) {
-            console.warn('[capgo] could not unstage the bundle:', err instanceof Error ? err.message : String(err))
+            console.warn(`[capgo] could not queue ${id}:`, err instanceof Error ? err.message : String(err))
+            continue
         }
+        // An unreadable queue counts as still armed: a disarm nothing can
+        // confirm is not one to act on.
+        const queued = await updater.getNextBundle().catch(() => staged)
+        if (queued?.id === staged.id) continue
+        // Only now — delete() refuses while the bundle is still queued.
+        await updater
+            .delete({ id: staged.id })
+            .catch((err) =>
+                console.warn(
+                    '[capgo] staged bundle disarmed but not deleted:',
+                    err instanceof Error ? err.message : String(err)
+                )
+            )
         return null
-    })
+    }
+
+    console.error(
+        `[capgo-apply] could not disarm staged bundle ${staged.version} (${staged.id}); the plugin may still install it`
+    )
+    return null
 }
 
 // One launch-time apply per staged bundle. A set() that never lands must not
@@ -397,13 +450,10 @@ const LAUNCH_APPLY_KEY = 'capgoLaunchApplyAttempt'
  */
 export async function applyStagedBundleOnLaunch(): Promise<BundleInfo | null> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
-    const [next, current] = await Promise.all([
-        // Reads through the store-update gate, so a bundle built for a newer
-        // binary is unstaged here rather than applied behind the splash.
-        readStagedBundle(),
-        CapacitorUpdater.current().catch(() => null),
-    ])
-    if (!next || next.id === current?.bundle?.id) return null
+    // Reads through the store-update gate, which disarms a bundle built for a
+    // newer binary and answers null for one that is already running.
+    const next = await readStagedBundle()
+    if (!next) return null
     // Deadlocking binaries can only quit to apply (see canRestartInPlace), and
     // quitting an app the user just opened is worse than the background apply.
     if (readStoredValue(LAUNCH_APPLY_KEY) === next.id || !(await canRestartInPlace())) return next

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -4,6 +4,7 @@
 import type { BundleInfo, CapacitorUpdaterPlugin } from '@capgo/capacitor-updater'
 import { isAndroidNativeBridge } from '@/utils/capacitor'
 import { isDemoMode } from '@/utils/demo'
+import { needsStoreUpdate } from '@/utils/ota-native-gate'
 import { readStoredValue, removeStoredValue, writeStoredValue } from '@/utils/safe-storage'
 
 export interface OtaUpdateCallbacks {
@@ -102,6 +103,18 @@ async function checkAndStageUpdate(callbacks: OtaUpdateCallbacks = {}): Promise<
         const latest = await CapacitorUpdater.getLatest()
         // getLatest resolves with a url only when a genuinely newer bundle exists.
         if (latest.url && latest.version) {
+            // Refused before the download, not after: a bundle built for a newer
+            // binary must never reach the device's disk, because everything that
+            // stages one (next(), the plugin's background apply) works off what is
+            // downloaded. Capgo's own floor is the server-side half of this rule and
+            // only applies under one channel strategy, in a dashboard nothing here
+            // can read — so the client decides too.
+            if (await needsStoreUpdate(latest.version)) {
+                console.info(`[capgo] bundle ${latest.version} needs a newer binary — store update only`)
+                removeStoredValue(FAILURE_STREAK_KEY)
+                callbacks.onStoreUpdateRequired?.()
+                return 'store-update-required'
+            }
             const bundle = await CapacitorUpdater.download({
                 url: latest.url,
                 version: latest.version,
@@ -316,6 +329,52 @@ async function reportFailedUpdate(updater: Pick<CapacitorUpdaterPlugin, 'getFail
     )
 }
 
+/**
+ * The bundle the plugin has queued for the next restart, or null when there is
+ * none this binary may run.
+ *
+ * The queue outlives the JS that filled it: a bundle staged before the
+ * store-update gate existed is still sitting there, and the plugin's own
+ * background apply will install it from appMovedToBackground() with no JS
+ * involved. So an incompatible entry is not merely hidden — `next` is pointed
+ * back at the running bundle, which is what installNext() consumes, and the
+ * download is deleted. Best effort in both steps: a queue that refuses to be
+ * rewritten must still not be offered as a restart.
+ *
+ * Queued with the checks so the rewrite cannot land between a check's download
+ * and the next() that stages it.
+ */
+export async function readStagedBundle(
+    callbacks: Pick<OtaUpdateCallbacks, 'onStoreUpdateRequired'> = {}
+): Promise<BundleInfo | null> {
+    const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
+    const [next, current] = await Promise.all([
+        CapacitorUpdater.getNextBundle().catch(() => null),
+        CapacitorUpdater.current().catch(() => null),
+    ])
+    if (!next?.version || next.id === current?.bundle?.id) return next ?? null
+    if (!(await needsStoreUpdate(next.version))) return next
+
+    // Say so, rather than letting the update row vanish: the launch check would
+    // reach the same verdict, but only once it has reached the network.
+    callbacks.onStoreUpdateRequired?.()
+
+    console.info(`[capgo] dropping staged bundle ${next.version} — it needs a newer binary`)
+    return queueOtaWork(async () => {
+        const runningId = current?.bundle?.id
+        try {
+            // Pointing `next` at the running bundle is what neutralises the
+            // background apply; delete() refuses while the bundle is still
+            // queued, so the order matters.
+            if (runningId) await CapacitorUpdater.next({ id: runningId })
+            await CapacitorUpdater.delete({ id: next.id })
+        } catch (err) {
+            console.warn('[capgo] could not unstage the bundle:', err instanceof Error ? err.message : String(err))
+        }
+        return null
+    })
+}
+
 // One launch-time apply per staged bundle. A set() that never lands must not
 // turn every subsequent launch into a reload.
 const LAUNCH_APPLY_KEY = 'capgoLaunchApplyAttempt'
@@ -339,7 +398,9 @@ const LAUNCH_APPLY_KEY = 'capgoLaunchApplyAttempt'
 export async function applyStagedBundleOnLaunch(): Promise<BundleInfo | null> {
     const { CapacitorUpdater } = await import('@capgo/capacitor-updater')
     const [next, current] = await Promise.all([
-        CapacitorUpdater.getNextBundle().catch(() => null),
+        // Reads through the store-update gate, so a bundle built for a newer
+        // binary is unstaged here rather than applied behind the splash.
+        readStagedBundle(),
         CapacitorUpdater.current().catch(() => null),
     ])
     if (!next || next.id === current?.bundle?.id) return null

--- a/src/utils/ota-native-gate.ts
+++ b/src/utils/ota-native-gate.ts
@@ -1,0 +1,51 @@
+import { getBinaryInfo } from '@/utils/app-version'
+
+/**
+ * Which binary a release version belongs to.
+ *
+ * Peanut's scheme is `<major>.<build>.<ota>` (scripts/release-version.mjs):
+ * `<major>.<build>` names a native build and `<ota>` counts the JS shipped on
+ * top of it, so the first two segments — and only those — say which binary a
+ * bundle was built against. Staging bundles use the same shape with the commit
+ * count as their `<ota>`, so they compare identically.
+ */
+export function nativeLine(version: string): [number, number] | null {
+    const match = /^(\d+)\.(\d+)(?:\.|$)/.exec(version.trim())
+    return match ? [Number(match[1]), Number(match[2])] : null
+}
+
+/**
+ * Whether `bundleVersion` was built for a newer binary than `binaryVersion` —
+ * i.e. only a store update can deliver it.
+ *
+ * Capgo already refuses the opposite direction on-device
+ * (`disable_auto_update_under_native`); this is the direction nothing enforced.
+ * A native release auto-publishes a matching `<major>.<build>.0` bundle so that
+ * devices on the new binary have something to update to (TASK-21793), and that
+ * bundle is built from the same commit as the binary — new plugins, permissions
+ * and entitlements included. Delivered to an older shell it is JS calling
+ * native code that install does not have, which fails silently.
+ *
+ * Fails OPEN on a version either side cannot be parsed. Capgo's own floor
+ * (`min_update_version`) is the server-side half of this rule; refusing every
+ * update because a version is off-scheme is the failure that killed OTA for the
+ * fleet for a month, and it is strictly worse than the one this guards against.
+ */
+export function bundleNeedsNewerBinary(bundleVersion: string, binaryVersion: string): boolean {
+    const bundle = nativeLine(bundleVersion)
+    const binary = nativeLine(binaryVersion)
+    if (!bundle || !binary) return false
+    if (bundle[0] !== binary[0]) return bundle[0] > binary[0]
+    return bundle[1] > binary[1]
+}
+
+/**
+ * Same question, against the binary this install is actually running. False on
+ * web and whenever the binary's own version cannot be read — see the fail-open
+ * reasoning above.
+ */
+export async function needsStoreUpdate(bundleVersion: string): Promise<boolean> {
+    const binary = await getBinaryInfo()
+    if (!binary?.appVersion) return false
+    return bundleNeedsNewerBinary(bundleVersion, binary.appVersion)
+}


### PR DESCRIPTION
## What happened

An install reading **1.5.3** was offered an update, took the reload, and came back as **1.6.0** — a native build, delivered over the air.

`v1.6.0` is a native release. Native releases deliberately auto-publish a matching `<major>.<build>.0` production bundle, because without one every device on the new binary refuses all existing bundles (`disable_auto_update_under_native` — TASK-21793 took OTA out for 102 devices for a month that way). That bundle is built from the **same commit as the binary**: new plugins, permissions and entitlements included.

Nothing on the device stopped it landing on an older shell:

- Capgo enforces a bundle's `--min-update-version` only under the channel's **`metadata`** "disable auto update" strategy. Production is not on it, and the default (`major`) reads a `<major>.<build>` bump as a permitted *minor*.
- The client's existing `storeUpdateRequired` path only fires when Capgo **rejects** the check (`disable_auto_update_to_major` / `_to_minor`). No rejection came, so the bundle downloaded, staged, and the reload modal appeared.

In this instance the JS survived — `v1.5.0..v1.6.0` moved only Android R8 keep-rules (`native-fingerprint` does differ across the two tags, so the mechanism did engage; the part that moved just happened not to be JS-facing). That was luck, not design.

## The fix

**1. The device decides, not the dashboard.** `src/utils/ota-native-gate.ts` re-derives the rule from the version scheme itself. Under `<major>.<build>.<ota>` (`scripts/release-version.mjs`) the first two segments name the binary a bundle was built against and `<ota>` carries no compatibility information — so a bundle whose `<major>.<build>` outranks `App.getInfo().version` is refused. It is checked **before** `download()`, since everything that stages a bundle works off what is already on disk.

A bundle already in the plugin's queue (staged before this shipped) is **unstaged**, not merely hidden: `installNext()` runs from `appMovedToBackground()` with no JS involved, so hiding it would not stop it installing. `next` is pointed back at the running bundle and the download deleted — best effort in both steps, and an incompatible bundle is withheld either way.

It fails **open** when either version is off-scheme. Refusing every update because a version cannot be parsed is the TASK-21793 failure, and strictly worse than the one this guards against. The below-native direction is left to Capgo, which already blocks it.

**2. A store update no longer offers a restart.** `StoreUpdateModal` names the store and opens it. The old path went straight to `openStore` with no modal; before that, a store-only update could reach the reload modal, and restarting for a bundle that is not on the device reloads the same JS — an update that silently did nothing. The iOS gate (`IOS_APP_STORE_LISTING_LIVE`) is unchanged: the listing is not published, so the store URL still 404s and the row stays hidden there.

`readStagedBundle` reports `onStoreUpdateRequired` when it drops a queued bundle, so the update row explains itself instead of vanishing while the launch check is still waiting on the network.

## Left to an operator

The **`metadata` channel strategy** is the server-side half and is one fleet-wide switch — a wrong value takes OTA out for everyone, which is exactly the TASK-21793 shape. Deliberately not written by CI. The one-time command is in `docs/NATIVE-RELEASE.md`:

```
npx @capgo/cli@8.42.4 channel set production --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
npx @capgo/cli@8.42.4 channel set staging --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
```

Every upload already passes `--min-update-version`, so no pipeline change is needed alongside it.

Worth knowing before flipping it: devices on a 1.5.x binary that already **applied** the 1.6.0 bundle will then be held at 1.6.0 until they update through the store, because the next production OTA's floor is `1.6.0`. That is the correct end state — they are running JS their binary was not built for — but it means a store update, not another OTA, is what recovers them.

## Tests

- `ota-native-gate.test.ts` — the scheme: staging's commit-count band, bare `1.6`, `builtin`, the both-directions cases, fail-open.
- `capgo-updater.test.ts` — no download for a newer-binary bundle; an in-build OTA still stages; a queued incompatible bundle is unstaged; it is withheld even when the unstage rejects; unreadable binary version lets the update through.
- `OtaUpdateContext.test.tsx` — no restart offered for a queued incompatible bundle, `storeUpdateRequired` set, `delete` called; a compatible one still offered.
- `StoreUpdateModal.test.tsx` — store naming per platform, no restart copy, CTA opens the store and closes.

180 tests across the touched suites pass; `tsc --noEmit` is clean; prettier checked.

## Docs

`docs/NATIVE-RELEASE.md` said the floor is enforced under the *version number* strategy in one place and *metadata* in another. Corrected to `metadata`, with what actually happened and the client-side half recorded.
