### PR TITLE
fix(setup): Back after a fresh signup showed "Something went wrong"

### DIFF
--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -61,7 +61,13 @@ jest.mock('@/components/Invites/JoinWaitlistPage', () => ({ __esModule: true, de
 jest.mock('@/components/Migration/SunsetScreen', () => ({ __esModule: true, default: () => <div /> }))
 
 import Layout from '../layout'
-import { beginIntentionalLogout, clearRedirectUrl, endIntentionalLogout, getRedirectUrl } from '@/utils/general.utils'
+import {
+    beginIntentionalLogout,
+    clearRedirectUrl,
+    endIntentionalLogout,
+    getRedirectOrigin,
+    getRedirectUrl,
+} from '@/utils/general.utils'
 
 const CACHED_USER = {
     user: { userId: 'u1', username: 'probe', hasAppAccess: true },
@@ -168,6 +174,28 @@ describe('(mobile-ui) layout — no user', () => {
 
             expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
             expect(getRedirectUrl()).toBe('/pay-request/abc')
+            // never held a session: this is the visitor's own intent
+            expect(getRedirectOrigin()).toBe('deep-link')
+        })
+
+        /*
+         * The other tab in the two-tab logout: this document held a session
+         * that then went away (logout elsewhere, revocation, expiry), so its
+         * latch never ran. Marking the destination for what it is keeps a
+         * fresh signup from inheriting it — see the consumer spec.
+         */
+        it('a session collapsing under a standing app is marked session-end', () => {
+            window.history.replaceState({}, '', '/card')
+            mockUseAuth.mockReturnValue(authState({ user: CACHED_USER }))
+            const { rerender } = renderLayout()
+            expect(getRedirectUrl()).toBeNull()
+
+            mockUseAuth.mockReturnValue(authState())
+            act(() => rerenderLayout(rerender))
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+            expect(getRedirectUrl()).toBe('/card')
+            expect(getRedirectOrigin()).toBe('session-end')
         })
 
         it('logging out from /profile: reaches /setup with no destination stored', () => {

--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -68,7 +68,7 @@ import {
     getRedirectOrigin,
     getRedirectUrl,
 } from '@/utils/general.utils'
-import { clearSessionHeld, markSessionHeld } from '@/utils/session-presence'
+import { clearSessionHeld, hasHeldSession, markSessionHeld } from '@/utils/session-presence'
 
 const CACHED_USER = {
     user: { userId: 'u1', username: 'probe', hasAppAccess: true },
@@ -216,6 +216,29 @@ describe('(mobile-ui) layout — no user', () => {
 
             expect(getRedirectUrl()).toBe('/card')
             expect(getRedirectOrigin()).toBe('session-end')
+        })
+
+        it('consumes passive session residue so a later protected link is intent again', () => {
+            markSessionHeld()
+            window.history.replaceState({}, '', '/card')
+            mockUseAuth.mockReturnValue(authState())
+
+            const firstBounce = renderLayout()
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+            expect(getRedirectOrigin()).toBe('session-end')
+            expect(hasHeldSession()).toBe(false)
+
+            firstBounce.unmount()
+            clearRedirectUrl()
+            mockRouterReplace.mockClear()
+            window.history.replaceState({}, '', '/card')
+
+            const laterDeepLink = renderLayout()
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+            expect(getRedirectOrigin()).toBe('deep-link')
+            laterDeepLink.unmount()
         })
 
         it('but a logged-out tab opening a deep link later is intent again', () => {

--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -10,10 +10,11 @@ import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 
 const mockRouterReplace = jest.fn()
+let mockPathname = '/home'
 
 jest.mock('next/navigation', () => ({
     useRouter: () => ({ replace: mockRouterReplace, push: jest.fn(), back: jest.fn(), prefetch: jest.fn() }),
-    usePathname: () => '/home',
+    usePathname: () => mockPathname,
 }))
 
 const mockUseAuth = jest.fn()
@@ -102,6 +103,7 @@ describe('(mobile-ui) layout — no user', () => {
     beforeEach(() => {
         jest.useFakeTimers()
         mockRouterReplace.mockClear()
+        mockPathname = '/home'
     })
 
     afterEach(() => {
@@ -239,6 +241,18 @@ describe('(mobile-ui) layout — no user', () => {
             expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
             expect(getRedirectOrigin()).toBe('deep-link')
             laterDeepLink.unmount()
+        })
+
+        it('retires held-session residue when settled unauthenticated state is public', () => {
+            markSessionHeld()
+            mockPathname = '/support'
+            mockUseAuth.mockReturnValue(authState())
+
+            renderLayout()
+
+            expect(mockRouterReplace).not.toHaveBeenCalled()
+            expect(hasHeldSession()).toBe(false)
+            expect(getRedirectUrl()).toBeNull()
         })
 
         it('but a logged-out tab opening a deep link later is intent again', () => {

--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -68,6 +68,7 @@ import {
     getRedirectOrigin,
     getRedirectUrl,
 } from '@/utils/general.utils'
+import { clearSessionHeld, markSessionHeld } from '@/utils/session-presence'
 
 const CACHED_USER = {
     user: { userId: 'u1', username: 'probe', hasAppAccess: true },
@@ -160,10 +161,12 @@ describe('(mobile-ui) layout — no user', () => {
         beforeEach(() => {
             endIntentionalLogout()
             clearRedirectUrl()
+            clearSessionHeld()
         })
         afterEach(() => {
             endIntentionalLogout()
             clearRedirectUrl()
+            clearSessionHeld()
         })
 
         it('logged out on a protected deep link: keeps the target for after login', () => {
@@ -196,6 +199,34 @@ describe('(mobile-ui) layout — no user', () => {
             expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
             expect(getRedirectUrl()).toBe('/card')
             expect(getRedirectOrigin()).toBe('session-end')
+        })
+
+        /*
+         * The marker is per TAB, not per document: an authenticated tab that
+         * reloads /card after its token was revoked never observes a user in
+         * the new document, and reading that as a first-time visitor would
+         * hand the previous session's page to the next account.
+         */
+        it('a tab that reloads after its session was revoked still knows it held one', () => {
+            markSessionHeld() // the document this tab reloaded away from
+            window.history.replaceState({}, '', '/card')
+            mockUseAuth.mockReturnValue(authState())
+
+            renderLayout()
+
+            expect(getRedirectUrl()).toBe('/card')
+            expect(getRedirectOrigin()).toBe('session-end')
+        })
+
+        it('but a logged-out tab opening a deep link later is intent again', () => {
+            markSessionHeld()
+            clearSessionHeld() // what an explicit logout does at its boundary
+            window.history.replaceState({}, '', '/pay-request/abc')
+            mockUseAuth.mockReturnValue(authState())
+
+            renderLayout()
+
+            expect(getRedirectOrigin()).toBe('deep-link')
         })
 
         it('logging out from /profile: reaches /setup with no destination stored', () => {

--- a/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
+++ b/src/app/(mobile-ui)/__tests__/layout-backend-error.test.tsx
@@ -61,6 +61,7 @@ jest.mock('@/components/Invites/JoinWaitlistPage', () => ({ __esModule: true, de
 jest.mock('@/components/Migration/SunsetScreen', () => ({ __esModule: true, default: () => <div /> }))
 
 import Layout from '../layout'
+import { beginIntentionalLogout, clearRedirectUrl, endIntentionalLogout, getRedirectUrl } from '@/utils/general.utils'
 
 const CACHED_USER = {
     user: { userId: 'u1', username: 'probe', hasAppAccess: true },
@@ -139,6 +140,46 @@ describe('(mobile-ui) layout — no user', () => {
 
         expect(screen.getByTestId('backend-error-screen')).toBeInTheDocument()
         expect(jest.getTimerCount()).toBe(0)
+    })
+
+    /*
+     * The gate stores where the person was so login can return them there.
+     * That is right for a deep link and wrong for an explicit logout: logout
+     * empties the user cache before its hard nav to /setup, so this gate runs
+     * with the profile URL still in the bar, and the stored path was then
+     * consumed by the NEXT account created on this device — a fresh signup
+     * landed on the previous session's profile instead of /home.
+     */
+    describe('what the bounce to /setup leaves behind', () => {
+        beforeEach(() => {
+            endIntentionalLogout()
+            clearRedirectUrl()
+        })
+        afterEach(() => {
+            endIntentionalLogout()
+            clearRedirectUrl()
+        })
+
+        it('logged out on a protected deep link: keeps the target for after login', () => {
+            window.history.replaceState({}, '', '/pay-request/abc')
+            mockUseAuth.mockReturnValue(authState())
+
+            renderLayout()
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+            expect(getRedirectUrl()).toBe('/pay-request/abc')
+        })
+
+        it('logging out from /profile: reaches /setup with no destination stored', () => {
+            window.history.replaceState({}, '', '/profile')
+            beginIntentionalLogout()
+            mockUseAuth.mockReturnValue(authState())
+
+            renderLayout()
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/setup')
+            expect(getRedirectUrl()).toBeNull()
+        })
     })
 
     it('refetch blip over cached data: keeps the app, no error screen, no redirect', () => {

--- a/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
+++ b/src/app/(mobile-ui)/add-money/__tests__/add-money-states.test.tsx
@@ -329,6 +329,7 @@ jest.mock('@/utils/general.utils', () => ({
     getExplorerUrl: jest.fn(() => 'https://arbiscan.io'),
     saveRedirectUrl: jest.fn(),
     getRedirectUrl: jest.fn(() => null),
+    getStoredRedirect: jest.fn(() => null),
     clearRedirectUrl: jest.fn(),
     getFromLocalStorage: jest.fn(() => null),
     isCryptoAddress: jest.fn(() => false),

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -23,6 +23,7 @@ import { ShellBannerFallback } from '@/components/Global/Banner/ShellBannerFallb
 import ForceIOSPWAInstall from '@/components/ForceIOSPWAInstall'
 import { isPublicRoute } from '@/constants/routes'
 import { saveRedirectUrl } from '@/utils/general.utils'
+import { hasHeldSession, markSessionHeld } from '@/utils/session-presence'
 import { IS_DEV } from '@/constants/general.consts'
 import { HARNESS_ENABLED } from '@/constants/harness.consts'
 import { FixtureBanner } from '@/dev/fixtures/FixtureBanner'
@@ -86,19 +87,16 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 
     const isRedirecting = useRef(false)
     /*
-     * Did this document ever hold a session? It separates the two reasons the
-     * gate below fires: a logged-out arrival at a protected deep link (the
-     * person's own intent — keep it) from a session collapsing under a
-     * standing app (logout, revocation, expiry — where it happened to be
-     * standing is nobody's intent, and belongs to an account that is not
-     * necessarily the next one to authenticate here).
+     * Whether this TAB has held a session separates the two reasons the gate
+     * below fires — a logged-out arrival at a deep link, or a session
+     * collapsing where it stood — and it is recorded per tab rather than per
+     * document so a reload after the token was revoked still knows the
+     * difference (see session-presence). In an effect, not during render:
+     * React can discard or replay a render, and this outlives the one it was
+     * observed in. Declared above the gate so the gate reads it settled.
      */
-    const hadSession = useRef(false)
-    // Recorded in an effect, not during render: React can discard or replay a
-    // render, and this outlives the one it was observed in. Declared above the
-    // gate so the gate reads it already settled.
     useEffect(() => {
-        if (user) hadSession.current = true
+        if (user) markSessionHeld()
     }, [user])
 
     useEffect(() => {
@@ -133,7 +131,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             // consume this via consumePostAuthRedirect — which is why the
             // origin rides along: a fresh signup must not inherit the page a
             // previous session was standing on.
-            saveRedirectUrl(hadSession.current ? 'session-end' : 'deep-link')
+            saveRedirectUrl(hasHeldSession() ? 'session-end' : 'deep-link')
             router.replace('/setup')
             // Hard-nav fallback if the soft nav silently fails; re-check at fire time.
             const fallback = setTimeout(() => {

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -85,6 +85,21 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
     useLongPressGuard()
 
     const isRedirecting = useRef(false)
+    /*
+     * Did this document ever hold a session? It separates the two reasons the
+     * gate below fires: a logged-out arrival at a protected deep link (the
+     * person's own intent — keep it) from a session collapsing under a
+     * standing app (logout, revocation, expiry — where it happened to be
+     * standing is nobody's intent, and belongs to an account that is not
+     * necessarily the next one to authenticate here).
+     */
+    const hadSession = useRef(false)
+    // Recorded in an effect, not during render: React can discard or replay a
+    // render, and this outlives the one it was observed in. Declared above the
+    // gate so the gate reads it already settled.
+    useEffect(() => {
+        if (user) hadSession.current = true
+    }, [user])
 
     useEffect(() => {
         // Harness-only: if a reproduce session is in progress, ReproduceBootstrap
@@ -115,8 +130,10 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             // Keep the target: a logged-out tap on a protected deep link
             // (/pay-request, /card, /receipt, every push) used to be dropped
             // here and land on /home after login. useLogin/useAccountSetup
-            // consume this via consumePostAuthRedirect.
-            saveRedirectUrl()
+            // consume this via consumePostAuthRedirect — which is why the
+            // origin rides along: a fresh signup must not inherit the page a
+            // previous session was standing on.
+            saveRedirectUrl(hadSession.current ? 'session-end' : 'deep-link')
             router.replace('/setup')
             // Hard-nav fallback if the soft nav silently fails; re-check at fire time.
             const fallback = setTimeout(() => {

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -23,7 +23,7 @@ import { ShellBannerFallback } from '@/components/Global/Banner/ShellBannerFallb
 import ForceIOSPWAInstall from '@/components/ForceIOSPWAInstall'
 import { isPublicRoute } from '@/constants/routes'
 import { saveRedirectUrl } from '@/utils/general.utils'
-import { hasHeldSession, markSessionHeld } from '@/utils/session-presence'
+import { consumeHeldSession, markSessionHeld } from '@/utils/session-presence'
 import { IS_DEV } from '@/constants/general.consts'
 import { HARNESS_ENABLED } from '@/constants/harness.consts'
 import { FixtureBanner } from '@/dev/fixtures/FixtureBanner'
@@ -131,7 +131,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
             // consume this via consumePostAuthRedirect — which is why the
             // origin rides along: a fresh signup must not inherit the page a
             // previous session was standing on.
-            saveRedirectUrl(hasHeldSession() ? 'session-end' : 'deep-link')
+            saveRedirectUrl(consumeHeldSession() ? 'session-end' : 'deep-link')
             router.replace('/setup')
             // Hard-nav fallback if the soft nav silently fails; re-check at fire time.
             const fallback = setTimeout(() => {

--- a/src/app/(mobile-ui)/layout.tsx
+++ b/src/app/(mobile-ui)/layout.tsx
@@ -115,15 +115,14 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         // for a 5xx or a network failure. so an error here means the backend is
         // down, not that the person is logged out. leave them on the error screen
         // below — a bounce to signup reads as "you are logged out" during an outage.
-        if (
-            !isPublicPath &&
-            isReady &&
-            !isFetchingUser &&
-            !user &&
-            !userFetchError &&
-            !isRedirecting.current &&
-            !isDemoMode()
-        ) {
+        if (isPublicPath) {
+            // A session can expire while this tab is sitting on a public route.
+            // Retire that tab-local provenance here without storing the public
+            // route, so its next protected deep link is fresh intent.
+            if (isReady && !isFetchingUser && !user && !userFetchError) consumeHeldSession()
+            return undefined
+        }
+        if (isReady && !isFetchingUser && !user && !userFetchError && !isRedirecting.current && !isDemoMode()) {
             isRedirecting.current = true
             // Keep the target: a logged-out tap on a protected deep link
             // (/pay-request, /card, /receipt, every push) used to be dropped

--- a/src/app/(setup)/setup/__tests__/page.test.tsx
+++ b/src/app/(setup)/setup/__tests__/page.test.tsx
@@ -184,6 +184,24 @@ it('bounds waiting for session hydration', async () => {
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
 })
 
+it('suppresses timeout recovery when a completed session starts leaving for home', async () => {
+    mockAuth.isFetchingUser = true
+    const view = renderWithIntl(<SetupPage />)
+    await advance(100)
+    await advance(15000)
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+
+    mockAuth.isFetchingUser = false
+    mockAuth.user = { user: { username: 'peanutter', hasAppAccess: true } }
+    await act(async () => {
+        view.rerender(<SetupPage />)
+    })
+
+    expect(mockRouter.replace).toHaveBeenCalledWith('/home')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
+})
+
 it.each([true, false])('preserves the resolved entry flow (native=%s)', async (native) => {
     mockNative = native
     Object.defineProperty(window, 'PublicKeyCredential', {

--- a/src/app/(setup)/setup/__tests__/page.test.tsx
+++ b/src/app/(setup)/setup/__tests__/page.test.tsx
@@ -15,7 +15,13 @@ const mockFlow = {
     setScreenId: jest.fn(),
 }
 const mockStore = { steps: [] as ISetupStep[], inviteCode: undefined }
-const mockAuth = { user: undefined, isFetchingUser: false, logoutUser: jest.fn(), isLoggingOut: false }
+type MockUser = { user: { username: string; hasAppAccess: boolean } }
+const mockAuth = {
+    user: undefined as MockUser | undefined,
+    isFetchingUser: false,
+    logoutUser: jest.fn(),
+    isLoggingOut: false,
+}
 let mockNative = true
 
 jest.mock('@/features/setup/SetupFlowContext', () => ({
@@ -79,6 +85,7 @@ beforeEach(() => {
     mockStore.steps = [landing]
     mockFlow.step = landing
     mockAuth.isFetchingUser = false
+    mockAuth.user = undefined
     mockNative = true
 })
 afterEach(() => {
@@ -194,4 +201,26 @@ it('does not initialize after unmount', async () => {
     view.unmount()
     await advance(100)
     expect(mockFlow.setScreenId).not.toHaveBeenCalled()
+})
+
+/*
+ * Back after a completed signup lands here: the flow leaves a history entry
+ * per step on web, and the post-signup redirect only replaces the last one.
+ * The session effect already bounces such a visit to /home — while that soft
+ * nav is in flight the page must keep waiting, not report a fault it is
+ * already recovering from (PEANUT-UI-T3A, reason=missing_step).
+ */
+it('bounces a completed session home without showing the recovery screen', async () => {
+    mockAuth.user = { user: { username: 'peanutter', hasAppAccess: true } }
+    mockFlow.step = undefined
+    renderWithIntl(<SetupPage />)
+    await advance(100)
+    expect(mockRouter.replace).toHaveBeenCalledWith('/home')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    // the initialization bound must not turn the pending bounce into a fault either
+    await advance(15000)
+    expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
 })

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -79,17 +79,17 @@ function SetupPageContent() {
      */
     const [isLeavingForHome, setIsLeavingForHome] = useState(false)
 
-    const recoveryReason =
-        initializationError ??
-        (!isLoading &&
-        sessionChecked &&
-        !step &&
-        !isLeavingForHome &&
-        !existingSessionUsername &&
-        !showDeviceNotSupportedModal &&
-        !showBrowserNotSupportedModal
-            ? 'missing_step'
-            : null)
+    const recoveryReason = isLeavingForHome
+        ? null
+        : (initializationError ??
+          (!isLoading &&
+          sessionChecked &&
+          !step &&
+          !existingSessionUsername &&
+          !showDeviceNotSupportedModal &&
+          !showBrowserNotSupportedModal
+              ? 'missing_step'
+              : null))
 
     useEffect(() => {
         if (recoveryReason) {

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -69,12 +69,22 @@ function SetupPageContent() {
     const legacyStepParam = searchParams.get('step')
     const [sessionChecked, setSessionChecked] = useState(false)
     const [existingSessionUsername, setExistingSessionUsername] = useState<string | null>(null)
+    /*
+     * A completed session is on its way to /home (see the session effect
+     * below), but the soft nav takes a beat and this page keeps rendering and
+     * resolving its entry step meanwhile. Nothing here is a fault the user
+     * should see: an authenticated pop back into /setup — the signup flow
+     * leaves a history entry per step — showed the recovery screen instead of
+     * the bounce it was already performing.
+     */
+    const [isLeavingForHome, setIsLeavingForHome] = useState(false)
 
     const recoveryReason =
         initializationError ??
         (!isLoading &&
         sessionChecked &&
         !step &&
+        !isLeavingForHome &&
         !existingSessionUsername &&
         !showDeviceNotSupportedModal &&
         !showBrowserNotSupportedModal
@@ -91,13 +101,13 @@ function SetupPageContent() {
     }, [recoveryReason])
 
     useEffect(() => {
-        if ((!isLoading && sessionChecked) || initializationError) return
+        if ((!isLoading && sessionChecked) || initializationError || isLeavingForHome) return
         const timeout = setTimeout(() => {
             initializationExpired.current = true
             setInitializationError('initialization_timeout')
         }, 15000)
         return () => clearTimeout(timeout)
-    }, [isLoading, sessionChecked, initializationError])
+    }, [isLoading, sessionChecked, initializationError, isLeavingForHome])
 
     // only count steps that actually render: not while the entry step is
     // being determined, and not behind the existing-session interstitial
@@ -150,6 +160,7 @@ function SetupPageContent() {
              */
             if (user.user.hasAppAccess) {
                 posthog.capture(ANALYTICS_EVENTS.SIGNUP_EXISTING_SESSION_CONTINUED, { auto: true })
+                setIsLeavingForHome(true)
                 router.replace('/home')
                 return
             }
@@ -371,7 +382,7 @@ function SetupPageContent() {
         )
     }
 
-    if (isLoading || !sessionChecked)
+    if (isLoading || !sessionChecked || isLeavingForHome)
         return (
             <div className="flex h-dvh w-full flex-col items-center justify-center">
                 <Loading variant="mascot" />

--- a/src/app/shhhhh/shhhhh-acquisition.test.ts
+++ b/src/app/shhhhh/shhhhh-acquisition.test.ts
@@ -1,4 +1,4 @@
-import { getRedirectUrl } from '@/utils/general.utils'
+import { getRedirectOrigin, getRedirectUrl, saveRedirectUrl } from '@/utils/general.utils'
 import {
     destinationForShhhhhClaims,
     queueShhhhhCampaignContinuation,
@@ -55,6 +55,27 @@ describe('Shhhhh campaign continuation', () => {
             expect(getRedirectUrl()).toBe('/home')
         }
     )
+
+    /*
+     * A session that ended earlier recorded itself as the reason a destination
+     * was stored. This continuation is the new account's own, so settling it
+     * must replace that provenance along with the destination — otherwise the
+     * fresh signup discards a confirmed Skip Pass as someone else's leftover.
+     */
+    it('replaces an earlier session-end provenance along with the destination', () => {
+        window.history.replaceState({}, '', '/profile')
+        saveRedirectUrl('session-end')
+        queueShhhhhCampaignContinuation()
+        expect(getRedirectOrigin()).toBe('deep-link')
+
+        expect(
+            settleShhhhhCampaignContinuation([
+                { badgeCampaign: 'skip', badgeCode: 'WAITLIST_SKIP', outcome: 'awarded' },
+            ])
+        ).toBe('/card')
+        expect(getRedirectUrl()).toBe('/card')
+        expect(getRedirectOrigin()).toBe('deep-link')
+    })
 
     it("does not consume another acquisition flow's stored destination", () => {
         localStorage.setItem('redirect', JSON.stringify('/claim?step=claim'))

--- a/src/app/shhhhh/shhhhh-acquisition.ts
+++ b/src/app/shhhhh/shhhhh-acquisition.ts
@@ -1,5 +1,5 @@
 import { isConfirmedBadgeCampaignClaim, type BadgeCampaignClaim } from '@/services/badge-campaigns'
-import { getRedirectUrl, saveToLocalStorage } from '@/utils/general.utils'
+import { getRedirectUrl, setRedirectUrl } from '@/utils/general.utils'
 
 const WAITLIST_SKIP_BADGE_CODE = 'WAITLIST_SKIP'
 const PENDING_SHHHHH_REDIRECT = '/home?badge_campaign_continuation=shhhhh'
@@ -9,7 +9,7 @@ const PENDING_SHHHHH_REDIRECT = '/home?badge_campaign_continuation=shhhhh'
  * with `/card` only after the API confirms that this intent awarded Skip Pass.
  */
 export function queueShhhhhCampaignContinuation(): void {
-    saveToLocalStorage('redirect', PENDING_SHHHHH_REDIRECT)
+    setRedirectUrl(PENDING_SHHHHH_REDIRECT)
 }
 
 export function shhhhhCampaignSignupRoute(): string {
@@ -33,6 +33,6 @@ export function destinationForShhhhhClaims(claims: readonly BadgeCampaignClaim[]
 export function settleShhhhhCampaignContinuation(claims: readonly BadgeCampaignClaim[]): '/card' | '/home' | undefined {
     if (getRedirectUrl() !== PENDING_SHHHHH_REDIRECT) return undefined
     const destination = destinationForShhhhhClaims(claims)
-    saveToLocalStorage('redirect', destination)
+    setRedirectUrl(destination)
     return destination
 }

--- a/src/components/Global/PostSignupActionManager/__tests__/index.test.tsx
+++ b/src/components/Global/PostSignupActionManager/__tests__/index.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { PostSignupActionManager } from '../index'
+
+const mockRouterPush = jest.fn()
+const mockRouter = { push: mockRouterPush }
+const mockGetStoredRedirect = jest.fn()
+const mockClearRedirectUrl = jest.fn()
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => mockRouter,
+}))
+
+jest.mock('@/utils/general.utils', () => ({
+    getStoredRedirect: (...args: any[]) => mockGetStoredRedirect(...args),
+    clearRedirectUrl: (...args: any[]) => mockClearRedirectUrl(...args),
+}))
+
+jest.mock('@/hooks/useIdentityVerification', () => ({
+    useIdentityVerification: () => ({ isVerified: true }),
+}))
+
+jest.mock('../../ActionModal', () => ({
+    __esModule: true,
+    default: ({ visible, ctas, onClose }: any) =>
+        visible ? (
+            <div>
+                <button onClick={ctas[0].onClick}>{ctas[0].text}</button>
+                <button onClick={onClose}>Close</button>
+            </div>
+        ) : null,
+}))
+
+describe('PostSignupActionManager', () => {
+    const redirect = {
+        destination: '/claim?step=claim&id=payment-1',
+        origin: 'deep-link' as const,
+        generationId: 'generation-a',
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockGetStoredRedirect.mockReturnValue(redirect)
+    })
+
+    it('clears the redirect snapshot that opened the action modal', () => {
+        render(<PostSignupActionManager onActionModalVisibilityChange={jest.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Claim to bank' }))
+
+        expect(mockRouterPush).toHaveBeenCalledWith(redirect.destination)
+        expect(mockClearRedirectUrl).toHaveBeenCalledWith(redirect)
+    })
+
+    it('clears the modal snapshot when the user closes it', () => {
+        render(<PostSignupActionManager onActionModalVisibilityChange={jest.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+        expect(mockClearRedirectUrl).toHaveBeenCalledWith(redirect)
+    })
+})

--- a/src/components/Global/PostSignupActionManager/index.tsx
+++ b/src/components/Global/PostSignupActionManager/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getRedirectUrl, clearRedirectUrl } from '@/utils/general.utils'
+import { clearRedirectUrl, getStoredRedirect, type StoredRedirect } from '@/utils/general.utils'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import ActionModal from '../ActionModal'
@@ -19,6 +19,7 @@ export const PostSignupActionManager = ({
         title: string
         description: string
         icon: IconName
+        redirect: StoredRedirect
         action: () => void
     } | null>(null)
     const router = useRouter()
@@ -29,15 +30,17 @@ export const PostSignupActionManager = ({
     const { isVerified: isIdentityVerified } = useIdentityVerification()
 
     const checkClaimModalAfterKYC = () => {
-        const redirectUrl = getRedirectUrl()
-        if (isIdentityVerified && redirectUrl) {
+        const redirect = getStoredRedirect()
+        if (isIdentityVerified && redirect) {
+            const redirectUrl = redirect.destination
             const matchedAction = POST_SIGNUP_ACTIONS.find((action) => action.pathPattern.test(redirectUrl))
             if (matchedAction) {
                 setActionConfig({
                     ...matchedAction.config,
+                    redirect,
                     action: () => {
                         router.push(redirectUrl)
-                        clearRedirectUrl()
+                        clearRedirectUrl(redirect)
                         setShowModal(false)
                     },
                 })
@@ -61,7 +64,7 @@ export const PostSignupActionManager = ({
             visible={showModal}
             onClose={() => {
                 setShowModal(false)
-                clearRedirectUrl()
+                if (actionConfig) clearRedirectUrl(actionConfig.redirect)
             }}
             preventClose // Prevent closing the modal by clicking outside
             title={actionConfig.title}

--- a/src/components/Setup/Views/SignTestTransaction.tsx
+++ b/src/components/Setup/Views/SignTestTransaction.tsx
@@ -51,7 +51,10 @@ const SignTestTransaction = () => {
         if (redirectingRef.current) return
         redirectingRef.current = true
         setIsRedirecting(true)
-        handleRedirect()
+        // This screen is only reachable for an account created in this
+        // session, so it inherits no earlier session's page — only a deep link
+        // the person themselves asked for.
+        handleRedirect({ isNewAccount: true })
     }
 
     // ensure user is fetched when component mounts (important for new signups)

--- a/src/components/Setup/Views/__tests__/SignTestTransaction.test.tsx
+++ b/src/components/Setup/Views/__tests__/SignTestTransaction.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithIntl } from '@/test-utils/intl'
-import { saveToLocalStorage } from '@/utils/general.utils'
+import { getRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
 import SignTestTransaction from '../SignTestTransaction'
 import { capturePasskeyDebugInfo } from '@/utils/passkeyDebug'
 
@@ -98,6 +98,37 @@ describe('SignTestTransaction — the account-ready screen', () => {
         fireEvent.click(cta)
 
         expect(mockRouterReplace).toHaveBeenCalledTimes(1)
+        expect(mockRouterReplace).toHaveBeenCalledWith('/receipt?id=abc')
+    })
+
+    /*
+     * This CTA is the only caller that declares the account new, and so the
+     * only place the cross-account guard is switched on. Without a classified
+     * record in the fixture the flag is unobserved — the argument could be
+     * deleted with every test here still green, and logout-from-/profile then
+     * signup would land on /profile again.
+     */
+    const completeSignupAndTapCta = async () => {
+        renderWithIntl(<SignTestTransaction />)
+        fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
+        await screen.findByText(/works right now/i)
+        fireEvent.click(screen.getByRole('button', { name: /go to my account/i }))
+    }
+
+    it('refuses a page the previous session was standing on', async () => {
+        setRedirectUrl('/profile', 'session-end')
+
+        await completeSignupAndTapCta()
+
+        expect(mockRouterReplace).toHaveBeenCalledWith('/home')
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('still takes a deep link the person asked for', async () => {
+        setRedirectUrl('/receipt?id=abc')
+
+        await completeSignupAndTapCta()
+
         expect(mockRouterReplace).toHaveBeenCalledWith('/receipt?id=abc')
     })
 })

--- a/src/context/__tests__/authContext-logout.test.tsx
+++ b/src/context/__tests__/authContext-logout.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * logoutUser, through the provider.
+ *
+ * The redirect latch has to be armed BEFORE anything empties the user cache:
+ * that is what re-runs the (mobile-ui) auth gate, which stores the current
+ * path as the post-auth destination — and the logout button lives on
+ * /profile, so a fresh account created afterwards inherited that page. Unit
+ * tests that call `beginIntentionalLogout` themselves cannot see that
+ * ordering, so these drive the real logout and let the emptied cache stand in
+ * for the gate.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+const mockClear = jest.fn()
+const mockCancelQueries = jest.fn().mockResolvedValue(undefined)
+const mockRefetch = jest.fn().mockResolvedValue({ data: null })
+const mockApiFetch = jest.fn().mockResolvedValue(undefined)
+const mockToastError = jest.fn()
+
+jest.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => ({ error: mockToastError }) }))
+jest.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({ clear: mockClear, cancelQueries: mockCancelQueries }),
+}))
+jest.mock('@/hooks/query/user', () => ({
+    useUserQuery: () => ({
+        data: { user: { userId: 'u1', username: 'probe' }, accounts: [] },
+        isLoading: false,
+        refetch: mockRefetch,
+        error: null,
+    }),
+}))
+jest.mock('@/hooks/useUserAutoRefresh', () => ({ useUserAutoRefresh: jest.fn() }))
+jest.mock('@/hooks/useAppLocked', () => ({ useAppLocked: () => false }))
+jest.mock('@/hooks/useZeroDevFlow', () => ({ zeroDevFlowActions: { reset: jest.fn() } }))
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: (...args: unknown[]) => mockApiFetch(...args) }))
+jest.mock('@/utils/auth-token', () => ({ clearAuthToken: jest.fn().mockResolvedValue(undefined) }))
+jest.mock('@/utils/login-session', () => ({ recoverLoginSession: jest.fn() }))
+jest.mock('@/utils/cache.utils', () => ({ purgeCaches: jest.fn().mockResolvedValue(undefined) }))
+jest.mock('@/utils/crisp', () => ({ resetCrispProxySessions: jest.fn() }))
+jest.mock('@/utils/capacitor', () => ({ isCapacitor: () => false }))
+jest.mock('@/utils/sentry-lazy', () => ({ captureException: jest.fn(), setUser: jest.fn() }))
+jest.mock('@/i18n/app/locale-store', () => ({
+    currentAppLocale: () => 'en',
+    currentDeviceContext: () => ({}),
+    currentDeviceIdentity: () => ({}),
+}))
+jest.mock('@/services/step-up', () => ({ clearStepUpToken: jest.fn() }))
+jest.mock('@/services/badge-campaigns', () => ({
+    claimAndSettlePendingBadgeCampaigns: jest.fn(),
+    isConfirmedBadgeCampaignClaim: () => false,
+}))
+jest.mock('@/components/Invites/badge-campaign-context', () => ({
+    clearPendingBadgeCampaigns: jest.fn(),
+    getPendingBadgeCampaigns: () => [],
+}))
+jest.mock('@/utils/invite-stash', () => ({ clearInvite: jest.fn() }))
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { identify: jest.fn(), reset: jest.fn(), register: jest.fn() },
+}))
+
+import { AuthProvider, useAuth } from '../authContext'
+import { clearRedirectUrl, endIntentionalLogout, getRedirectUrl, saveRedirectUrl } from '@/utils/general.utils'
+import { clearSessionHeld, hasHeldSession, markSessionHeld } from '@/utils/session-presence'
+
+const wrapper = ({ children }: { children: ReactNode }) => <AuthProvider>{children}</AuthProvider>
+
+const originalLocation = window.location
+
+/** Replaces window.location so assigning href is observable, or explodes. */
+const stubLocation = (onNavigate?: () => void) => {
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+            ...originalLocation,
+            get href() {
+                return originalLocation.href
+            },
+            set href(_value: string) {
+                onNavigate?.()
+            },
+        },
+    })
+}
+
+describe('logoutUser', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockCancelQueries.mockResolvedValue(undefined)
+        mockRefetch.mockResolvedValue({ data: null })
+        endIntentionalLogout()
+        clearRedirectUrl()
+        clearSessionHeld()
+        window.history.replaceState({}, '', '/profile')
+    })
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+        endIntentionalLogout()
+        clearRedirectUrl()
+        clearSessionHeld()
+    })
+
+    it('arms the latch before the user cache is emptied', async () => {
+        /*
+         * Read back inside the hook, not after the call: logout clears the
+         * stored redirect later in its own teardown, which would mask a save
+         * that did land here. What this pins is the state AT the moment the
+         * gate reacts — arming the latch any later leaves the path stored.
+         */
+        let storedWhenCacheEmptied: unknown = 'not-observed'
+        mockClear.mockImplementation(() => {
+            saveRedirectUrl('session-end')
+            storedWhenCacheEmptied = getRedirectUrl()
+        })
+        stubLocation()
+        const { result } = renderHook(() => useAuth(), { wrapper })
+
+        await act(async () => {
+            await result.current.logoutUser()
+        })
+
+        expect(mockClear).toHaveBeenCalled()
+        expect(storedWhenCacheEmptied).toBeNull()
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('leaves this tab logged out, so a later deep link is intent again', async () => {
+        markSessionHeld()
+        stubLocation()
+        const { result } = renderHook(() => useAuth(), { wrapper })
+
+        await act(async () => {
+            await result.current.logoutUser()
+        })
+
+        expect(hasHeldSession()).toBe(false)
+    })
+
+    it('releases the latch when the hard navigation never happens', async () => {
+        stubLocation(() => {
+            throw new Error('navigation blocked')
+        })
+        const { result } = renderHook(() => useAuth(), { wrapper })
+
+        await act(async () => {
+            await result.current.logoutUser({ skipBackendCall: true })
+        })
+        await waitFor(() => expect(mockToastError).toHaveBeenCalled())
+
+        // this document keeps serving the app: a deep-link bounce must store again
+        saveRedirectUrl()
+        expect(getRedirectUrl()).toBe('/profile')
+    })
+
+    it('revokes the session server-side before clearing local state', async () => {
+        const order: string[] = []
+        mockApiFetch.mockImplementation(async (path: string) => {
+            order.push(`api:${path}`)
+        })
+        mockClear.mockImplementation(() => order.push('cache-cleared'))
+        stubLocation()
+        const { result } = renderHook(() => useAuth(), { wrapper })
+
+        await act(async () => {
+            await result.current.logoutUser()
+        })
+
+        expect(order).toEqual(['api:/users/logout', 'cache-cleared'])
+    })
+})

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -10,7 +10,9 @@ import { zeroDevFlowActions } from '@/hooks/useZeroDevFlow'
 import {
     removeFromCookie,
     syncLocalStorageToCookie,
+    beginIntentionalLogout,
     clearRedirectUrl,
+    endIntentionalLogout,
     updateUserPreferences,
 } from '@/utils/general.utils'
 import { apiFetch } from '@/utils/api-fetch'
@@ -355,6 +357,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             if (isLoggingOut) return
 
             setIsLoggingOut(true)
+            // Before anything empties the user cache: the auth gate reacts to
+            // that by storing the current path as the post-auth destination.
+            beginIntentionalLogout()
             try {
                 /*
                  * Revoke server-side FIRST (needs the still-valid JWT): POST
@@ -382,6 +387,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 // force full page refresh to /setup to clear all state
                 window.location.href = '/setup'
             } catch (error) {
+                // The hard nav never happened, so this document keeps serving
+                // the app — a later deep-link bounce must store its target again.
+                endIntentionalLogout()
                 captureException(error)
                 console.error('Error logging out user', error)
                 // TODO: remove debug info after native testing

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -15,6 +15,7 @@ import {
     endIntentionalLogout,
     updateUserPreferences,
 } from '@/utils/general.utils'
+import { clearSessionHeld } from '@/utils/session-presence'
 import { apiFetch } from '@/utils/api-fetch'
 import { useAppLocked } from '@/hooks/useAppLocked'
 import { currentAppLocale, currentDeviceContext, currentDeviceIdentity } from '@/i18n/app/locale-store'
@@ -324,6 +325,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         try {
             sessionStorage.removeItem('hasSeenIOSPWAPromptThisSession')
         } catch {}
+
+        // This tab is a logged-out tab again, so a deep link opened in it later
+        // is that person's own intent rather than a dead session's residue.
+        clearSessionHeld()
 
         // clear demo mode flag
         disableDemoMode()

--- a/src/features/add-money/__tests__/useAddMoneyFlow.test.ts
+++ b/src/features/add-money/__tests__/useAddMoneyFlow.test.ts
@@ -6,6 +6,9 @@ import { withNuqsTestingAdapter, type UrlUpdateEvent } from 'nuqs/adapters/testi
 
 const mockRouterPush = jest.fn()
 const mockRouterReplace = jest.fn()
+const mockGetStoredRedirect = jest.fn() as jest.Mock
+const mockClearRedirectUrl = jest.fn()
+const mockGetFromLocalStorage = jest.fn() as jest.Mock
 
 jest.mock('next/navigation', () => ({
     useRouter: () => ({ push: mockRouterPush, replace: mockRouterReplace, back: jest.fn(), prefetch: jest.fn() }),
@@ -23,9 +26,9 @@ jest.mock('posthog-js', () => ({
 }))
 
 jest.mock('@/utils/general.utils', () => ({
-    getRedirectUrl: jest.fn(() => null),
-    clearRedirectUrl: jest.fn(),
-    getFromLocalStorage: jest.fn(() => null),
+    getStoredRedirect: mockGetStoredRedirect,
+    clearRedirectUrl: mockClearRedirectUrl,
+    getFromLocalStorage: mockGetFromLocalStorage,
     // real behavior: same-origin paths pass, everything else is rejected
     sanitizeRedirectURL: jest.fn((url: string) =>
         url.startsWith('/') && !url.startsWith('//') && !url.includes('://') ? url : null
@@ -57,6 +60,8 @@ const renderFlow = (search = '', onUrlUpdate?: (e: UrlUpdateEvent) => void) =>
 describe('useAddMoneyFlow', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockGetStoredRedirect.mockReturnValue(null)
+        mockGetFromLocalStorage.mockReturnValue(null)
     })
 
     it('bare root redirects to the home add drawer and resets onramp state', () => {
@@ -91,6 +96,22 @@ describe('useAddMoneyFlow', () => {
         const { result: r2 } = renderFlow('?method=bank')
         act(() => r2.current.handleBack())
         expect(mockRouterPush).toHaveBeenCalledWith('/home')
+    })
+
+    it('clears the redirect snapshot it routed from', () => {
+        const redirect = {
+            destination: '/claim?step=claim&id=payment-1',
+            origin: 'deep-link',
+            generationId: 'generation-a',
+        }
+        mockGetStoredRedirect.mockReturnValue(redirect)
+        mockGetFromLocalStorage.mockReturnValue(true)
+
+        const { result } = renderFlow('?method=bank')
+        act(() => result.current.handleBack())
+
+        expect(mockRouterPush).toHaveBeenCalledWith(redirect.destination)
+        expect(mockClearRedirectUrl).toHaveBeenCalledWith(redirect)
     })
 
     it('a country in the URL keeps onramp state (only the root list resets it)', () => {

--- a/src/features/add-money/useAddMoneyFlow.ts
+++ b/src/features/add-money/useAddMoneyFlow.ts
@@ -4,7 +4,7 @@ import type { CountryData } from '@/components/AddMoney/consts'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { useOnrampFlow } from '@/context/OnrampFlowContext'
-import { getRedirectUrl, clearRedirectUrl, getFromLocalStorage } from '@/utils/general.utils'
+import { clearRedirectUrl, getFromLocalStorage, getStoredRedirect } from '@/utils/general.utils'
 import { addMoneyCountryUrl, rewriteMethodPath } from '@/utils/native-routes'
 import { isBridgeSupportedCountry } from '@/utils/regions.utils'
 import { readReturnTo, RETURN_TO_PARAM } from '@/utils/return-to.utils'
@@ -58,11 +58,12 @@ export function useAddMoneyFlow() {
         }
 
         // check if we have a saved redirect url (from request fulfillment or similar flows)
-        const redirectUrl = getRedirectUrl()
+        const redirect = getStoredRedirect()
+        const redirectUrl = redirect?.destination
         const fromRequestFulfillment = getFromLocalStorage('fromRequestFulfillment')
 
         if (redirectUrl && fromRequestFulfillment) {
-            clearRedirectUrl()
+            clearRedirectUrl(redirect)
             if (typeof localStorage !== 'undefined') {
                 localStorage.removeItem('fromRequestFulfillment')
             }

--- a/src/features/setup/__tests__/useSetupFlow.test.tsx
+++ b/src/features/setup/__tests__/useSetupFlow.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { NuqsTestingAdapter, type OnUrlUpdateFunction } from 'nuqs/adapters/testing'
 import type { ReactNode } from 'react'
-import { useSetupFlow } from '@/hooks/useSetupFlow'
+import { SETUP_DEFAULT_SCREEN, useSetupFlow } from '@/hooks/useSetupFlow'
 import { SetupFlowProvider, useSetupFlowContext } from '../SetupFlowContext'
 import { setupSteps } from '@/components/Setup/Setup.consts'
 
@@ -19,6 +19,12 @@ jest.mock('@/utils/capacitor', () => ({
 
 const STEPS = setupSteps.filter((s) =>
     ['landing', 'welcome', 'signup', 'residence', 'passkey-permission', 'sign-test-transaction'].includes(s.screenId)
+)
+
+// What the (setup) layout hands over during the pwa-sunset window: the three
+// install/unsupported screens the master list STARTS with are filtered out.
+const SUNSET_STEPS = setupSteps.filter(
+    (s) => !['pwa-install', 'android-initial-pwa-install', 'unsupported-browser'].includes(s.screenId)
 )
 
 const wrapperFor = (searchParams: Record<string, string>) =>
@@ -40,9 +46,12 @@ const renderFlow = (searchParams: Record<string, string> = {}) =>
         { wrapper: wrapperFor(searchParams) }
     )
 
-const seedSteps = async (result: { current: { context: { setSteps: (s: typeof STEPS) => void } } }) => {
+const seedSteps = async (
+    result: { current: { context: { setSteps: (s: typeof setupSteps) => void } } },
+    steps: typeof setupSteps = STEPS
+) => {
     await act(async () => {
-        result.current.context.setSteps(STEPS)
+        result.current.context.setSteps(steps)
     })
 }
 
@@ -130,6 +139,34 @@ describe('useSetupFlow (URL stepper)', () => {
             await result.current.flow.setScreenId('signup')
         })
         expect(result.current.flow.step?.screenId).toBe('signup')
+    })
+
+    /*
+     * The cursor a clean /setup URL means must be a screen the runtime filter
+     * keeps. While it was steps[0] it moved with the list — the master
+     * fallback starts at 'unsupported-browser', the sunset list at 'landing' —
+     * so a clean URL could name a screen absent from the list in force, which
+     * is no step at all and put the page on its recovery screen instead of the
+     * flow (PEANUT-UI-T3A: back into /setup after signup).
+     */
+    it('the default cursor survives every runtime filter the layout applies', () => {
+        for (const list of [setupSteps, STEPS, SUNSET_STEPS]) {
+            expect(list.some((s) => s.screenId === SETUP_DEFAULT_SCREEN)).toBe(true)
+        }
+    })
+
+    it('a clean URL resolves to a step the sunset-filtered list actually has', async () => {
+        const { result } = renderFlow()
+        await seedSteps(result, SUNSET_STEPS)
+        expect(result.current.flow.step?.screenId).toBe(SETUP_DEFAULT_SCREEN)
+        expect(result.current.flow.currentIndex).toBeGreaterThanOrEqual(0)
+    })
+
+    it('a filtered-out screen in the URL resolves to the default, never to no step', async () => {
+        const { result } = renderFlow({ screen: 'unsupported-browser' })
+        await seedSteps(result, SUNSET_STEPS)
+        expect(result.current.flow.step).toBeDefined()
+        expect(result.current.flow.step?.screenId).toBe(SETUP_DEFAULT_SCREEN)
     })
 
     it('resetSetupFlow disarms the lock (start-fresh on the existing-session interstitial)', async () => {

--- a/src/hooks/__tests__/post-auth-redirect-consumers.test.tsx
+++ b/src/hooks/__tests__/post-auth-redirect-consumers.test.tsx
@@ -1,7 +1,7 @@
 import { act, waitFor } from '@testing-library/react'
 // These hooks localize their error copy now, so they need the intl provider.
 import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
-import { getRedirectUrl, saveToLocalStorage } from '@/utils/general.utils'
+import { getRedirectUrl, saveRedirectUrl, saveToLocalStorage } from '@/utils/general.utils'
 import { useAccountSetup } from '../useAccountSetup'
 import { useLogin } from '../useLogin'
 
@@ -74,6 +74,50 @@ describe('post-auth redirect consumers', () => {
         expect(mockRouterReplace).not.toHaveBeenCalled()
         // the redirect is still queued for the CTA to consume
         expect(getRedirectUrl()).toBe(CAMPAIGN_REDIRECT)
+    })
+
+    /*
+     * A destination that only marks where an earlier session ended is not the
+     * new account's inheritance. This is the reported bug — logout from
+     * /profile, create an account, land on /profile — and it survives every
+     * same-tab guard: another tab's session can collapse (revoked, expired)
+     * and store its own page after this device's logout already finished.
+     */
+    describe('a brand-new account and a session-end destination', () => {
+        beforeEach(() => {
+            explicitRedirect = null
+            window.history.replaceState({}, '', '/profile')
+        })
+
+        it('refuses it and consumes it, so the next account cannot inherit it either', () => {
+            saveRedirectUrl('session-end')
+            expect(getRedirectUrl()).toBe('/profile')
+            const { result } = renderHook(() => useAccountSetup())
+
+            act(() => expect(result.current.handleRedirect({ isNewAccount: true })).toBe(false))
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/home')
+            expect(getRedirectUrl()).toBeNull()
+        })
+
+        it('still honours a deep link the person asked for', () => {
+            window.history.replaceState({}, '', CAMPAIGN_REDIRECT)
+            saveRedirectUrl('deep-link')
+            const { result } = renderHook(() => useAccountSetup())
+
+            act(() => expect(result.current.handleRedirect({ isNewAccount: true })).toBe(false))
+
+            expect(mockRouterReplace).toHaveBeenCalledWith(CAMPAIGN_REDIRECT)
+        })
+
+        it('an existing account logging in on this device still resumes where it was', () => {
+            saveRedirectUrl('session-end')
+            const { result } = renderHook(() => useAccountSetup())
+
+            act(() => expect(result.current.handleRedirect()).toBe(false))
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/profile')
+        })
     })
 
     it('login cannot resurrect a campaign redirect after an explicit financial route consumed it', async () => {

--- a/src/hooks/__tests__/post-auth-redirect-consumers.test.tsx
+++ b/src/hooks/__tests__/post-auth-redirect-consumers.test.tsx
@@ -1,7 +1,7 @@
 import { act, waitFor } from '@testing-library/react'
 // These hooks localize their error copy now, so they need the intl provider.
 import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
-import { getRedirectUrl, saveRedirectUrl, saveToLocalStorage } from '@/utils/general.utils'
+import { getRedirectUrl, saveRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
 import { useAccountSetup } from '../useAccountSetup'
 import { useLogin } from '../useLogin'
 
@@ -108,6 +108,22 @@ describe('post-auth redirect consumers', () => {
             act(() => expect(result.current.handleRedirect({ isNewAccount: true })).toBe(false))
 
             expect(mockRouterReplace).toHaveBeenCalledWith(CAMPAIGN_REDIRECT)
+        })
+
+        /*
+         * Mixed writers: a session ended and recorded itself, then a confirmed
+         * invite or campaign continuation replaced the destination. The
+         * continuation is the new account's own, so the earlier session's
+         * provenance must not outlive the destination it described.
+         */
+        it('honours a continuation written over a session-end destination', () => {
+            saveRedirectUrl('session-end')
+            setRedirectUrl('/card')
+            const { result } = renderHook(() => useAccountSetup())
+
+            act(() => expect(result.current.handleRedirect({ isNewAccount: true })).toBe(false))
+
+            expect(mockRouterReplace).toHaveBeenCalledWith('/card')
         })
 
         it('an existing account logging in on this device still resumes where it was', () => {

--- a/src/hooks/__tests__/useFlowStepper.test.tsx
+++ b/src/hooks/__tests__/useFlowStepper.test.tsx
@@ -137,4 +137,28 @@ describe('useFlowStepper', () => {
         const { result } = render({ screen: 'amount' }, { urlKey: 'screen' })
         expect(result.current.step).toBe('amount')
     })
+
+    /*
+     * A step list can be a runtime decision that narrows after the first
+     * render (setup filters its screens by PWA and sunset state), and the URL
+     * outlives it: nuqs keeps serving the cursor it parsed against the wider
+     * list. Resolving that to the default is what keeps the flow from having
+     * no step at all (PEANUT-UI-T3A).
+     */
+    it('a cursor that left the step list resolves to the default step', async () => {
+        const { result, rerender } = renderHook(
+            ({ steps }: { steps: readonly Step[] }) => useFlowStepper<Step>({ steps }),
+            {
+                wrapper: wrapperFor({ step: 'review' }),
+                initialProps: { steps: STEPS as readonly Step[] },
+            }
+        )
+        expect(result.current.step).toBe('review')
+
+        // the URL still says review, but this flow no longer has that screen
+        await act(async () => {
+            rerender({ steps: ['method', 'amount'] as readonly Step[] })
+        })
+        expect(result.current.step).toBe('method')
+    })
 })

--- a/src/hooks/useAccountSetup.ts
+++ b/src/hooks/useAccountSetup.ts
@@ -19,10 +19,17 @@ export const useAccountSetup = () => {
     const [error, setError] = useState<string | null>(null)
     const [isProcessing, setIsProcessing] = useState(false)
 
-    const handleRedirect = (): boolean => {
+    /**
+     * @param options.isNewAccount - This account was just created here, so a
+     * destination that only marks where an earlier session ended is not its
+     * inheritance (a fresh signup landed on the previous account's /profile).
+     * A deep link the person actually asked for still wins.
+     */
+    const handleRedirect = (options?: { isNewAccount?: boolean }): boolean => {
         const redirect = consumePostAuthRedirect(searchParams.get('redirect_uri'), {
             deferStoredRedirect: (destination) =>
                 POST_SIGNUP_ACTIONS.some((action) => action.pathPattern.test(destination)),
+            rejectSessionEndOrigin: options?.isNewAccount,
         })
 
         console.log('[useAccountSetup] Resolved post-auth redirect:', redirect)

--- a/src/hooks/useAccountSetup.ts
+++ b/src/hooks/useAccountSetup.ts
@@ -20,16 +20,18 @@ export const useAccountSetup = () => {
     const [isProcessing, setIsProcessing] = useState(false)
 
     /**
-     * @param options.isNewAccount - This account was just created here, so a
-     * destination that only marks where an earlier session ended is not its
-     * inheritance (a fresh signup landed on the previous account's /profile).
-     * A deep link the person actually asked for still wins.
+     * @param options.isNewAccount - This account was just created here, so it
+     * takes a stored destination only where that page is classified as the
+     * person's own intent — not where an earlier session happened to end, and
+     * not an unclassified record from before this policy (a fresh signup
+     * landed on the previous account's /profile). A deep link still wins, and
+     * an explicit `redirect_uri` outranks all of it.
      */
     const handleRedirect = (options?: { isNewAccount?: boolean }): boolean => {
         const redirect = consumePostAuthRedirect(searchParams.get('redirect_uri'), {
             deferStoredRedirect: (destination) =>
                 POST_SIGNUP_ACTIONS.some((action) => action.pathPattern.test(destination)),
-            rejectSessionEndOrigin: options?.isNewAccount,
+            onlyClassifiedIntent: options?.isNewAccount,
         })
 
         console.log('[useAccountSetup] Resolved post-auth redirect:', redirect)

--- a/src/hooks/useAccountSetup.ts
+++ b/src/hooks/useAccountSetup.ts
@@ -20,18 +20,17 @@ export const useAccountSetup = () => {
     const [isProcessing, setIsProcessing] = useState(false)
 
     /**
-     * @param options.isNewAccount - This account was just created here, so it
-     * takes a stored destination only where that page is classified as the
-     * person's own intent — not where an earlier session happened to end, and
-     * not an unclassified record from before this policy (a fresh signup
-     * landed on the previous account's /profile). A deep link still wins, and
-     * an explicit `redirect_uri` outranks all of it.
+     * @param options.isNewAccount - This account was just created here, so a
+     * destination that only marks where an earlier session ended is not its
+     * inheritance (a fresh signup landed on the previous account's /profile).
+     * A deep link the person actually asked for still wins, stored or passed
+     * as `redirect_uri`.
      */
     const handleRedirect = (options?: { isNewAccount?: boolean }): boolean => {
         const redirect = consumePostAuthRedirect(searchParams.get('redirect_uri'), {
             deferStoredRedirect: (destination) =>
                 POST_SIGNUP_ACTIONS.some((action) => action.pathPattern.test(destination)),
-            onlyClassifiedIntent: options?.isNewAccount,
+            rejectSessionEndOrigin: options?.isNewAccount,
         })
 
         console.log('[useAccountSetup] Resolved post-auth redirect:', redirect)

--- a/src/hooks/useFlowStepper.ts
+++ b/src/hooks/useFlowStepper.ts
@@ -34,13 +34,25 @@ export function useFlowStepper<Step extends string>(options: FlowStepperOptions<
             .withOptions({ history })
     )
 
+    /*
+     * A value that is not in the CURRENT list is not a step. `steps` is a
+     * runtime decision (setup filters screens by PWA and sunset state), and
+     * the URL outlives it: nuqs keeps serving a cursor it parsed against an
+     * earlier, wider list, so a flow could be left with no step at all — an
+     * undefined screen, and for /setup its recovery screen instead of the flow
+     * (PEANUT-UI-T3A). Resolve to the default and let the effect below rewrite
+     * the URL.
+     */
+    const isKnownStep = steps.includes(rawStep)
+
     // A guarded step never renders — resolve to its fallback synchronously so
     // there is no one-frame flash of the dead screen.
     const guard = guards?.[rawStep]
-    const step = guard && !guard.ok ? (guard.fallback ?? defaultStep) : rawStep
+    const step = !isKnownStep ? defaultStep : guard && !guard.ok ? (guard.fallback ?? defaultStep) : rawStep
 
-    // Keep the URL honest after a guard redirect (replace, no history entry —
-    // also under history:'push', or a bounced pop would mint an extra entry).
+    // Keep the URL honest after a guard redirect or an off-list cursor
+    // (replace, no history entry — also under history:'push', or a bounced pop
+    // would mint an extra entry).
     // Strict-mode safe: setting the same value again is a no-op for nuqs.
     useEffect(() => {
         if (step !== rawStep) void setStep(step === defaultStep ? null : step, { history: 'replace' })

--- a/src/hooks/useSetupFlow.ts
+++ b/src/hooks/useSetupFlow.ts
@@ -12,6 +12,16 @@ import { useCallback, useMemo } from 'react'
  * that skips the invite gate (see determineInitialStep). */
 export const SETUP_SCREEN_PARAM = 'screen'
 
+/*
+ * The cursor a clean /setup URL means, pinned to a screen the runtime filter
+ * never removes. NOT steps[0]: that moves as the filtered list arrives (the
+ * master list starts at 'unsupported-browser', a sunset/PWA-filtered list at
+ * 'landing'), so a clean URL could resolve to a screen absent from the list
+ * in force — indexOf -1, no step, and the page's recovery screen instead of
+ * the flow (PEANUT-UI-T3A).
+ */
+export const SETUP_DEFAULT_SCREEN: ScreenId = 'landing'
+
 /**
  * The setup flow's cursor: a named screen id in the URL (?screen=signup),
  * driven by the shared stepper (TASK-21460). This replaced a redux numeric
@@ -61,6 +71,7 @@ export const useSetupFlow = () => {
 
     const stepper = useFlowStepper<ScreenId>({
         steps: screenIds,
+        defaultStep: SETUP_DEFAULT_SCREEN,
         urlKey: SETUP_SCREEN_PARAM,
         history: isNativeBridge() ? 'replace' : 'push',
         guards,

--- a/src/hooks/useZeroDev.ts
+++ b/src/hooks/useZeroDev.ts
@@ -10,7 +10,7 @@ import {
     getFromCookie,
     removeFromCookie,
     saveToCookie,
-    saveToLocalStorage,
+    setRedirectUrl,
     updateUserPreferences,
 } from '@/utils/general.utils'
 import { clearAuthState } from '@/utils/auth.utils'
@@ -172,7 +172,7 @@ export const useZeroDev = () => {
 
                             // Keep an already-published migration continuation
                             // through setup only after the matching claim confirms.
-                            if (destination !== '/home') saveToLocalStorage('redirect', destination)
+                            if (destination !== '/home') setRedirectUrl(destination)
                             if (pending.some((tag) => tag.toLowerCase() === acceptedBadgeCampaigns[0].toLowerCase())) {
                                 captureException(new Error('accept-time legacy acquisition retained for retry'), {
                                     tags: { error_type: 'invite_accept_campaign_retryable' },

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -1,5 +1,5 @@
 import { consumePostAuthRedirect } from '../post-auth-redirect'
-import { getRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
+import { getRedirectOrigin, getRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
 
 const FINANCIAL_REDIRECT = '/claim?step=claim&id=payment-1'
 const CAMPAIGN_REDIRECT = '/add-money/crypto?network=EVM'
@@ -240,7 +240,7 @@ describe('post-auth redirect reads one snapshot', () => {
         const removeItem = jest.spyOn(Storage.prototype, 'removeItem')
         let replaced = false
         removeItem.mockImplementation(function patched(this: Storage, key: string) {
-            if (!replaced && (key === 'redirect' || key.startsWith('redirect-record:'))) {
+            if (!replaced && (key === 'redirect' || key.startsWith('redirect-v2-record:'))) {
                 replaced = true
                 setRedirectUrl('/receipt?id=abc', 'deep-link')
             }
@@ -253,6 +253,24 @@ describe('post-auth redirect reads one snapshot', () => {
             deferred: false,
         })
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
+    })
+
+    it('keeps v2 state when a pre-deploy tab clears the legacy handoff', () => {
+        setRedirectUrl('/pay-request/abc', 'deep-link')
+
+        // The base bundle only knows about v1's destination key.
+        localStorage.removeItem('redirect')
+
+        expect(getRedirectUrl()).toBe('/pay-request/abc')
+        expect(getRedirectOrigin()).toBe('deep-link')
+    })
+
+    it('honours a newer legacy handoff written by a pre-deploy tab', () => {
+        setRedirectUrl('/profile', 'session-end')
+        saveToLocalStorage('redirect', '/receipt?id=abc')
+
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+        expect(getRedirectOrigin()).toBeNull()
     })
 })
 

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -509,6 +509,49 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBe('/card')
     })
 
+    it('does not remove a mirror record created after cleanup observed it absent', () => {
+        saveToLocalStorage('redirect', '/home')
+        let interleaved = false
+        let pendingCreated = false
+        let suppressFreshnessRead = false
+        let newerPublicationComplete = false
+        let mirrorObserved = false
+        let pendingKey = ''
+        Storage.prototype.getItem = function patched(key: string) {
+            if (suppressFreshnessRead && key === pendingKey) {
+                suppressFreshnessRead = false
+                return null
+            }
+            const value = originalGetItem.call(this, key)
+            if (key === 'redirect-v2' && !interleaved && value !== null) {
+                interleaved = true
+                pendingKey = `redirect-v2-mirror-pending:${JSON.parse(value).generationId}`
+                setRedirectUrl('/card', 'deep-link')
+                newerPublicationComplete = true
+            } else if (key === pendingKey && value === null && newerPublicationComplete && !pendingCreated) {
+                pendingCreated = true
+                localStorage.setItem(pendingKey, JSON.stringify({ destination: '/profile', createdAt: Date.now() }))
+                suppressFreshnessRead = true
+            }
+            return value
+        }
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === pendingKey && pendingCreated) return
+            const result = originalSetItem.call(this, key, value)
+            if (key === 'redirect' && newerPublicationComplete && !mirrorObserved) {
+                mirrorObserved = true
+                expect(getRedirectUrl()).toBe('/card')
+                newerPublicationComplete = false
+            }
+            return result
+        })
+
+        setRedirectUrl('/profile', 'session-end')
+
+        expect(getRedirectUrl()).toBe('/card')
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -424,6 +424,25 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(consumedSlots.some((key) => localStorage.getItem(key) === JSON.stringify('1'))).toBe(true)
     })
 
+    it('does not let a stale publisher overwrite a newer legacy mirror', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        let interleaved = false
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            const result = originalSetItem.call(this, key, value)
+            if (key === 'redirect-v2' && !interleaved) {
+                interleaved = true
+                setRedirectUrl('/card', 'deep-link')
+            }
+            return result
+        })
+
+        setRedirectUrl('/profile', 'session-end')
+
+        expect(getRedirectUrl()).toBe('/card')
+        expect(getRedirectOrigin()).toBe('deep-link')
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -285,6 +285,29 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBeNull()
     })
 
+    it('keeps revalidating when two newer v2 generations arrive during one read', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const getItem = jest.spyOn(Storage.prototype, 'getItem')
+        let publications = 0
+        getItem.mockImplementation(function patched(this: Storage, key: string) {
+            if (key === 'redirect-expiry' && publications === 0) {
+                publications += 1
+                setRedirectUrl('/card', 'session-end')
+            } else if (key === 'redirect-v2' && publications === 1) {
+                publications += 1
+                setRedirectUrl('/receipt?id=abc', 'session-end')
+            }
+            return originalGetItem.call(this, key)
+        })
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
     it('does not re-consume a redirect when the primary consumption marker write fails', () => {
         setRedirectUrl('/receipt?id=abc', 'deep-link')
         const setItem = jest.spyOn(Storage.prototype, 'setItem')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -1,5 +1,12 @@
 import { consumePostAuthRedirect } from '../post-auth-redirect'
-import { getRedirectOrigin, getRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
+import {
+    clearRedirectUrl,
+    getRedirectOrigin,
+    getRedirectUrl,
+    getStoredRedirect,
+    saveToLocalStorage,
+    setRedirectUrl,
+} from '@/utils/general.utils'
 
 const FINANCIAL_REDIRECT = '/claim?step=claim&id=payment-1'
 const CAMPAIGN_REDIRECT = '/add-money/crypto?network=EVM'
@@ -312,7 +319,7 @@ describe('post-auth redirect reads one snapshot', () => {
         setRedirectUrl('/receipt?id=abc', 'deep-link')
         const setItem = jest.spyOn(Storage.prototype, 'setItem')
         setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
-            if (key === 'redirect-v2-consumed') throw new Error('quota')
+            if (key.startsWith('redirect-v2-consumed:')) throw new Error('quota')
             return originalSetItem.call(this, key, value)
         })
 
@@ -324,12 +331,27 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBeNull()
     })
 
+    it('keeps a completed newer generation consumed when an older tab resumes', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const olderSnapshot = getStoredRedirect()
+
+        setRedirectUrl('/card', 'deep-link')
+        expect(consumePostAuthRedirect(null)).toEqual({
+            destination: '/card',
+            source: 'stored',
+            deferred: false,
+        })
+
+        clearRedirectUrl(olderSnapshot)
+        expect(getRedirectUrl()).toBeNull()
+    })
+
     it('does not consume a newer generation when it arrives before the consumption marker', () => {
         setRedirectUrl('/profile', 'session-end')
         const setItem = jest.spyOn(Storage.prototype, 'setItem')
         let replaced = false
         setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
-            if (!replaced && key === 'redirect-v2-consumed') {
+            if (!replaced && key.startsWith('redirect-v2-consumed:')) {
                 replaced = true
                 setRedirectUrl('/receipt?id=abc', 'deep-link')
             }

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -79,6 +79,49 @@ describe('post-auth redirect consumption', () => {
  * not have to reach anywhere, which is why the new account is safe either way.
  * The same holds when tab B's session simply expires and no logout ever runs.
  */
+/*
+ * Records written before the origin existed are a bare path, and the reported
+ * bug IS one of them: a logout on /profile. A missing origin therefore cannot
+ * read as intent on the new-account path, or the first deploy would reproduce
+ * the very thing this fixes for everyone already carrying one.
+ */
+describe('post-auth redirect for a record from before the origin existed', () => {
+    beforeEach(() => localStorage.clear())
+
+    const storeLegacyRecord = (destination: string) => saveToLocalStorage('redirect', destination)
+
+    it('a brand-new account discards it', () => {
+        storeLegacyRecord('/profile')
+
+        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('an existing account logging in still resumes it', () => {
+        storeLegacyRecord(CAMPAIGN_REDIRECT)
+
+        expect(consumePostAuthRedirect(null)).toEqual({
+            destination: CAMPAIGN_REDIRECT,
+            source: 'stored',
+            deferred: false,
+        })
+    })
+
+    it('and an explicit redirect_uri outranks it for a new account too', () => {
+        storeLegacyRecord('/profile')
+
+        expect(consumePostAuthRedirect(FINANCIAL_REDIRECT, { onlyClassifiedIntent: true })).toEqual({
+            destination: FINANCIAL_REDIRECT,
+            source: 'explicit',
+            deferred: false,
+        })
+    })
+})
+
 describe('post-auth redirect across two tabs', () => {
     type UtilsModule = typeof import('@/utils/general.utils')
 
@@ -112,7 +155,7 @@ describe('post-auth redirect across two tabs', () => {
         expect(tabB.getRedirectUrl()).toBe('/card')
 
         // the account created back in tab A inherits none of it
-        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
             destination: '/home',
             source: 'fallback',
             deferred: false,
@@ -129,7 +172,7 @@ describe('post-auth redirect across two tabs', () => {
         window.history.replaceState({}, '', '/pay-request/abc')
         tabB.saveRedirectUrl()
 
-        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
             destination: '/pay-request/abc',
             source: 'stored',
             deferred: false,

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -190,6 +190,28 @@ describe('post-auth redirect reads one snapshot', () => {
             deferred: false,
         })
     })
+
+    it('does not clear a newer record after consuming an older snapshot', () => {
+        const stale = JSON.stringify({ destination: '/profile', origin: 'session-end' })
+        const fresher = JSON.stringify({ destination: '/receipt?id=abc', origin: 'deep-link' })
+        localStorage.setItem('redirect', stale)
+        let replaced = false
+        Storage.prototype.getItem = function patched(key: string) {
+            const value = originalGetItem.call(this, key)
+            if (key === 'redirect' && !replaced) {
+                replaced = true
+                localStorage.setItem('redirect', fresher)
+            }
+            return value
+        }
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+    })
 })
 
 describe('post-auth redirect across two tabs', () => {

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -69,3 +69,70 @@ describe('post-auth redirect consumption', () => {
         expect(getRedirectUrl()).toBeNull()
     })
 })
+
+/*
+ * Two tabs, one localStorage — the shape of Chip's round-1 repro. The logout
+ * latch is module memory, so only the tab the person logged out in has it
+ * armed: tab B's revoked session refetches to null and its gate stores tab B's
+ * own page, because nothing in that document knows a logout happened. A logout
+ * broadcast would have to reach it in time; the provenance on the record does
+ * not have to reach anywhere, which is why the new account is safe either way.
+ * The same holds when tab B's session simply expires and no logout ever runs.
+ */
+describe('post-auth redirect across two tabs', () => {
+    type UtilsModule = typeof import('@/utils/general.utils')
+
+    // a separate module registry per tab: distinct module memory (the latch),
+    // one shared localStorage — exactly what two same-origin documents get
+    const openTab = (): UtilsModule => {
+        let tab!: UtilsModule
+        jest.isolateModules(() => {
+            tab = require('@/utils/general.utils')
+        })
+        return tab
+    }
+
+    beforeEach(() => localStorage.clear())
+
+    it("a second tab's collapsing session cannot hand its page to the new account", () => {
+        const tabA = openTab()
+        const tabB = openTab()
+
+        // tab A: the person logs out here, so this tab's latch is armed and it
+        // leaves nothing behind
+        window.history.replaceState({}, '', '/profile')
+        tabA.beginIntentionalLogout()
+        tabA.saveRedirectUrl('session-end')
+        expect(tabA.getRedirectUrl()).toBeNull()
+
+        // tab B: same origin, different document, latch never armed — it
+        // stores its own protected page as tab A's logout revokes the session
+        window.history.replaceState({}, '', '/card')
+        tabB.saveRedirectUrl('session-end')
+        expect(tabB.getRedirectUrl()).toBe('/card')
+
+        // the account created back in tab A inherits none of it
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        // consumed, so a later account cannot pick it up either
+        expect(tabA.getRedirectUrl()).toBeNull()
+    })
+
+    it('a deep link opened in that second tab still reaches the new account', () => {
+        const tabB = openTab()
+
+        // this document never held a session: the destination is the visitor's
+        // own intent, not the residue of someone's session
+        window.history.replaceState({}, '', '/pay-request/abc')
+        tabB.saveRedirectUrl()
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/pay-request/abc',
+            source: 'stored',
+            deferred: false,
+        })
+    })
+})

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -346,6 +346,26 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBeNull()
     })
 
+    it('reclaims consumed generation slots after later redirect publications', () => {
+        for (let index = 0; index < 8; index += 1) {
+            setRedirectUrl(`/receipt?id=${index}`, 'deep-link')
+            expect(consumePostAuthRedirect(null)).toEqual({
+                destination: `/receipt?id=${index}`,
+                source: 'stored',
+                deferred: false,
+            })
+        }
+
+        const generationSlots = Array.from({ length: localStorage.length }, (_, index) =>
+            localStorage.key(index)
+        ).filter(
+            (key): key is string =>
+                typeof key === 'string' &&
+                (key.startsWith('redirect-v2-consumed:') || key.startsWith('redirect-v2-consumed-fallback:'))
+        )
+        expect(generationSlots).toHaveLength(2)
+    })
+
     it('does not consume a newer generation when it arrives before the consumption marker', () => {
         setRedirectUrl('/profile', 'session-end')
         const setItem = jest.spyOn(Storage.prototype, 'setItem')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -58,6 +58,24 @@ describe('post-auth redirect consumption', () => {
         expect(getRedirectUrl()).toBe(FINANCIAL_REDIRECT)
     })
 
+    /*
+     * Order matters where the two rules overlap: a claim or request route that
+     * a PREVIOUS session was standing on is still that session's, so it is
+     * refused and consumed rather than held for the new account to continue.
+     * Deferral exists to carry a continuation forward for the same person.
+     */
+    it('refuses a session-end money route for a new account instead of deferring it', () => {
+        setRedirectUrl(FINANCIAL_REDIRECT, 'session-end')
+
+        expect(
+            consumePostAuthRedirect(null, {
+                rejectSessionEndOrigin: true,
+                deferStoredRedirect: (destination) => destination.includes('/claim'),
+            })
+        ).toEqual({ destination: '/home', source: 'fallback', deferred: false })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
     it('never defers an unsafe stored URL merely because its text matches the predicate', () => {
         saveToLocalStorage('redirect', 'https://attacker.example/claim')
 

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -442,6 +442,50 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectOrigin()).toBe('deep-link')
     })
 
+    it('identifies a stale mirror while its ownership write is pending', () => {
+        setRedirectUrl('/profile', 'session-end')
+        let interleaved = false
+        Storage.prototype.getItem = function patched(key: string) {
+            const value = originalGetItem.call(this, key)
+            if (key === 'redirect-v2' && !interleaved && value !== null) {
+                interleaved = true
+                setRedirectUrl('/card', 'deep-link')
+            }
+            return value
+        }
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        let observed = false
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            const result = originalSetItem.call(this, key, value)
+            if (key === 'redirect' && !observed) {
+                observed = true
+                expect(getRedirectUrl()).toBe('/card')
+            }
+            return result
+        })
+
+        setRedirectUrl('/profile', 'session-end')
+
+        expect(getRedirectUrl()).toBe('/card')
+    })
+
+    it('keeps the pending mirror record when ownership persistence fails', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === 'redirect-v2-mirror-owner') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+
+        setRedirectUrl('/card', 'deep-link')
+
+        const pendingMirrorKeys = Array.from({ length: localStorage.length }, (_, index) =>
+            localStorage.key(index)
+        ).filter((key): key is string => key?.startsWith('redirect-v2-mirror-pending:') ?? false)
+        expect(pendingMirrorKeys).toHaveLength(1)
+        expect(getRedirectUrl()).toBe('/card')
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -265,6 +265,42 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectOrigin()).toBe('deep-link')
     })
 
+    it('re-reads the v2 pointer when a newer v2 generation arrives during the legacy read', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const getItem = jest.spyOn(Storage.prototype, 'getItem')
+        let replaced = false
+        getItem.mockImplementation(function patched(this: Storage, key: string) {
+            if (key === 'redirect-expiry' && !replaced) {
+                replaced = true
+                setRedirectUrl('/card', 'session-end')
+            }
+            return originalGetItem.call(this, key)
+        })
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('does not re-consume a redirect when the primary consumption marker write fails', () => {
+        setRedirectUrl('/receipt?id=abc', 'deep-link')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === 'redirect-v2-consumed') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+
+        expect(consumePostAuthRedirect(null)).toEqual({
+            destination: '/receipt?id=abc',
+            source: 'stored',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
     it('does not consume a newer generation when it arrives before the consumption marker', () => {
         setRedirectUrl('/profile', 'session-end')
         const setItem = jest.spyOn(Storage.prototype, 'setItem')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -426,16 +426,15 @@ describe('post-auth redirect reads one snapshot', () => {
 
     it('does not let a stale publisher overwrite a newer legacy mirror', () => {
         setRedirectUrl('/profile', 'session-end')
-        const setItem = jest.spyOn(Storage.prototype, 'setItem')
         let interleaved = false
-        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
-            const result = originalSetItem.call(this, key, value)
-            if (key === 'redirect-v2' && !interleaved) {
+        Storage.prototype.getItem = function patched(key: string) {
+            const value = originalGetItem.call(this, key)
+            if (key === 'redirect-v2' && !interleaved && value !== null) {
                 interleaved = true
                 setRedirectUrl('/card', 'deep-link')
             }
-            return result
-        })
+            return value
+        }
 
         setRedirectUrl('/profile', 'session-end')
 

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -164,9 +164,11 @@ describe('post-auth redirect for a record from before the origin existed', () =>
  */
 describe('post-auth redirect reads one snapshot', () => {
     const originalGetItem = Storage.prototype.getItem
+    const originalRemoveItem = Storage.prototype.removeItem
 
     afterEach(() => {
         Storage.prototype.getItem = originalGetItem
+        Storage.prototype.removeItem = originalRemoveItem
         localStorage.clear()
     })
 
@@ -230,6 +232,27 @@ describe('post-auth redirect reads one snapshot', () => {
             source: 'fallback',
             deferred: false,
         })
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+    })
+
+    it('does not remove a newer record when cleanup would follow an unusable snapshot', () => {
+        const invalid = JSON.stringify({ origin: 'deep-link' })
+        const fresher = JSON.stringify({ destination: '/receipt?id=abc', origin: 'deep-link' })
+        localStorage.setItem('redirect', invalid)
+
+        const removeItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => undefined)
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+
+        // Model the newer tab winning immediately after the no-record
+        // decision. Since the unusable snapshot is not cleaned up, this valid
+        // continuation cannot be removed by the consumer.
+        localStorage.setItem('redirect', fresher)
+        expect(removeItem).not.toHaveBeenCalledWith('redirect')
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
     })
 })

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -1,5 +1,5 @@
 import { consumePostAuthRedirect } from '../post-auth-redirect'
-import { getRedirectUrl, saveToLocalStorage } from '@/utils/general.utils'
+import { getRedirectUrl, saveToLocalStorage, setRedirectUrl } from '@/utils/general.utils'
 
 const FINANCIAL_REDIRECT = '/claim?step=claim&id=payment-1'
 const CAMPAIGN_REDIRECT = '/add-money/crypto?network=EVM'
@@ -80,28 +80,32 @@ describe('post-auth redirect consumption', () => {
  * The same holds when tab B's session simply expires and no logout ever runs.
  */
 /*
- * Records written before the origin existed are a bare path, and the reported
- * bug IS one of them: a logout on /profile. A missing origin therefore cannot
- * read as intent on the new-account path, or the first deploy would reproduce
- * the very thing this fixes for everyone already carrying one.
+ * Records written before the origin existed are a bare path — the deployed
+ * version stored no provenance. They are honoured, deliberately: discarding
+ * them would drop the stored pay-link continuation for anyone mid-funnel
+ * across the deploy (a signup entered from /receipt landing on /home), which
+ * is a worse transitional harm than the reverse case of a new account on the
+ * previous session's page — and that case no longer errors on Back. Every
+ * writer classifies from the first write after deploy, so the window closes
+ * on its own.
  */
 describe('post-auth redirect for a record from before the origin existed', () => {
     beforeEach(() => localStorage.clear())
 
     const storeLegacyRecord = (destination: string) => saveToLocalStorage('redirect', destination)
 
-    it('a brand-new account discards it', () => {
-        storeLegacyRecord('/profile')
+    it('reaches a brand-new account, so a pay-link signup still completes', () => {
+        storeLegacyRecord('/receipt?id=abc')
 
-        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
-            destination: '/home',
-            source: 'fallback',
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/receipt?id=abc',
+            source: 'stored',
             deferred: false,
         })
         expect(getRedirectUrl()).toBeNull()
     })
 
-    it('an existing account logging in still resumes it', () => {
+    it('an existing account logging in resumes it too', () => {
         storeLegacyRecord(CAMPAIGN_REDIRECT)
 
         expect(consumePostAuthRedirect(null)).toEqual({
@@ -111,10 +115,22 @@ describe('post-auth redirect for a record from before the origin existed', () =>
         })
     })
 
-    it('and an explicit redirect_uri outranks it for a new account too', () => {
+    it('but a classified session-end record is still refused for a new account', () => {
+        // what the gate writes once this ships, which is the case that matters
+        setRedirectUrl('/profile', 'session-end')
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('and an explicit redirect_uri outranks a stored record either way', () => {
         storeLegacyRecord('/profile')
 
-        expect(consumePostAuthRedirect(FINANCIAL_REDIRECT, { onlyClassifiedIntent: true })).toEqual({
+        expect(consumePostAuthRedirect(FINANCIAL_REDIRECT, { rejectSessionEndOrigin: true })).toEqual({
             destination: FINANCIAL_REDIRECT,
             source: 'explicit',
             deferred: false,
@@ -155,7 +171,7 @@ describe('post-auth redirect across two tabs', () => {
         expect(tabB.getRedirectUrl()).toBe('/card')
 
         // the account created back in tab A inherits none of it
-        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
             destination: '/home',
             source: 'fallback',
             deferred: false,
@@ -172,7 +188,7 @@ describe('post-auth redirect across two tabs', () => {
         window.history.replaceState({}, '', '/pay-request/abc')
         tabB.saveRedirectUrl()
 
-        expect(consumePostAuthRedirect(null, { onlyClassifiedIntent: true })).toEqual({
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
             destination: '/pay-request/abc',
             source: 'stored',
             deferred: false,

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -235,24 +235,23 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
     })
 
-    it('does not remove a newer record when cleanup would follow an unusable snapshot', () => {
-        const invalid = JSON.stringify({ origin: 'deep-link' })
-        const fresher = JSON.stringify({ destination: '/receipt?id=abc', origin: 'deep-link' })
-        localStorage.setItem('redirect', invalid)
-
-        const removeItem = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => undefined)
+    it('deletes only the consumed generation when a newer record arrives before deletion', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const removeItem = jest.spyOn(Storage.prototype, 'removeItem')
+        let replaced = false
+        removeItem.mockImplementation(function patched(this: Storage, key: string) {
+            if (!replaced && (key === 'redirect' || key.startsWith('redirect-record:'))) {
+                replaced = true
+                setRedirectUrl('/receipt?id=abc', 'deep-link')
+            }
+            return originalRemoveItem.call(this, key)
+        })
 
         expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
             destination: '/home',
             source: 'fallback',
             deferred: false,
         })
-
-        // Model the newer tab winning immediately after the no-record
-        // decision. Since the unusable snapshot is not cleaned up, this valid
-        // continuation cannot be removed by the consumer.
-        localStorage.setItem('redirect', fresher)
-        expect(removeItem).not.toHaveBeenCalledWith('redirect')
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
     })
 })

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -173,11 +173,13 @@ describe('post-auth redirect reads one snapshot', () => {
     const originalGetItem = Storage.prototype.getItem
     const originalRemoveItem = Storage.prototype.removeItem
     const originalSetItem = Storage.prototype.setItem
+    const originalKey = Storage.prototype.key
 
     afterEach(() => {
         Storage.prototype.getItem = originalGetItem
         Storage.prototype.removeItem = originalRemoveItem
         Storage.prototype.setItem = originalSetItem
+        Storage.prototype.key = originalKey
         localStorage.clear()
     })
 
@@ -343,6 +345,74 @@ describe('post-auth redirect reads one snapshot', () => {
         })
 
         clearRedirectUrl(olderSnapshot)
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('reclaims reserved slots when a later redirect overwrites an unconsumed one', () => {
+        setRedirectUrl('/profile', 'session-end')
+        setRedirectUrl('/card', 'deep-link')
+
+        const generationSlots = Array.from({ length: localStorage.length }, (_, index) =>
+            localStorage.key(index)
+        ).filter(
+            (key): key is string =>
+                typeof key === 'string' &&
+                (key.startsWith('redirect-v2-consumed:') || key.startsWith('redirect-v2-consumed-fallback:'))
+        )
+        expect(generationSlots).toHaveLength(2)
+    })
+
+    it('reclaims reservations left by a failed v2 publication', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === 'redirect-v2') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+
+        setRedirectUrl('/card', 'deep-link')
+
+        const generationSlots = Array.from({ length: localStorage.length }, (_, index) =>
+            localStorage.key(index)
+        ).filter(
+            (key): key is string =>
+                typeof key === 'string' &&
+                (key.startsWith('redirect-v2-consumed:') || key.startsWith('redirect-v2-consumed-fallback:'))
+        )
+        expect(generationSlots).toHaveLength(2)
+        expect(getRedirectUrl()).toBe('/profile')
+    })
+
+    it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const getKey = jest.spyOn(Storage.prototype, 'key')
+        let interleaved = false
+        getKey.mockImplementation(function patched(this: Storage, index: number) {
+            if (!interleaved) {
+                interleaved = true
+                setRedirectUrl('/card', 'deep-link')
+                expect(consumePostAuthRedirect(null)).toEqual({
+                    destination: '/card',
+                    source: 'stored',
+                    deferred: false,
+                })
+            }
+            return originalKey.call(this, index)
+        })
+
+        clearRedirectUrl()
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('retires the v2 generation superseded by a consumed legacy handoff', () => {
+        setRedirectUrl('/profile', 'session-end')
+        saveToLocalStorage('redirect', '/receipt?id=abc')
+
+        expect(consumePostAuthRedirect(null)).toEqual({
+            destination: '/receipt?id=abc',
+            source: 'stored',
+            deferred: false,
+        })
         expect(getRedirectUrl()).toBeNull()
     })
 

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -165,10 +165,12 @@ describe('post-auth redirect for a record from before the origin existed', () =>
 describe('post-auth redirect reads one snapshot', () => {
     const originalGetItem = Storage.prototype.getItem
     const originalRemoveItem = Storage.prototype.removeItem
+    const originalSetItem = Storage.prototype.setItem
 
     afterEach(() => {
         Storage.prototype.getItem = originalGetItem
         Storage.prototype.removeItem = originalRemoveItem
+        Storage.prototype.setItem = originalSetItem
         localStorage.clear()
     })
 
@@ -235,16 +237,44 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
     })
 
-    it('deletes only the consumed generation when a newer record arrives before deletion', () => {
+    it('does not publish a legacy mirror when the authoritative v2 write fails', () => {
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === 'redirect-v2') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+
+        setRedirectUrl('/receipt?id=abc', 'deep-link')
+
+        expect(localStorage.getItem('redirect-v2')).toBeNull()
+        expect(localStorage.getItem('redirect')).toBeNull()
+        expect(getRedirectUrl()).toBeNull()
+    })
+
+    it('keeps the authoritative v2 payload ahead when its legacy mirror write fails', () => {
         setRedirectUrl('/profile', 'session-end')
-        const removeItem = jest.spyOn(Storage.prototype, 'removeItem')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (key === 'redirect') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+
+        setRedirectUrl('/receipt?id=abc', 'deep-link')
+
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+        expect(getRedirectOrigin()).toBe('deep-link')
+    })
+
+    it('does not consume a newer generation when it arrives before the consumption marker', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
         let replaced = false
-        removeItem.mockImplementation(function patched(this: Storage, key: string) {
-            if (!replaced && (key === 'redirect' || key.startsWith('redirect-v2-record:'))) {
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            if (!replaced && key === 'redirect-v2-consumed') {
                 replaced = true
                 setRedirectUrl('/receipt?id=abc', 'deep-link')
             }
-            return originalRemoveItem.call(this, key)
+            return originalSetItem.call(this, key, value)
         })
 
         expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -396,6 +396,34 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(localStorage.getItem(`redirect-v2-consumed-fallback:${inFlightGenerationId}`)).toBe(reservationValue)
     })
 
+    it('does not republish a generation after another tab consumes it', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        let interleaved = false
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            const result = originalSetItem.call(this, key, value)
+            if (key === 'redirect-v2' && !interleaved) {
+                interleaved = true
+                expect(consumePostAuthRedirect(null)).toEqual({
+                    destination: '/card',
+                    source: 'stored',
+                    deferred: false,
+                })
+            }
+            return result
+        })
+
+        setRedirectUrl('/card', 'deep-link')
+
+        expect(getRedirectUrl()).toBeNull()
+        const consumedSlots = Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index)).filter(
+            (key): key is string =>
+                typeof key === 'string' &&
+                (key.startsWith('redirect-v2-consumed:') || key.startsWith('redirect-v2-consumed-fallback:'))
+        )
+        expect(consumedSlots.some((key) => localStorage.getItem(key) === JSON.stringify('1'))).toBe(true)
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -138,6 +138,42 @@ describe('post-auth redirect for a record from before the origin existed', () =>
     })
 })
 
+/*
+ * The pair has to come from one snapshot. Reading the destination and the
+ * origin separately is two getItems, and another tab can replace the record
+ * in between — which would pair an old destination with the newer record's
+ * origin, and then consume the newer intent along with it.
+ */
+describe('post-auth redirect reads one snapshot', () => {
+    const originalGetItem = Storage.prototype.getItem
+
+    afterEach(() => {
+        Storage.prototype.getItem = originalGetItem
+        localStorage.clear()
+    })
+
+    it('decides from the record it first observed, not a pair from two reads', () => {
+        localStorage.clear()
+        const stale = JSON.stringify({ destination: '/profile', origin: 'session-end' })
+        const fresher = JSON.stringify({ destination: '/receipt?id=abc', origin: 'deep-link' })
+        let reads = 0
+        Storage.prototype.getItem = function patched(key: string) {
+            if (key !== 'redirect') return originalGetItem.call(this, key)
+            reads += 1
+            // another tab replaces the record after the first read
+            return reads === 1 ? stale : fresher
+        }
+
+        // the stale record is session-end, so a new account must refuse it —
+        // never accept /profile while reading the newer record's deep-link
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+    })
+})
+
 describe('post-auth redirect across two tabs', () => {
     type UtilsModule = typeof import('@/utils/general.utils')
 

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -442,6 +442,25 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectOrigin()).toBe('deep-link')
     })
 
+    it('binds mirror ownership to the value written by that generation', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const staleOwner = localStorage.getItem('redirect-v2-mirror-owner')
+        expect(staleOwner).not.toBeNull()
+        expect(JSON.parse(staleOwner!)).toEqual({
+            generationId: JSON.parse(localStorage.getItem('redirect-v2')!).generationId,
+            destination: '/profile',
+        })
+
+        setRedirectUrl('/card', 'deep-link')
+
+        // A late owner write from the older publication must not claim a
+        // different value written by a legacy tab.
+        localStorage.setItem('redirect-v2-mirror-owner', staleOwner!)
+        localStorage.setItem('redirect', JSON.stringify('/receipt?id=abc'))
+
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+    })
+
     it('identifies a stale mirror while its ownership write is pending', () => {
         setRedirectUrl('/profile', 'session-end')
         let interleaved = false

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -383,6 +383,19 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBe('/profile')
     })
 
+    it('protects fresh in-flight reservation slots from cleanup', () => {
+        setRedirectUrl('/profile', 'session-end')
+        const inFlightGenerationId = 'in-flight-generation'
+        const reservationValue = `r${Date.now().toString(36).padStart(10, '0')}`
+        localStorage.setItem(`redirect-v2-consumed:${inFlightGenerationId}`, reservationValue)
+        localStorage.setItem(`redirect-v2-consumed-fallback:${inFlightGenerationId}`, reservationValue)
+
+        setRedirectUrl('/card', 'deep-link')
+
+        expect(localStorage.getItem(`redirect-v2-consumed:${inFlightGenerationId}`)).toBe(reservationValue)
+        expect(localStorage.getItem(`redirect-v2-consumed-fallback:${inFlightGenerationId}`)).toBe(reservationValue)
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -212,6 +212,26 @@ describe('post-auth redirect reads one snapshot', () => {
         })
         expect(getRedirectUrl()).toBe('/receipt?id=abc')
     })
+
+    it('does not clear a newer record after observing no usable snapshot', () => {
+        const fresher = JSON.stringify({ destination: '/receipt?id=abc', origin: 'deep-link' })
+        let replaced = false
+        Storage.prototype.getItem = function patched(key: string) {
+            const value = originalGetItem.call(this, key)
+            if (key === 'redirect' && !replaced) {
+                replaced = true
+                localStorage.setItem('redirect', fresher)
+            }
+            return value
+        }
+
+        expect(consumePostAuthRedirect(null, { rejectSessionEndOrigin: true })).toEqual({
+            destination: '/home',
+            source: 'fallback',
+            deferred: false,
+        })
+        expect(getRedirectUrl()).toBe('/receipt?id=abc')
+    })
 })
 
 describe('post-auth redirect across two tabs', () => {

--- a/src/services/__tests__/post-auth-redirect.test.ts
+++ b/src/services/__tests__/post-auth-redirect.test.ts
@@ -486,6 +486,29 @@ describe('post-auth redirect reads one snapshot', () => {
         expect(getRedirectUrl()).toBe('/card')
     })
 
+    it('does not reclaim a pending mirror before its publisher writes the legacy mirror', () => {
+        saveToLocalStorage('redirect', '/home')
+        let interleaved = false
+        let newerPublicationComplete = false
+        const setItem = jest.spyOn(Storage.prototype, 'setItem')
+        setItem.mockImplementation(function patched(this: Storage, key: string, value: string) {
+            const result = originalSetItem.call(this, key, value)
+            if (key.startsWith('redirect-v2-mirror-pending:') && !interleaved) {
+                interleaved = true
+                setRedirectUrl('/card', 'deep-link')
+                newerPublicationComplete = true
+            } else if (key === 'redirect' && newerPublicationComplete) {
+                expect(getRedirectUrl()).toBe('/card')
+                newerPublicationComplete = false
+            }
+            return result
+        })
+
+        setRedirectUrl('/profile', 'session-end')
+
+        expect(getRedirectUrl()).toBe('/card')
+    })
+
     it('aborts tombstone cleanup when the authoritative pointer changes during the scan', () => {
         setRedirectUrl('/profile', 'session-end')
         const getKey = jest.spyOn(Storage.prototype, 'key')

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -86,10 +86,9 @@ export function consumePostAuthRedirect(
     /*
      * Corrupt or blank generic state is no more reusable than an unsafe URL.
      * Do not clean it up here: `null` conflates an absent key with an
-     * unusable value, so a second read followed by removeItem could delete a
-     * valid continuation written by another tab in between. An unusable value
-     * is ignored until a later writer replaces it, which is safe because this
-     * reader never treats it as a destination.
+     * unusable value, and there is no generation to delete safely. An
+     * unusable value is ignored until a later writer replaces the pointer,
+     * which is safe because this reader never treats it as a destination.
      */
     return { destination: fallbackRoute, source: 'fallback', deferred: false }
 }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -70,7 +70,7 @@ export function consumePostAuthRedirect(
         // Consumed, not merely skipped: leaving it would hand the same page to
         // whoever authenticates next on this device.
         if (options.rejectSessionEndOrigin && stored.origin === 'session-end') {
-            clearRedirectUrl()
+            clearRedirectUrl(stored)
             return { destination: fallbackRoute, source: 'fallback', deferred: false }
         }
 
@@ -79,7 +79,7 @@ export function consumePostAuthRedirect(
             return { destination: fallbackRoute, source: 'stored', deferred: true }
         }
 
-        clearRedirectUrl()
+        clearRedirectUrl(stored)
         return { destination, source: 'stored', deferred: false }
     }
 

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -85,10 +85,11 @@ export function consumePostAuthRedirect(
 
     /*
      * Corrupt or blank generic state is no more reusable than an unsafe URL.
-     * Unconditional now that a reader reports an unusable record as no record
-     * at all: the raw value can still be sitting there, and clearing a key
-     * that does not exist costs nothing.
+     * Do not clean it up here: `null` conflates an absent key with an
+     * unusable value, so a second read followed by removeItem could delete a
+     * valid continuation written by another tab in between. An unusable value
+     * is ignored until a later writer replaces it, which is safe because this
+     * reader never treats it as a destination.
      */
-    clearRedirectUrl(stored)
     return { destination: fallbackRoute, source: 'fallback', deferred: false }
 }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -1,4 +1,4 @@
-import { clearRedirectUrl, getRedirectOrigin, getRedirectUrl, getValidRedirectUrl } from '@/utils/general.utils'
+import { clearRedirectUrl, getStoredRedirect, getValidRedirectUrl } from '@/utils/general.utils'
 
 export type PostAuthRedirectDecision = {
     destination: string
@@ -59,16 +59,22 @@ export function consumePostAuthRedirect(
         }
     }
 
-    const storedValue = getRedirectUrl()
-    if (typeof storedValue === 'string' && storedValue.length > 0) {
+    /*
+     * One snapshot, one decision. Reading the destination and the origin
+     * separately is two getItems, and another tab can replace the record
+     * between them — pairing an old destination with the newer record's
+     * origin, then consuming the newer intent along with it.
+     */
+    const stored = getStoredRedirect()
+    if (stored) {
         // Consumed, not merely skipped: leaving it would hand the same page to
         // whoever authenticates next on this device.
-        if (options.rejectSessionEndOrigin && getRedirectOrigin() === 'session-end') {
+        if (options.rejectSessionEndOrigin && stored.origin === 'session-end') {
             clearRedirectUrl()
             return { destination: fallbackRoute, source: 'fallback', deferred: false }
         }
 
-        const destination = getValidRedirectUrl(storedValue, fallbackRoute)
+        const destination = getValidRedirectUrl(stored.destination, fallbackRoute)
         if (destination !== fallbackRoute && options.deferStoredRedirect?.(destination)) {
             return { destination: fallbackRoute, source: 'stored', deferred: true }
         }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -1,4 +1,4 @@
-import { clearRedirectUrl, getRedirectUrl, getValidRedirectUrl } from '@/utils/general.utils'
+import { clearRedirectUrl, getRedirectOrigin, getRedirectUrl, getValidRedirectUrl } from '@/utils/general.utils'
 
 export type PostAuthRedirectDecision = {
     destination: string
@@ -13,6 +13,13 @@ type PostAuthRedirectOptions = {
      * showing the bank-claim continuation after identity verification).
      */
     deferStoredRedirect?: (destination: string) => boolean
+    /**
+     * Refuse a destination that only records where an earlier session ended.
+     * Set by a brand-new account: it inherits no other session's page, however
+     * that page came to be stored (this device's own logout, a revoked session
+     * in another tab, a token that expired while the app stood open).
+     */
+    rejectSessionEndOrigin?: boolean
 }
 
 /**
@@ -44,6 +51,13 @@ export function consumePostAuthRedirect(
 
     const storedValue = getRedirectUrl()
     if (typeof storedValue === 'string' && storedValue.length > 0) {
+        // Consumed, not merely skipped: leaving it would hand the same page to
+        // whoever authenticates next on this device.
+        if (options.rejectSessionEndOrigin && getRedirectOrigin() === 'session-end') {
+            clearRedirectUrl()
+            return { destination: fallbackRoute, source: 'fallback', deferred: false }
+        }
+
         const destination = getValidRedirectUrl(storedValue, fallbackRoute)
         if (destination !== fallbackRoute && options.deferStoredRedirect?.(destination)) {
             return { destination: fallbackRoute, source: 'stored', deferred: true }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -14,21 +14,22 @@ type PostAuthRedirectOptions = {
      */
     deferStoredRedirect?: (destination: string) => boolean
     /**
-     * Take a stored destination ONLY where it is classified as the intent of
-     * the person authenticating. Set by a brand-new account, which inherits no
-     * other session's page however that page came to be stored — this device's
-     * own logout, a revoked session in another tab, a token that expired while
-     * the app stood open.
+     * Refuse a destination that only records where an earlier session ended.
+     * Set by a brand-new account: it inherits no other session's page, however
+     * that page came to be stored (this device's own logout, a revoked session
+     * in another tab, a token that expired while the app stood open).
      *
-     * A whitelist rather than a session-end blacklist, because that is also
-     * the rollout policy for records written before the origin existed: the
-     * deployed version stored a bare path, and the reported bug IS such a
-     * record (a logout on /profile). Unclassified ones are discarded here, so
-     * an existing stale record cannot reproduce it on the first deploy; login
-     * keeps honouring them, and an explicit `redirect_uri` outranks this
-     * entirely, which is what campaign and claim entry points use.
+     * Rollout: a record written before the origin existed is a bare path, and
+     * it is honoured. Discarding those instead would have dropped the stored
+     * pay-link continuation for anyone mid-funnel across the deploy — a
+     * signup entered from /receipt or a request link landing on /home, which
+     * SendWithPeanutCta and the account-ready CTA exist to prevent. The
+     * transitional cost of honouring them is the reverse case, a new account
+     * on the previous session's page, which the Back fix in this PR already
+     * makes harmless; and the window closes at the first write after deploy,
+     * because every writer classifies from then on.
      */
-    onlyClassifiedIntent?: boolean
+    rejectSessionEndOrigin?: boolean
 }
 
 /**
@@ -62,7 +63,7 @@ export function consumePostAuthRedirect(
     if (typeof storedValue === 'string' && storedValue.length > 0) {
         // Consumed, not merely skipped: leaving it would hand the same page to
         // whoever authenticates next on this device.
-        if (options.onlyClassifiedIntent && getRedirectOrigin() !== 'deep-link') {
+        if (options.rejectSessionEndOrigin && getRedirectOrigin() === 'session-end') {
             clearRedirectUrl()
             return { destination: fallbackRoute, source: 'fallback', deferred: false }
         }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -89,6 +89,6 @@ export function consumePostAuthRedirect(
      * at all: the raw value can still be sitting there, and clearing a key
      * that does not exist costs nothing.
      */
-    clearRedirectUrl()
+    clearRedirectUrl(stored)
     return { destination: fallbackRoute, source: 'fallback', deferred: false }
 }

--- a/src/services/post-auth-redirect.ts
+++ b/src/services/post-auth-redirect.ts
@@ -14,12 +14,21 @@ type PostAuthRedirectOptions = {
      */
     deferStoredRedirect?: (destination: string) => boolean
     /**
-     * Refuse a destination that only records where an earlier session ended.
-     * Set by a brand-new account: it inherits no other session's page, however
-     * that page came to be stored (this device's own logout, a revoked session
-     * in another tab, a token that expired while the app stood open).
+     * Take a stored destination ONLY where it is classified as the intent of
+     * the person authenticating. Set by a brand-new account, which inherits no
+     * other session's page however that page came to be stored — this device's
+     * own logout, a revoked session in another tab, a token that expired while
+     * the app stood open.
+     *
+     * A whitelist rather than a session-end blacklist, because that is also
+     * the rollout policy for records written before the origin existed: the
+     * deployed version stored a bare path, and the reported bug IS such a
+     * record (a logout on /profile). Unclassified ones are discarded here, so
+     * an existing stale record cannot reproduce it on the first deploy; login
+     * keeps honouring them, and an explicit `redirect_uri` outranks this
+     * entirely, which is what campaign and claim entry points use.
      */
-    rejectSessionEndOrigin?: boolean
+    onlyClassifiedIntent?: boolean
 }
 
 /**
@@ -53,7 +62,7 @@ export function consumePostAuthRedirect(
     if (typeof storedValue === 'string' && storedValue.length > 0) {
         // Consumed, not merely skipped: leaving it would hand the same page to
         // whoever authenticates next on this device.
-        if (options.rejectSessionEndOrigin && getRedirectOrigin() === 'session-end') {
+        if (options.onlyClassifiedIntent && getRedirectOrigin() !== 'deep-link') {
             clearRedirectUrl()
             return { destination: fallbackRoute, source: 'fallback', deferred: false }
         }
@@ -67,7 +76,12 @@ export function consumePostAuthRedirect(
         return { destination, source: 'stored', deferred: false }
     }
 
-    // Corrupt or blank generic state is no more reusable than an unsafe URL.
-    if (storedValue !== null && storedValue !== undefined) clearRedirectUrl()
+    /*
+     * Corrupt or blank generic state is no more reusable than an unsafe URL.
+     * Unconditional now that a reader reports an unusable record as no record
+     * at all: the raw value can still be sitting there, and clearing a key
+     * that does not exist costs nothing.
+     */
+    clearRedirectUrl()
     return { destination: fallbackRoute, source: 'fallback', deferred: false }
 }

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -13,6 +13,7 @@ import {
     isUuid,
     printableUserHandle,
     saveRedirectUrl,
+    saveToLocalStorage,
     toInviteCode,
 } from '../general.utils'
 import { AccountType } from '@/interfaces/interfaces'
@@ -601,11 +602,26 @@ describe('General Utilities', () => {
             expect(getRedirectOrigin()).toBe('deep-link')
         })
 
-        it('keeps the origin with the path, and clears the two together', () => {
+        it('keeps the origin with the path in one record, cleared together', () => {
             saveRedirectUrl('session-end')
             expect(getRedirectOrigin()).toBe('session-end')
 
             clearRedirectUrl()
+            expect(getRedirectUrl()).toBeNull()
+            expect(getRedirectOrigin()).toBeNull()
+        })
+
+        it('reads a record from before the origin existed as unclassified, not intent', () => {
+            // the shape the deployed version wrote: a bare path
+            saveToLocalStorage('redirect', '/profile')
+
+            expect(getRedirectUrl()).toBe('/profile')
+            expect(getRedirectOrigin()).toBeNull()
+        })
+
+        it('reports an unusable record as no record at all', () => {
+            saveToLocalStorage('redirect', { origin: 'deep-link' })
+
             expect(getRedirectUrl()).toBeNull()
             expect(getRedirectOrigin()).toBeNull()
         })

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -587,7 +587,7 @@ describe('General Utilities', () => {
     describe('post-auth redirect through an intentional logout', () => {
         beforeEach(() => {
             endIntentionalLogout()
-            clearRedirectUrl()
+            localStorage.clear()
             window.history.replaceState({}, '', '/profile')
         })
         afterEach(() => {

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -1,12 +1,17 @@
 import {
+    beginIntentionalLogout,
+    clearRedirectUrl,
+    endIntentionalLogout,
     formatAmount,
     formatExtendedNumber,
     generateInviteCodeLink,
     getContributorsFromCharge,
+    getRedirectUrl,
     getRequestLink,
     formatTokenAmount,
     isUuid,
     printableUserHandle,
+    saveRedirectUrl,
     toInviteCode,
 } from '../general.utils'
 import { AccountType } from '@/interfaces/interfaces'
@@ -567,6 +572,43 @@ describe('General Utilities', () => {
             const contributors = getContributorsFromCharge(charges)
             expect(contributors).toHaveLength(1)
             expect(contributors[0].username).toBe('alice')
+        })
+    })
+
+    /*
+     * An explicit logout ends in a hard nav to /setup, but emptying the user
+     * cache first re-runs the auth gate, which stores the CURRENT path as the
+     * post-auth destination — and the logout button lives on /profile, so the
+     * next account created on this device was redirected onto the previous
+     * session's page instead of /home.
+     */
+    describe('post-auth redirect through an intentional logout', () => {
+        beforeEach(() => {
+            endIntentionalLogout()
+            clearRedirectUrl()
+            window.history.replaceState({}, '', '/profile')
+        })
+        afterEach(() => {
+            endIntentionalLogout()
+            clearRedirectUrl()
+        })
+
+        it('stores the current path for a normal auth-gate bounce', () => {
+            saveRedirectUrl()
+            expect(getRedirectUrl()).toBe('/profile')
+        })
+
+        it('stores nothing once a logout is under way', () => {
+            beginIntentionalLogout()
+            saveRedirectUrl()
+            expect(getRedirectUrl()).toBeNull()
+        })
+
+        it('resumes storing when the logout failed and the app kept running', () => {
+            beginIntentionalLogout()
+            endIntentionalLogout()
+            saveRedirectUrl()
+            expect(getRedirectUrl()).toBe('/profile')
         })
     })
 })

--- a/src/utils/__tests__/general.utils.test.ts
+++ b/src/utils/__tests__/general.utils.test.ts
@@ -6,6 +6,7 @@ import {
     formatExtendedNumber,
     generateInviteCodeLink,
     getContributorsFromCharge,
+    getRedirectOrigin,
     getRedirectUrl,
     getRequestLink,
     formatTokenAmount,
@@ -596,6 +597,17 @@ describe('General Utilities', () => {
         it('stores the current path for a normal auth-gate bounce', () => {
             saveRedirectUrl()
             expect(getRedirectUrl()).toBe('/profile')
+            // a caller that says nothing is storing someone's own intent
+            expect(getRedirectOrigin()).toBe('deep-link')
+        })
+
+        it('keeps the origin with the path, and clears the two together', () => {
+            saveRedirectUrl('session-end')
+            expect(getRedirectOrigin()).toBe('session-end')
+
+            clearRedirectUrl()
+            expect(getRedirectUrl()).toBeNull()
+            expect(getRedirectOrigin()).toBeNull()
         })
 
         it('stores nothing once a logout is under way', () => {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -759,20 +759,32 @@ export const endIntentionalLogout = () => {
 export type RedirectOrigin = 'deep-link' | 'session-end'
 
 const REDIRECT_KEY = 'redirect'
-/** Never shipped: only this branch's first draft wrote a separate origin key. */
-const LEGACY_REDIRECT_ORIGIN_KEY = 'redirect-origin'
+const REDIRECT_RECORD_PREFIX = 'redirect-record:'
+/**
+ * Legacy bare-path records cannot be deleted conditionally without the same
+ * check/remove race. Remembering their consumed value makes them inert while
+ * allowing every new generation (stored through setRedirectUrl) to replace
+ * the pointer safely.
+ */
+const LEGACY_REDIRECT_CONSUMED_KEY = 'redirect-consumed-legacy'
 
 /**
- * Destination and origin are ONE record under ONE key, written in a single
- * setItem. Two writes could half-fail — localStorage errors are swallowed —
- * and leave an old destination wearing a new origin, or a fresh continuation
- * wearing a dead session's. Readers therefore never see a mixed pair.
+ * `redirect` is a pointer to an immutable generation record. The generation
+ * record is written before the pointer, so a reader never observes a pointer
+ * whose payload does not exist. A consumer deletes only the generation it
+ * decided from; if another tab moves the pointer before that deletion, the
+ * newer record is still a different localStorage key and survives.
  *
  * A record stored by a version that had no origin (a plain string) reads back
  * as unclassified rather than as intent: see consumePostAuthRedirect for what
  * a brand-new account does with one.
  */
-export type StoredRedirect = { destination: string; origin: RedirectOrigin | null }
+export type StoredRedirect = {
+    destination: string
+    origin: RedirectOrigin | null
+    generationId: string | null
+    legacyIdentity?: string
+}
 
 /**
  * One parsed snapshot, for a caller that has to decide on the pair. Reading
@@ -780,22 +792,57 @@ export type StoredRedirect = { destination: string; origin: RedirectOrigin | nul
  * and another tab can replace the record between them — pairing an old
  * destination with the newer record's origin.
  */
-export const getStoredRedirect = (): StoredRedirect | null => {
-    const stored = getFromLocalStorage(REDIRECT_KEY)
+const parseStoredRedirect = (
+    stored: unknown,
+    generationId: string | null,
+    legacyIdentity?: string
+): StoredRedirect | null => {
     if (typeof stored === 'string') {
-        return stored.length > 0 ? { destination: stored, origin: null } : null
+        return stored.length > 0 ? { destination: stored, origin: null, generationId, legacyIdentity } : null
     }
     if (stored && typeof stored === 'object') {
         const { destination, origin } = stored as Partial<StoredRedirect>
         if (typeof destination !== 'string' || destination.length === 0) return null
-        return { destination, origin: origin === 'session-end' || origin === 'deep-link' ? origin : null }
+        return {
+            destination,
+            origin: origin === 'session-end' || origin === 'deep-link' ? origin : null,
+            generationId,
+            legacyIdentity,
+        }
     }
     return null
 }
 
+const isRedirectGenerationId = (value: unknown): value is string =>
+    typeof value === 'string' && /^[A-Za-z0-9_-]+$/.test(value)
+
+const createRedirectGenerationId = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID()
+    }
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+export const getStoredRedirect = (): StoredRedirect | null => {
+    const stored = getFromLocalStorage(REDIRECT_KEY)
+
+    if (stored && typeof stored === 'object') {
+        const { generationId } = stored as Partial<StoredRedirect>
+        if (isRedirectGenerationId(generationId)) {
+            return parseStoredRedirect(getFromLocalStorage(`${REDIRECT_RECORD_PREFIX}${generationId}`), generationId)
+        }
+    }
+
+    const legacyIdentity = stored === undefined ? undefined : jsonStringify(stored)
+    if (legacyIdentity && getFromLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY) === legacyIdentity) return null
+    return parseStoredRedirect(stored, null, legacyIdentity)
+}
+
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
-    saveToLocalStorage(REDIRECT_KEY, { destination, origin })
+    const generationId = createRedirectGenerationId()
+    saveToLocalStorage(`${REDIRECT_RECORD_PREFIX}${generationId}`, { destination, origin })
+    saveToLocalStorage(REDIRECT_KEY, { generationId })
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -815,21 +862,24 @@ export const getRedirectOrigin = (): RedirectOrigin | null => {
 
 /**
  * Clear the stored redirect, optionally only if it is still the snapshot a
- * caller consumed. That optimistic compare-and-clear keeps a newer same-origin
- * tab's continuation from being removed after this tab has made its decision.
- * `null` is an intentional snapshot too: it protects the no-record cleanup
- * path from deleting a record written after the read.
+ * caller consumed. Generated records are immutable, so deleting their key is
+ * safe even when another same-origin tab has already published a newer
+ * pointer. Legacy records are marked consumed instead of removed because they
+ * do not have a generation key to delete safely.
  */
 export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
     if (typeof localStorage !== 'undefined') {
-        if (expected !== undefined) {
-            const current = getStoredRedirect()
-            if (current?.destination !== expected?.destination || current?.origin !== expected?.origin) {
-                return
-            }
+        const current = expected === undefined ? getStoredRedirect() : expected
+        if (!current) return
+
+        if (current.generationId) {
+            localStorage.removeItem(`${REDIRECT_RECORD_PREFIX}${current.generationId}`)
+            return
         }
-        localStorage.removeItem(REDIRECT_KEY)
-        localStorage.removeItem(LEGACY_REDIRECT_ORIGIN_KEY)
+
+        if (current.legacyIdentity) {
+            saveToLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY, current.legacyIdentity)
+        }
     }
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -799,6 +799,7 @@ export type StoredRedirect = {
     generationId: string | null
     generationKey?: string
     legacyIdentity?: string
+    supersededGenerationId?: string
 }
 
 const parseStoredRedirect = (
@@ -919,7 +920,10 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
             // baseline distinguishes that from a stale mirror left behind by
             // a failed v2 -> v1 mirror write.
             const legacy = parseLegacyRedirect(legacyValue)
-            if (legacy) return legacy
+            if (legacy) return { ...legacy, supersededGenerationId: generationId }
+            // This legacy handoff was already consumed. It superseded the
+            // v2 generation, so do not resurrect that older destination.
+            return null
         }
 
         const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
@@ -965,8 +969,8 @@ const reclaimRedirectConsumptionSlots = () => {
     if (typeof localStorage === 'undefined') return
 
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
-    const reachableGenerationId = isRedirectPointer(pointer) ? pointer.generationId : null
-    const consumedGenerationIds = new Set<string>()
+    const initiallyReachableGenerationId = isRedirectPointer(pointer) ? pointer.generationId : null
+    const reclaimableGenerationIds = new Set<string>()
 
     for (let index = 0; index < localStorage.length; index += 1) {
         const key = localStorage.key(index)
@@ -978,12 +982,18 @@ const reclaimRedirectConsumptionSlots = () => {
         } else if (key.startsWith(REDIRECT_V2_CONSUMED_FALLBACK_PREFIX)) {
             generationId = key.slice(REDIRECT_V2_CONSUMED_FALLBACK_PREFIX.length)
         }
-        if (!generationId || !isRedirectGenerationId(generationId) || generationId === reachableGenerationId) continue
+        if (!generationId || !isRedirectGenerationId(generationId)) continue
 
-        if (getFromLocalStorage(key) === '1') consumedGenerationIds.add(generationId)
+        const value = getFromLocalStorage(key)
+        if (value === '0' || value === '1') reclaimableGenerationIds.add(generationId)
     }
 
-    for (const generationId of consumedGenerationIds) {
+    const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    const refreshedReachableGenerationId = isRedirectPointer(refreshedPointer) ? refreshedPointer.generationId : null
+    if (refreshedReachableGenerationId !== initiallyReachableGenerationId) return
+
+    for (const generationId of reclaimableGenerationIds) {
+        if (generationId === refreshedReachableGenerationId) continue
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
     }
@@ -1005,7 +1015,7 @@ export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'de
     // Keep the v1 handoff readable for documents that predate this change, but
     // never publish a mirror that has no authoritative v2 payload behind it.
     if (published) saveToLocalStorage(REDIRECT_KEY, destination)
-    if (published) reclaimRedirectConsumptionSlots()
+    reclaimRedirectConsumptionSlots()
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -1038,10 +1048,11 @@ export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
         if (current.generationKey) {
             localStorage.removeItem(current.generationKey)
         }
-        if (current.generationId) {
-            markRedirectConsumed(current.generationId)
-            reclaimRedirectConsumptionSlots()
-        }
+        const generationsToConsume = [current.generationId, current.supersededGenerationId].filter(
+            (generationId): generationId is string => !!generationId
+        )
+        for (const generationId of new Set(generationsToConsume)) markRedirectConsumed(generationId)
+        if (generationsToConsume.length > 0) reclaimRedirectConsumptionSlots()
 
         if (current.legacyIdentity) {
             saveToLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY, current.legacyIdentity)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -877,9 +877,9 @@ const parseLegacyRedirect = (stored: unknown): StoredRedirect | null => {
     return parseStoredRedirect(stored, null, undefined, legacyIdentity)
 }
 
-const getStoredRedirectForSnapshot = (retryOnMirrorRace: boolean): StoredRedirect | null => {
-    const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
-    if (isRedirectPointer(pointer)) {
+const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
+    let pointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    while (isRedirectPointer(pointer)) {
         const { generationId, destination } = pointer as RedirectPointer
         let generated: StoredRedirect | null = null
 
@@ -906,11 +906,13 @@ const getStoredRedirectForSnapshot = (retryOnMirrorRace: boolean): StoredRedirec
             legacyValue !== destination &&
             legacyValue !== legacyMirror
         ) {
-            if (retryOnMirrorRace) {
-                const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
-                if (isRedirectPointer(refreshedPointer) && refreshedPointer.generationId !== generationId) {
-                    return getStoredRedirectForSnapshot(false)
-                }
+            const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
+            if (!isRedirectPointer(refreshedPointer)) {
+                return parseLegacyRedirect(getFromLocalStorage(REDIRECT_KEY))
+            }
+            if (refreshedPointer.generationId !== generationId) {
+                pointer = refreshedPointer
+                continue
             }
             // A pre-deploy v1 tab can still publish a new handoff. The
             // baseline distinguishes that from a stale mirror left behind by
@@ -933,7 +935,7 @@ const getStoredRedirectForSnapshot = (retryOnMirrorRace: boolean): StoredRedirec
     return parseLegacyRedirect(getFromLocalStorage(REDIRECT_KEY))
 }
 
-export const getStoredRedirect = (): StoredRedirect | null => getStoredRedirectForSnapshot(true)
+export const getStoredRedirect = (): StoredRedirect | null => getStoredRedirectForSnapshot()
 
 const reserveRedirectConsumptionCapacity = (): boolean => {
     if (typeof localStorage === 'undefined') return false

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -758,18 +758,38 @@ export const endIntentionalLogout = () => {
  */
 export type RedirectOrigin = 'deep-link' | 'session-end'
 
-const REDIRECT_ORIGIN_KEY = 'redirect-origin'
+const REDIRECT_KEY = 'redirect'
+/** Never shipped: only this branch's first draft wrote a separate origin key. */
+const LEGACY_REDIRECT_ORIGIN_KEY = 'redirect-origin'
 
 /**
- * The ONLY way to store a post-auth destination: the origin is part of the
- * record, so writing the destination alone cannot leave a previous writer's
- * origin standing over it (which would make a fresh signup discard a
- * confirmed invite or campaign continuation as if it were someone's
- * abandoned session).
+ * Destination and origin are ONE record under ONE key, written in a single
+ * setItem. Two writes could half-fail — localStorage errors are swallowed —
+ * and leave an old destination wearing a new origin, or a fresh continuation
+ * wearing a dead session's. Readers therefore never see a mixed pair.
+ *
+ * A record stored by a version that had no origin (a plain string) reads back
+ * as unclassified rather than as intent: see consumePostAuthRedirect for what
+ * a brand-new account does with one.
  */
+type StoredRedirect = { destination: string; origin: RedirectOrigin | null }
+
+const readStoredRedirect = (): StoredRedirect | null => {
+    const stored = getFromLocalStorage(REDIRECT_KEY)
+    if (typeof stored === 'string') {
+        return stored.length > 0 ? { destination: stored, origin: null } : null
+    }
+    if (stored && typeof stored === 'object') {
+        const { destination, origin } = stored as Partial<StoredRedirect>
+        if (typeof destination !== 'string' || destination.length === 0) return null
+        return { destination, origin: origin === 'session-end' || origin === 'deep-link' ? origin : null }
+    }
+    return null
+}
+
+/** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
-    saveToLocalStorage('redirect', destination)
-    saveToLocalStorage(REDIRECT_ORIGIN_KEY, origin)
+    saveToLocalStorage(REDIRECT_KEY, { destination, origin })
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -778,19 +798,19 @@ export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
     setRedirectUrl(currentUrl.href.replace(currentUrl.origin, ''), origin)
 }
 
-export const getRedirectUrl = () => {
-    return getFromLocalStorage('redirect')
+export const getRedirectUrl = (): string | null => {
+    return readStoredRedirect()?.destination ?? null
 }
 
+/** `null` for a record written before the origin existed — unclassified, not intent. */
 export const getRedirectOrigin = (): RedirectOrigin | null => {
-    const stored = getFromLocalStorage(REDIRECT_ORIGIN_KEY)
-    return stored === 'session-end' || stored === 'deep-link' ? stored : null
+    return readStoredRedirect()?.origin ?? null
 }
 
 export const clearRedirectUrl = () => {
     if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem('redirect')
-        localStorage.removeItem(REDIRECT_ORIGIN_KEY)
+        localStorage.removeItem(REDIRECT_KEY)
+        localStorage.removeItem(LEGACY_REDIRECT_ORIGIN_KEY)
     }
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -777,6 +777,8 @@ const REDIRECT_V2_CONSUMED_RESERVATION_TTL_MS = 60_000
 /** Publication state is separate so it can never overwrite a consumed slot. */
 const REDIRECT_V2_PUBLISHED_PREFIX = 'redirect-v2-published:'
 const REDIRECT_V2_PUBLISHED_VALUE = '1'
+/** Identifies the v2 generation that last wrote the v1-compatible mirror. */
+const REDIRECT_V2_MIRROR_OWNER_KEY = 'redirect-v2-mirror-owner'
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -922,14 +924,19 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
                 pointer = refreshedPointer
                 continue
             }
-            // A pre-deploy v1 tab can still publish a new handoff. The
-            // baseline distinguishes that from a stale mirror left behind by
-            // a failed v2 -> v1 mirror write.
-            const legacy = parseLegacyRedirect(legacyValue)
-            if (legacy) return { ...legacy, supersededGenerationId: generationId }
-            // This legacy handoff was already consumed. It superseded the
-            // v2 generation, so do not resurrect that older destination.
-            return null
+            const mirrorOwner = getFromLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY)
+            if (!isRedirectGenerationId(mirrorOwner) || mirrorOwner === generationId) {
+                // A pre-deploy v1 tab can still publish a new handoff. The
+                // baseline distinguishes that from a stale mirror left behind by
+                // a failed v2 -> v1 mirror write.
+                const legacy = parseLegacyRedirect(legacyValue)
+                if (legacy) return { ...legacy, supersededGenerationId: generationId }
+                // This legacy handoff was already consumed. It superseded the
+                // v2 generation, so do not resurrect that older destination.
+                return null
+            }
+            // A current v2 publisher from another generation wrote this late.
+            // Ignore its mirror mismatch and continue to the consumption check.
         }
 
         const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
@@ -983,6 +990,7 @@ const publishLegacyRedirectMirror = (generationId: string, destination: string) 
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
     if (!isRedirectPointer(pointer) || pointer.generationId !== generationId) return
     saveToLocalStorage(REDIRECT_KEY, destination)
+    saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, generationId)
 }
 
 const discardRedirectConsumptionReservations = (generationId: string) => {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -767,9 +767,10 @@ const REDIRECT_RECORD_PREFIX = 'redirect-v2-record:'
 /** The generation-key format briefly used by the preceding unreleased build. */
 const LEGACY_GENERATION_RECORD_PREFIX = 'redirect-record:'
 const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
-/** Fixed-size fallback tombstone capacity reserved before v2 publication. */
-const REDIRECT_V2_CONSUMED_RESERVE_KEY = 'redirect-v2-consumed-reserve'
-const REDIRECT_V2_CONSUMED_RESERVE_VALUE = '0'.repeat(36)
+/** Generation-scoped tombstones prevent stale consumers from overwriting each other. */
+const REDIRECT_V2_CONSUMED_PREFIX = 'redirect-v2-consumed:'
+const REDIRECT_V2_CONSUMED_FALLBACK_PREFIX = 'redirect-v2-consumed-fallback:'
+const REDIRECT_V2_CONSUMED_RESERVE_VALUE = '0'
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -922,10 +923,15 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
         }
 
         const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
-        const reservedConsumption = getFromLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY)
+        const generationConsumed = getFromLocalStorage(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
+        const fallbackGenerationConsumed = getFromLocalStorage(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
         if (
+            generationConsumed === '1' ||
+            fallbackGenerationConsumed === '1' ||
             (isRedirectGenerationId(consumed) && consumed === generationId) ||
-            (isRedirectGenerationId(reservedConsumption) && reservedConsumption === generationId)
+            (consumed &&
+                typeof consumed === 'object' &&
+                (consumed as Partial<RedirectPointer>).generationId === generationId)
         ) {
             return null
         }
@@ -937,22 +943,28 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
 
 export const getStoredRedirect = (): StoredRedirect | null => getStoredRedirectForSnapshot()
 
-const reserveRedirectConsumptionCapacity = (): boolean => {
+const reserveRedirectConsumptionCapacity = (generationId: string): boolean => {
     if (typeof localStorage === 'undefined') return false
-    if (getFromLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY) !== null) return true
-    return saveToLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+    const primaryKey = `${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`
+    const fallbackKey = `${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`
+    const primaryReserved =
+        getFromLocalStorage(primaryKey) !== null || saveToLocalStorage(primaryKey, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+    const fallbackReserved =
+        getFromLocalStorage(fallbackKey) !== null || saveToLocalStorage(fallbackKey, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+    return primaryReserved && fallbackReserved
 }
 
 const markRedirectConsumed = (generationId: string): boolean => {
-    if (saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, generationId)) return true
-    if (!reserveRedirectConsumptionCapacity()) return false
-    return saveToLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY, generationId)
+    const primaryKey = `${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`
+    const fallbackKey = `${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`
+    if (saveToLocalStorage(primaryKey, '1')) return true
+    return saveToLocalStorage(fallbackKey, '1')
 }
 
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
-    if (!reserveRedirectConsumptionCapacity()) return
     const generationId = createRedirectGenerationId()
+    if (!reserveRedirectConsumptionCapacity(generationId)) return
     const previousLegacy = getFromLocalStorage(REDIRECT_KEY)
     const legacyMirror = typeof previousLegacy === 'string' ? previousLegacy : null
     const published = saveToLocalStorage(REDIRECT_V2_KEY, {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -779,6 +779,8 @@ const REDIRECT_V2_PUBLISHED_PREFIX = 'redirect-v2-published:'
 const REDIRECT_V2_PUBLISHED_VALUE = '1'
 /** Identifies the v2 generation that last wrote the v1-compatible mirror. */
 const REDIRECT_V2_MIRROR_OWNER_KEY = 'redirect-v2-mirror-owner'
+/** Keeps a late v2 mirror identifiable until its owner write has completed. */
+const REDIRECT_V2_MIRROR_PENDING_PREFIX = 'redirect-v2-mirror-pending:'
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -925,7 +927,15 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
                 continue
             }
             const mirrorOwner = getFromLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY)
-            if (!isRedirectGenerationId(mirrorOwner) || mirrorOwner === generationId) {
+            let hasPendingV2Mirror = false
+            for (let index = 0; index < localStorage.length; index += 1) {
+                const key = localStorage.key(index)
+                if (key?.startsWith(REDIRECT_V2_MIRROR_PENDING_PREFIX)) {
+                    hasPendingV2Mirror = getFromLocalStorage(key) === legacyValue
+                    if (hasPendingV2Mirror) break
+                }
+            }
+            if (!hasPendingV2Mirror && (!isRedirectGenerationId(mirrorOwner) || mirrorOwner === generationId)) {
                 // A pre-deploy v1 tab can still publish a new handoff. The
                 // baseline distinguishes that from a stale mirror left behind by
                 // a failed v2 -> v1 mirror write.
@@ -989,8 +999,10 @@ const publishRedirectConsumption = (generationId: string) =>
 const publishLegacyRedirectMirror = (generationId: string, destination: string) => {
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
     if (!isRedirectPointer(pointer) || pointer.generationId !== generationId) return
+    const pendingKey = `${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`
+    if (!saveToLocalStorage(pendingKey, destination)) return
     saveToLocalStorage(REDIRECT_KEY, destination)
-    saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, generationId)
+    if (saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, generationId)) localStorage.removeItem(pendingKey)
 }
 
 const discardRedirectConsumptionReservations = (generationId: string) => {
@@ -999,6 +1011,7 @@ const discardRedirectConsumptionReservations = (generationId: string) => {
     localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
     localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
     localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)
+    localStorage.removeItem(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
 }
 
 const isReclaimableRedirectConsumptionSlot = (generationId: string, value: unknown): boolean => {
@@ -1043,6 +1056,7 @@ const reclaimRedirectConsumptionSlots = () => {
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)
+        localStorage.removeItem(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
     }
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -777,7 +777,7 @@ const REDIRECT_V2_CONSUMED_RESERVATION_TTL_MS = 60_000
 /** Publication state is separate so it can never overwrite a consumed slot. */
 const REDIRECT_V2_PUBLISHED_PREFIX = 'redirect-v2-published:'
 const REDIRECT_V2_PUBLISHED_VALUE = '1'
-/** Identifies the v2 generation that last wrote the v1-compatible mirror. */
+/** Identifies the v2 generation and value that last wrote the v1-compatible mirror. */
 const REDIRECT_V2_MIRROR_OWNER_KEY = 'redirect-v2-mirror-owner'
 /** Keeps a late v2 mirror identifiable until its owner write has completed. */
 const REDIRECT_V2_MIRROR_PENDING_PREFIX = 'redirect-v2-mirror-pending:'
@@ -868,6 +868,11 @@ type RedirectMirrorPending = {
     createdAt: number
 }
 
+type RedirectMirrorOwner = {
+    generationId: string
+    destination: string
+}
+
 const isRedirectPointer = (stored: unknown): stored is RedirectPointer =>
     !!stored &&
     typeof stored === 'object' &&
@@ -877,6 +882,12 @@ const isRedirectPointer = (stored: unknown): stored is RedirectPointer =>
 
 const isRedirectMirrorPendingForDestination = (stored: unknown, destination: string): boolean =>
     !!stored && typeof stored === 'object' && (stored as Partial<RedirectMirrorPending>).destination === destination
+
+const isRedirectMirrorOwnerForDestination = (stored: unknown, destination: string): stored is RedirectMirrorOwner =>
+    !!stored &&
+    typeof stored === 'object' &&
+    isRedirectGenerationId((stored as Partial<RedirectMirrorOwner>).generationId) &&
+    (stored as Partial<RedirectMirrorOwner>).destination === destination
 
 const isFreshRedirectMirrorPending = (generationId: string): boolean => {
     const pending = getFromLocalStorage(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
@@ -944,6 +955,9 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
                 continue
             }
             const mirrorOwner = getFromLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY)
+            const mirrorOwnedByAnotherV2Generation =
+                isRedirectMirrorOwnerForDestination(mirrorOwner, legacyValue) &&
+                mirrorOwner.generationId !== generationId
             let hasPendingV2Mirror = false
             for (let index = 0; index < localStorage.length; index += 1) {
                 const key = localStorage.key(index)
@@ -952,7 +966,7 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
                     if (hasPendingV2Mirror) break
                 }
             }
-            if (!hasPendingV2Mirror && (!isRedirectGenerationId(mirrorOwner) || mirrorOwner === generationId)) {
+            if (!hasPendingV2Mirror && !mirrorOwnedByAnotherV2Generation) {
                 // A pre-deploy v1 tab can still publish a new handoff. The
                 // baseline distinguishes that from a stale mirror left behind by
                 // a failed v2 -> v1 mirror write.
@@ -1019,7 +1033,8 @@ const publishLegacyRedirectMirror = (generationId: string, destination: string) 
     const pendingKey = `${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`
     if (!saveToLocalStorage(pendingKey, { destination, createdAt: Date.now() })) return
     saveToLocalStorage(REDIRECT_KEY, destination)
-    if (saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, generationId)) localStorage.removeItem(pendingKey)
+    if (saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, { generationId, destination }))
+        localStorage.removeItem(pendingKey)
 }
 
 const discardRedirectConsumptionReservations = (generationId: string) => {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -119,8 +119,8 @@ export const validateEnsName = (ensName: string = ''): boolean => {
 
 // Default matches JSON.parse's own return type so legacy untyped call sites keep compiling.
 
-export const saveToLocalStorage = (key: string, data: unknown, expirySeconds?: number) => {
-    if (typeof localStorage === 'undefined') return
+export const saveToLocalStorage = (key: string, data: unknown, expirySeconds?: number): boolean => {
+    if (typeof localStorage === 'undefined') return false
     try {
         // Convert the data to a string before storing it in localStorage
         const serializedData = jsonStringify(data)
@@ -133,9 +133,11 @@ export const saveToLocalStorage = (key: string, data: unknown, expirySeconds?: n
         // key is passed as an argument (not interpolated into the format string)
         // so a user-controlled key can't act as a console format string (CodeQL).
         console.log('Saved to localStorage:', key, data)
+        return true
     } catch (error) {
         Sentry.captureException(error)
         console.error('Error saving to localStorage:', error)
+        return false
     }
 }
 
@@ -760,6 +762,7 @@ export type RedirectOrigin = 'deep-link' | 'session-end'
 
 const REDIRECT_KEY = 'redirect'
 const REDIRECT_V2_KEY = 'redirect-v2'
+/** Generation-key format used by the immediately preceding deployed build. */
 const REDIRECT_RECORD_PREFIX = 'redirect-v2-record:'
 /** The generation-key format briefly used by the preceding unreleased build. */
 const LEGACY_GENERATION_RECORD_PREFIX = 'redirect-record:'
@@ -773,13 +776,14 @@ const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
 const LEGACY_REDIRECT_CONSUMED_KEY = 'redirect-consumed-legacy'
 
 /**
- * `redirect-v2` is a pointer to an immutable generation record, while
- * `redirect` remains a v1-readable destination handoff. The generation
- * record is written before the v2 pointer, so a reader never observes a
- * pointer whose payload does not exist. A consumer deletes only the
- * generation it decided from; if another tab moves the pointer before that
- * deletion, the newer record is still a different localStorage key and
- * survives.
+ * `redirect-v2` is the authoritative, self-contained generation payload,
+ * while `redirect` remains a v1-readable destination handoff. Publishing the
+ * v2 payload is one localStorage write; the v1 mirror is written only after
+ * that succeeds. Once a valid v2 payload exists, it has explicit precedence
+ * over the legacy mirror, so a failed mirror write cannot make an old value
+ * win. A consumer records the consumed generation instead of deleting the
+ * shared pointer, so a newer generation cannot be erased by a stale tab and
+ * old payload records cannot accumulate.
  *
  * A record stored by a version that had no origin (a plain string) reads back
  * as unclassified rather than as intent: see consumePostAuthRedirect for what
@@ -791,20 +795,13 @@ export type StoredRedirect = {
     generationId: string | null
     generationKey?: string
     legacyIdentity?: string
-    supersededGenerationKey?: string
 }
 
-/**
- * Parse one immutable generation record. The pointer and this record are
- * separate keys, but a generation record cannot be changed after it is
- * published, so a pointer replacement cannot mix its destination and origin.
- */
 const parseStoredRedirect = (
     stored: unknown,
     generationId: string | null,
     generationKey?: string,
-    legacyIdentity?: string,
-    supersededGenerationKey?: string
+    legacyIdentity?: string
 ): StoredRedirect | null => {
     if (typeof stored === 'string') {
         return stored.length > 0
@@ -814,7 +811,6 @@ const parseStoredRedirect = (
                   generationId,
                   generationKey,
                   legacyIdentity,
-                  supersededGenerationKey,
               }
             : null
     }
@@ -827,7 +823,6 @@ const parseStoredRedirect = (
             generationId,
             generationKey,
             legacyIdentity,
-            supersededGenerationKey,
         }
     }
     return null
@@ -843,23 +838,33 @@ const createRedirectGenerationId = (): string => {
     return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
-type RedirectPointer = { version: 2; generationId: string; destination: string }
+type RedirectPointer = {
+    version: 2
+    generationId: string
+    destination: string
+    origin: RedirectOrigin
+    /** The legacy mirror observed before this generation was published. */
+    legacyMirror?: string | null
+}
 
 const getLegacyIdentity = (stored: unknown): string | undefined =>
     stored === undefined ? undefined : jsonStringify(stored)
 
-const parseLegacyRedirect = (stored: unknown, supersededGenerationKey?: string): StoredRedirect | null => {
+const parseLegacyRedirect = (stored: unknown): StoredRedirect | null => {
     if (stored && typeof stored === 'object') {
         const { generationId } = stored as Partial<StoredRedirect>
         if (isRedirectGenerationId(generationId)) {
-            const generationKey = `${LEGACY_GENERATION_RECORD_PREFIX}${generationId}`
-            return parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
+            for (const prefix of [REDIRECT_RECORD_PREFIX, LEGACY_GENERATION_RECORD_PREFIX]) {
+                const generationKey = `${prefix}${generationId}`
+                const parsed = parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
+                if (parsed) return parsed
+            }
         }
     }
 
     const legacyIdentity = getLegacyIdentity(stored)
     if (legacyIdentity && getFromLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY) === legacyIdentity) return null
-    return parseStoredRedirect(stored, null, undefined, legacyIdentity, supersededGenerationKey)
+    return parseStoredRedirect(stored, null, undefined, legacyIdentity)
 }
 
 export const getStoredRedirect = (): StoredRedirect | null => {
@@ -872,21 +877,40 @@ export const getStoredRedirect = (): StoredRedirect | null => {
         typeof (pointer as Partial<RedirectPointer>).destination === 'string'
     ) {
         const { generationId, destination } = pointer as RedirectPointer
-        const generationKey = `${REDIRECT_RECORD_PREFIX}${generationId}`
-        const generated = parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
-        const legacyValue = getFromLocalStorage(REDIRECT_KEY)
+        let generated: StoredRedirect | null = null
 
-        // A still-running v1 tab can replace only the legacy key. Treat a
-        // different legacy destination as newer than this v2 pointer, while
-        // ignoring the legacy mirror written by setRedirectUrl itself.
-        if (typeof legacyValue === 'string' && legacyValue.length > 0 && legacyValue !== destination) {
-            const legacy = parseLegacyRedirect(legacyValue, generationKey)
+        // Read records from the two transitional generation-key formats so a
+        // state written by the preceding build keeps its provenance. Current
+        // v2 payloads are self-contained and do not need a secondary read.
+        const pointerOrigin = (pointer as Partial<RedirectPointer>).origin
+        if (pointerOrigin !== 'session-end' && pointerOrigin !== 'deep-link') {
+            for (const prefix of [REDIRECT_RECORD_PREFIX, LEGACY_GENERATION_RECORD_PREFIX]) {
+                const generationKey = `${prefix}${generationId}`
+                generated = parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
+                if (generated) break
+            }
+        }
+        generated ??= parseStoredRedirect(pointer, generationId)
+
+        const legacyValue = getFromLocalStorage(REDIRECT_KEY)
+        const legacyMirror = (pointer as Partial<RedirectPointer>).legacyMirror
+        const hasLegacyMirror = Object.prototype.hasOwnProperty.call(pointer, 'legacyMirror')
+        if (
+            hasLegacyMirror &&
+            typeof legacyValue === 'string' &&
+            legacyValue.length > 0 &&
+            legacyValue !== destination &&
+            legacyValue !== legacyMirror
+        ) {
+            // A pre-deploy v1 tab can still publish a new handoff. The
+            // baseline distinguishes that from a stale mirror left behind by
+            // a failed v2 -> v1 mirror write.
+            const legacy = parseLegacyRedirect(legacyValue)
             if (legacy) return legacy
         }
 
         const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
         if (
-            !generated &&
             consumed &&
             typeof consumed === 'object' &&
             (consumed as Partial<RedirectPointer>).generationId === generationId &&
@@ -903,11 +927,18 @@ export const getStoredRedirect = (): StoredRedirect | null => {
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
     const generationId = createRedirectGenerationId()
-    const generationKey = `${REDIRECT_RECORD_PREFIX}${generationId}`
-    saveToLocalStorage(generationKey, { destination, origin })
-    // Keep the v1 handoff readable for documents that predate this change.
-    saveToLocalStorage(REDIRECT_KEY, destination)
-    saveToLocalStorage(REDIRECT_V2_KEY, { version: 2, generationId, destination })
+    const previousLegacy = getFromLocalStorage(REDIRECT_KEY)
+    const legacyMirror = typeof previousLegacy === 'string' ? previousLegacy : null
+    const published = saveToLocalStorage(REDIRECT_V2_KEY, {
+        version: 2,
+        generationId,
+        destination,
+        origin,
+        legacyMirror,
+    })
+    // Keep the v1 handoff readable for documents that predate this change, but
+    // never publish a mirror that has no authoritative v2 payload behind it.
+    if (published) saveToLocalStorage(REDIRECT_KEY, destination)
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -927,10 +958,10 @@ export const getRedirectOrigin = (): RedirectOrigin | null => {
 
 /**
  * Clear the stored redirect, optionally only if it is still the snapshot a
- * caller consumed. Generated records are immutable, so deleting their key is
- * safe even when another same-origin tab has already published a newer
- * pointer. Legacy records are marked consumed instead of removed because they
- * do not have a generation key to delete safely.
+ * caller consumed. Current v2 generations are marked consumed instead of
+ * removing the shared pointer, so a newer same-origin generation survives.
+ * Records from the two transitional generation-key formats are still removed
+ * by their immutable key.
  */
 export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
     if (typeof localStorage !== 'undefined') {
@@ -939,15 +970,12 @@ export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
 
         if (current.generationKey) {
             localStorage.removeItem(current.generationKey)
-            if (current.generationKey.startsWith(REDIRECT_RECORD_PREFIX) && current.generationId) {
-                saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, {
-                    generationId: current.generationId,
-                    destination: current.destination,
-                })
-            }
         }
-        if (current.supersededGenerationKey && current.supersededGenerationKey !== current.generationKey) {
-            localStorage.removeItem(current.supersededGenerationKey)
+        if (current.generationId) {
+            saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, {
+                generationId: current.generationId,
+                destination: current.destination,
+            })
         }
 
         if (current.legacyIdentity) {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -759,7 +759,11 @@ export const endIntentionalLogout = () => {
 export type RedirectOrigin = 'deep-link' | 'session-end'
 
 const REDIRECT_KEY = 'redirect'
-const REDIRECT_RECORD_PREFIX = 'redirect-record:'
+const REDIRECT_V2_KEY = 'redirect-v2'
+const REDIRECT_RECORD_PREFIX = 'redirect-v2-record:'
+/** The generation-key format briefly used by the preceding unreleased build. */
+const LEGACY_GENERATION_RECORD_PREFIX = 'redirect-record:'
+const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -769,11 +773,13 @@ const REDIRECT_RECORD_PREFIX = 'redirect-record:'
 const LEGACY_REDIRECT_CONSUMED_KEY = 'redirect-consumed-legacy'
 
 /**
- * `redirect` is a pointer to an immutable generation record. The generation
- * record is written before the pointer, so a reader never observes a pointer
- * whose payload does not exist. A consumer deletes only the generation it
- * decided from; if another tab moves the pointer before that deletion, the
- * newer record is still a different localStorage key and survives.
+ * `redirect-v2` is a pointer to an immutable generation record, while
+ * `redirect` remains a v1-readable destination handoff. The generation
+ * record is written before the v2 pointer, so a reader never observes a
+ * pointer whose payload does not exist. A consumer deletes only the
+ * generation it decided from; if another tab moves the pointer before that
+ * deletion, the newer record is still a different localStorage key and
+ * survives.
  *
  * A record stored by a version that had no origin (a plain string) reads back
  * as unclassified rather than as intent: see consumePostAuthRedirect for what
@@ -783,22 +789,34 @@ export type StoredRedirect = {
     destination: string
     origin: RedirectOrigin | null
     generationId: string | null
+    generationKey?: string
     legacyIdentity?: string
+    supersededGenerationKey?: string
 }
 
 /**
- * One parsed snapshot, for a caller that has to decide on the pair. Reading
- * the destination and the origin through separate calls means two getItems,
- * and another tab can replace the record between them — pairing an old
- * destination with the newer record's origin.
+ * Parse one immutable generation record. The pointer and this record are
+ * separate keys, but a generation record cannot be changed after it is
+ * published, so a pointer replacement cannot mix its destination and origin.
  */
 const parseStoredRedirect = (
     stored: unknown,
     generationId: string | null,
-    legacyIdentity?: string
+    generationKey?: string,
+    legacyIdentity?: string,
+    supersededGenerationKey?: string
 ): StoredRedirect | null => {
     if (typeof stored === 'string') {
-        return stored.length > 0 ? { destination: stored, origin: null, generationId, legacyIdentity } : null
+        return stored.length > 0
+            ? {
+                  destination: stored,
+                  origin: null,
+                  generationId,
+                  generationKey,
+                  legacyIdentity,
+                  supersededGenerationKey,
+              }
+            : null
     }
     if (stored && typeof stored === 'object') {
         const { destination, origin } = stored as Partial<StoredRedirect>
@@ -807,7 +825,9 @@ const parseStoredRedirect = (
             destination,
             origin: origin === 'session-end' || origin === 'deep-link' ? origin : null,
             generationId,
+            generationKey,
             legacyIdentity,
+            supersededGenerationKey,
         }
     }
     return null
@@ -823,26 +843,71 @@ const createRedirectGenerationId = (): string => {
     return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
-export const getStoredRedirect = (): StoredRedirect | null => {
-    const stored = getFromLocalStorage(REDIRECT_KEY)
+type RedirectPointer = { version: 2; generationId: string; destination: string }
 
+const getLegacyIdentity = (stored: unknown): string | undefined =>
+    stored === undefined ? undefined : jsonStringify(stored)
+
+const parseLegacyRedirect = (stored: unknown, supersededGenerationKey?: string): StoredRedirect | null => {
     if (stored && typeof stored === 'object') {
         const { generationId } = stored as Partial<StoredRedirect>
         if (isRedirectGenerationId(generationId)) {
-            return parseStoredRedirect(getFromLocalStorage(`${REDIRECT_RECORD_PREFIX}${generationId}`), generationId)
+            const generationKey = `${LEGACY_GENERATION_RECORD_PREFIX}${generationId}`
+            return parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
         }
     }
 
-    const legacyIdentity = stored === undefined ? undefined : jsonStringify(stored)
+    const legacyIdentity = getLegacyIdentity(stored)
     if (legacyIdentity && getFromLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY) === legacyIdentity) return null
-    return parseStoredRedirect(stored, null, legacyIdentity)
+    return parseStoredRedirect(stored, null, undefined, legacyIdentity, supersededGenerationKey)
+}
+
+export const getStoredRedirect = (): StoredRedirect | null => {
+    const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    if (
+        pointer &&
+        typeof pointer === 'object' &&
+        (pointer as Partial<RedirectPointer>).version === 2 &&
+        isRedirectGenerationId((pointer as Partial<RedirectPointer>).generationId) &&
+        typeof (pointer as Partial<RedirectPointer>).destination === 'string'
+    ) {
+        const { generationId, destination } = pointer as RedirectPointer
+        const generationKey = `${REDIRECT_RECORD_PREFIX}${generationId}`
+        const generated = parseStoredRedirect(getFromLocalStorage(generationKey), generationId, generationKey)
+        const legacyValue = getFromLocalStorage(REDIRECT_KEY)
+
+        // A still-running v1 tab can replace only the legacy key. Treat a
+        // different legacy destination as newer than this v2 pointer, while
+        // ignoring the legacy mirror written by setRedirectUrl itself.
+        if (typeof legacyValue === 'string' && legacyValue.length > 0 && legacyValue !== destination) {
+            const legacy = parseLegacyRedirect(legacyValue, generationKey)
+            if (legacy) return legacy
+        }
+
+        const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
+        if (
+            !generated &&
+            consumed &&
+            typeof consumed === 'object' &&
+            (consumed as Partial<RedirectPointer>).generationId === generationId &&
+            (consumed as Partial<RedirectPointer>).destination === destination
+        ) {
+            return null
+        }
+        return generated
+    }
+
+    return parseLegacyRedirect(getFromLocalStorage(REDIRECT_KEY))
 }
 
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
     const generationId = createRedirectGenerationId()
-    saveToLocalStorage(`${REDIRECT_RECORD_PREFIX}${generationId}`, { destination, origin })
-    saveToLocalStorage(REDIRECT_KEY, { generationId })
+    const generationKey = `${REDIRECT_RECORD_PREFIX}${generationId}`
+    saveToLocalStorage(generationKey, { destination, origin })
+    // Keep the v1 handoff readable for documents that predate this change.
+    saveToLocalStorage(REDIRECT_KEY, destination)
+    saveToLocalStorage(REDIRECT_V2_KEY, { version: 2, generationId, destination })
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -872,9 +937,17 @@ export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
         const current = expected === undefined ? getStoredRedirect() : expected
         if (!current) return
 
-        if (current.generationId) {
-            localStorage.removeItem(`${REDIRECT_RECORD_PREFIX}${current.generationId}`)
-            return
+        if (current.generationKey) {
+            localStorage.removeItem(current.generationKey)
+            if (current.generationKey.startsWith(REDIRECT_RECORD_PREFIX) && current.generationId) {
+                saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, {
+                    generationId: current.generationId,
+                    destination: current.destination,
+                })
+            }
+        }
+        if (current.supersededGenerationKey && current.supersededGenerationKey !== current.generationKey) {
+            localStorage.removeItem(current.supersededGenerationKey)
         }
 
         if (current.legacyIdentity) {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -772,9 +772,15 @@ const LEGACY_REDIRECT_ORIGIN_KEY = 'redirect-origin'
  * as unclassified rather than as intent: see consumePostAuthRedirect for what
  * a brand-new account does with one.
  */
-type StoredRedirect = { destination: string; origin: RedirectOrigin | null }
+export type StoredRedirect = { destination: string; origin: RedirectOrigin | null }
 
-const readStoredRedirect = (): StoredRedirect | null => {
+/**
+ * One parsed snapshot, for a caller that has to decide on the pair. Reading
+ * the destination and the origin through separate calls means two getItems,
+ * and another tab can replace the record between them — pairing an old
+ * destination with the newer record's origin.
+ */
+export const getStoredRedirect = (): StoredRedirect | null => {
     const stored = getFromLocalStorage(REDIRECT_KEY)
     if (typeof stored === 'string') {
         return stored.length > 0 ? { destination: stored, origin: null } : null
@@ -799,12 +805,12 @@ export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
 }
 
 export const getRedirectUrl = (): string | null => {
-    return readStoredRedirect()?.destination ?? null
+    return getStoredRedirect()?.destination ?? null
 }
 
 /** `null` for a record written before the origin existed — unclassified, not intent. */
 export const getRedirectOrigin = (): RedirectOrigin | null => {
-    return readStoredRedirect()?.origin ?? null
+    return getStoredRedirect()?.origin ?? null
 }
 
 export const clearRedirectUrl = () => {

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -882,11 +882,8 @@ const isFreshRedirectMirrorPending = (generationId: string): boolean => {
     const pending = getFromLocalStorage(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
     if (!pending || typeof pending !== 'object') return false
     const createdAt = (pending as Partial<RedirectMirrorPending>).createdAt
-    return (
-        typeof createdAt === 'number' &&
-        Date.now() - createdAt >= 0 &&
-        Date.now() - createdAt < REDIRECT_V2_MIRROR_PENDING_TTL_MS
-    )
+    const age = Date.now() - (typeof createdAt === 'number' ? createdAt : Date.now())
+    return typeof createdAt === 'number' && age >= 0 && age < REDIRECT_V2_MIRROR_PENDING_TTL_MS
 }
 
 const getLegacyIdentity = (stored: unknown): string | undefined =>
@@ -1073,11 +1070,15 @@ const reclaimRedirectConsumptionSlots = () => {
 
     for (const generationId of reclaimableGenerationIds) {
         if (generationId === refreshedReachableGenerationId) continue
+        const pendingKey = `${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`
+        const observedPending = localStorage.getItem(pendingKey)
         if (isFreshRedirectMirrorPending(generationId)) continue
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)
-        localStorage.removeItem(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
+        if (observedPending !== null && localStorage.getItem(pendingKey) === observedPending) {
+            localStorage.removeItem(pendingKey)
+        }
     }
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -770,11 +770,13 @@ const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
 /** Generation-scoped tombstones prevent stale consumers from overwriting each other. */
 const REDIRECT_V2_CONSUMED_PREFIX = 'redirect-v2-consumed:'
 const REDIRECT_V2_CONSUMED_FALLBACK_PREFIX = 'redirect-v2-consumed-fallback:'
-const REDIRECT_V2_CONSUMED_PUBLISHED_VALUE = 'p'
 /** Fresh reservations are in-flight publications; only aged ones are abandoned. */
 const REDIRECT_V2_CONSUMED_RESERVATION_PREFIX = 'r'
 const REDIRECT_V2_CONSUMED_RESERVATION_LENGTH = 11
 const REDIRECT_V2_CONSUMED_RESERVATION_TTL_MS = 60_000
+/** Publication state is separate so it can never overwrite a consumed slot. */
+const REDIRECT_V2_PUBLISHED_PREFIX = 'redirect-v2-published:'
+const REDIRECT_V2_PUBLISHED_VALUE = '1'
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -974,20 +976,21 @@ const createRedirectConsumptionReservation = (): string =>
         .toString(36)
         .padStart(REDIRECT_V2_CONSUMED_RESERVATION_LENGTH - REDIRECT_V2_CONSUMED_RESERVATION_PREFIX.length, '0')}`
 
-const publishRedirectConsumptionSlots = (generationId: string) => {
-    saveToLocalStorage(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`, REDIRECT_V2_CONSUMED_PUBLISHED_VALUE)
-    saveToLocalStorage(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`, REDIRECT_V2_CONSUMED_PUBLISHED_VALUE)
-}
+const publishRedirectConsumption = (generationId: string) =>
+    saveToLocalStorage(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`, REDIRECT_V2_PUBLISHED_VALUE)
 
 const discardRedirectConsumptionReservations = (generationId: string) => {
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
     if (isRedirectPointer(pointer) && pointer.generationId === generationId) return
     localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
     localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
+    localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)
 }
 
-const isReclaimableRedirectConsumptionSlot = (value: unknown): boolean => {
-    if (value === '0' || value === REDIRECT_V2_CONSUMED_PUBLISHED_VALUE || value === '1') return true
+const isReclaimableRedirectConsumptionSlot = (generationId: string, value: unknown): boolean => {
+    if (value === '0' || value === '1') return true
+    if (getFromLocalStorage(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`) === REDIRECT_V2_PUBLISHED_VALUE)
+        return true
     if (typeof value !== 'string' || !value.startsWith(REDIRECT_V2_CONSUMED_RESERVATION_PREFIX)) return false
 
     const reservedAt = Number.parseInt(value.slice(REDIRECT_V2_CONSUMED_RESERVATION_PREFIX.length), 36)
@@ -1014,7 +1017,7 @@ const reclaimRedirectConsumptionSlots = () => {
         if (!generationId || !isRedirectGenerationId(generationId)) continue
 
         const value = getFromLocalStorage(key)
-        if (isReclaimableRedirectConsumptionSlot(value)) reclaimableGenerationIds.add(generationId)
+        if (isReclaimableRedirectConsumptionSlot(generationId, value)) reclaimableGenerationIds.add(generationId)
     }
 
     const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
@@ -1025,6 +1028,7 @@ const reclaimRedirectConsumptionSlots = () => {
         if (generationId === refreshedReachableGenerationId) continue
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
+        localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)
     }
 }
 
@@ -1044,7 +1048,7 @@ export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'de
     // Keep the v1 handoff readable for documents that predate this change, but
     // never publish a mirror that has no authoritative v2 payload behind it.
     if (published) {
-        publishRedirectConsumptionSlots(generationId)
+        publishRedirectConsumption(generationId)
         saveToLocalStorage(REDIRECT_KEY, destination)
     } else {
         discardRedirectConsumptionReservations(generationId)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -785,9 +785,9 @@ const LEGACY_REDIRECT_CONSUMED_KEY = 'redirect-consumed-legacy'
  * v2 payload is one localStorage write; the v1 mirror is written only after
  * that succeeds. Once a valid v2 payload exists, it has explicit precedence
  * over the legacy mirror, so a failed mirror write cannot make an old value
- * win. A consumer records the consumed generation instead of deleting the
- * shared pointer, so a newer generation cannot be erased by a stale tab and
- * old payload records cannot accumulate.
+ * win. Each generation reserves its own primary and fallback consumption
+ * slots before publication, and consumed slots for older generations are
+ * reclaimed after the pointer moves so the journal stays bounded.
  *
  * A record stored by a version that had no origin (a plain string) reads back
  * as unclassified rather than as intent: see consumePostAuthRedirect for what
@@ -961,6 +961,34 @@ const markRedirectConsumed = (generationId: string): boolean => {
     return saveToLocalStorage(fallbackKey, '1')
 }
 
+const reclaimRedirectConsumptionSlots = () => {
+    if (typeof localStorage === 'undefined') return
+
+    const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    const reachableGenerationId = isRedirectPointer(pointer) ? pointer.generationId : null
+    const consumedGenerationIds = new Set<string>()
+
+    for (let index = 0; index < localStorage.length; index += 1) {
+        const key = localStorage.key(index)
+        if (!key) continue
+
+        let generationId: string | null = null
+        if (key.startsWith(REDIRECT_V2_CONSUMED_PREFIX)) {
+            generationId = key.slice(REDIRECT_V2_CONSUMED_PREFIX.length)
+        } else if (key.startsWith(REDIRECT_V2_CONSUMED_FALLBACK_PREFIX)) {
+            generationId = key.slice(REDIRECT_V2_CONSUMED_FALLBACK_PREFIX.length)
+        }
+        if (!generationId || !isRedirectGenerationId(generationId) || generationId === reachableGenerationId) continue
+
+        if (getFromLocalStorage(key) === '1') consumedGenerationIds.add(generationId)
+    }
+
+    for (const generationId of consumedGenerationIds) {
+        localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
+        localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
+    }
+}
+
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
     const generationId = createRedirectGenerationId()
@@ -977,6 +1005,7 @@ export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'de
     // Keep the v1 handoff readable for documents that predate this change, but
     // never publish a mirror that has no authoritative v2 payload behind it.
     if (published) saveToLocalStorage(REDIRECT_KEY, destination)
+    if (published) reclaimRedirectConsumptionSlots()
 }
 
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
@@ -1009,7 +1038,10 @@ export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
         if (current.generationKey) {
             localStorage.removeItem(current.generationKey)
         }
-        if (current.generationId) markRedirectConsumed(current.generationId)
+        if (current.generationId) {
+            markRedirectConsumed(current.generationId)
+            reclaimRedirectConsumptionSlots()
+        }
 
         if (current.legacyIdentity) {
             saveToLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY, current.legacyIdentity)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -817,12 +817,14 @@ export const getRedirectOrigin = (): RedirectOrigin | null => {
  * Clear the stored redirect, optionally only if it is still the snapshot a
  * caller consumed. That optimistic compare-and-clear keeps a newer same-origin
  * tab's continuation from being removed after this tab has made its decision.
+ * `null` is an intentional snapshot too: it protects the no-record cleanup
+ * path from deleting a record written after the read.
  */
-export const clearRedirectUrl = (expected?: StoredRedirect) => {
+export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
     if (typeof localStorage !== 'undefined') {
-        if (expected) {
+        if (expected !== undefined) {
             const current = getStoredRedirect()
-            if (!current || current.destination !== expected.destination || current.origin !== expected.origin) {
+            if (current?.destination !== expected?.destination || current?.origin !== expected?.origin) {
                 return
             }
         }

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -767,6 +767,9 @@ const REDIRECT_RECORD_PREFIX = 'redirect-v2-record:'
 /** The generation-key format briefly used by the preceding unreleased build. */
 const LEGACY_GENERATION_RECORD_PREFIX = 'redirect-record:'
 const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
+/** Fixed-size fallback tombstone capacity reserved before v2 publication. */
+const REDIRECT_V2_CONSUMED_RESERVE_KEY = 'redirect-v2-consumed-reserve'
+const REDIRECT_V2_CONSUMED_RESERVE_VALUE = '0'.repeat(36)
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -842,10 +845,17 @@ type RedirectPointer = {
     version: 2
     generationId: string
     destination: string
-    origin: RedirectOrigin
+    origin?: RedirectOrigin
     /** The legacy mirror observed before this generation was published. */
     legacyMirror?: string | null
 }
+
+const isRedirectPointer = (stored: unknown): stored is RedirectPointer =>
+    !!stored &&
+    typeof stored === 'object' &&
+    (stored as Partial<RedirectPointer>).version === 2 &&
+    isRedirectGenerationId((stored as Partial<RedirectPointer>).generationId) &&
+    typeof (stored as Partial<RedirectPointer>).destination === 'string'
 
 const getLegacyIdentity = (stored: unknown): string | undefined =>
     stored === undefined ? undefined : jsonStringify(stored)
@@ -867,15 +877,9 @@ const parseLegacyRedirect = (stored: unknown): StoredRedirect | null => {
     return parseStoredRedirect(stored, null, undefined, legacyIdentity)
 }
 
-export const getStoredRedirect = (): StoredRedirect | null => {
+const getStoredRedirectForSnapshot = (retryOnMirrorRace: boolean): StoredRedirect | null => {
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
-    if (
-        pointer &&
-        typeof pointer === 'object' &&
-        (pointer as Partial<RedirectPointer>).version === 2 &&
-        isRedirectGenerationId((pointer as Partial<RedirectPointer>).generationId) &&
-        typeof (pointer as Partial<RedirectPointer>).destination === 'string'
-    ) {
+    if (isRedirectPointer(pointer)) {
         const { generationId, destination } = pointer as RedirectPointer
         let generated: StoredRedirect | null = null
 
@@ -892,9 +896,9 @@ export const getStoredRedirect = (): StoredRedirect | null => {
         }
         generated ??= parseStoredRedirect(pointer, generationId)
 
-        const legacyValue = getFromLocalStorage(REDIRECT_KEY)
         const legacyMirror = (pointer as Partial<RedirectPointer>).legacyMirror
         const hasLegacyMirror = Object.prototype.hasOwnProperty.call(pointer, 'legacyMirror')
+        const legacyValue = hasLegacyMirror ? getFromLocalStorage(REDIRECT_KEY) : null
         if (
             hasLegacyMirror &&
             typeof legacyValue === 'string' &&
@@ -902,6 +906,12 @@ export const getStoredRedirect = (): StoredRedirect | null => {
             legacyValue !== destination &&
             legacyValue !== legacyMirror
         ) {
+            if (retryOnMirrorRace) {
+                const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
+                if (isRedirectPointer(refreshedPointer) && refreshedPointer.generationId !== generationId) {
+                    return getStoredRedirectForSnapshot(false)
+                }
+            }
             // A pre-deploy v1 tab can still publish a new handoff. The
             // baseline distinguishes that from a stale mirror left behind by
             // a failed v2 -> v1 mirror write.
@@ -910,11 +920,10 @@ export const getStoredRedirect = (): StoredRedirect | null => {
         }
 
         const consumed = getFromLocalStorage(REDIRECT_V2_CONSUMED_KEY)
+        const reservedConsumption = getFromLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY)
         if (
-            consumed &&
-            typeof consumed === 'object' &&
-            (consumed as Partial<RedirectPointer>).generationId === generationId &&
-            (consumed as Partial<RedirectPointer>).destination === destination
+            (isRedirectGenerationId(consumed) && consumed === generationId) ||
+            (isRedirectGenerationId(reservedConsumption) && reservedConsumption === generationId)
         ) {
             return null
         }
@@ -924,8 +933,23 @@ export const getStoredRedirect = (): StoredRedirect | null => {
     return parseLegacyRedirect(getFromLocalStorage(REDIRECT_KEY))
 }
 
+export const getStoredRedirect = (): StoredRedirect | null => getStoredRedirectForSnapshot(true)
+
+const reserveRedirectConsumptionCapacity = (): boolean => {
+    if (typeof localStorage === 'undefined') return false
+    if (getFromLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY) !== null) return true
+    return saveToLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+}
+
+const markRedirectConsumed = (generationId: string): boolean => {
+    if (saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, generationId)) return true
+    if (!reserveRedirectConsumptionCapacity()) return false
+    return saveToLocalStorage(REDIRECT_V2_CONSUMED_RESERVE_KEY, generationId)
+}
+
 /** The ONLY way to store a post-auth destination. */
 export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
+    if (!reserveRedirectConsumptionCapacity()) return
     const generationId = createRedirectGenerationId()
     const previousLegacy = getFromLocalStorage(REDIRECT_KEY)
     const legacyMirror = typeof previousLegacy === 'string' ? previousLegacy : null
@@ -971,12 +995,7 @@ export const clearRedirectUrl = (expected?: StoredRedirect | null) => {
         if (current.generationKey) {
             localStorage.removeItem(current.generationKey)
         }
-        if (current.generationId) {
-            saveToLocalStorage(REDIRECT_V2_CONSUMED_KEY, {
-                generationId: current.generationId,
-                destination: current.destination,
-            })
-        }
+        if (current.generationId) markRedirectConsumed(current.generationId)
 
         if (current.legacyIdentity) {
             saveToLocalStorage(LEGACY_REDIRECT_CONSUMED_KEY, current.legacyIdentity)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -730,7 +730,27 @@ export function isStableCoin(tokenSymbol: string): boolean {
     return STABLE_COINS.includes(tokenSymbol.toUpperCase())
 }
 
+/*
+ * An explicit logout must not leave a post-auth destination behind, and
+ * clearing the stored redirect is not enough on its own: emptying the user
+ * cache re-runs the (mobile-ui) auth gate, which saves the CURRENT path before
+ * bouncing to /setup — and the logout button lives on /profile, so the next
+ * account created on this device was redirected onto the previous session's
+ * page. The latch outlives the logout call (isLoggingOut flips back before the
+ * hard nav completes) and is dropped only if the logout itself failed.
+ */
+let intentionalLogout = false
+
+export const beginIntentionalLogout = () => {
+    intentionalLogout = true
+}
+
+export const endIntentionalLogout = () => {
+    intentionalLogout = false
+}
+
 export const saveRedirectUrl = () => {
+    if (intentionalLogout) return
     const currentUrl = new URL(window.location.href)
     const relativeUrl = currentUrl.href.replace(currentUrl.origin, '')
     saveToLocalStorage('redirect', relativeUrl)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -770,7 +770,11 @@ const REDIRECT_V2_CONSUMED_KEY = 'redirect-v2-consumed'
 /** Generation-scoped tombstones prevent stale consumers from overwriting each other. */
 const REDIRECT_V2_CONSUMED_PREFIX = 'redirect-v2-consumed:'
 const REDIRECT_V2_CONSUMED_FALLBACK_PREFIX = 'redirect-v2-consumed-fallback:'
-const REDIRECT_V2_CONSUMED_RESERVE_VALUE = '0'
+const REDIRECT_V2_CONSUMED_PUBLISHED_VALUE = 'p'
+/** Fresh reservations are in-flight publications; only aged ones are abandoned. */
+const REDIRECT_V2_CONSUMED_RESERVATION_PREFIX = 'r'
+const REDIRECT_V2_CONSUMED_RESERVATION_LENGTH = 11
+const REDIRECT_V2_CONSUMED_RESERVATION_TTL_MS = 60_000
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -951,10 +955,10 @@ const reserveRedirectConsumptionCapacity = (generationId: string): boolean => {
     if (typeof localStorage === 'undefined') return false
     const primaryKey = `${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`
     const fallbackKey = `${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`
-    const primaryReserved =
-        getFromLocalStorage(primaryKey) !== null || saveToLocalStorage(primaryKey, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+    const reservationValue = createRedirectConsumptionReservation()
+    const primaryReserved = getFromLocalStorage(primaryKey) !== null || saveToLocalStorage(primaryKey, reservationValue)
     const fallbackReserved =
-        getFromLocalStorage(fallbackKey) !== null || saveToLocalStorage(fallbackKey, REDIRECT_V2_CONSUMED_RESERVE_VALUE)
+        getFromLocalStorage(fallbackKey) !== null || saveToLocalStorage(fallbackKey, reservationValue)
     return primaryReserved && fallbackReserved
 }
 
@@ -963,6 +967,31 @@ const markRedirectConsumed = (generationId: string): boolean => {
     const fallbackKey = `${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`
     if (saveToLocalStorage(primaryKey, '1')) return true
     return saveToLocalStorage(fallbackKey, '1')
+}
+
+const createRedirectConsumptionReservation = (): string =>
+    `${REDIRECT_V2_CONSUMED_RESERVATION_PREFIX}${Date.now()
+        .toString(36)
+        .padStart(REDIRECT_V2_CONSUMED_RESERVATION_LENGTH - REDIRECT_V2_CONSUMED_RESERVATION_PREFIX.length, '0')}`
+
+const publishRedirectConsumptionSlots = (generationId: string) => {
+    saveToLocalStorage(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`, REDIRECT_V2_CONSUMED_PUBLISHED_VALUE)
+    saveToLocalStorage(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`, REDIRECT_V2_CONSUMED_PUBLISHED_VALUE)
+}
+
+const discardRedirectConsumptionReservations = (generationId: string) => {
+    const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    if (isRedirectPointer(pointer) && pointer.generationId === generationId) return
+    localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
+    localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
+}
+
+const isReclaimableRedirectConsumptionSlot = (value: unknown): boolean => {
+    if (value === '0' || value === REDIRECT_V2_CONSUMED_PUBLISHED_VALUE || value === '1') return true
+    if (typeof value !== 'string' || !value.startsWith(REDIRECT_V2_CONSUMED_RESERVATION_PREFIX)) return false
+
+    const reservedAt = Number.parseInt(value.slice(REDIRECT_V2_CONSUMED_RESERVATION_PREFIX.length), 36)
+    return Number.isFinite(reservedAt) && Date.now() - reservedAt >= REDIRECT_V2_CONSUMED_RESERVATION_TTL_MS
 }
 
 const reclaimRedirectConsumptionSlots = () => {
@@ -985,7 +1014,7 @@ const reclaimRedirectConsumptionSlots = () => {
         if (!generationId || !isRedirectGenerationId(generationId)) continue
 
         const value = getFromLocalStorage(key)
-        if (value === '0' || value === '1') reclaimableGenerationIds.add(generationId)
+        if (isReclaimableRedirectConsumptionSlot(value)) reclaimableGenerationIds.add(generationId)
     }
 
     const refreshedPointer = getFromLocalStorage(REDIRECT_V2_KEY)
@@ -1014,7 +1043,12 @@ export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'de
     })
     // Keep the v1 handoff readable for documents that predate this change, but
     // never publish a mirror that has no authoritative v2 payload behind it.
-    if (published) saveToLocalStorage(REDIRECT_KEY, destination)
+    if (published) {
+        publishRedirectConsumptionSlots(generationId)
+        saveToLocalStorage(REDIRECT_KEY, destination)
+    } else {
+        discardRedirectConsumptionReservations(generationId)
+    }
     reclaimRedirectConsumptionSlots()
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -813,8 +813,19 @@ export const getRedirectOrigin = (): RedirectOrigin | null => {
     return getStoredRedirect()?.origin ?? null
 }
 
-export const clearRedirectUrl = () => {
+/**
+ * Clear the stored redirect, optionally only if it is still the snapshot a
+ * caller consumed. That optimistic compare-and-clear keeps a newer same-origin
+ * tab's continuation from being removed after this tab has made its decision.
+ */
+export const clearRedirectUrl = (expected?: StoredRedirect) => {
     if (typeof localStorage !== 'undefined') {
+        if (expected) {
+            const current = getStoredRedirect()
+            if (!current || current.destination !== expected.destination || current.origin !== expected.origin) {
+                return
+            }
+        }
         localStorage.removeItem(REDIRECT_KEY)
         localStorage.removeItem(LEGACY_REDIRECT_ORIGIN_KEY)
     }

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -749,20 +749,38 @@ export const endIntentionalLogout = () => {
     intentionalLogout = false
 }
 
-export const saveRedirectUrl = () => {
+/**
+ * Why a post-auth destination was stored. `deep-link` is an intent of the
+ * person who will authenticate — they asked for that page and could not have
+ * it yet. `session-end` is merely where some session happened to be standing
+ * when it collapsed (logout, revocation, token expiry), which is nobody's
+ * intent and belongs to an account that is not necessarily the next one.
+ */
+export type RedirectOrigin = 'deep-link' | 'session-end'
+
+const REDIRECT_ORIGIN_KEY = 'redirect-origin'
+
+export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
     if (intentionalLogout) return
     const currentUrl = new URL(window.location.href)
     const relativeUrl = currentUrl.href.replace(currentUrl.origin, '')
     saveToLocalStorage('redirect', relativeUrl)
+    saveToLocalStorage(REDIRECT_ORIGIN_KEY, origin)
 }
 
 export const getRedirectUrl = () => {
     return getFromLocalStorage('redirect')
 }
 
+export const getRedirectOrigin = (): RedirectOrigin | null => {
+    const stored = getFromLocalStorage(REDIRECT_ORIGIN_KEY)
+    return stored === 'session-end' || stored === 'deep-link' ? stored : null
+}
+
 export const clearRedirectUrl = () => {
     if (typeof localStorage !== 'undefined') {
         localStorage.removeItem('redirect')
+        localStorage.removeItem(REDIRECT_ORIGIN_KEY)
     }
 }
 

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -979,6 +979,12 @@ const createRedirectConsumptionReservation = (): string =>
 const publishRedirectConsumption = (generationId: string) =>
     saveToLocalStorage(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`, REDIRECT_V2_PUBLISHED_VALUE)
 
+const publishLegacyRedirectMirror = (generationId: string, destination: string) => {
+    const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
+    if (!isRedirectPointer(pointer) || pointer.generationId !== generationId) return
+    saveToLocalStorage(REDIRECT_KEY, destination)
+}
+
 const discardRedirectConsumptionReservations = (generationId: string) => {
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
     if (isRedirectPointer(pointer) && pointer.generationId === generationId) return
@@ -1049,7 +1055,7 @@ export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'de
     // never publish a mirror that has no authoritative v2 payload behind it.
     if (published) {
         publishRedirectConsumption(generationId)
-        saveToLocalStorage(REDIRECT_KEY, destination)
+        publishLegacyRedirectMirror(generationId, destination)
     } else {
         discardRedirectConsumptionReservations(generationId)
     }

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -781,6 +781,7 @@ const REDIRECT_V2_PUBLISHED_VALUE = '1'
 const REDIRECT_V2_MIRROR_OWNER_KEY = 'redirect-v2-mirror-owner'
 /** Keeps a late v2 mirror identifiable until its owner write has completed. */
 const REDIRECT_V2_MIRROR_PENDING_PREFIX = 'redirect-v2-mirror-pending:'
+const REDIRECT_V2_MIRROR_PENDING_TTL_MS = 60_000
 /**
  * Legacy bare-path records cannot be deleted conditionally without the same
  * check/remove race. Remembering their consumed value makes them inert while
@@ -862,12 +863,31 @@ type RedirectPointer = {
     legacyMirror?: string | null
 }
 
+type RedirectMirrorPending = {
+    destination: string
+    createdAt: number
+}
+
 const isRedirectPointer = (stored: unknown): stored is RedirectPointer =>
     !!stored &&
     typeof stored === 'object' &&
     (stored as Partial<RedirectPointer>).version === 2 &&
     isRedirectGenerationId((stored as Partial<RedirectPointer>).generationId) &&
     typeof (stored as Partial<RedirectPointer>).destination === 'string'
+
+const isRedirectMirrorPendingForDestination = (stored: unknown, destination: string): boolean =>
+    !!stored && typeof stored === 'object' && (stored as Partial<RedirectMirrorPending>).destination === destination
+
+const isFreshRedirectMirrorPending = (generationId: string): boolean => {
+    const pending = getFromLocalStorage(`${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`)
+    if (!pending || typeof pending !== 'object') return false
+    const createdAt = (pending as Partial<RedirectMirrorPending>).createdAt
+    return (
+        typeof createdAt === 'number' &&
+        Date.now() - createdAt >= 0 &&
+        Date.now() - createdAt < REDIRECT_V2_MIRROR_PENDING_TTL_MS
+    )
+}
 
 const getLegacyIdentity = (stored: unknown): string | undefined =>
     stored === undefined ? undefined : jsonStringify(stored)
@@ -931,7 +951,7 @@ const getStoredRedirectForSnapshot = (): StoredRedirect | null => {
             for (let index = 0; index < localStorage.length; index += 1) {
                 const key = localStorage.key(index)
                 if (key?.startsWith(REDIRECT_V2_MIRROR_PENDING_PREFIX)) {
-                    hasPendingV2Mirror = getFromLocalStorage(key) === legacyValue
+                    hasPendingV2Mirror = isRedirectMirrorPendingForDestination(getFromLocalStorage(key), legacyValue)
                     if (hasPendingV2Mirror) break
                 }
             }
@@ -1000,7 +1020,7 @@ const publishLegacyRedirectMirror = (generationId: string, destination: string) 
     const pointer = getFromLocalStorage(REDIRECT_V2_KEY)
     if (!isRedirectPointer(pointer) || pointer.generationId !== generationId) return
     const pendingKey = `${REDIRECT_V2_MIRROR_PENDING_PREFIX}${generationId}`
-    if (!saveToLocalStorage(pendingKey, destination)) return
+    if (!saveToLocalStorage(pendingKey, { destination, createdAt: Date.now() })) return
     saveToLocalStorage(REDIRECT_KEY, destination)
     if (saveToLocalStorage(REDIRECT_V2_MIRROR_OWNER_KEY, generationId)) localStorage.removeItem(pendingKey)
 }
@@ -1053,6 +1073,7 @@ const reclaimRedirectConsumptionSlots = () => {
 
     for (const generationId of reclaimableGenerationIds) {
         if (generationId === refreshedReachableGenerationId) continue
+        if (isFreshRedirectMirrorPending(generationId)) continue
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_CONSUMED_FALLBACK_PREFIX}${generationId}`)
         localStorage.removeItem(`${REDIRECT_V2_PUBLISHED_PREFIX}${generationId}`)

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -760,12 +760,22 @@ export type RedirectOrigin = 'deep-link' | 'session-end'
 
 const REDIRECT_ORIGIN_KEY = 'redirect-origin'
 
+/**
+ * The ONLY way to store a post-auth destination: the origin is part of the
+ * record, so writing the destination alone cannot leave a previous writer's
+ * origin standing over it (which would make a fresh signup discard a
+ * confirmed invite or campaign continuation as if it were someone's
+ * abandoned session).
+ */
+export const setRedirectUrl = (destination: string, origin: RedirectOrigin = 'deep-link') => {
+    saveToLocalStorage('redirect', destination)
+    saveToLocalStorage(REDIRECT_ORIGIN_KEY, origin)
+}
+
 export const saveRedirectUrl = (origin: RedirectOrigin = 'deep-link') => {
     if (intentionalLogout) return
     const currentUrl = new URL(window.location.href)
-    const relativeUrl = currentUrl.href.replace(currentUrl.origin, '')
-    saveToLocalStorage('redirect', relativeUrl)
-    saveToLocalStorage(REDIRECT_ORIGIN_KEY, origin)
+    setRedirectUrl(currentUrl.href.replace(currentUrl.origin, ''), origin)
 }
 
 export const getRedirectUrl = () => {

--- a/src/utils/session-presence.ts
+++ b/src/utils/session-presence.ts
@@ -1,5 +1,5 @@
 /**
- * Whether THIS TAB has ever held an authenticated session.
+ * Whether THIS TAB has an unconsumed authenticated session marker.
  *
  * It separates the two reasons the app can find itself logged out on a
  * protected route: someone arrived at a deep link they cannot have yet (their
@@ -38,10 +38,9 @@ export function hasHeldSession(): boolean {
 }
 
 /**
- * Called when the session ends deliberately: this tab is a logged-out tab
+ * Called when the session ends deliberately or after the auth gate has
+ * observed the first passive session collapse: this tab is a logged-out tab
  * again, so a later deep link opened in it is that person's own intent.
- * Passive expiry deliberately does NOT clear it — the tab did hold a session,
- * which is the whole point of the marker.
  */
 export function clearSessionHeld(): void {
     try {
@@ -49,4 +48,15 @@ export function clearSessionHeld(): void {
     } catch {
         // storage unavailable — see the note above
     }
+}
+
+/**
+ * Consume the marker when the auth gate records the first unauthenticated
+ * bounce after a session collapse. The current route is session residue; a
+ * later protected route in this same tab is a new visitor intent.
+ */
+export function consumeHeldSession(): boolean {
+    if (!hasHeldSession()) return false
+    clearSessionHeld()
+    return true
 }

--- a/src/utils/session-presence.ts
+++ b/src/utils/session-presence.ts
@@ -1,0 +1,52 @@
+/**
+ * Whether THIS TAB has ever held an authenticated session.
+ *
+ * It separates the two reasons the app can find itself logged out on a
+ * protected route: someone arrived at a deep link they cannot have yet (their
+ * own intent — worth returning them to after auth), or a session that was
+ * standing here collapsed (logout, revocation, expiry — where it happened to
+ * be standing is nobody's intent, and belongs to an account that is not
+ * necessarily the next one to authenticate here).
+ *
+ * sessionStorage, not a React ref: the marker has to survive a reload of the
+ * same tab. An authenticated tab that reloads after its token expired never
+ * observes a user in the new document, and a ref would read that as a
+ * first-time visitor — handing the previous session's page to the next
+ * account. It is per-tab by design, so a second tab answers for itself.
+ *
+ * Storage can be unavailable (private mode, blocked site data), in which case
+ * this reports no session. The stored destination it qualifies lives in
+ * localStorage, which is unavailable in exactly the same conditions, so there
+ * is nothing left to qualify.
+ */
+const SESSION_PRESENCE_KEY = 'had-session'
+
+export function markSessionHeld(): void {
+    try {
+        sessionStorage.setItem(SESSION_PRESENCE_KEY, '1')
+    } catch {
+        // storage unavailable — see the note above
+    }
+}
+
+export function hasHeldSession(): boolean {
+    try {
+        return sessionStorage.getItem(SESSION_PRESENCE_KEY) === '1'
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Called when the session ends deliberately: this tab is a logged-out tab
+ * again, so a later deep link opened in it is that person's own intent.
+ * Passive expiry deliberately does NOT clear it — the tab did hold a session,
+ * which is the whole point of the marker.
+ */
+export function clearSessionHeld(): void {
+    try {
+        sessionStorage.removeItem(SESSION_PRESENCE_KEY)
+    } catch {
+        // storage unavailable — see the note above
+    }
+}


### PR DESCRIPTION
## The bug

Log out of the app and create a new account. You land on **/profile**. Press Back and the app shows **"Something went wrong"** instead of the app. Reproduced in the PWA.

The error on Back is the defect. Landing on /profile is not itself the complaint — it is how you get onto a page whose Back goes somewhere that breaks.

## Why Back errors

The signup flow leaves a history entry per step on web (`history: 'push'` — deliberate, so browser Back walks the funnel), and the post-signup redirect only *replaces* the last one. So Back from wherever signup dropped you pops back into `/setup`, and two things there produced the recovery screen added in cb3bbbd6:

- **The stepper served a cursor that had left the step list.** The setup step list is a runtime decision (PWA + sunset filtering) that narrows after the first render, while nuqs keeps returning the value it parsed against the wider master list. `screenIds.indexOf(...)` was then `-1`, so the flow had no step at all and the page reported a fault. An off-list cursor now resolves to the default step, and the stepper's existing "keep the URL honest" effect rewrites the URL (replace, no history entry).
- **The default cursor was `steps[0]`**, which moves with that same list — `unsupported-browser` in the master list, `landing` once filtered — so a clean `/setup` URL could name a screen the flow does not have. It is pinned to `landing`, which no filter removes.

The page also no longer reports a fault while it is already bouncing a completed session to `/home`: that soft nav takes a beat, during which entry resolution finishes, and the recovery screen won the race every time.

Back after a fresh signup now lands in the app. Each press resolves one stale `/setup` entry to `/home`; the per-step history entries are left alone, since the funnel deliberately lets Back walk its steps.

### Evidence

Sentry **PEANUT-UI-T3A** "Setup recovery required", `reason=missing_step`, staging, 8 distinct users between 11:42 and 11:53 UTC on 10 Sep. Breadcrumbs of one event are the repro:

```
navigation  from:/profile  to:/setup?screen=landing
console     [SetupPage] waiting for steps to be initialized by layout...
navigation  /setup?screen=landing -> /setup        (the cursor param is dropped)
captureMessage "Setup recovery required" reason=missing_step
```

The same issue also carries `initialization_timeout` events from native — a stuck steps handshake, a different cause, untouched here.

## How a new account ends up on /profile

Not the reported defect, but it is what puts a fresh signup on that page, so it is fixed too: `localStorage.redirect` is the post-auth destination, consumed once by `useAccountSetup.handleRedirect()`. Logout clears it, but emptying the user cache re-runs the `(mobile-ui)` auth gate, which stores the **current** path before bouncing to `/setup` — and the logout button lives on `/profile`. The path survived the hard nav, and the next account created on this device consumed it.

`saveRedirectUrl()` now no-ops once a logout is under way, latched for the life of the document (`isLoggingOut` flips back before the hard nav lands) and released only if the logout itself threw.

## Review follow-ups

Four rounds on that secondary fix, each a real hole rather than a style note:

- **The latch is per document, and storage is shared.** A second tab's session can collapse (another tab's logout, revocation, expiry) and store *its* page, with no latch armed there. Rather than broadcasting logout — which would not cover a tab whose token merely expires — a stored destination now records why it exists: `deep-link` (the intent of the person about to authenticate) or `session-end` (merely where a session stood when it collapsed). An account created in this session refuses a `session-end` destination and consumes it. Login still resumes where it was; a deep link still wins for both.
- **Provenance has to travel with the destination.** The invite and campaign continuations write the destination directly, so a stale `session-end` origin could sit over a confirmed continuation and the new account would discard a destination that was its own. `setRedirectUrl(destination, origin)` is now the only way to store one, and writes both fields; the three writers outside `general.utils` go through it.
- **"This tab held a session" has to survive a reload.** A React ref does not, so an authenticated tab reloading after revocation looked like a first-time visitor. It lives in sessionStorage now — per tab, durable across reloads — cleared at the explicit-logout boundary, and deliberately not on passive expiry.
- **Destination and provenance have to be one record.** Two writes with swallowed errors could put a new origin on an old destination, or leave a dead session's origin on a fresh continuation; they are now a single serialized record under one key, written in one `setItem`.
- **Records already stored have an explicit rollout policy: they are honoured.** The deployed version stores a bare path with no origin. Discarding those on the new-account path — my first answer here — dropped the stored pay-link continuation for anyone mid-funnel across the deploy, landing a signup entered from `/receipt` on `/home`; the existing `SignTestTransaction` suite pins exactly that case and caught it. The reverse harm, a new account on the previous session's page, is the smaller one and no longer errors on Back. Every writer classifies from the first write after deploy, so the window closes without a migration. A classified `session-end` record — what the gate writes once this ships — is still refused.


## Tests

- `useFlowStepper`: a cursor that left the step list resolves to the default. **Fails on `dev`** (`step` is `undefined`) — the deterministic repro of the crash.
- `useSetupFlow`: the same through the setup step list, plus the default screen surviving every filter variant the layout applies.
- setup page: a completed session is bounced to `/home` with the loader, no recovery screen and no Sentry report, including past the 15s initialization bound. **Fails on `dev`.**
- `post-auth-redirect`: a legacy bare-path record reaching a new account (so a pay-link signup completes) while a classified `session-end` one is refused, both resumed for a login, and `redirect_uri` outranking either; reader coverage for the bare-path shape and for a record with no usable destination; and the two-tab case with a module registry per tab over one localStorage — the latch not crossing tabs, and the new account refusing that page anyway; plus a deep link in that second tab still arriving.
- `authContext-logout`: renders `AuthProvider` and drives the real logout, asserting the stored path at the moment the cache empties (moving the call after `clearLocalAuthState` fails it — checked), the failure path releasing the latch, and revocation preceding local teardown.
- `(mobile-ui)` layout: deep link vs session-end provenance, the revoked-session reload, and a logout from `/profile` storing nothing.
- Re-ran the withdraw flows (the stepper's other consumers): 89 tests, green.

One `ds-shots` failure on `5c8cc6b` was environmental — it died in its Build step, was failing the same way on an unrelated branch, and passed on rerun of the same SHA.

## Deliberately not changed

`hasKnownDeviceCredentials()` reads every account's stored `webAuthnKey`, and logout only clears the current user's, so a device holding another account's credentials still enters setup at the landing gate. That is the right outcome — the landing step is the one with Log In — and wiping other accounts' keys would strand their login on a shared device.
