### PR TITLE
fix(support): refresh unread badge on native push

### DIFF
--- a/src/components/Global/SupportDrawer/index.tsx
+++ b/src/components/Global/SupportDrawer/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/constants/crisp'
 import type { AppLocale } from '@/i18n/app/config'
 import { notificationsApi } from '@/services/notifications'
+import { notifyNotificationsUpdated } from '@/utils/notifications-events'
 import { isCapacitor } from '@/utils/capacitor'
 import { ensureNativeCrispConfigured, nativeCrispFields } from '@/utils/crisp'
 
@@ -137,7 +138,7 @@ const SupportDrawer = () => {
         if (!isLoggedIn) return
         notificationsApi
             .markAllRead('support')
-            .then(() => window.dispatchEvent(new CustomEvent('notifications:updated')))
+            .then(notifyNotificationsUpdated)
             // A failed mark-read only means the badge stays on a bit longer.
             .catch(() => {})
     }, [isLoggedIn])

--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -30,8 +30,15 @@ jest.mock('@/utils/capacitor', () => ({
     markInAppBrowserClosed: jest.fn(),
 }))
 
+const mockOnNotificationClick = jest.fn(() => () => {})
+const mockOnNotificationReceived = jest.fn((_listener: () => void) => () => {})
 jest.mock('@/services/onesignal', () => ({
-    getOneSignalAdapter: jest.fn(() => Promise.resolve({ onNotificationClick: jest.fn(() => () => {}) })),
+    getOneSignalAdapter: jest.fn(() =>
+        Promise.resolve({
+            onNotificationClick: mockOnNotificationClick,
+            onNotificationReceived: mockOnNotificationReceived,
+        })
+    ),
 }))
 
 let launchUrl: string | undefined
