### PR TITLE
chore: back-merge dev → main (ships production OTA 1.6.3)

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -67,6 +67,27 @@ jobs:
               with:
                   node-version: '22'
 
+            # `native` returns latestBuild + 1 — a number, derived from the tags,
+            # with no opinion on whether this commit contains the build it is
+            # numbering itself after. Cut from a ref that lags the newest release
+            # and the store gets a HIGHER version carrying OLDER code, which only
+            # another store release can undo. The OTA lane makes the same check
+            # for the same reason (see release-ota.yml).
+            - name: Guard release provenance
+              run: |
+                  # native-floor has no answer for the first release of a new major
+                  # (`native` starts it at <major>.1.0), and there is no earlier
+                  # build for this commit to contain.
+                  if ! FLOOR="$(node scripts/release-version.mjs native-floor 2>/dev/null)"; then
+                      echo "no previous native release for this major — nothing to contain"
+                      exit 0
+                  fi
+                  if ! git merge-base --is-ancestor "v$FLOOR" HEAD; then
+                      echo "::error::$GITHUB_REF_NAME (${GITHUB_SHA:0:7}) does not contain the newest native release v$FLOOR — a build from it would ship a higher version than v$FLOOR carrying older code. Back-merge the release into this ref first." >&2
+                      exit 1
+                  fi
+                  echo "${GITHUB_SHA:0:7} contains v$FLOOR"
+
             - name: Resolve next build version
               id: resolve
               run: |

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -59,6 +59,27 @@ jobs:
                   node-version: '22'
                   cache: 'pnpm'
 
+            # The resolver below compares NUMBERS only: it lands the next OTA inside
+            # the newest native build's range, which by construction sorts above the
+            # binary — whether or not the commit being published actually contains
+            # that release. Nothing here asked, and on 2026-09-10 a production bundle
+            # shipped from a commit predating the v1.6.0 release, handing every
+            # device on the new binary JS older than the one baked into it.
+            #
+            # check-native-ota-surface asserts the same ancestry, but only as a
+            # precondition of its fingerprint diff, in the deploy job, after a full
+            # install and native build — and a stale ref whose native surface happens
+            # to match would still read as "matches". Say it here, in seconds, and say
+            # what the consequence is.
+            - name: Guard release provenance
+              run: |
+                  FLOOR="$(node scripts/release-version.mjs native-floor)"
+                  if ! git merge-base --is-ancestor "v$FLOOR" HEAD; then
+                      echo "::error::$GITHUB_REF_NAME (${GITHUB_SHA:0:7}) does not contain the newest native release v$FLOOR — publishing it would hand every device on that binary JS older than the one it shipped with. Back-merge the release into this ref first." >&2
+                      exit 1
+                  fi
+                  echo "${GITHUB_SHA:0:7} contains v$FLOOR"
+
             # The Capgo CLI reads `capacitor.config.ts` to resolve the appId on
             # every command, and parsing a .ts config needs the project's own
             # TypeScript. Without it the CLI aborts at config load and prints the

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,8 +37,6 @@
 
                 <data android:scheme="https" android:host="peanut.me" />
 
-                <data android:path="/app" />
-                <data android:pathPrefix="/app/" />
                 <data android:path="/home" />
                 <data android:pathPrefix="/home/" />
                 <data android:path="/card" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,8 @@
 
                 <data android:scheme="https" android:host="peanut.me" />
 
+                <data android:path="/app" />
+                <data android:pathPrefix="/app/" />
                 <data android:path="/home" />
                 <data android:pathPrefix="/home/" />
                 <data android:path="/card" />

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -197,6 +197,18 @@ and it is fine for it to lag behind what ships.
 
 ### Cutting a release
 
+> **Owed to the next native release: the `/app` App Links paths.**
+> `d91ea7cee` ("keep one download action across app entry points") added
+> `<data android:path="/app" />` and `<data android:pathPrefix="/app/" />` to
+> `android/app/src/main/AndroidManifest.xml`. They were reverted on `dev` so the
+> stuck production OTA could ship — an intent filter cannot reach a device over the
+> air, so those lines were inert on every shipped binary while blocking every
+> bundle behind the native-surface check. `public/.well-known/apple-app-site-association`
+> still claims `/app` and `native-routes.ts` still maps `/app/*` → `/app`, so iOS is
+> unaffected and only Android `/app` deep links are missing. **Restore the two lines
+> in the same PR that cuts the next native release.** Do not restore them on their
+> own: on `dev` alone they block OTA again for no user-visible gain.
+
 All three manual workflows accept `dev`, `main`, and `release/android-kyc`.
 Select the source branch before dispatch. A supported branch name does not prove
 that its current commit is ready to ship.

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -197,18 +197,6 @@ and it is fine for it to lag behind what ships.
 
 ### Cutting a release
 
