### PR TITLE
feat(nav): spring pill, icon pop, touch-down haptics (TASK-22208)

### DIFF
--- a/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
+++ b/src/app/(mobile-ui)/dev/ds/foundations/tokens.generated.ts
@@ -1028,6 +1028,16 @@ export const TOKEN_GROUPS: Record<string, ThemeToken[]> = {
             "name": "slow",
             "value": "500ms",
             "section": "semantic"
+        },
+        {
+            "name": "nav-spring",
+            "value": "350ms",
+            "section": "semantic"
+        },
+        {
+            "name": "nav-pop",
+            "value": "250ms",
+            "section": "semantic"
         }
     ],
     "ease": [
@@ -1039,6 +1049,16 @@ export const TOKEN_GROUPS: Record<string, ThemeToken[]> = {
         {
             "name": "sharp",
             "value": "cubic-bezier(0.87, 0, 0.13, 1)",
+            "section": "semantic"
+        },
+        {
+            "name": "nav-spring",
+            "value": "cubic-bezier(0.34, 1.56, 0.64, 1)",
+            "section": "semantic"
+        },
+        {
+            "name": "nav-pop",
+            "value": "cubic-bezier(0.34, 1.56, 0.64, 1)",
             "section": "semantic"
         }
     ],

--- a/src/components/Global/BottomNav/__tests__/BottomNav.test.tsx
+++ b/src/components/Global/BottomNav/__tests__/BottomNav.test.tsx
@@ -94,6 +94,18 @@ describe('BottomNav pill release', () => {
         expect(mockPush).not.toHaveBeenCalled()
     })
 
+    it('a finger down on a tab squashes its icon and release springs it back', () => {
+        render(<BottomNav />)
+        const supportTab = screen.getByRole('button', { name: 'support' })
+        const icon = supportTab.querySelector('span')!
+
+        expect(icon.className).not.toContain('scale-[0.82]')
+        fireEvent.pointerDown(supportTab, { pointerId: 1 })
+        expect(icon.className).toContain('scale-[0.82]')
+        fireEvent.pointerUp(supportTab, { pointerId: 1 })
+        expect(icon.className).not.toContain('scale-[0.82]')
+    })
+
     it('leaving the tab routes clears the pill', () => {
         const { rerender } = render(<BottomNav />)
         expect(screen.getByTestId('bottom-nav-pill')).toBeInTheDocument()

--- a/src/components/Global/BottomNav/index.tsx
+++ b/src/components/Global/BottomNav/index.tsx
@@ -39,7 +39,12 @@ import { TAB_ORDER, type TabId } from './tab-order'
  *   the commit.
  * - native tab bars respond on touch, not after navigation settles — the
  *   pill now moves in the same tick as the tap, like the drag path used to.
- * The bezier overshoots a few percent: the ruled "little bounce", no jitter.
+ * The curve is a real underdamped spring sampled into linear() easing —
+ * picked on /dev/nav-bounce as variant D (TASK-22208). Values live in
+ * globals.css (--nav-spring-*, --nav-pop-*) with a bezier fallback where
+ * linear() is unsupported. Two more native-feel layers ride along: the
+ * tapped icon squashes on finger-down and springs back on release, and the
+ * haptic fires on pointerdown (touch timing), not after the click resolves.
  *
  * Drag-the-pill survives the framer removal as manual pointer events: while
  * a finger holds the pill the transition is suspended and the transform
@@ -54,6 +59,16 @@ const tabClass =
 
 // icons sit above the pill (z) and let pointer events fall through
 const iconClass = 'pointer-events-none relative z-10'
+
+// the tapped icon squashes under the finger and springs back on release.
+// inline-flex because transforms do not apply to inline boxes; scale is a
+// compositor property, so this never touches layout.
+const iconPopClass = (pressed: boolean) =>
+    `${iconClass} inline-flex motion-safe:transition-transform ${
+        pressed
+            ? 'scale-[0.82] motion-safe:duration-instant motion-safe:ease-out'
+            : 'scale-100 motion-safe:duration-nav-pop motion-safe:ease-nav-pop'
+    }`
 
 /** A tab's box inside the bar, in the bar's own coordinates. */
 type TabBox = { left: number; width: number }
@@ -134,6 +149,22 @@ export const BottomNav = () => {
     // below), and this effect only reconciles EXTERNAL navigation — deep
     // links, hardware back, programmatic pushes.
     const [activeTab, setActiveTab] = useState<TabId | null>(routeTab)
+    // which tab a finger is currently down on, for the icon squash. The pill
+    // overlays the ACTIVE tab and captures its pointer events (drag path), so
+    // this only ever fires for the tabs you can switch to — no squash-under-
+    // drag conflict by construction.
+    const [pressedTab, setPressedTab] = useState<TabId | null>(null)
+    const releasePress = (id: TabId) => () => setPressedTab((prev) => (prev === id ? null : prev))
+    // native timing: feedback lands on finger-down, not after the click resolves
+    const tabPressHandlers = (id: TabId) => ({
+        onPointerDown: () => {
+            triggerHaptic()
+            setPressedTab(id)
+        },
+        onPointerUp: releasePress(id),
+        onPointerLeave: releasePress(id),
+        onPointerCancel: releasePress(id),
+    })
     useEffect(() => {
         // null included: leaving the tab routes (/profile, /history) must
         // clear the pill (chip P15-minor). Optimistic taps survive because
@@ -226,47 +257,41 @@ export const BottomNav = () => {
                     href="/home"
                     draggable={false}
                     aria-label={t('home')}
-                    onClick={() => {
-                        triggerHaptic()
-                        setActiveTab('home')
-                    }}
+                    {...tabPressHandlers('home')}
+                    onClick={() => setActiveTab('home')}
                     className={tabClass}
                     ref={(el) => {
                         tabRefs.current.home = el
                     }}
                 >
-                    <Icon name="home" size={20} className={iconClass} />
+                    <Icon name="home" size={20} className={iconPopClass(pressedTab === 'home')} />
                 </Link>
                 <Link
                     href={middleTab.href}
                     draggable={false}
                     aria-label={middleTab.label}
-                    onClick={() => {
-                        triggerHaptic()
-                        setActiveTab('middle')
-                    }}
+                    {...tabPressHandlers('middle')}
+                    onClick={() => setActiveTab('middle')}
                     className={tabClass}
                     ref={(el) => {
                         tabRefs.current.middle = el
                     }}
                 >
-                    <Icon name={middleTab.icon} size={20} className={iconClass} />
+                    <Icon name={middleTab.icon} size={20} className={iconPopClass(pressedTab === 'middle')} />
                 </Link>
                 {/* while the drawer is open the tab shows a static pressed
                     state (white fill) instead of borrowing the route pill */}
                 <button
                     type="button"
                     aria-label={t('support')}
-                    onClick={() => {
-                        triggerHaptic()
-                        setIsSupportModalOpen(true)
-                    }}
+                    {...tabPressHandlers('support')}
+                    onClick={() => setIsSupportModalOpen(true)}
                     className={`${tabClass} ${isSupportModalOpen ? 'bg-background-default' : ''}`}
                     ref={(el) => {
                         tabRefs.current.support = el
                     }}
                 >
-                    <span className={iconClass}>
+                    <span className={iconPopClass(pressedTab === 'support')}>
                         <Icon name="peanut-support" size={20} />
                         {/* role="status" so the dot is announced — aria-label alone on
                             a bare span is ignored by assistive tech (generic role). */}
@@ -294,7 +319,7 @@ export const BottomNav = () => {
                         onPointerCancel={(e) => endPillDrag(e, true)}
                         // -1px, not -2px: the bar's own border is 1px, so a 1px inset puts the
                         // pill's outer edge exactly on the bar's — at 2px it stood proud of it.
-                        className="absolute -top-px -bottom-px left-0 z-0 touch-none rounded-round border border-border-default bg-background-default motion-safe:transition-transform motion-safe:duration-[250ms] motion-safe:ease-[cubic-bezier(0.3,1.06,0.4,1)]"
+                        className="absolute -top-px -bottom-px left-0 z-0 touch-none rounded-round border border-border-default bg-background-default motion-safe:transition-transform motion-safe:duration-nav-spring motion-safe:ease-nav-spring"
                         style={{
                             transform: `translateX(${restingX(activeBox)}px)`,
                             width: activeBox.width + 2,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -296,6 +296,15 @@
     --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
     --ease-sharp: cubic-bezier(0.87, 0, 0.13, 1);
 
+    /* bottom-nav springs (TASK-22208, /dev/nav-bounce variant D). these are
+       the bezier fallback values; webviews with linear() support get real
+       sampled spring curves from the @supports override below @theme.
+       nav-spring: pill travel. nav-pop: the tapped icon's release-back. */
+    --transition-duration-nav-spring: 350ms;
+    --transition-duration-nav-pop: 250ms;
+    --ease-nav-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+    --ease-nav-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+
     /* safe-area insets — see the :root contract below @theme. ported from the
        v3 tailwind.config.js spacing extension (deleted in the v4 migration).
        the env() step in the fallback chain is load-bearing: an undefined
@@ -1117,6 +1126,154 @@
     --safe-right: var(--safe-area-inset-right);
     --safe-bottom: var(--safe-area-inset-bottom);
     --safe-left: var(--safe-area-inset-left);
+}
+
+/* bottom-nav springs (TASK-22208, /dev/nav-bounce variant D): real
+   underdamped-spring physics sampled into linear() easing — the motion stays
+   a compositor transition on transform, per the 2026-09-03 nav ruling.
+   nav-spring = pill travel (response 0.45s, damping 0.62); nav-pop = icon
+   release-back (response 0.30s, damping 0.45). this override outranks the
+   @theme bezier defaults because it is unlayered; webviews without linear()
+   (ios < 17.2 / chrome < 113) keep the bezier: one overshoot, no settle. */
+@supports (transition-timing-function: linear(0, 1)) {
+    :root {
+        --transition-duration-nav-spring: 716ms;
+        --transition-duration-nav-pop: 658ms;
+        --ease-nav-spring: linear(
+            0,
+            0.0114,
+            0.0427,
+            0.0897,
+            0.1486,
+            0.216,
+            0.2889,
+            0.3647,
+            0.4412,
+            0.5166,
+            0.5894,
+            0.6585,
+            0.723,
+            0.7823,
+            0.8359,
+            0.8838,
+            0.9258,
+            0.962,
+            0.9927,
+            1.0181,
+            1.0387,
+            1.0548,
+            1.0668,
+            1.0753,
+            1.0805,
+            1.0831,
+            1.0834,
+            1.0818,
+            1.0786,
+            1.0743,
+            1.0691,
+            1.0633,
+            1.0571,
+            1.0507,
+            1.0443,
+            1.0381,
+            1.0321,
+            1.0265,
+            1.0212,
+            1.0165,
+            1.0122,
+            1.0083,
+            1.005,
+            1.0022,
+            0.9998,
+            0.9978,
+            0.9962,
+            0.995,
+            0.9941,
+            0.9935,
+            0.9932,
+            0.993,
+            0.9931,
+            0.9933,
+            0.9936,
+            0.9939,
+            0.9944,
+            0.9949,
+            0.9954,
+            0.996,
+            0.9965,
+            0.997,
+            0.9975,
+            0.998,
+            1
+        );
+        --ease-nav-pop: linear(
+            0,
+            0.0217,
+            0.0806,
+            0.1677,
+            0.2744,
+            0.3928,
+            0.5158,
+            0.6374,
+            0.7529,
+            0.8584,
+            0.9512,
+            1.0297,
+            1.0932,
+            1.1416,
+            1.1755,
+            1.1961,
+            1.2048,
+            1.2034,
+            1.1937,
+            1.1776,
+            1.1568,
+            1.1332,
+            1.1081,
+            1.0829,
+            1.0586,
+            1.0362,
+            1.0162,
+            0.9991,
+            0.985,
+            0.974,
+            0.966,
+            0.9609,
+            0.9583,
+            0.9579,
+            0.9594,
+            0.9623,
+            0.9663,
+            0.9709,
+            0.976,
+            0.9812,
+            0.9863,
+            0.991,
+            0.9953,
+            0.9991,
+            1.0022,
+            1.0046,
+            1.0065,
+            1.0077,
+            1.0084,
+            1.0087,
+            1.0085,
+            1.008,
+            1.0072,
+            1.0063,
+            1.0053,
+            1.0042,
+            1.0032,
+            1.0022,
+            1.0012,
+            1.0004,
+            0.9998,
+            0.9992,
+            0.9988,
+            0.9985,
+            1
+        );
+    }
 }
 
 @layer components {

--- a/src/utils/tw.ts
+++ b/src/utils/tw.ts
@@ -47,8 +47,8 @@ const DS_RADIUS_TOKEN = /^(?:round|1)$/
 // inset/…, shadow → shadow, ease → ease, animate → animate), so one entry per
 // token is enough. `--transition-duration-*` has no theme scale in
 // tailwind-merge, so those go through the duration class group directly.
-const DS_DURATION_TOKENS = ['instant', 'fast', 'moderate', 'slow']
-const DS_EASE_TOKENS = ['spring', 'sharp']
+const DS_DURATION_TOKENS = ['instant', 'fast', 'moderate', 'slow', 'nav-spring', 'nav-pop']
+const DS_EASE_TOKENS = ['spring', 'sharp', 'nav-spring', 'nav-pop']
 const DS_ANIMATE_TOKENS = [
     'pulsate',
     'pulse-strong',


### PR DESCRIPTION
## Summary
The bottom-nav pill moved on a bezier with one ~5% overshoot — flat next to a native tab bar. This ships variant D from the /dev/nav-bounce pick-by-feel page (#3065): a real underdamped spring sampled into CSS `linear()` easing, the tapped icon squashing under the finger (scale 0.82) and springing back on release, and the tab haptic moved from click to pointerdown so feedback lands on touch, like native. Motion stays a compositor transition on `transform` — the 2026-09-03 no-JS-spring ruling holds.

## Task
TASK-22208 — https://app.notion.com/p/3d0838117579802bb126e3e0d0af8942

## Design notes / accepted trade-offs
- Curves live as theme tokens (`duration-nav-spring`/`nav-pop`, `ease-nav-spring`/`nav-pop`); the sampled `linear()` values override the bezier defaults in an unlayered `@supports (transition-timing-function: linear(0, 1))` block. Webviews without `linear()` (iOS <17.2 / Chrome <113) keep the `ease-spring` bezier at 350ms — one overshoot, no settle.
- The pill overlays the active tab and captures its pointer events, so the press-squash and touch-down haptic only fire on tabs you can switch to — no conflict with the drag path by construction. Drag-release reuses the same spring transition automatically.
- Haptic on pointerdown fires even if the finger slides off and never navigates — same as native tab bars.
- Support-drawer pill behavior deliberately untouched (separate discussion with Kush).
- ds-lint `rawDuration` ratchets 6 → 5 (the old `duration-[250ms]` is gone); new tokens registered in the twMerge census (`tw.ts`).

## Risks / breaking changes
None cross-repo. Visual-behavior only; no color/shadow/layout change. Reduced-motion keeps the existing `motion-safe` guards.

## QA
- `/dev/nav-bounce` variant D (PR #3065 preview) is the exact motion+haptic spec this implements — compare against the bar on `/home`.
- Tap home/card: pill springs with a settle-back, icon squashes and pops, haptic on finger-down. Drag the pill: release snaps with the same spring.
- BottomNav jest suite extended (press-squash state); typecheck, build, ds-lint ratchet all green locally. `AddWithdrawCountriesList`/`UnlockPayments` fail locally in non-UTC timezones (pre-existing, pass on CI).

Screenshots: N/A (no static visual change — motion/haptics only; at rest the bar renders pixel-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjK52PhzfghqWoNnx1G8z7