### PR TITLE
fix: update signup username description copy

### DIFF
--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -723,7 +723,7 @@
             },
             "signup": {
                 "title": "How should we call you?",
-                "description": "Your @username is how friends send you money. Think of it as an account number you can say out loud."
+                "description": "Choose your username. You will use it to send and receive money."
             },
             "residence": {
                 "title": "Where do you legally live?",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -723,7 +723,7 @@
             },
             "signup": {
                 "title": "¿Cómo te llamamos?",
-                "description": "Tu @usuario es la forma en que tus amigos te envían dinero. Piensa en él como un número de cuenta que puedes decir en voz alta."
+                "description": "Elige tu nombre de usuario. Lo usarás para enviar y recibir dinero."
             },
             "residence": {
                 "title": "¿Dónde vives legalmente?",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -421,7 +421,7 @@
                 "description": "¿Quién te invitó? Ingresá su nombre de usuario para continuar, o unite a la lista de espera y te avisaremos cuando puedas entrar."
             },
             "signup": {
-                "description": "Tu @usuario es la forma en que tus amigos te envían dinero. Pensalo como un número de cuenta que podés decir en voz alta."
+                "description": "Elegí tu nombre de usuario. Lo vas a usar para enviar y recibir dinero."
             },
             "residence": {
                 "title": "¿Dónde vivís legalmente?",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -723,7 +723,7 @@
             },
             "signup": {
                 "title": "Como devemos te chamar?",
-                "description": "Seu @usuário é como os amigos enviam dinheiro para você. Pense nele como um número de conta que dá para falar em voz alta."
+                "description": "Escolha seu nome de usuário. Você vai usá-lo para enviar e receber dinheiro."
             },
             "residence": {
                 "title": "Onde você mora legalmente?",


### PR DESCRIPTION
## Summary
- Update the signup screen's username description copy to "Choose your username. You will use it to send and receive money."

## Test plan
- [x] Verified `en.json` stays valid JSON and matches existing formatting
- [ ] Visual check of the signup step in the app