-> **Owed to the next native release: the `/app` App Links paths.**
-> `d91ea7cee` ("keep one download action across app entry points") added
-> `<data android:path="/app" />` and `<data android:pathPrefix="/app/" />` to
-> `android/app/src/main/AndroidManifest.xml`. They were reverted on `dev` so the
-> stuck production OTA could ship — an intent filter cannot reach a device over the
-> air, so those lines were inert on every shipped binary while blocking every
-> bundle behind the native-surface check. `public/.well-known/apple-app-site-association`
-> still claims `/app` and `native-routes.ts` still maps `/app/*` → `/app`, so iOS is
-> unaffected and only Android `/app` deep links are missing. **Restore the two lines
-> in the same PR that cuts the next native release.** Do not restore them on their
-> own: on `dev` alone they block OTA again for no user-visible gain.
-
 All three manual workflows accept `dev`, `main`, and `release/android-kyc`.
 Select the source branch before dispatch. A supported branch name does not prove
 that its current commit is ready to ship.

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -382,6 +382,39 @@ production channel and refuses other refs.
 Staging is published separately and manually through **App Staging OTA**; there is no
 automatic staging publish or `ota-*` break-glass workflow.
 
+### Provenance: the ref must contain the newest native release
+
+Both release workflows assert that the dispatched commit contains the newest
+`v<major>.<build>.0` tag, before anything is built. Neither resolver can tell on its own:
+`ota` lands the next bundle inside the newest native build's range and `native` returns
+`latestBuild + 1`, so **both produce a number that outranks the binary whether or not the
+commit contains it**. A bundle numbered above the binary is accepted by every device, and
+an OTA carrying pre-release code is therefore a silent downgrade of the JS the binary
+shipped with; a store build in that state is worse, since only another store release
+undoes it.
+
+This is not hypothetical. On **2026-09-10** production bundle `1.6.1` was published from
+`ff3489650` — the tip of `main`, which did not yet contain the `v1.6.0` release cut from
+`dev` the day before. Every install on the 1.6.0 binary took it and ran JS older than its
+own. Two things had to line up:
+
+- **`main` lagged `dev`**, so the code was old. The routine fix is a back-merge (§ release
+  flow); the guard now names it as the remedy instead of leaving the operator to work it
+  out from a fingerprint diff.
+- **The bundle shipped through a tag push at that old commit.** A `push`-triggered workflow
+  runs the workflow file **as it existed at the pushed ref**, so `ota-1.6.1` ran the
+  long-retired `capgo-deploy.yml` still present at `ff3489650` — with no floor check, no
+  surface check and `--auto-min-update-version`. Retiring a workflow on `dev`/`main` does
+  **not** retire it at older commits, and the same trap applies to the `v*` prefix. Treat
+  every `ota-*` / `v*` tag push as running last month's pipeline, and ship through the
+  dispatch workflows instead.
+
+`check-native-ota-surface.mjs` already asserted the same ancestry, but only as a
+precondition of its fingerprint diff — in the deploy job, after a full install and native
+build, and reported as `v1.6.0 is not an ancestor of HEAD`. The explicit guard fails in
+seconds and says what the consequence would have been. A stale ref whose native surface
+happened to match would have passed the fingerprint diff entirely.
+
 One deliberate exception to "opt-in per release": a **native release auto-publishes a
 matching production bundle** when its versionName is ahead of the newest production
 bundle. Capgo refuses on-device any bundle sorting below the installed native version

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -197,6 +197,22 @@ and it is fine for it to lag behind what ships.
 
 ### Cutting a release
 
