### PR TITLE
Polish setup download buttons

### DIFF
--- a/src/components/Migration/StoreBadges.tsx
+++ b/src/components/Migration/StoreBadges.tsx
@@ -7,9 +7,9 @@ import { DeviceType, useDeviceType } from '@/hooks/useGetDeviceType'
 // store-button pair. compact: under download CTAs and QRs, same design
 // language as /app (purple App Store, stroke Google Play). hero: the landing
 // hero's desktop CTA row — two equal white buttons on the pink hero. stacked:
-// inside a modal, where the platform is usually known — one full-width white
-// button for the device you are on, falling back to both, one under the other,
-// when it is not.
+// inside a modal or setup gate, where the platform is usually known — one
+// full-width pink button for the device you are on, falling back to both, one
+// under the other, when it is not.
 export default function StoreBadges({
     surface,
     appearance = 'compact',
@@ -34,7 +34,7 @@ export default function StoreBadges({
                     className={isStacked ? 'w-full' : undefined}
                 >
                     <Button
-                        variant={isHero || isStacked ? 'stroke' : s === 'ios' ? 'purple' : 'stroke'}
+                        variant={isHero ? 'stroke' : isStacked ? 'purple' : s === 'ios' ? 'purple' : 'stroke'}
                         shadowSize="4"
                         size={isHero ? undefined : 'small'}
                         icon={s === 'ios' ? 'apple-logo' : 'google-play'}
@@ -42,7 +42,7 @@ export default function StoreBadges({
                             isHero
                                 ? 'w-52 bg-white px-6 py-3 text-button-m hover:bg-white/90 md:py-7 md:text-button-l'
                                 : isStacked
-                                  ? 'w-full justify-center bg-white hover:bg-white/90'
+                                  ? 'h-11 w-full justify-center'
                                   : 'w-auto px-4'
                         }
                     >

--- a/src/components/Migration/StoreButtons.tsx
+++ b/src/components/Migration/StoreButtons.tsx
@@ -15,7 +15,7 @@ export default function StoreButtons({ surface }: { surface: MigrationSurface })
             variant="purple"
             shadowSize="4"
             icon={store === 'ios' ? 'apple-logo' : 'google-play'}
-            className="w-full"
+            className="h-11 w-full"
             onClick={() => openStore(store, surface)}
         >
             {STORE_NAME[store]}

--- a/src/components/Setup/Views/Landing.tsx
+++ b/src/components/Setup/Views/Landing.tsx
@@ -7,6 +7,7 @@ import { useLogin } from '@/hooks/useLogin'
 import * as Sentry from '@sentry/nextjs'
 import { Button } from '@/components/0_Bruddle/Button'
 import { Card } from '@/components/0_Bruddle/Card'
+import Divider from '@/components/0_Bruddle/Divider'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { useEffect } from 'react'
@@ -22,6 +23,7 @@ import { isCapacitor } from '@/utils/capacitor'
 
 const LandingStep = () => {
     const t = useTranslations('setup')
+    const tCommon = useTranslations('common')
     const tMigration = useTranslations('migration')
     const migrationOn = useMigrationFlag()
     const hasKeepWebBypass = useKeepWebBypass()
@@ -91,6 +93,7 @@ const LandingStep = () => {
                         {t('landing.signUp')}
                     </Button>
                 )}
+                <Divider text={tCommon('or')} />
                 <Button
                     loading={isLoggingIn}
                     shadowSize="4"


### PR DESCRIPTION
## Summary
- make setup download store buttons pink
- match store CTA heights to the signup button
- add the shared localized divider above Log In

## Validation
- pnpm exec prettier --check src/components/Setup/Views/Landing.tsx src/components/Migration/StoreButtons.tsx src/components/Migration/StoreBadges.tsx
- pnpm exec eslint src/components/Setup/Views/Landing.tsx src/components/Migration/StoreButtons.tsx src/components/Migration/StoreBadges.tsx
- pnpm exec tsc --noEmit
- pnpm exec jest --runInBand src/components/Migration/__tests__/MigrationDownloadModal.test.tsx
