### PR TITLE
fix(ios): stop hiding the store-update prompt behind a stale listing gate

### DIFF
--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -24,8 +24,6 @@ import { AVATAR_PICKER_PARAM, avatarPickerParser } from '@/components/Avatar/ava
 import { useOtaUpdate } from '@/context/OtaUpdateContext'
 import OtaUpdateModal from './components/OtaUpdateModal'
 import StoreUpdateModal from './components/StoreUpdateModal'
-import { IOS_APP_STORE_LISTING_LIVE } from '@/constants/migration.consts'
-import { isIOSNative } from '@/utils/capacitor'
 
 export const Profile = () => {
     const { logoutUser, isLoggingOut, user } = useAuth()
@@ -45,7 +43,6 @@ export const Profile = () => {
     const { pendingBundle, storeUpdateRequired } = useOtaUpdate()
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false)
     const [isStoreUpdateModalOpen, setIsStoreUpdateModalOpen] = useState(false)
-    const storeUpdateOffered = storeUpdateRequired && (!isIOSNative() || IOS_APP_STORE_LISTING_LIVE)
     // A staged OTA bundle wins over the store hint: it is already on the device,
     // and the gate only ever stages one this binary can run. Store updates get
     // their own modal — offering a restart for one would reload the same JS.
@@ -152,7 +149,7 @@ export const Profile = () => {
                             the path and opens the in-app browser in Capacitor */}
                         <ProfileMenuItem icon="question-mark" label={t('menu.help')} href="/en/help" isDocsLink />
                         <ProfileMenuItem icon="info" label={t('menu.about')} href="/profile/about" />
-                        {(pendingBundle || storeUpdateOffered) && (
+                        {(pendingBundle || storeUpdateRequired) && (
                             <ProfileMenuItem
                                 icon="download"
                                 label={t('menu.updateAvailable')}

--- a/src/constants/migration.consts.ts
+++ b/src/constants/migration.consts.ts
@@ -50,10 +50,6 @@ export const STORE_URL = {
     android: 'https://play.google.com/store/apps/details?id=me.peanut.wallet',
 } as const
 
-// The iOS listing (App Store Connect app 6786373552) is not published yet:
-// the store URL 404s, so store-update prompts stay hidden on iOS until then.
-export const IOS_APP_STORE_LISTING_LIVE = false
-
 export const STORE_NAME = {
     ios: 'App Store',
     android: 'Google Play',


### PR DESCRIPTION
Every iOS install has been silently denied the update row and the store prompt by a constant that went stale.

## What happened

`IOS_APP_STORE_LISTING_LIVE` was added on 2026-09-02 (`e75d9eed9`, *"iOS store prompt gated"*) with this comment:

> The iOS listing (App Store Connect app 6786373552) is not published yet: the store URL 404s, so store-update prompts stay hidden on iOS until then.

"Until then" arrived and nobody flipped it:

```
$ curl -sL https://apps.apple.com/us/app/id6786373552 | grep '<title>'
<title>‎Peanut: Send Money & Card App - App Store</title>   ← HTTP 200
```

Meanwhile, on both `dev` and `main`:

```
export const IOS_APP_STORE_LISTING_LIVE = false
```

Which fed straight into the only thing that decides whether iOS sees an update at all:

```ts
const storeUpdateOffered = storeUpdateRequired && (!isIOSNative() || IOS_APP_STORE_LISTING_LIVE)
```

`false` there means **no row, no modal, nothing** — the invisible failure mode, and it was one boolean rather than anything inherent.

## Removed, not flipped

A `true` boolean named `LISTING_LIVE` tells the next reader nothing except that someone once expected it to be false. The row condition now reads as what it means: an update only the store can deliver is offered on both platforms. Two call sites, no tests referenced it, no docs mentioned it.

## What this does and does not fix

**Does:** an iOS binary older than the published App Store build now gets the prompt instead of silence, and can act on it.

**Does not** rescue installs already stuck behind a store update, for two independent reasons:

1. **The published App Store build is 1.5.0.** An iOS `1.5.0` binary is offered nothing newer, so the prompt would be a dead end for exactly that cohort.
2. **A device running a bundle built before this change carries the old gate.** Nothing shipped now reaches them anyway.

I want to be explicit because I got this wrong an hour ago and said flipping it would cancel the need for a new iOS build: **it does not.** Recovering the stuck iOS cohort still needs a newer iOS build in TestFlight or the App Store. This change is about the population that *can* act.

## The gap it leaves

Nothing checks the store's actual version, so the prompt can point at a store with nothing newer — inherent to a client-side prompt, and true on Android too.

The cheap, honest improvement is available from work already in flight: #3111 computes the **per-platform floor** of the bundle being withheld, which *is* the version the user needs. The modal could name it — "Update to 1.7.0 in the App Store" rather than a vague "an update is needed" — which stays truthful even when the store hasn't caught up. That needs the floor plumbed through `OtaUpdateContext`, so it belongs with #3111 rather than here.

For a real store-version check there's the iTunes Lookup API on iOS (`itunes.apple.com/lookup?id=…` returns `version`) and no official equivalent for Play. That's a third-party call from the app with CSP and privacy implications — worth a decision, not worth smuggling into a one-line PR.

## Verification

123 tests pass across the Profile suites and `migration.utils`; `tsc --noEmit` clean; `prettier --check` clean.
