### PR TITLE
fix(claim): poll fresh claim status

### DIFF
--- a/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
+++ b/src/components/Claim/Link/Onchain/__tests__/useClaimSuccessPolling.test.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from 'react'
 
 const mockGet = jest.fn()
 jest.mock('@/services/sendLinks', () => ({
-    sendLinksApi: { get: mockGet },
+    sendLinksApi: { getClaimStatus: mockGet },
     ESendLinkStatus: {
         creating: 'creating',
         completed: 'completed',

--- a/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
+++ b/src/components/Claim/Link/Onchain/useClaimSuccessPolling.ts
@@ -33,7 +33,10 @@ const toFailure = (link: SendLink): ClaimPollFailure => ({
 })
 
 /**
- * Polls the send link after an optimistic claim until the claim tx is indexed.
+ * Polls the authoritative send-link status after an optimistic claim until
+ * the claim tx is indexed. The status endpoint bypasses the recent-create
+ * cache and reads primary, so a completed claim is not hidden behind the 30s
+ * initial-link cache.
  * react-query owns the cadence: in-flight requests are deduped (a bare
  * setInterval here once piled up 89 concurrent GETs on a slow Android
  * connection), gcTime 0 stops polling on unmount, and after the fast phase the
@@ -65,7 +68,7 @@ export function useClaimSuccessPolling(
         queryKey: ['send-link-claim-status', link],
         queryFn: () => {
             attempts.current += 1
-            return sendLinksApi.get(link)
+            return sendLinksApi.getClaimStatus(link)
         },
         enabled,
         retry: false,

--- a/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
+++ b/src/components/Claim/__tests__/claim-success-poll-failure.test.tsx
@@ -28,7 +28,7 @@ jest.mock('next/image', () => ({
     },
 }))
 
-const mockSendLinksApi = { get: jest.fn() }
+const mockSendLinksApi = { getClaimStatus: jest.fn() }
 jest.mock('@/services/sendLinks', () => ({
     ESendLinkStatus: {
         creating: 'creating',
@@ -125,14 +125,14 @@ const renderView = (onCustom = jest.fn(), initialHash?: string) => {
 
 describe('SUCCESS view — polled claim failure', () => {
     beforeEach(() => {
-        mockSendLinksApi.get.mockReset()
+        mockSendLinksApi.getClaimStatus.mockReset()
         mockRouterPush.mockReset()
         mockSoundPlayed.mockReset()
         mockTriggerHaptic.mockReset()
     })
 
     test('a retryable failure replaces the success card with the retry copy and a way back', async () => {
-        mockSendLinksApi.get.mockResolvedValue({
+        mockSendLinksApi.getClaimStatus.mockResolvedValue({
             status: 'FAILED',
             claimFailureCode: 'CHAIN_INFRA_UNAVAILABLE',
             events: [],
@@ -149,7 +149,7 @@ describe('SUCCESS view — polled claim failure', () => {
     })
 
     test('a failure with no code gets the generic copy and no retry button', async () => {
-        mockSendLinksApi.get.mockResolvedValue({ status: 'FAILED', claimFailureCode: null, events: [] })
+        mockSendLinksApi.getClaimStatus.mockResolvedValue({ status: 'FAILED', claimFailureCode: null, events: [] })
 
         renderView()
 
@@ -159,7 +159,7 @@ describe('SUCCESS view — polled claim failure', () => {
     })
 
     test('a confirmed claim still renders the success card', async () => {
-        mockSendLinksApi.get.mockResolvedValue({
+        mockSendLinksApi.getClaimStatus.mockResolvedValue({
             status: 'CLAIMED',
             claim: { txHash: '0xabc' },
             events: [],
@@ -174,7 +174,7 @@ describe('SUCCESS view — polled claim failure', () => {
     test('a CLAIMED status with no projected hash still renders the success card', async () => {
         // matches the backend's notify point: CLAIMED means the money moved, so
         // the view must not sit on "processing" waiting the txHash out
-        mockSendLinksApi.get.mockResolvedValue({
+        mockSendLinksApi.getClaimStatus.mockResolvedValue({
             status: 'CLAIMED',
             events: [],
         })
@@ -188,14 +188,14 @@ describe('SUCCESS view — polled claim failure', () => {
 
 describe('SUCCESS view — before the poll resolves', () => {
     beforeEach(() => {
-        mockSendLinksApi.get.mockReset()
+        mockSendLinksApi.getClaimStatus.mockReset()
         mockSoundPlayed.mockReset()
         mockTriggerHaptic.mockReset()
     })
 
     test('a claim with no outcome yet shows processing — no success card, sound or haptic', async () => {
         // a poll that never settles: the optimistic 202 has landed, nothing else
-        mockSendLinksApi.get.mockReturnValue(new Promise(() => {}))
+        mockSendLinksApi.getClaimStatus.mockReturnValue(new Promise(() => {}))
 
         renderView()
 
@@ -206,17 +206,17 @@ describe('SUCCESS view — before the poll resolves', () => {
     })
 
     test('a poll that keeps erroring stays in processing rather than claiming success', async () => {
-        mockSendLinksApi.get.mockRejectedValue(new Error('network down'))
+        mockSendLinksApi.getClaimStatus.mockRejectedValue(new Error('network down'))
 
         renderView()
 
-        await waitFor(() => expect(mockSendLinksApi.get).toHaveBeenCalled())
+        await waitFor(() => expect(mockSendLinksApi.getClaimStatus).toHaveBeenCalled())
         expect(screen.getByTestId('peanut-loading')).toBeInTheDocument()
         expect(screen.queryByTestId('success-card')).not.toBeInTheDocument()
     })
 
     test('a synchronous claim arrives with its hash and renders success immediately', () => {
-        mockSendLinksApi.get.mockReturnValue(new Promise(() => {}))
+        mockSendLinksApi.getClaimStatus.mockReturnValue(new Promise(() => {}))
 
         renderView(jest.fn(), '0xabc')
 

--- a/src/services/__tests__/send-links-claim-status.test.ts
+++ b/src/services/__tests__/send-links-claim-status.test.ts
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import { sendLinksApi, CLAIM_STATUS_TIMEOUT_MS } from '@/services/sendLinks'
+import { serverFetch } from '@/utils/api-fetch'
+
+jest.mock('@/utils/api-fetch', () => ({ apiFetch: jest.fn(), serverFetch: jest.fn() }))
+
+const mockServerFetch = serverFetch as jest.MockedFunction<typeof serverFetch>
+const LINK = 'https://peanut.to/claim?c=42161&v=v4.3&i=7#p=secret'
+
+describe('sendLinksApi.getClaimStatus', () => {
+    beforeEach(() => mockServerFetch.mockReset())
+
+    test('uses the uncached status endpoint with a bounded transport budget', async () => {
+        mockServerFetch.mockResolvedValue({
+            ok: true,
+            text: async () => JSON.stringify({ status: 'CLAIMING' }),
+        } as Response)
+
+        await sendLinksApi.getClaimStatus(LINK)
+
+        expect(mockServerFetch).toHaveBeenCalledWith(
+            expect.stringMatching(/^\/send-links\/0x[0-9a-f]+\/status\?c=42161&v=v4\.3&i=7$/i),
+            {
+                method: 'GET',
+                cache: 'no-store',
+                timeoutMs: CLAIM_STATUS_TIMEOUT_MS,
+                silentTimeout: true,
+            }
+        )
+    })
+})

--- a/src/services/__tests__/send-links-claim-status.test.ts
+++ b/src/services/__tests__/send-links-claim-status.test.ts
@@ -28,4 +28,30 @@ describe('sendLinksApi.getClaimStatus', () => {
             }
         )
     })
+
+    test('falls back to the legacy endpoint when the status route is unavailable', async () => {
+        mockServerFetch.mockResolvedValueOnce({ ok: false, status: 404 } as Response).mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ status: 'SUCCESS' }),
+        } as Response)
+
+        await expect(sendLinksApi.getClaimStatus(LINK)).resolves.toMatchObject({ status: 'SUCCESS' })
+
+        expect(mockServerFetch).toHaveBeenNthCalledWith(
+            2,
+            expect.stringMatching(/^\/send-links\/0x[0-9a-f]+\?c=42161&v=v4\.3&i=7$/i),
+            {
+                method: 'GET',
+                cache: 'no-store',
+            }
+        )
+    })
+
+    test('does not hide non-rollout errors behind the legacy endpoint', async () => {
+        mockServerFetch.mockResolvedValue({ ok: false, status: 500 } as Response)
+
+        await expect(sendLinksApi.getClaimStatus(LINK)).rejects.toThrow('HTTP error! status: 500')
+        expect(mockServerFetch).toHaveBeenCalledTimes(1)
+    })
 })

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -179,6 +179,12 @@ export const sendLinksApi = {
                 silentTimeout: true,
             }
         )
+        // Keep UI and API releases independently deployable while the status
+        // route rolls out. The legacy endpoint is slower, but it is preferable
+        // to leaving a settled claim stuck in the processing state.
+        if (response.status === 404) {
+            return sendLinksApi.get(link)
+        }
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)
         }

--- a/src/services/sendLinks.ts
+++ b/src/services/sendLinks.ts
@@ -13,6 +13,10 @@ export type ClaimLinkData = SendLink & { link: string; password: string }
 const CLAIM_LINK_SLOT_PREFIX = 'claim-link-slot'
 // KYC review between opening a link and returning to claim can span days.
 const CLAIM_LINK_TTL_SECONDS = 7 * 24 * 60 * 60
+// Claim status must not wait behind the API's recent-create cache or a slow
+// replica/on-chain fallback. The fetch helper may retry a GET once, so the
+// caller-visible transport budget is still bounded to roughly two attempts.
+export const CLAIM_STATUS_TIMEOUT_MS = 5_000
 
 /**
  * Resolve the link used to fetch + claim a send link, hardened against the
@@ -154,6 +158,25 @@ export const sendLinksApi = {
             {
                 method: 'GET',
                 cache: 'no-store',
+            }
+        )
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        const data: SendLink = jsonParse(await response.text())
+        return data
+    },
+
+    getClaimStatus: async (link: string): Promise<SendLink> => {
+        const params = getParamsFromLink(link)
+        const pubKey = generateKeysFromString(params.password).address
+        const response = await serverFetch(
+            `/send-links/${pubKey}/status?c=${params.chainId}&v=${params.contractVersion}&i=${params.depositIdx}`,
+            {
+                method: 'GET',
+                cache: 'no-store',
+                timeoutMs: CLAIM_STATUS_TIMEOUT_MS,
+                silentTimeout: true,
             }
         )
         if (!response.ok) {

--- a/src/utils/__tests__/demo-api.test.ts
+++ b/src/utils/__tests__/demo-api.test.ts
@@ -95,6 +95,13 @@ describe('demoRespond — routing', () => {
         expect(res.status).toBe(404)
     })
 
+    it('returns a terminal claim status for the optimistic-claim poll', async () => {
+        const { res, data } = await body('/send-links/demo-pubkey/status?c=42161&v=v4.4&i=0')
+
+        expect(res.status).toBe(200)
+        expect(data).toMatchObject({ pubKey: 'demo-pubkey', status: 'CLAIMED' })
+    })
+
     it('returns a believable off-ramp success for POST /bridge/offramp/create', async () => {
         const { data } = await body('/bridge/offramp/create', { method: 'POST', body: '{}' })
         expect(data.transferId).toBeTruthy()

--- a/src/utils/demo-api.ts
+++ b/src/utils/demo-api.ts
@@ -474,6 +474,11 @@ const ROUTES: Array<{ method: string; pattern: string; handler: Handler }> = [
     { method: 'GET', pattern: '/send-links', handler: () => demoSendLink('demo-pubkey') },
     { method: 'POST', pattern: '/send-links', handler: () => demoSendLink('demo-pubkey') },
     { method: 'PATCH', pattern: '/send-links/claim/:txHash/associate-user', handler: () => ({}) },
+    {
+        method: 'GET',
+        pattern: '/send-links/:pubKey/status',
+        handler: ({ params }) => ({ ...demoSendLink(params.pubKey), status: 'CLAIMED' }),
+    },
     { method: 'GET', pattern: '/send-links/:pubKey', handler: ({ params }) => demoSendLink(params.pubKey) },
     { method: 'PATCH', pattern: '/send-links/:pubKey', handler: ({ params }) => demoSendLink(params.pubKey) },
 


### PR DESCRIPTION
## Summary

- Poll the dedicated authoritative claim-status endpoint after optimistic claims.
- Use no-store requests with a 5-second transport budget.
- Preserve existing claim settlement and polling cadence coverage.

## Verification

- Focused UI tests: 17 passed.
- Scoped ESLint: passed.
- Full typecheck remains blocked by existing generated and missing-asset issues outside this change.

Depends on [API PR #1577](https://github.com/peanutprotocol/peanut-api-ts/pull/1577).

No deployment or merge included.