@@ -158,6 +165,38 @@ describe('hardware back button', () => {
 
         expect(back).not.toHaveBeenCalled()
         expect(App.minimizeApp).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('notification unread refresh', () => {
+    it('refreshes consumers when the native app resumes', async () => {
+        const onUpdated = jest.fn()
+        window.addEventListener('notifications:updated', onUpdated)
+        renderHook(() => useNativeAppLinks())
+
+        const addListener = App.addListener as jest.Mock
+        await waitFor(() => expect(addListener.mock.calls.some(([name]) => name === 'appStateChange')).toBe(true))
+        const onAppStateChange = addListener.mock.calls.find(([name]) => name === 'appStateChange')![1]
+
+        onAppStateChange({ isActive: false })
+        expect(onUpdated).not.toHaveBeenCalled()
+        onAppStateChange({ isActive: true })
+        expect(onUpdated).toHaveBeenCalledTimes(1)
+
+        window.removeEventListener('notifications:updated', onUpdated)
+    })
+
+    it('refreshes consumers when a push arrives while the app remains foregrounded', async () => {
+        const onUpdated = jest.fn()
+        window.addEventListener('notifications:updated', onUpdated)
+        renderHook(() => useNativeAppLinks())
+
+        await waitFor(() => expect(mockOnNotificationReceived).toHaveBeenCalled())
+        const onReceived = mockOnNotificationReceived.mock.calls[0][0]
+        onReceived()
+
+        expect(onUpdated).toHaveBeenCalledTimes(1)
+        window.removeEventListener('notifications:updated', onUpdated)
     })
 })
 

--- a/src/hooks/__tests__/useNativeAppLinks.test.tsx
+++ b/src/hooks/__tests__/useNativeAppLinks.test.tsx
@@ -32,9 +32,11 @@ jest.mock('@/utils/capacitor', () => ({
 
 const mockOnNotificationClick = jest.fn(() => () => {})
 const mockOnNotificationReceived = jest.fn((_listener: () => void) => () => {})
+const mockAdapterInit = jest.fn(() => Promise.resolve())
 jest.mock('@/services/onesignal', () => ({
     getOneSignalAdapter: jest.fn(() =>
         Promise.resolve({
+            init: mockAdapterInit,
             onNotificationClick: mockOnNotificationClick,
             onNotificationReceived: mockOnNotificationReceived,
         })
@@ -186,17 +188,33 @@ describe('notification unread refresh', () => {
         window.removeEventListener('notifications:updated', onUpdated)
     })
 
-    it('refreshes consumers when a push arrives while the app remains foregrounded', async () => {
+    it('refreshes consumers when a push arrives while the app remains foregrounded, then rechecks once', async () => {
         const onUpdated = jest.fn()
         window.addEventListener('notifications:updated', onUpdated)
         renderHook(() => useNativeAppLinks())
 
         await waitFor(() => expect(mockOnNotificationReceived).toHaveBeenCalled())
         const onReceived = mockOnNotificationReceived.mock.calls[0][0]
-        onReceived()
 
-        expect(onUpdated).toHaveBeenCalledTimes(1)
-        window.removeEventListener('notifications:updated', onUpdated)
+        jest.useFakeTimers()
+        try {
+            onReceived()
+            expect(onUpdated).toHaveBeenCalledTimes(1)
+
+            // The dispatcher writes the in-app unread row in parallel with the
+            // push send, so the immediate refresh can read zero. The bounded
+            // recheck is what closes that race — pin it.
+            jest.advanceTimersByTime(2_500)
+            expect(onUpdated).toHaveBeenCalledTimes(2)
+        } finally {
+            jest.useRealTimers()
+            window.removeEventListener('notifications:updated', onUpdated)
+        }
+    })
+
+    it('drives adapter init so delivery events fire in sessions that never mount useNotifications', async () => {
+        renderHook(() => useNativeAppLinks())
+        await waitFor(() => expect(mockAdapterInit).toHaveBeenCalledTimes(1))
     })
 })
 

--- a/src/hooks/__tests__/useNotifications.loginDedupe.test.ts
+++ b/src/hooks/__tests__/useNotifications.loginDedupe.test.ts
@@ -23,6 +23,7 @@ const mockAdapter = {
     onPermissionChange: jest.fn(() => () => {}),
     onSubscriptionChange: jest.fn((_listener: (change: PushSubscriptionChange) => void) => () => {}),
     onNotificationClick: jest.fn(() => () => {}),
+    onNotificationReceived: jest.fn(() => () => {}),
 }
 jest.mock('@/services/onesignal', () => ({
     getOneSignalAdapter: () => Promise.resolve(mockAdapter),

--- a/src/hooks/__tests__/useNotifications.subscription.test.ts
+++ b/src/hooks/__tests__/useNotifications.subscription.test.ts
@@ -18,6 +18,7 @@ const mockAdapter = {
     onPermissionChange: jest.fn(() => () => {}),
     onSubscriptionChange: jest.fn((_listener: (change: PushSubscriptionChange) => void) => () => {}),
     onNotificationClick: jest.fn(() => () => {}),
+    onNotificationReceived: jest.fn(() => () => {}),
 }
 jest.mock('@/services/onesignal', () => ({
     getOneSignalAdapter: () => Promise.resolve(mockAdapter),

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -22,6 +22,7 @@ const mockAdapter = {
     onPermissionChange: jest.fn(() => () => {}),
     onSubscriptionChange: jest.fn(() => () => {}),
     onNotificationClick: jest.fn(() => () => {}),
+    onNotificationReceived: jest.fn(() => () => {}),
 }
 jest.mock('@/services/onesignal', () => ({
     getOneSignalAdapter: () => Promise.resolve(mockAdapter),

--- a/src/hooks/__tests__/useSupportUnread.test.ts
+++ b/src/hooks/__tests__/useSupportUnread.test.ts
@@ -61,12 +61,35 @@ describe('useSupportUnread', () => {
         expect(result.current).toBe(false)
     })
 
+    it('coalesces a burst of triggers into one request', async () => {
+        renderHook(() => useSupportUnread())
+        await waitFor(() => expect(mockUnreadCount).toHaveBeenCalledTimes(1))
+
+        jest.useFakeTimers()
+        try {
+            // an iOS resume fires both the lifecycle event and visibilitychange
+            window.dispatchEvent(new CustomEvent('notifications:updated'))
+            document.dispatchEvent(new Event('visibilitychange'))
+            jest.advanceTimersByTime(1_000)
+            expect(mockUnreadCount).toHaveBeenCalledTimes(2)
+        } finally {
+            jest.useRealTimers()
+        }
+    })
+
     it('stops listening after unmount', async () => {
         const { unmount } = renderHook(() => useSupportUnread())
         await waitFor(() => expect(mockUnreadCount).toHaveBeenCalledTimes(1))
 
         unmount()
-        window.dispatchEvent(new CustomEvent('notifications:updated'))
-        expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+        jest.useFakeTimers()
+        try {
+            window.dispatchEvent(new CustomEvent('notifications:updated'))
+            // past the coalesce window — a leaked listener would fetch here
+            jest.advanceTimersByTime(1_000)
+            expect(mockUnreadCount).toHaveBeenCalledTimes(1)
+        } finally {
+            jest.useRealTimers()
+        }
     })
 })

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -166,9 +166,13 @@ export function useNativeAppLinks() {
                 // which Android WebViews don't reliably fire on app resume — a
                 // resumed app kept rendering its pre-background query data (stale
                 // home Activity). Drive the focusManager from the native lifecycle.
-                const stateListener = await App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) =>
+                const stateListener = await App.addListener('appStateChange', ({ isActive }: { isActive: boolean }) => {
                     focusManager.setFocused(isActive)
-                )
+                    // Android WebViews do not reliably emit visibilitychange on
+                    // resume. Refresh lightweight notification consumers (the
+                    // support unread badge) from the native lifecycle too.
+                    if (isActive) window.dispatchEvent(new CustomEvent('notifications:updated'))
+                })
                 track(() => {
                     stateListener.remove()
                     focusManager.setFocused(undefined)
@@ -269,6 +273,13 @@ export function useNativeAppLinks() {
                 // relative path the API sends; the launch URL is the fallback for
                 // notifications sent before that field existed.
                 const adapter = await getOneSignalAdapter()
+                // A push can arrive while the app stays foregrounded, so there
+                // may be no lifecycle or document-visibility edge to refresh the
+                // support badge. The unread endpoint remains the source of truth;
+                // this event only tells its consumers to recheck it.
+                track(
+                    adapter.onNotificationReceived(() => window.dispatchEvent(new CustomEvent('notifications:updated')))
+                )
                 track(
                     adapter.onNotificationClick(({ deepLink, additionalData }) => {
                         const target = additionalData.deepLink

--- a/src/hooks/useNativeAppLinks.ts
+++ b/src/hooks/useNativeAppLinks.ts
@@ -12,6 +12,8 @@ import { hasDeepLinkNavigated, markDeepLinkNavigated } from '@/utils/deep-link-s
 import { sanitizeRedirectURL } from '@/utils/cookie-url.utils'
 import { toInviteCode } from '@/utils/invite-code.utils'
 import { getOneSignalAdapter } from '@/services/onesignal'
+import { isDemoMode } from '@/utils/demo'
+import { notifyNotificationsUpdated, onForegroundPushDelivered } from '@/utils/notifications-events'
 import { dispatchBackPress } from '@/utils/back-handler'
 import { stashInvite } from '@/utils/invite-stash'
 import { EInviteType } from '@/services/services.types'
@@ -171,7 +173,7 @@ export function useNativeAppLinks() {
                     // Android WebViews do not reliably emit visibilitychange on
                     // resume. Refresh lightweight notification consumers (the
                     // support unread badge) from the native lifecycle too.
-                    if (isActive) window.dispatchEvent(new CustomEvent('notifications:updated'))
+                    if (isActive) notifyNotificationsUpdated()
                 })
                 track(() => {
                     stateListener.remove()
@@ -276,10 +278,9 @@ export function useNativeAppLinks() {
                 // A push can arrive while the app stays foregrounded, so there
                 // may be no lifecycle or document-visibility edge to refresh the
                 // support badge. The unread endpoint remains the source of truth;
-                // this event only tells its consumers to recheck it.
-                track(
-                    adapter.onNotificationReceived(() => window.dispatchEvent(new CustomEvent('notifications:updated')))
-                )
+                // the events only tell its consumers to recheck it (with a
+                // bounded delayed recheck — see onForegroundPushDelivered).
+                track(adapter.onNotificationReceived(onForegroundPushDelivered))
                 track(
                     adapter.onNotificationClick(({ deepLink, additionalData }) => {
                         const target = additionalData.deepLink
@@ -301,6 +302,17 @@ export function useNativeAppLinks() {
                         openDeepLink(link, 'push')
                     })
                 )
+                /*
+                 * foregroundWillDisplay only fires once init() attached the
+                 * underlying SDK listeners, and useNotifications drives init on
+                 * home surfaces only — a session deep-linked elsewhere would
+                 * never get the event. Drive init here too (idempotent, no
+                 * permission prompt); registrations above come first so the
+                 * cold-start click replay lands in a non-empty listener set.
+                 */
+                if (!isDemoMode()) {
+                    adapter.init().catch((e) => console.warn('onesignal init from app links failed:', e))
+                }
             } catch (e) {
                 console.warn('failed to init notification click listener:', e)
                 // launch URLs are suppressed in the SDKs, so without this listener a push tap does nothing

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -4,7 +4,9 @@ import { useEffect, useSyncExternalStore } from 'react'
 import { addBreadcrumb, captureException, captureMessage } from '@sentry/nextjs'
 import { getOneSignalAdapter, type NotificationPermissionState } from '@/services/onesignal'
 import { getUserPreferences, updateUserPreferences } from '@/utils/general.utils'
+import { isCapacitor } from '@/utils/capacitor'
 import { isDemoMode } from '@/utils/demo'
+import { onForegroundPushDelivered } from '@/utils/notifications-events'
 import { useAuth } from '@/context/authContext'
 import posthog from 'posthog-js'
 import { ANALYTICS_EVENTS, MODAL_TYPES } from '@/constants/analytics.consts'
@@ -214,6 +216,12 @@ async function ensureInitialized() {
     try {
         const adapter = await getOneSignalAdapter()
         await adapter.init()
+
+        // Web half of the foreground-push badge refresh. On native the bridge
+        // lives in useNativeAppLinks, which runs on every cold-start
+        // destination; on web nothing can fire before this init anyway, so
+        // registering here costs marketing pages no extra chunk.
+        if (!isCapacitor()) adapter.onNotificationReceived(onForegroundPushDelivered)
 
         adapter.onPermissionChange((permissionState) => {
             addBreadcrumb({ category: 'onesignal', message: 'permission change', data: { permissionState } })

--- a/src/hooks/useSupportUnread.ts
+++ b/src/hooks/useSupportUnread.ts
@@ -12,8 +12,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  * writes one in-app notification row per support reply, and this reads the
  * count for the `support` category.
  *
- * No polling. It refetches on mount, when the notifications list changes, and
- * when the tab or app comes back to the foreground.
+ * No polling. It refetches on mount, when the notifications list changes or a
+ * foreground push arrives, and when the tab or native app comes back to the
+ * foreground.
  */
 export const useSupportUnread = (): boolean => {
     const [hasUnread, setHasUnread] = useState(false)

--- a/src/hooks/useSupportUnread.ts
+++ b/src/hooks/useSupportUnread.ts
@@ -1,7 +1,17 @@
 'use client'
 
 import { notificationsApi } from '@/services/notifications'
+import { NOTIFICATIONS_UPDATED_EVENT } from '@/utils/notifications-events'
 import { useCallback, useEffect, useRef, useState } from 'react'
+
+/*
+ * One trigger can arrive several times within a moment: an iOS resume fires
+ * both `visibilitychange` and the native lifecycle event, and a burst of
+ * foreground pushes fires one event each. Coalesce event-driven refetches on
+ * the trailing edge so each burst costs one request. The mount fetch stays
+ * immediate so the badge is right on first paint.
+ */
+const REFRESH_COALESCE_MS = 250
 
 /**
  * True when support has replied since the user last opened the chat.
@@ -12,9 +22,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
  * writes one in-app notification row per support reply, and this reads the
  * count for the `support` category.
  *
- * No polling. It refetches on mount, when the notifications list changes or a
- * foreground push arrives, and when the tab or native app comes back to the
- * foreground.
+ * No polling. It refetches on mount; after that, refetches are event-driven —
+ * the notifications list changed, the tab or native app came back to the
+ * foreground, or a foreground push arrived (dispatched wherever OneSignal is
+ * wired: useNativeAppLinks on native, useNotifications on web).
  */
 export const useSupportUnread = (): boolean => {
     const [hasUnread, setHasUnread] = useState(false)
@@ -39,20 +50,27 @@ export const useSupportUnread = (): boolean => {
             .catch(() => {})
     }, [])
 
+    const coalesceTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+    const scheduleRefresh = useCallback(() => {
+        clearTimeout(coalesceTimer.current)
+        coalesceTimer.current = setTimeout(refresh, REFRESH_COALESCE_MS)
+    }, [refresh])
+
     useEffect(() => {
         refresh()
 
         const onVisibilityChange = () => {
-            if (document.visibilityState === 'visible') refresh()
+            if (document.visibilityState === 'visible') scheduleRefresh()
         }
 
-        window.addEventListener('notifications:updated', refresh)
+        window.addEventListener(NOTIFICATIONS_UPDATED_EVENT, scheduleRefresh)
         document.addEventListener('visibilitychange', onVisibilityChange)
         return () => {
-            window.removeEventListener('notifications:updated', refresh)
+            clearTimeout(coalesceTimer.current)
+            window.removeEventListener(NOTIFICATIONS_UPDATED_EVENT, scheduleRefresh)
             document.removeEventListener('visibilitychange', onVisibilityChange)
         }
-    }, [refresh])
+    }, [refresh, scheduleRefresh])
 
     return hasUnread
 }

--- a/src/services/onesignal/native.adapter.test.ts
+++ b/src/services/onesignal/native.adapter.test.ts
@@ -101,4 +101,24 @@ describe('nativeOneSignalAdapter cold-start click buffering', () => {
         getForegroundNotificationCallback()()
         expect(listener).toHaveBeenCalledTimes(1)
     })
+
+    // The plugin preventDefault()s the banner natively and re-displays it only
+    // after the JS listeners return — an escaping throw would suppress the
+    // banner and starve the listeners after it.
+    it('contains a throwing listener so delivery completes and later listeners run', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        const throwing = jest.fn(() => {
+            throw new Error('boom')
+        })
+        const after = jest.fn()
+        const offThrowing = nativeOneSignalAdapter.onNotificationReceived(throwing)
+        const offAfter = nativeOneSignalAdapter.onNotificationReceived(after)
+
+        expect(() => getForegroundNotificationCallback()()).not.toThrow()
+        expect(after).toHaveBeenCalledTimes(1)
+
+        offThrowing()
+        offAfter()
+        warn.mockRestore()
+    })
 })

--- a/src/services/onesignal/native.adapter.test.ts
+++ b/src/services/onesignal/native.adapter.test.ts
@@ -40,6 +40,14 @@ function getClickCallback(): (event: unknown) => void {
     return call![1]
 }
 
+function getForegroundNotificationCallback(): () => void {
+    const call = (OneSignal.Notifications.addEventListener as jest.Mock).mock.calls.find(
+        ([name]) => name === 'foregroundWillDisplay'
+    )
+    expect(call).toBeDefined()
+    return call![1]
+}
+
 describe('nativeOneSignalAdapter cold-start click buffering', () => {
     beforeAll(async () => {
         process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID = 'test-app-id'
@@ -80,5 +88,17 @@ describe('nativeOneSignalAdapter cold-start click buffering', () => {
 
         off()
         offLater()
+    })
+
+    it('fans foreground notification delivery out to registered listeners', () => {
+        const listener = jest.fn()
+        const off = nativeOneSignalAdapter.onNotificationReceived(listener)
+
+        getForegroundNotificationCallback()()
+        expect(listener).toHaveBeenCalledTimes(1)
+
+        off()
+        getForegroundNotificationCallback()()
+        expect(listener).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -22,6 +22,7 @@ let initPromise: Promise<void> | null = null
 
 const permissionListeners = new Set<(state: NotificationPermissionState) => void>()
 const subscriptionListeners = new Set<(change: PushSubscriptionChange) => void>()
+const notificationReceivedListeners = new Set<() => void>()
 const clickListeners = new Set<(info: NotificationClickInfo) => void>()
 /**
  * Cold-start tap buffer. Capacitor retains the click event only until the first
@@ -97,6 +98,10 @@ function attachUnderlyingListeners() {
         subscriptionListeners.forEach((cb) => cb(change))
     })
 
+    OneSignal.Notifications.addEventListener('foregroundWillDisplay', () => {
+        notificationReceivedListeners.forEach((cb) => cb())
+    })
+
     OneSignal.Notifications.addEventListener('click', (event: NotificationClickEvent) => {
         const info: NotificationClickInfo = {
             deepLink: event?.result?.url ?? event?.notification?.launchURL,
@@ -165,6 +170,11 @@ export const nativeOneSignalAdapter: OneSignalAdapter = {
     onSubscriptionChange(listener) {
         subscriptionListeners.add(listener)
         return () => subscriptionListeners.delete(listener)
+    },
+
+    onNotificationReceived(listener) {
+        notificationReceivedListeners.add(listener)
+        return () => notificationReceivedListeners.delete(listener)
     },
 
     onNotificationClick(listener) {

--- a/src/services/onesignal/native.adapter.ts
+++ b/src/services/onesignal/native.adapter.ts
@@ -98,8 +98,22 @@ function attachUnderlyingListeners() {
         subscriptionListeners.forEach((cb) => cb(change))
     })
 
+    /*
+     * Attaching ANY foregroundWillDisplay listener changes plugin behavior:
+     * @onesignal/capacitor-plugin (1.0.6) then calls preventDefault() natively
+     * and re-displays the banner only after the JS listeners return, with no
+     * timeout fallback. Accepted for the badge refresh — but a listener that
+     * throws would suppress the banner entirely, so each callback is guarded
+     * and must stay synchronous and cheap.
+     */
     OneSignal.Notifications.addEventListener('foregroundWillDisplay', () => {
-        notificationReceivedListeners.forEach((cb) => cb())
+        notificationReceivedListeners.forEach((cb) => {
+            try {
+                cb()
+            } catch (e) {
+                console.warn('notification received listener failed:', e)
+            }
+        })
     })
 
     OneSignal.Notifications.addEventListener('click', (event: NotificationClickEvent) => {

--- a/src/services/onesignal/types.ts
+++ b/src/services/onesignal/types.ts
@@ -33,5 +33,7 @@ export interface OneSignalAdapter {
     isOptedIn(): Promise<boolean>
     onPermissionChange(listener: (state: NotificationPermissionState) => void): () => void
     onSubscriptionChange(listener: (change: PushSubscriptionChange) => void): () => void
+    /** Fires when a push reaches an already-foregrounded app/tab. */
+    onNotificationReceived(listener: () => void): () => void
     onNotificationClick(listener: (info: NotificationClickInfo) => void): () => void
 }

--- a/src/services/onesignal/web.adapter.ts
+++ b/src/services/onesignal/web.adapter.ts
@@ -42,7 +42,14 @@ function attachUnderlyingListeners() {
     })
 
     OneSignal.Notifications.addEventListener('foregroundWillDisplay', () => {
-        notificationReceivedListeners.forEach((cb) => cb())
+        notificationReceivedListeners.forEach((cb) => {
+            // a throwing listener must not starve the ones after it
+            try {
+                cb()
+            } catch (e) {
+                console.warn('notification received listener failed:', e)
+            }
+        })
     })
 
     OneSignal.Notifications.addEventListener('click', (event) => {

--- a/src/services/onesignal/web.adapter.ts
+++ b/src/services/onesignal/web.adapter.ts
@@ -16,6 +16,7 @@ let initPromise: Promise<void> | null = null
 
 const permissionListeners = new Set<(state: NotificationPermissionState) => void>()
 const subscriptionListeners = new Set<(change: PushSubscriptionChange) => void>()
+const notificationReceivedListeners = new Set<() => void>()
 const clickListeners = new Set<(info: NotificationClickInfo) => void>()
 let underlyingListenersAttached = false
 
@@ -38,6 +39,10 @@ function attachUnderlyingListeners() {
             previousOptedIn: !!event.previous?.optedIn,
         }
         subscriptionListeners.forEach((cb) => cb(change))
+    })
+
+    OneSignal.Notifications.addEventListener('foregroundWillDisplay', () => {
+        notificationReceivedListeners.forEach((cb) => cb())
     })
 
     OneSignal.Notifications.addEventListener('click', (event) => {
@@ -138,6 +143,11 @@ export const webOneSignalAdapter: OneSignalAdapter = {
     onSubscriptionChange(listener) {
         subscriptionListeners.add(listener)
         return () => subscriptionListeners.delete(listener)
+    },
+
+    onNotificationReceived(listener) {
+        notificationReceivedListeners.add(listener)
+        return () => notificationReceivedListeners.delete(listener)
     },
 
     onNotificationClick(listener) {

--- a/src/utils/notifications-events.ts
+++ b/src/utils/notifications-events.ts
@@ -1,0 +1,29 @@
+/**
+ * The one event that tells notification consumers (the support unread badge)
+ * to re-read server state. Server truth stays with the unread endpoint —
+ * dispatching only says "recheck now". Every dispatch site goes through these
+ * helpers so the sites can never disagree on the event name.
+ */
+export const NOTIFICATIONS_UPDATED_EVENT = 'notifications:updated'
+
+export function notifyNotificationsUpdated() {
+    window.dispatchEvent(new CustomEvent(NOTIFICATIONS_UPDATED_EVENT))
+}
+
+/**
+ * The backend dispatcher writes the in-app unread row in parallel with the
+ * push send (peanut-api-ts src/notifications/dispatcher.ts), so a push that
+ * reaches an already-foregrounded app can trigger the recheck before the row
+ * commits — the badge would read zero and, with no later lifecycle edge, stay
+ * off. One more recheck after a grace period closes that race.
+ */
+const UNREAD_ROW_COMMIT_GRACE_MS = 2_500
+
+let pendingRecheck: ReturnType<typeof setTimeout> | undefined
+
+/** Refresh consumers for a push delivered to an already-foregrounded app/tab. */
+export function onForegroundPushDelivered() {
+    notifyNotificationsUpdated()
+    clearTimeout(pendingRecheck)
+    pendingRecheck = setTimeout(notifyNotificationsUpdated, UNREAD_ROW_COMMIT_GRACE_MS)
+}


### PR DESCRIPTION
## Summary

- refresh the existing support-unread badge when a push arrives while the native app is already foregrounded
- refresh notification consumers when a native app resumes, without relying on WebView `visibilitychange`
- keep the backend unread count as the source of truth; this adds event triggers, not client-side guessing or polling
- cover both native lifecycle and foreground-push paths with regression tests

## Regression postmortem

**Impact:** A support reply could produce the expected OS push notification while the pink unread indicator remained absent in the running app. Fully reopening the app caused the indicator to appear because the badge hook re-fetched on mount.

**What regressed:** The original badge implementation listened to browser `visibilitychange`. That worked in the PWA/browser environment, but Android WebViews do not reliably emit that event when the native app resumes. Separately, our OneSignal adapter exposed notification clicks but not foreground delivery, so a push received while the app stayed open produced no refresh signal at all.

**Why the navigation redesign was not the cause:** The unread hook, server-backed `support` count, pink `IndicatorDot`, and Support-tab rendering all survived the BottomNav migration. The missing link was between native notification/lifecycle events and the hook's existing `notifications:updated` refresh event.

**Why tests missed it:** Coverage proved that `useSupportUnread` responds to `notifications:updated`, and that OneSignal click events route correctly, but no test connected native resume or foreground push delivery to that event.

**Fix and prevention:** Both OneSignal adapters now expose foreground delivery. Native app wiring emits `notifications:updated` on foreground delivery and on active resume. Regression tests pin both paths, while the existing unread-count request still decides whether the support dot is actually shown.

## Verification

- 37 focused Jest tests passed across support unread, native app links, OneSignal adapter, and notification hooks
- changed-file ESLint passed
- Prettier and `git diff --check` passed
- full local typecheck reached pre-existing missing static-asset module errors in this worktree; no changed-file type error remained

Requested by @Hugo0 — https://discord.com/channels/972435984954302464/1547180308707676241/1547180650149183519

