### PR TITLE
fix(setup): one-step back navigation, remove top-right Log In (TASK-22232)

### DIFF
--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -5,6 +5,7 @@ import { SetupWrapper } from '@/components/Setup/components/SetupWrapper'
 import { type BeforeInstallPromptEvent, type ScreenId, type ISetupStep } from '@/components/Setup/Setup.types'
 import { useSetupFlow } from '@/hooks/useSetupFlow'
 import { useSetupBackHandler } from '@/hooks/useSetupBackHandler'
+import { dispatchBackPress } from '@/utils/back-handler'
 import { useSetupFlowContext } from '@/features/setup/SetupFlowContext'
 import { useSetupStepAnalytics } from '@/features/setup/useSetupStepAnalytics'
 import { useIosPwaInstallGate } from '@/hooks/useIosPwaInstallGate'
@@ -418,9 +419,12 @@ function SetupPageContent() {
             showBackButton={step.showBackButton}
             showSkipButton={step.showSkipButton}
             showLogoutButton={step.screenId === 'sign-test-transaction'}
-            showLoginButton={step.showLoginButton}
             imageClassName={step.imageClassName}
-            onBack={handleBack}
+            // The visible back button walks the same handler stack as hardware
+            // back, so a step's sub-view (residence heads-up) collapses first
+            // instead of being skipped straight to the previous step. The page
+            // handler below it steps back when nothing consumed the press.
+            onBack={dispatchBackPress}
             onSkip={() => handleNext()}
             onLogout={logoutUser}
             isLoggingOut={isLoggingOut}

--- a/src/components/Setup/Setup.consts.tsx
+++ b/src/components/Setup/Setup.consts.tsx
@@ -34,7 +34,6 @@ export const setupSteps: ISetupStep[] = [
         component: InstallPWA,
         showBackButton: false,
         showSkipButton: false,
-        showLoginButton: false,
         imageClassName: 'w-[50%] md:w-[30%] h-auto',
         titleClassName: 'text-heading-s',
         contentClassName: 'flex flex-col items-center justify-center gap-6',
@@ -46,7 +45,6 @@ export const setupSteps: ISetupStep[] = [
         component: InstallPWA,
         showBackButton: false,
         showSkipButton: true,
-        showLoginButton: false,
         imageClassName: 'w-[50%] md:w-[30%] h-auto mt-16 md:mt-0',
     },
     {
@@ -65,7 +63,6 @@ export const setupSteps: ISetupStep[] = [
         component: JoinWaitlist,
         showBackButton: true,
         showSkipButton: false,
-        showLoginButton: true,
         contentClassName: 'flex flex-col items-center justify-center gap-6',
     },
     {
@@ -75,7 +72,6 @@ export const setupSteps: ISetupStep[] = [
         component: SignupStep,
         showBackButton: true,
         showSkipButton: false,
-        showLoginButton: true,
         contentClassName: 'flex flex-col items-end pt-8 justify-center gap-6',
     },
     {

--- a/src/components/Setup/Setup.types.ts
+++ b/src/components/Setup/Setup.types.ts
@@ -49,8 +49,6 @@ export interface ISetupStep {
     component: React.ComponentType<StepComponentProps>
     showBackButton?: boolean
     showSkipButton?: boolean
-    /** Pre-auth steps offer Log In in the top-right group so a returning user is never trapped in signup. */
-    showLoginButton?: boolean
     /**
      * The step component renders the description itself (e.g. only on one of
      * its sub-views), so the chrome must not also render it.

--- a/src/components/Setup/Views/Residence.tsx
+++ b/src/components/Setup/Views/Residence.tsx
@@ -39,17 +39,32 @@ const ResidenceStep = () => {
     const locale = useLocale()
     const { residenceCountry, setResidenceCountry, secondResidenceCountry, setSecondResidenceCountry } =
         useSetupFlowContext()
-    const { handleNext, isLoading } = useSetupFlow()
+    const { handleNext, isLoading, direction } = useSetupFlow()
     const { countryCode: geoCountryCode } = useGeoLocation()
     // server-authoritative tier lists with the bundled mirror as fallback
     const { sets: restrictionSets, settled: restrictionSetsSettled } = useResidenceRestrictionSetsWithStatus()
 
-    const [view, setView] = useState<ResidenceView>('select')
+    // Stepping BACK into this step (from the passkey step) must land on the
+    // screen the user actually left: a restricted pick left from its heads-up,
+    // so re-derive that view from the stored country. The congrats view is not
+    // restored — it needs settled server data to be an honest claim, and the
+    // selector is the natural place to change the answer. Forward entry and
+    // deep links (direction 1 / 0) always start on the selector.
+    const [view, setView] = useState<ResidenceView>(() => {
+        if (direction >= 0 || !residenceCountry) return 'select'
+        if (restrictionSets.full.has(residenceCountry)) return 'restricted'
+        if (restrictionSets.cardOnly.has(residenceCountry) || restrictionSets.bankingOnly.has(residenceCountry)) {
+            return 'partial'
+        }
+        return 'select'
+    })
     useBackHandler(() => {
         if (!isLoading) setView('select')
         return true
     }, view !== 'select')
-    const [partialRestriction, setPartialRestriction] = useState<PartialRestriction>('card')
+    const [partialRestriction, setPartialRestriction] = useState<PartialRestriction>(() =>
+        restrictionSets.bankingOnly.has(residenceCountry) ? 'banking' : 'card'
+    )
     const [showSecondCountry, setShowSecondCountry] = useState(!!secondResidenceCountry)
     const [email, setEmail] = useState('')
     const [emailError, setEmailError] = useState('')

--- a/src/components/Setup/Views/__tests__/Residence.test.tsx
+++ b/src/components/Setup/Views/__tests__/Residence.test.tsx
@@ -31,8 +31,9 @@ jest.mock('@/features/setup/SetupFlowContext', () => ({
 
 const mockHandleNext = jest.fn()
 let mockIsLoading = false
+let mockDirection = 1
 jest.mock('@/hooks/useSetupFlow', () => ({
-    useSetupFlow: () => ({ handleNext: mockHandleNext, isLoading: mockIsLoading }),
+    useSetupFlow: () => ({ handleNext: mockHandleNext, isLoading: mockIsLoading, direction: mockDirection }),
 }))
 
 let mockGeoCountry: string | null = null
@@ -67,6 +68,7 @@ describe('ResidenceStep', () => {
         jest.clearAllMocks()
         resetBackHandlersForTests()
         mockIsLoading = false
+        mockDirection = 1
         mockSetupState = { residenceCountry: '', secondResidenceCountry: '' }
         mockGeoCountry = null
         mockRestrictionSets = undefined
@@ -412,6 +414,41 @@ describe('ResidenceStep', () => {
         fireEvent.click(screen.getByText('Choose a different country'))
         expect(screen.queryByText('Heads up')).not.toBeInTheDocument()
         expect(screen.getByText('Have documents from more than one country?')).toBeInTheDocument()
+    })
+
+    describe('stepping back into the step', () => {
+        // One step back from the passkey step must land on the screen the
+        // user actually left: the heads-up for a restricted pick, never the
+        // username screen two steps away (TASK-22232).
+        it('restores the generic heads-up for a fully restricted pick', () => {
+            mockDirection = -1
+            mockSetupState.residenceCountry = 'CN'
+            render(<ResidenceStep />)
+            expect(screen.getByRole('heading', { level: 1, name: 'Heads up' })).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: 'Continue anyway' })).toBeInTheDocument()
+        })
+
+        it('restores the partial heads-up with the matching restriction copy', () => {
+            mockDirection = -1
+            mockSetupState.residenceCountry = 'JP'
+            render(<ResidenceStep />)
+            expect(screen.getByRole('heading', { level: 1, name: 'Heads up' })).toBeInTheDocument()
+            expect(screen.getByText(/Bank transfers aren't available in your country/)).toBeInTheDocument()
+        })
+
+        it('lands on the selector for an unrestricted pick', () => {
+            mockDirection = -1
+            mockSetupState.residenceCountry = 'BR'
+            render(<ResidenceStep />)
+            expect(screen.getByRole('heading', { level: 1, name: 'Where do you legally live?' })).toBeInTheDocument()
+        })
+
+        it('starts on the selector when entering forward with a stored pick', () => {
+            mockDirection = 1
+            mockSetupState.residenceCountry = 'CN'
+            render(<ResidenceStep />)
+            expect(screen.getByRole('heading', { level: 1, name: 'Where do you legally live?' })).toBeInTheDocument()
+        })
     })
 
     describe('hardware back', () => {

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -1,24 +1,18 @@
 import starImage from '@/assets/icons/star.png'
 import { Button } from '@/components/0_Bruddle/Button'
 import CloudsBackground from '@/components/0_Bruddle/CloudsBackground'
-import { useToast } from '@/components/0_Bruddle/Toast'
 import { Icon } from '@/components/Global/Icons/Icon'
 import { type BeforeInstallPromptEvent, type LayoutType, type ScreenId } from '@/components/Setup/Setup.types'
 import InstallPWA from '@/components/Setup/Views/InstallPWA'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useBravePWAInstallState } from '@/hooks/useBravePWAInstallState'
 import { DeviceType } from '@/hooks/useGetDeviceType'
 import { useKeepWebBypass } from '@/hooks/useKeepWebBypass'
-import { useLogin } from '@/hooks/useLogin'
 import { useMigrationFlag } from '@/hooks/useMigrationFlag'
 import { isCapacitor } from '@/utils/capacitor'
-import { getPasskeyErrorSetupKey, isAlreadyReported } from '@/utils/webauthn.utils'
-import * as Sentry from '@sentry/nextjs'
 import classNames from 'classnames'
 import { motion, useReducedMotion } from 'framer-motion'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
-import posthog from 'posthog-js'
 import {
     Children,
     type ReactNode,
@@ -65,7 +59,6 @@ interface SetupWrapperProps {
     showBackButton?: boolean
     showSkipButton?: boolean
     showLogoutButton?: boolean
-    showLoginButton?: boolean
     onBack?: () => void
     onSkip?: () => void
     onLogout?: () => void
@@ -96,72 +89,24 @@ const STAR_POSITIONS = [
 ] as const
 
 /**
- * Log In for the pre-auth steps (install walls, waitlist, signup): a returning
- * user whose entry link carried an invite code or ?step=signup used to have no
- * way back to the passkey ceremony. Same click path as the landing step.
- */
-function LoginButton() {
-    const t = useTranslations('setup')
-    const { handleLoginClick, isLoggingIn } = useLogin()
-    const toast = useToast()
-
-    const onLoginClick = async () => {
-        try {
-            await handleLoginClick()
-        } catch (error) {
-            const errorCode = error instanceof Error && 'code' in error ? String(error.code) : undefined
-            // PasskeyError carries a curated English message; known codes have
-            // translated catalog copy, so prefer that.
-            const i18nKey = getPasskeyErrorSetupKey(error)
-            toast.error(i18nKey ? t(i18nKey) : (error instanceof Error && error.message) || t('loginFailed'))
-            if (!isAlreadyReported(error)) {
-                Sentry.captureException(error, { extra: { errorCode } })
-            }
-            posthog.capture(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, { error_code: errorCode, native: isCapacitor() })
-        }
-    }
-
-    return (
-        <Button
-            onClick={onLoginClick}
-            variant="transparent-dark"
-            size="small"
-            className="h-auto w-fit p-0"
-            loading={isLoggingIn}
-            disabled={isLoggingIn}
-        >
-            <span className="text-foreground-over-color-secondary">{t('logIn')}</span>
-        </Button>
-    )
-}
-
-/**
- * navigation component for back, skip, login and logout buttons
+ * navigation component for back, skip and logout buttons
  * rendered at the top of the layout when any button is enabled
  */
 const Navigation = memo(function Navigation({
     showBackButton,
     showSkipButton,
     showLogoutButton,
-    showLoginButton,
     onBack,
     onSkip,
     onLogout,
     isLoggingOut,
 }: Pick<
     SetupWrapperProps,
-    | 'showBackButton'
-    | 'showSkipButton'
-    | 'showLogoutButton'
-    | 'showLoginButton'
-    | 'onBack'
-    | 'onSkip'
-    | 'onLogout'
-    | 'isLoggingOut'
+    'showBackButton' | 'showSkipButton' | 'showLogoutButton' | 'onBack' | 'onSkip' | 'onLogout' | 'isLoggingOut'
 >) {
     const t = useTranslations('setup.navigation')
 
-    if (!showBackButton && !showSkipButton && !showLogoutButton && !showLoginButton) return null
+    if (!showBackButton && !showSkipButton && !showLogoutButton) return null
 
     // Icons inherit currentColor: the stroke button inverts on hover/active, and
     // a hard-coded fill vanished into the black background.
@@ -183,7 +128,6 @@ const Navigation = memo(function Navigation({
                 )}
             </div>
             <div className="flex items-center gap-3">
-                {showLoginButton && <LoginButton />}
                 {showSkipButton && (
                     <Button onClick={onSkip} variant="transparent-dark" className="h-auto w-fit p-0">
                         <span className="text-foreground-over-color-secondary">{t('skip')}</span>
@@ -298,7 +242,6 @@ export const SetupWrapper = memo(function SetupWrapper({
     showBackButton,
     showSkipButton,
     showLogoutButton,
-    showLoginButton,
     onBack,
     onSkip,
     onLogout,
@@ -344,7 +287,6 @@ export const SetupWrapper = memo(function SetupWrapper({
                     showSkipButton || (screenId === 'pwa-install' && (!canInstall || deviceType === DeviceType.WEB))
                 }
                 showLogoutButton={showLogoutButton}
-                showLoginButton={showLoginButton}
                 onBack={onBack}
                 onSkip={onSkip}
                 onLogout={onLogout}

--- a/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
+++ b/src/components/Setup/components/__tests__/SetupWrapper.test.tsx
@@ -1,35 +1,17 @@
 /** @jest-environment jsdom */
 /**
  * Setup chrome: the back chevron must inherit currentColor (the stroke button
- * inverts on hover/active, and a hard-coded black stroke vanished into it), and
- * pre-auth steps expose Log In next to Skip so a returning user routed past the
- * landing step can still reach the passkey ceremony.
+ * inverts on hover/active, and a hard-coded black stroke vanished into it).
  */
 import React from 'react'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
-import posthog from 'posthog-js'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithIntl } from '@/test-utils/intl'
-import en from '@/i18n/app/messages/en.json'
-import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { SetupWrapper } from '../SetupWrapper'
-
-const mockHandleLoginClick = jest.fn(() => Promise.resolve())
-let mockIsLoggingIn = false
-jest.mock('@/hooks/useLogin', () => ({
-    useLogin: () => ({ handleLoginClick: mockHandleLoginClick, isLoggingIn: mockIsLoggingIn }),
-}))
-
-const mockToastError = jest.fn()
-jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => ({ error: mockToastError }) }))
 
 jest.mock('@/hooks/useBravePWAInstallState', () => ({ useBravePWAInstallState: () => ({ isBrave: false }) }))
 jest.mock('@/hooks/useKeepWebBypass', () => ({ useKeepWebBypass: () => false }))
 jest.mock('@/hooks/useMigrationFlag', () => ({ useMigrationFlag: () => false }))
 jest.mock('@/utils/capacitor', () => ({ ...jest.requireActual('@/utils/capacitor'), isCapacitor: () => false }))
-jest.mock('@/utils/webauthn.utils', () => ({
-    ...jest.requireActual('@/utils/webauthn.utils'),
-    isAlreadyReported: () => false,
-}))
 jest.mock('@/components/0_Bruddle/CloudsBackground', () => ({ __esModule: true, default: () => null }))
 jest.mock('@/components/Setup/Views/InstallPWA', () => ({ __esModule: true, default: () => null }))
 jest.mock('framer-motion', () => ({
@@ -44,11 +26,6 @@ jest.mock('next/image', () => ({
     __esModule: true,
     default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
 }))
-jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }))
-
-const mockedCapture = posthog.capture as jest.Mock
-
 function renderWrapper(props: Partial<React.ComponentProps<typeof SetupWrapper>> = {}) {
     return renderWithIntl(
         <SetupWrapper layoutType="signup" screenId="signup" title="Pick a handle" {...props}>
@@ -60,7 +37,6 @@ function renderWrapper(props: Partial<React.ComponentProps<typeof SetupWrapper>>
 describe('SetupWrapper navigation', () => {
     beforeEach(() => {
         jest.clearAllMocks()
-        mockIsLoggingIn = false
     })
 
     it('renders the back chevron without a hard-coded stroke colour', () => {
@@ -89,54 +65,5 @@ describe('SetupWrapper navigation', () => {
         renderWrapper({ showBackButton: true, onBack })
         fireEvent.click(screen.getByRole('button', { name: 'Go back' }))
         expect(onBack).toHaveBeenCalledTimes(1)
-    })
-
-    it('hides Log In unless the step asks for it', () => {
-        renderWrapper({ showBackButton: true })
-        expect(screen.queryByRole('button', { name: 'Log In' })).not.toBeInTheDocument()
-    })
-
-    it('shows Log In next to Skip and runs the login ceremony', async () => {
-        renderWrapper({ showLoginButton: true, showSkipButton: true, onSkip: jest.fn() })
-        expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument()
-        fireEvent.click(screen.getByRole('button', { name: 'Log In' }))
-        await waitFor(() => expect(mockHandleLoginClick).toHaveBeenCalledTimes(1))
-        expect(mockToastError).not.toHaveBeenCalled()
-    })
-
-    it('shows Log In on its own when the step has no Skip or Back', () => {
-        renderWrapper({ showLoginButton: true })
-        expect(screen.getByRole('button', { name: 'Log In' })).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Skip' })).not.toBeInTheDocument()
-    })
-
-    it('disables Log In while the ceremony is running', () => {
-        mockIsLoggingIn = true
-        renderWrapper({ showLoginButton: true })
-        expect(screen.getByRole('button')).toBeDisabled()
-    })
-
-    it('surfaces a failed login as a toast and an analytics event', async () => {
-        const failure = Object.assign(new Error('No passkey found'), { code: 'NO_PASSKEY' })
-        mockHandleLoginClick.mockRejectedValueOnce(failure)
-        renderWrapper({ showLoginButton: true })
-        fireEvent.click(screen.getByRole('button', { name: 'Log In' }))
-        await waitFor(() => expect(mockToastError).toHaveBeenCalledWith('No passkey found'))
-        expect(mockedCapture).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIGNUP_LOGIN_ERROR, {
-            error_code: 'NO_PASSKEY',
-            native: false,
-        })
-    })
-
-    it('shows the catalog copy for a mapped passkey error code, not the curated English message', async () => {
-        const failure = Object.assign(new Error('Couldn’t reach Peanut’s servers (curated)'), {
-            name: 'PasskeyError',
-            code: 'NETWORK',
-        })
-        mockHandleLoginClick.mockRejectedValueOnce(failure)
-        renderWrapper({ showLoginButton: true })
-        fireEvent.click(screen.getByRole('button', { name: 'Log In' }))
-        await waitFor(() => expect(mockToastError).toHaveBeenCalledWith(en.setup.passkey.serverUnreachable))
-        expect(mockToastError).not.toHaveBeenCalledWith(failure.message)
     })
 })

--- a/src/dev/surfaces/registry.tsx
+++ b/src/dev/surfaces/registry.tsx
@@ -89,7 +89,6 @@ function SetupScreen({ screenId }: { screenId: ScreenId }) {
             showBackButton={step.showBackButton}
             showSkipButton={step.showSkipButton}
             showLogoutButton={step.screenId === 'sign-test-transaction'}
-            showLoginButton={step.showLoginButton}
             imageClassName={step.imageClassName}
             contentClassName={step.contentClassName}
             step={setupSteps.indexOf(step)}

--- a/src/utils/back-handler.ts
+++ b/src/utils/back-handler.ts
@@ -1,8 +1,10 @@
 /**
- * LIFO stack of hardware-back handlers. Overlays and in-page sub-views register
- * while they are showing; the native backButton listener dispatches top-down
- * and only falls through to history navigation when no handler consumed it.
- * Registration happens on every platform; dispatch only happens on Capacitor.
+ * LIFO stack of back handlers. Overlays and in-page sub-views register while
+ * they are showing; dispatch walks the stack top-down and only falls through
+ * to history navigation when no handler consumed it. Registration happens on
+ * every platform. Two things dispatch: the native backButton listener (on
+ * Capacitor) and the setup flow's visible back button (every platform), so
+ * both back paths share one semantics.
  */
 export type BackHandler = () => boolean
 


### PR DESCRIPTION
## Summary
Two setup-flow fixes ([TASK-22232](https://app.notion.com/p/peanutprotocol/3d083811757980af8198ea51c3df3dad)):

1. **Back is always one step.** The visible back button called `handleBack` directly (previous *step*) while hardware back went through the back-handler stack, where the residence step registers its sub-view collapse. On the "Heads up" sub-view the button therefore jumped two screens back to the username step. The button now dispatches the same stack (`dispatchBackPress`), so both back paths share one semantics. Stepping back from the passkey step also re-derives the heads-up sub-view from the stored residence country, so back from there lands on the screen the user left instead of the selector.
2. **Top-right Log In removed from the setup flow.** The `showLoginButton` plumbing (step config, wrapper `LoginButton`, page/dev-registry pass-through) is deleted. The landing step and invites page keep their own Log In paths; `useLogin` and the `setup.logIn` copy stay for them.

## Design notes / accepted trade-offs
- The **congrats ("Good news") view is not restored** on back-entry: it needs settled server restriction data to be an honest claim, and the selector is the natural place to change the answer. Back from passkey with an unrestricted country lands on the selector.
- **Web browser-back is unchanged**: the back-handler stack only receives browser history pops on Capacitor, so browser back on a heads-up still pops `?screen=` to the previous step. Fixing that means putting the residence sub-view in the URL — out of scope here.
- Restored heads-ups do not re-fire `*_SHOWN` analytics — a revisit is not a funnel event.

## Task
TASK-22232

## Risks / breaking changes
- Low blast radius, setup flow only. No backend contract change.
- A returning user mid-signup loses the top-right Log In escape hatch on welcome/signup (this was added for invite-link/?step=signup entries); the landing step Log In remains the supported path. Deliberate per the task.

## QA
- `npm run typecheck` clean, setup-area suites green (47 suites, 630 tests). New tests: back-entry view restoration (4 cases) in `Residence.test.tsx`.
- Pre-existing on dev, unrelated: `UnlockPayments.test.tsx` + `AddWithdrawCountriesList.test.tsx` fail (date-rot) — verified failing on clean `dev`.
- Manual: sandbox flow username → residence → heads-up → back lands on residence select; heads-up → continue → passkey → back lands on heads-up.

## Screenshots
Captured on the sandbox stack at 375×667 (assets branch `pr-assets-3087`, deleted post-merge). The bottom-left "N" badge is the Next.js dev-tools button, dev only.

| Signup — top-right Log In gone | Residence select | Heads up (Japan, banking) |
|---|---|---|
| ![signup](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/1-signup-no-login-button.png) | ![residence](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/2-residence-select.png) | ![heads-up](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/3-heads-up.png) |

| Back from heads-up → select (was: username screen) | Passkey step | Back from passkey → heads-up (was: select) |
|---|---|---|
| ![back-to-select](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/4-back-from-heads-up-lands-on-select.png) | ![passkey](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/5-passkey-step.png) | ![back-to-headsup](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3087/6-back-from-passkey-restores-heads-up.png) |
