### PR TITLE
fix(TASK-22506): allow accounting settlement time for funded withdrawals

### DIFF
--- a/src/services/__tests__/manteca-withdraw-transport.test.ts
+++ b/src/services/__tests__/manteca-withdraw-transport.test.ts
@@ -107,3 +107,13 @@ describe('withdraw transport to sign-only retry guard', () => {
         expect(mockServerFetch).toHaveBeenCalledTimes(1)
     })
 })
+
+it('allows accounting settlement time on an already-funded legacy withdrawal without retrying the POST', async () => {
+    mockServerFetch.mockReset().mockResolvedValue({ ok: true, json: async () => ({ id: 'withdrawal-1' }) } as Response)
+    await mantecaApi.withdraw({ amount: '10', txHash: '0xabc', destinationAddress: 'bank', currency: 'ARS' } as never)
+    expect(mockServerFetch).toHaveBeenCalledTimes(1)
+    expect(mockServerFetch).toHaveBeenCalledWith(
+        '/manteca/withdraw',
+        expect.objectContaining({ method: 'POST', timeoutMs: 120_000 })
+    )
+})

--- a/src/services/manteca.ts
+++ b/src/services/manteca.ts
@@ -324,6 +324,7 @@ export const mantecaApi = {
         try {
             const response = await serverFetch('/manteca/withdraw', {
                 method: 'POST',
+                timeoutMs: 120_000, // Funding can precede Manteca accounting; match the signed withdrawal budget.
                 body: jsonStringify(data),
             })
 


### PR DESCRIPTION
The legacy Manteca withdrawal call uses a 20-second browser timeout. The paired backend accounting guard can wait up to 30 seconds before submitting its first order, so the browser could report a timeout while the backend continues.

Use the same 120-second request budget as signed Manteca withdrawals. This changes one request option and adds no POST retry.

Task: [TASK-22506](https://app.notion.com/p/3d783811757981d49b51f8ce0ede088a). Deploy this before [backend #1576](https://github.com/peanutprotocol/peanut-api-ts/pull/1576); it is compatible with the current backend.

Validation: regression failed before the change and now passes; full unit suite 563 suites / 6,978 passed, five skipped. Typecheck, targeted ESLint and formatting pass. No schema, dependency or visual change. Screenshots: N/A.
