### PR TITLE
fix(ui): remove add drawer plus mark, top-align language list (TASK-22496)

### DIFF
--- a/src/components/Settings/LanguageView.tsx
+++ b/src/components/Settings/LanguageView.tsx
@@ -45,34 +45,34 @@ export const LanguageView = () => {
     return (
         <PageStack gap="6" className="h-full bg-background">
             <NavHeader title={t('title')} onPrev={onBack} />
-            <PageStack.Center>
-                {/* one child, not one per row: Center's gap-6 would otherwise land
-                    between the rows and break the joined list geometry */}
-                <div>
-                    {APP_LOCALES.map((appLocale, index) => (
-                        <ListItem
-                            key={appLocale}
-                            position={getCardPosition(index, APP_LOCALES.length)}
-                            onClick={() => select(appLocale)}
-                            leading={
-                                <Image
-                                    src={getFlagUrl(LOCALE_FLAG_CODES[appLocale])}
-                                    alt=""
-                                    width={80}
-                                    height={80}
-                                    className="size-6 rounded-full object-cover"
-                                />
-                            }
-                            title={
-                                <span className="text-body-m text-foreground-primary" lang={appLocale}>
-                                    {LOCALE_LABELS[appLocale]}
-                                </span>
-                            }
-                            trailing={appLocale === locale ? <Icon name="check" size={20} /> : undefined}
-                        />
-                    ))}
-                </div>
-            </PageStack.Center>
+            {/* top-aligned list page (design.md list recipe), not PageStack.Center:
+                a short settings list floating mid-screen read as misplaced.
+                one wrapper div, not one child per row: PageStack's gap-6 would
+                otherwise land between the rows and break the joined list geometry */}
+            <div>
+                {APP_LOCALES.map((appLocale, index) => (
+                    <ListItem
+                        key={appLocale}
+                        position={getCardPosition(index, APP_LOCALES.length)}
+                        onClick={() => select(appLocale)}
+                        leading={
+                            <Image
+                                src={getFlagUrl(LOCALE_FLAG_CODES[appLocale])}
+                                alt=""
+                                width={80}
+                                height={80}
+                                className="size-6 rounded-full object-cover"
+                            />
+                        }
+                        title={
+                            <span className="text-body-m text-foreground-primary" lang={appLocale}>
+                                {LOCALE_LABELS[appLocale]}
+                            </span>
+                        }
+                        trailing={appLocale === locale ? <Icon name="check" size={20} /> : undefined}
+                    />
+                ))}
+            </div>
         </PageStack>
     )
 }

--- a/src/features/home/components/HomeActionDrawers.tsx
+++ b/src/features/home/components/HomeActionDrawers.tsx
@@ -2,7 +2,6 @@
 
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/Global/Drawer'
 import { Icon, type IconName } from '@/components/Global/Icons/Icon'
-import { ScreenMark } from '@/components/0_Bruddle/ScreenMark'
 import { ListItem } from '@/components/0_Bruddle/ListItem'
 import { getCardPosition } from '@/components/Global/Card/card.utils'
 import { useHomeDrawer, type HomeDrawer } from '../useHomeDrawer'
@@ -96,7 +95,6 @@ export function HomeActionDrawers() {
             <DrawerContent className="pb-2">
                 {content && (
                     <div className="flex flex-col gap-4">
-                        {content === 'add' && <ScreenMark icon="plus" />}
                         <DrawerTitle className="text-center text-heading-s text-foreground-primary">
                             {tNav(content)}
                         </DrawerTitle>


### PR DESCRIPTION
## Summary
Two UI nits ([TASK-22496](https://app.notion.com/p/3d7838117579818cad2eda9901880743)):

1. **Home Add drawer**: drop the green plus `ScreenMark` above the drawer title. The Send drawer rendered by the same component has no mark, so the two are now consistent.
2. **/settings/language**: the locale list was vertically centered (`PageStack.Center`); it now follows the design.md list-page recipe and sits top-aligned under the header.

## Task
TASK-22496

## Risks / breaking changes
None — presentational only, two files, no state or routing changes.

## QA
- `npm run typecheck` clean; `src/features/home` + `src/components/Settings` suites green (5 suites, 32 tests).
- `settings-language` is fixture-covered — the ds-shots CI diff shows the alignment change against the dev baseline.
- Add drawer captured by hand via the fixture harness (no fixture exists for the open drawer state).

## Screenshots
After-states at 375×667 via the fixture harness (assets branch `pr-assets-3088`, deleted post-merge; the "fixture / API faked" ribbon and bottom-left "N" badge are dev-harness chrome).

| Add drawer — no plus mark | Language — top-aligned |
|---|---|
| ![add drawer](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3088/add-drawer-no-mark.png) | ![language](https://raw.githubusercontent.com/peanutprotocol/peanut-ui/pr-assets-3088/language-top-aligned.png) |

Before-states: the ds-shots CI diff on `settings-language` shows the alignment change vs the dev baseline; the add drawer's before is the same drawer with a green plus icon bubble above "Add".