+> **Owed to the next native release: the `/app` App Links claim.**
+> `d91ea7cee` added `/app` + `/app/*` to `public/.well-known/apple-app-site-association`
+> and `/app` + `/app/` to `android/app/src/main/AndroidManifest.xml`. `v1.6.0` predates
+> that commit, so no shipped binary or AASA ever carried the claim — but the manifest half
+> moved the native fingerprint, and `check-native-ota-surface` compares that fingerprint
+> against the binary an OTA targets. The two lines therefore blocked every production
+> bundle while delivering nothing, with the fleet stuck on JS older than its own binary.
+> Both platforms were reverted together so the iOS↔Android parity case in
+> `src/utils/__tests__/app-links.test.ts` stays enforced; only the two `/app`-presence
+> cases are `it.skip`.
+>
+> **Restore all three in the PR that cuts the next native release** — the AASA entries, the
+> manifest entries, and the two skipped cases. Never restore them on `dev` alone: an intent
+> filter cannot ship over the air, so on their own they block OTA again for no user-visible
+> gain. `native-routes.ts` still maps `/app/*` → `/app`, so nothing else needs touching.
+
 All three manual workflows accept `dev`, `main`, and `release/android-kyc`.
 Select the source branch before dispatch. A supported branch name does not prove
 that its current commit is ready to ship.

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,7 +5,6 @@
             {
                 "appID": "4K73GMPZP8.com.squirrellabs.peanut-app",
                 "paths": [
-                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",
@@ -27,7 +26,6 @@
             {
                 "appID": "web.app.peanut",
                 "paths": [
-                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",
@@ -49,7 +47,6 @@
             {
                 "appID": "PW388G893L.me.peanut.wallet",
                 "paths": [
-                    "/app", "/app/*",
                     "/home", "/home/*",
                     "/card", "/card/*",
                     "/claim", "/claim/*",

--- a/src/utils/__tests__/app-links.test.ts
+++ b/src/utils/__tests__/app-links.test.ts
@@ -23,7 +23,23 @@ const androidPaths = [...manifest.matchAll(/android:path="([^"]+)"/g)].map((m) =
 const androidPrefixes = [...manifest.matchAll(/android:pathPrefix="([^"]+)"/g)].map((m) => m[1])
 
 describe('App Links', () => {
-    it('claims /app and /app/* for every iOS appID', () => {
+    /*
+     * SKIPPED, NOT ABANDONED — restore both with the next native release.
+     *
+     * The `/app` claim never reached a binary: v1.6.0 predates d91ea7cee, so its
+     * manifest and AASA carry no `/app` at all, and an intent filter cannot be
+     * shipped over the air. What the two lines did reach was
+     * check-native-ota-surface, which compares this tree's native fingerprint
+     * against the binary an OTA targets — so they blocked every bundle while
+     * delivering nothing, with production stuck on JS older than the binary
+     * running it.
+     *
+     * Both platforms were reverted together, deliberately: dropping only the
+     * Android half would manufacture exactly the drift the parity case below
+     * exists to catch, and that case stays live. Restoring these two is part of
+     * cutting the next native release — see docs/NATIVE-RELEASE.md.
+     */
+    it.skip('claims /app and /app/* for every iOS appID', () => {
         expect(details.length).toBeGreaterThan(0)
         for (const detail of details) {
             expect(detail.paths).toContain('/app')
@@ -31,7 +47,7 @@ describe('App Links', () => {
         }
     })
 
-    it('claims /app on Android with the same exact-plus-prefix shape', () => {
+    it.skip('claims /app on Android with the same exact-plus-prefix shape', () => {
         expect(androidPaths).toContain('/app')
         expect(androidPrefixes).toContain('/app/')
     })


### PR DESCRIPTION
Back-merge `dev` → `main`. **Merging this ships production OTA `1.6.3`** — that is the point of it, not a side effect.

## Why this is the ship

`main` is behind `dev` and is missing both halves of what unblocks the OTA:

| on `main` today | after this merge |
| --- | --- |
| `/app` App Links claim still present → **surface check fails** | reverted → fingerprint matches `v1.6.0` |
| `release-ota.yml` is dispatch-only | runs on every push to `main`, `main` only |
| no provenance guard | refuses a ref that lags the newest native release |
| no per-platform floors | floors resolved and written into the bundle |

Once the trigger change is on `main`, **the merge commit itself fires App Release OTA**, which resolves `1.6.3` off the channel (`1.6.2`) and publishes it. No dispatch needed.

## Every gate dry-run against this tree

```
floors            → android 1.6.0, ios 1.5.0   (channel floor 1.5.0)
capabilities      → v1.6.0: provisioning compiled on Android and iOS
native surface    → matches original v1.6.0 (48586271a56340ed)
provenance guard  → HEAD contains v1.6.0
version resolver  → 1.6.3
tag ota-1.6.3     → clear, no collision
```

The surface check is the step that failed the 18:18 and 20:52 runs. It passes here.

## Order of operations

1. Merge **#3111** into `dev` (per-platform floors + the `main`-only trigger). This PR picks it up automatically.
2. Merge this PR.
3. App Release OTA fires on the merge commit and ships `1.6.3`. Watch the run.

Merging this *before* #3111 lands still works — `main` would get the `/app` revert and the provenance guard, and `1.6.3` could be shipped by a manual dispatch on `main`. It just would not be automatic.

## What `1.6.3` fixes for whom

- **Devices still on bundle `1.6.1`** (no gate in their JS) take `1.6.3` freely and land on the candidate-floor logic. Healthy from then on.
- **Android on the `1.6.0` binary** running `1.6.2`: `build 6 > 6` is false, so they were never blocked. They take `1.6.3` and stay correct.
- **Any binary older than `1.6.0` already running `1.6.2`** cannot be reached over the air — proven, not assumed: Capgo only offers a bundle sorting above `1.6.2`, which forces `build ≥ 6`, and that bundle's own gate refuses it against a `build 5` binary. Android sees the store prompt and can self-rescue if a `≥1.6.0` build is in its Play track; iOS has no prompt (listing not live) and needs a TestFlight build.

Shipping this promptly is what stops that last group growing — every device that adopts `1.6.2` before `1.6.3` is published becomes unreachable.
