### PR TITLE
fix: preserve manual dev OTA releases with platform-safe delivery

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -195,22 +195,19 @@ jobs:
             - name: Check production OTA floor
               id: ota_floor
               env:
+                  CAPGO_APP_ID: me.peanut.wallet
+                  PLATFORM: android
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   VERSION_NAME: ${{ steps.version.outputs.name }}
                   IS_REBUILD: ${{ steps.version.outputs.rebuild }}
               run: |
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
-                  if [ -z "$CURRENT" ]; then
-                      echo "::error::cannot read the production channel's current bundle from Capgo — refusing to ship a binary that may strand the fleet's OTA path" >&2
-                      exit 1
+                  CURRENT="$(node scripts/capgo-release-guard.mjs current-version)"
+                  if [ "$CURRENT" = builtin ]; then
+                    echo "needs_ota=true" >> "$GITHUB_OUTPUT"
+                    exit 0
                   fi
-                  # Fail closed on an anomalous read. CURRENT is scraped from a CLI
-                  # whose stdout format is not contractual, so a stray version-like
-                  # token that sorts ABOVE a new release would make needs_ota false,
-                  # silently skip the matching publish, and recreate TASK-21793 with
-                  # CI green. A same-build replacement is the one valid exception:
-                  # its existing .1+ OTA is expected to sort above the rebuilt .0.
+                  # A new native release cannot lag its platform channel. A same-
+                  # version replacement may already be covered by a newer OTA.
                   if [ "$(node scripts/semver-newer.mjs "$CURRENT" "$VERSION_NAME")" = "true" ]; then
                       CURRENT_CORE="${CURRENT%%-*}"
                       if [ "$IS_REBUILD" != "true" ] || [ "${CURRENT_CORE%.*}" != "${VERSION_NAME%.*}" ]; then
@@ -379,41 +376,18 @@ jobs:
                   # Staged production rollout: set status: inProgress + userFraction: 0.1,
                   # then promote in Play Console once crash/error rates look clean.
 
-            # The binary that just shipped is ahead of every production OTA bundle, so
-            # its devices would refuse all existing bundles. Publish the exact JS baked
-            # into this binary (native:release leaves it in out/) under the binary's own
-            # version — the lanes can no longer drift apart. A failure here is the floor
-            # guard firing: the job goes red instead of the fleet going silently dark.
-            # Upload flags in lockstep with release-ota.yml; ios-release.yml publishes
-            # the same version from the same tag, which --version-exists-ok turns into a
-            # verified no-op.
+            # Publish the native .0 record to this platform's channel. The other
+            # native job may reuse it only after exact source/floor/artifact checks;
+            # an existing record alone never counts as a successful upload.
             - name: Publish matching production OTA bundle
               if: steps.ota_floor.outputs.needs_ota == 'true'
               env:
+                  CAPGO_APP_ID: me.peanut.wallet
+                  PLATFORM: android
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
                   VERSION: ${{ steps.version.outputs.name }}
-              run: |
-                  if [ ! -f out/index.html ]; then
-                      echo "::error::out/ is missing its static export — cannot publish the matching OTA bundle, and without it every device on the $VERSION binary refuses OTA updates" >&2
-                      exit 1
-                  fi
-                  npx @capgo/cli@8.42.4 bundle upload \
-                    --channel production \
-                    --apikey "$CAPGO_API_KEY" \
-                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
-                    --path ./out \
-                    --bundle "$VERSION" \
-                    --min-update-version "$VERSION" \
-                    --version-exists-ok \
-                    --comment "${GITHUB_SHA:0:7} — auto-published with the $VERSION native release"
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
-                  if [ "$CURRENT" != "$VERSION" ]; then
-                      echo "::error::production channel serves '${CURRENT:-<none>}', expected $VERSION — devices on the $VERSION binary have no OTA path" >&2
-                      exit 1
-                  fi
-                  echo "Production channel now serves $VERSION"
+              run: bash scripts/publish-native-ota.sh
 
             - name: Upload AAB as build artifact
               if: always()

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -124,21 +124,18 @@ jobs:
             - name: Check production OTA floor
               id: ota_floor
               env:
+                  CAPGO_APP_ID: me.peanut.wallet
+                  PLATFORM: ios
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   VERSION_NAME: ${{ steps.version.outputs.name }}
               run: |
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
-                  if [ -z "$CURRENT" ]; then
-                      echo "::error::cannot read the production channel's current bundle from Capgo — refusing to ship a binary that may strand the fleet's OTA path" >&2
-                      exit 1
+                  CURRENT="$(node scripts/capgo-release-guard.mjs current-version)"
+                  if [ "$CURRENT" = builtin ]; then
+                    echo "needs_ota=true" >> "$GITHUB_OUTPUT"
+                    exit 0
                   fi
-                  # Fail closed on an anomalous read. CURRENT is scraped from a CLI
-                  # whose stdout format is not contractual, so a stray version-like
-                  # token that sorts ABOVE this release would make needs_ota false,
-                  # silently skip the matching publish, and recreate TASK-21793 with
-                  # CI green. A production bundle ahead of a brand-new binary cannot
-                  # happen in the version scheme, so treat it as a bad read.
+                  # A channel ahead of a brand-new native release is inconsistent
+                  # with the release sequence; stop instead of skipping its upload.
                   if [ "$(node scripts/semver-newer.mjs "$CURRENT" "$VERSION_NAME")" = "true" ]; then
                       echo "::error::production bundle $CURRENT sorts above the release $VERSION_NAME — impossible in the version scheme, so the channel read is unreliable; refusing to ship" >&2
                       exit 1
@@ -395,41 +392,18 @@ jobs:
                   # already in App Store Connect by then, so skip the wait.
                   wait-for-processing: 'false'
 
-            # The binary that just shipped is ahead of every production OTA bundle, so
-            # its devices would refuse all existing bundles. Publish the exact JS baked
-            # into this binary (the build step leaves it in out/) under the binary's own
-            # version — the lanes can no longer drift apart. A failure here is the floor
-            # guard firing: the job goes red instead of the fleet going silently dark.
-            # Upload flags in lockstep with release-ota.yml; android-release.yml
-            # publishes the same version from the same tag, which --version-exists-ok
-            # turns into a verified no-op.
+            # Publish the native .0 record to this platform's channel. The other
+            # native job may reuse it only after exact source/floor/artifact checks;
+            # an existing record alone never counts as a successful upload.
             - name: Publish matching production OTA bundle
               if: steps.ota_floor.outputs.needs_ota == 'true'
               env:
+                  CAPGO_APP_ID: me.peanut.wallet
+                  PLATFORM: ios
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
                   VERSION: ${{ steps.version.outputs.name }}
-              run: |
-                  if [ ! -f out/index.html ]; then
-                      echo "::error::out/ is missing its static export — cannot publish the matching OTA bundle, and without it every device on the $VERSION binary refuses OTA updates" >&2
-                      exit 1
-                  fi
-                  npx @capgo/cli@8.42.4 bundle upload \
-                    --channel production \
-                    --apikey "$CAPGO_API_KEY" \
-                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
-                    --path ./out \
-                    --bundle "$VERSION" \
-                    --min-update-version "$VERSION" \
-                    --version-exists-ok \
-                    --comment "${GITHUB_SHA:0:7} — auto-published with the $VERSION native release"
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
-                  if [ "$CURRENT" != "$VERSION" ]; then
-                      echo "::error::production channel serves '${CURRENT:-<none>}', expected $VERSION — devices on the $VERSION binary have no OTA path" >&2
-                      exit 1
-                  fi
-                  echo "Production channel now serves $VERSION"
+              run: bash scripts/publish-native-ota.sh
 
             - name: Upload IPA as build artifact
               if: always()

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -75,11 +75,14 @@ jobs:
             # for the same reason (see release-ota.yml).
             - name: Guard release provenance
               run: |
-                  # native-floor has no answer for the first release of a new major
-                  # (`native` starts it at <major>.1.0), and there is no earlier
-                  # build for this commit to contain.
-                  if ! FLOOR="$(node scripts/release-version.mjs native-floor 2>/dev/null)"; then
-                      echo "no previous native release for this major — nothing to contain"
+                  # Deliberately `newest-native`, not `native-floor`: the floor is
+                  # scoped to the CURRENT major, so the first release of a new major
+                  # has no floor — and skipping the check there is what would let a
+                  # lagging ref build 2.1.0 without containing v1.6.0. Only a
+                  # repository with no native release at all has nothing to contain.
+                  FLOOR="$(node scripts/release-version.mjs newest-native --allow-none)"
+                  if [ -z "$FLOOR" ]; then
+                      echo "no native release exists yet — nothing to contain"
                       exit 0
                   fi
                   if ! git merge-base --is-ancestor "v$FLOOR" HEAD; then

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -276,6 +276,9 @@ jobs:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   VERSION: ${{ steps.version.outputs.name }}
               run: |
+                  # Re-read after the build/upload: changing the stable bundle
+                  # does not clear a progressive rollout's separate target.
+                  node scripts/capgo-release-guard.mjs verify-promotion
                   npx @capgo/cli@8.42.4 channel set production \
                     --apikey "$CAPGO_API_KEY" --bundle "$VERSION"
 

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -2,9 +2,9 @@ name: App Release OTA
 
 # Production OTA releases remain manual from dev, main, or release/android-kyc.
 # The selected commit must contain the newest attested native release and pass
-# native compatibility checks. The workflow uploads a fresh signed bundle to an
-# inactive candidate channel, verifies its exact metadata, then promotes it to
-# production. A merge or push alone never publishes an OTA.
+# native compatibility checks. It uploads two signed platform bundle records to an
+# inactive candidate channel, verifies their exact metadata, then promotes each to
+# its platform production channel. A merge or push alone never publishes an OTA.
 #
 # The version always lands inside the current native build's range
 # (<major>.<build>.<ota+1>), so it cannot sort below the binary it targets — the
@@ -13,7 +13,7 @@ name: App Release OTA
 # `ota-1.0.48-hotfix1` style of suffixed tag is no longer needed.
 #
 # The tag is written afterwards as the record of what shipped. A failed deploy
-# leaves no tag, so a re-run resolves the same number instead of burning one.
+# leaves no tag; any partial upload still reserves its number for a fresh retry.
 
 on:
     workflow_dispatch:
@@ -26,8 +26,8 @@ permissions:
 
 concurrency:
     # One mutex across every sanctioned production release: this workflow and its
-    # counterpart both end by writing the production Capgo channel, and interleaving
-    # them leaves it serving a bundle the newest binary rejects. An OTA that resolves
+    # counterparts write the platform production channels, and interleaving
+    # them can leave a channel serving a bundle the newest binary rejects. An OTA that resolves
     # its version before a concurrent native release publishes its `.0` is exactly the
     # TASK-21793 shape, so the whole resolve-through-publish span holds the mutex.
     group: production-release
@@ -81,14 +81,6 @@ jobs:
                   fi
                   echo "${GITHUB_SHA:0:7} contains v$FLOOR"
 
-            # The Capgo CLI reads `capacitor.config.ts` to resolve the appId on
-            # every command, and parsing a .ts config needs the project's own
-            # TypeScript. Without it the CLI aborts at config load and prints the
-            # failure on STDOUT — straight into the version grep below, which
-            # matches nothing and leaves CURRENT empty. That reads exactly like
-            # "Capgo has no bundle for this channel", which is what the first two
-            # runs of this workflow looked like. Passing the appId positionally
-            # does not help: the config is loaded regardless.
             - name: Install dependencies
               run: pnpm install
 
@@ -97,10 +89,10 @@ jobs:
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
               run: |
-                  CURRENT="$(node scripts/capgo-release-guard.mjs current-version)"
+                  CURRENT="$(node scripts/capgo-release-guard.mjs current-release)"
                   VERSION="$(node scripts/release-version.mjs ota --current "$CURRENT")"
                   echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-                  echo "Production serves $CURRENT — next OTA is $VERSION"
+                  echo "Highest current or reserved release is $CURRENT — next OTA is $VERSION"
                   {
                     echo "## OTA $VERSION"
                     echo "- **Replaces:** $CURRENT"
@@ -143,13 +135,11 @@ jobs:
               run: |
                   ANDROID="$(node scripts/ota-platform-floor.mjs --platform android)"
                   IOS="$(node scripts/ota-platform-floor.mjs --platform ios)"
-                  LOWEST="$(node scripts/ota-platform-floor.mjs --lowest)"
                   {
                     echo "android=$ANDROID"
                     echo "ios=$IOS"
-                    echo "lowest=$LOWEST"
                   } >> "$GITHUB_OUTPUT"
-                  echo "Delivery floors — android $ANDROID, ios $IOS (channel floor $LOWEST)"
+                  echo "Delivery floors — android $ANDROID, ios $IOS"
 
             - name: Bake production NEXT_PUBLIC_* into the static export
               run: |
@@ -191,7 +181,7 @@ jobs:
                       exit 1
                   fi
                   echo "name=$VERSION" >> "$GITHUB_OUTPUT"
-                  echo "Uploading as bundle version $VERSION to production"
+                  echo "Uploading as platform bundle versions $VERSION-ios and $VERSION-android"
 
             # Resolve the floor from the release tags and fail closed when none is
             # visible. The bundle must target the newest native shell it can safely
@@ -221,82 +211,67 @@ jobs:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
               run: node scripts/capgo-release-guard.mjs prepare-candidate
 
-            - name: Upload bundle to Capgo
+            - name: Upload bundles to Capgo
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
                   COMMIT_MSG: ${{ github.event.head_commit.message }}
-                  CHANNEL: ota-candidate
-                  VERSION: ${{ steps.version.outputs.name }}
-                  # The lower of the two platform floors. One bundle serves both
-                  # platforms and Capgo carries one min_update_version, so the
-                  # server takes the permissive bound and the on-device gate
-                  # applies each platform's own — the newest native release would
-                  # have the server refuse the population the floors exist to keep
-                  # served (iOS 1.5.0, while every input that moved was android/).
-                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
+                  RELEASE_VERSION: ${{ steps.version.outputs.name }}
                   FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
                   FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
               run: |
-                  echo "Uploading bundle $VERSION to channel $CHANNEL"
-                  # The floors ride the comment because nothing else on the wire
-                  # carries them: getLatest() has no min_update_version field, and a
-                  # device judging a candidate by the floors baked into the bundle it
-                  # is already RUNNING would accept JS built after a native release
-                  # it knows nothing about. `comment` is round-tripped from here onto
-                  # the getLatest() result, so the candidate's own numbers arrive
-                  # before the download. Marker shape is parsed by
-                  # parseCandidateFloors — keep the two in lockstep.
                   COMMENT="${GITHUB_SHA:0:7} — $(printf '%s' "${COMMIT_MSG:-Manual deploy}" | head -n1) [ota-floors: android=$FLOOR_ANDROID ios=$FLOOR_IOS]"
-                  npx @capgo/cli@8.42.4 bundle upload \
-                    --channel "$CHANNEL" \
-                    --apikey "$CAPGO_API_KEY" \
-                    --key-data-v2 "$CAPGO_PRIVATE_KEY" \
-                    --path ./out \
-                    --bundle "$VERSION" \
-                    --min-update-version "$NATIVE_FLOOR" \
-                    --comment "$COMMENT" \
-                    --link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"
+                  # Different records: min_update_version belongs to the bundle,
+                  # not the channel. Old clients are protected by the server.
+                  for PLATFORM in ios android; do
+                    VERSION="$RELEASE_VERSION-$PLATFORM"
+                    if [ "$PLATFORM" = ios ]; then NATIVE_FLOOR="$FLOOR_IOS"; else NATIVE_FLOOR="$FLOOR_ANDROID"; fi
+                    npx @capgo/cli@8.42.4 bundle upload \
+                      --channel ota-candidate \
+                      --apikey "$CAPGO_API_KEY" --key-data-v2 "$CAPGO_PRIVATE_KEY" \
+                      --path ./out --bundle "$VERSION" --min-update-version "$NATIVE_FLOOR" \
+                      --comment "$COMMENT" --link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"
+                  done
 
-            # Upload must finish successfully in this run. Do not use
-            # --version-exists-ok: a failed upload can leave metadata behind
-            # without a usable artifact. Version collisions require investigation.
-            # Verify the exact record before production can serve the candidate.
-            - name: Verify the floors reached the bundle
+            # Both fresh uploads and exact artifact checks must succeed before
+            # either production channel moves. Collisions never count as success.
+            - name: Verify the floors reached the bundles
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
-                  VERSION: ${{ steps.version.outputs.name }}
+                  RELEASE_VERSION: ${{ steps.version.outputs.name }}
                   FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
                   FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
-                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
-              run: node scripts/capgo-release-guard.mjs verify-bundle
-
-            - name: Promote verified bundle to production
-              env:
-                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
-                  VERSION: ${{ steps.version.outputs.name }}
               run: |
-                  # Re-read after the build/upload: changing the stable bundle
-                  # does not clear a progressive rollout's separate target.
-                  node scripts/capgo-release-guard.mjs verify-promotion
-                  npx @capgo/cli@8.42.4 channel set production \
-                    --apikey "$CAPGO_API_KEY" --bundle "$VERSION"
+                  for PLATFORM in ios android; do
+                    export PLATFORM VERSION="$RELEASE_VERSION-$PLATFORM"
+                    if [ "$PLATFORM" = ios ]; then export NATIVE_FLOOR="$FLOOR_IOS"; else export NATIVE_FLOOR="$FLOOR_ANDROID"; fi
+                    node scripts/capgo-release-guard.mjs verify-bundle
+                  done
 
-            - name: Verify channel serves the new bundle
+            - name: Promote verified bundles to platform production
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
-                  VERSION: ${{ steps.version.outputs.name }}
+                  RELEASE_VERSION: ${{ steps.version.outputs.name }}
                   FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
                   FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
-                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
-              run: node scripts/capgo-release-guard.mjs verify-production
+              run: |
+                  for PLATFORM in ios android; do
+                    export PLATFORM VERSION="$RELEASE_VERSION-$PLATFORM"
+                    if [ "$PLATFORM" = ios ]; then export NATIVE_FLOOR="$FLOOR_IOS"; else export NATIVE_FLOOR="$FLOOR_ANDROID"; fi
+                    # The two promotions are independent. Recheck before each;
+                    # a failure leaves the other platform on its previous bundle.
+                    node scripts/capgo-release-guard.mjs verify-promotion
+                    npx @capgo/cli@8.42.4 channel set "$PLATFORM-mobile-release" \
+                      --apikey "$CAPGO_API_KEY" --bundle "$VERSION"
+                    node scripts/capgo-release-guard.mjs verify-production
+                  done
 
             - name: Deployment summary
               run: |
                   {
                     echo "## OTA Deployment"
-                    echo "- **Channel:** production"
-                    echo "- **Bundle version:** ${{ steps.version.outputs.name }}"
+                    echo "- **Channels:** ios-mobile-release, android-mobile-release"
+                    echo "- **Bundle versions:** ${{ steps.version.outputs.name }}-ios, ${{ steps.version.outputs.name }}-android"
                     echo "- **Commit:** ${{ github.sha }}"
                     echo "- **Branch:** ${{ github.ref_name }}"
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -1,12 +1,10 @@
 name: App Release OTA
 
-# The single entry point for a production OTA. Click "Run workflow" on `dev`, `main`, or `release/android-kyc`; the
-# bundle version is resolved from the channel's current bundle, not typed.
-#
-# Nothing here is automatic — this is a deliberate second step after the code is
-# on an approved release ref, saying "ship this JS to everyone", exactly as the `git tag ota-… &&
-# git push` it replaces, minus the hand-picked number. This workflow does not
-# publish or verify a staging bundle; the release-ref guard is its provenance gate.
+# Production OTA releases remain manual from dev, main, or release/android-kyc.
+# The selected commit must contain the newest attested native release and pass
+# native compatibility checks. The workflow uploads a fresh signed bundle to an
+# inactive candidate channel, verifies its exact metadata, then promotes it to
+# production. A merge or push alone never publishes an OTA.
 #
 # The version always lands inside the current native build's range
 # (<major>.<build>.<ota+1>), so it cannot sort below the binary it targets — the
@@ -19,6 +17,9 @@ name: App Release OTA
 
 on:
     workflow_dispatch:
+
+env:
+    CAPGO_APP_ID: me.peanut.wallet
 
 permissions:
     contents: read
@@ -38,8 +39,8 @@ jobs:
         outputs:
             version: ${{ steps.resolve.outputs.version }}
         steps:
-            # An OTA reaches every shipped install. Restrict the selected branch;
-            # release QA must verify its commit before this manual dispatch.
+            # Keep the existing manual release refs. Provenance and native
+            # compatibility are checked separately; a branch name proves neither.
             - name: Guard release ref
               run: |
                   if [ "$GITHUB_REF_NAME" != "dev" ] && [ "$GITHUB_REF_NAME" != "main" ] && [ "$GITHUB_REF_NAME" != "release/android-kyc" ]; then
@@ -73,7 +74,7 @@ jobs:
             # what the consequence is.
             - name: Guard release provenance
               run: |
-                  FLOOR="$(node scripts/release-version.mjs native-floor)"
+                  FLOOR="$(node scripts/release-version.mjs newest-native)"
                   if ! git merge-base --is-ancestor "v$FLOOR" HEAD; then
                       echo "::error::$GITHUB_REF_NAME (${GITHUB_SHA:0:7}) does not contain the newest native release v$FLOOR — publishing it would hand every device on that binary JS older than the one it shipped with. Back-merge the release into this ref first." >&2
                       exit 1
@@ -96,44 +97,7 @@ jobs:
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
               run: |
-                  # Keep the raw output rather than piping the CLI into grep, which
-                  # discarded its diagnostics and made a config-load or auth failure
-                  # indistinguishable from an empty channel.
-                  #
-                  # Streams stay separate and the EXIT STATUS is the gate. The CLI
-                  # mirrors its errors onto stdout as well as stderr, so "did any
-                  # version-shaped text appear" is not a safe success test: npx's
-                  # install warning names `@capgo/cli@8.42.4`, and npm prints its
-                  # own "new version available" notice at exit — either can satisfy
-                  # the version grep and be read as the current bundle.
-                  set +e
-                  npx @capgo/cli@8.42.4 channel currentBundle production \
-                    --apikey "$CAPGO_API_KEY" --quiet >"$RUNNER_TEMP/capgo-out.txt" 2>"$RUNNER_TEMP/capgo-err.txt"
-                  STATUS=$?
-                  set -e
-
-                  dump_capgo() {
-                      echo "--- capgo stdout ---" >&2
-                      cat "$RUNNER_TEMP/capgo-out.txt" >&2
-                      echo "--- capgo stderr ---" >&2
-                      cat "$RUNNER_TEMP/capgo-err.txt" >&2
-                      echo "--------------------" >&2
-                  }
-
-                  if [ "$STATUS" -ne 0 ]; then
-                      dump_capgo
-                      echo "::error::the Capgo CLI failed (exit $STATUS) reading the production channel" >&2
-                      exit 1
-                  fi
-
-                  # stdout only: npm's notices land on stderr after the CLI output,
-                  # where `tail -n1` would pick one up as if it were the version.
-                  CURRENT="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' "$RUNNER_TEMP/capgo-out.txt" | tail -n1 || true)"
-                  if [ -z "$CURRENT" ]; then
-                      dump_capgo
-                      echo "::error::cannot read the production channel's current bundle from Capgo — refusing to guess the next OTA version" >&2
-                      exit 1
-                  fi
+                  CURRENT="$(node scripts/capgo-release-guard.mjs current-version)"
                   VERSION="$(node scripts/release-version.mjs ota --current "$CURRENT")"
                   echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                   echo "Production serves $CURRENT — next OTA is $VERSION"
@@ -169,6 +133,24 @@ jobs:
             # IS_NATIVE_BUILD / GIT_COMMIT_HASH are auto-baked by next.config.native.js.
             # Delimiter is quoted: a secret holding $ or a backtick must land in the
             # file verbatim, not be expanded — or executed — by the shell.
+            # Before the bake: these two land in the static export, so the bundle
+            # carries the oldest binary of each platform it may run on. Also an
+            # early surface check — the resolver refuses outright when no shipped
+            # binary of a platform carries this tree's contract, which is the same
+            # condition "Check the native surface" fails on, minus the build.
+            - name: Resolve per-platform OTA floors
+              id: ota_floors
+              run: |
+                  ANDROID="$(node scripts/ota-platform-floor.mjs --platform android)"
+                  IOS="$(node scripts/ota-platform-floor.mjs --platform ios)"
+                  LOWEST="$(node scripts/ota-platform-floor.mjs --lowest)"
+                  {
+                    echo "android=$ANDROID"
+                    echo "ios=$IOS"
+                    echo "lowest=$LOWEST"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Delivery floors — android $ANDROID, ios $IOS (channel floor $LOWEST)"
+
             - name: Bake production NEXT_PUBLIC_* into the static export
               run: |
                   cat > .env.production.local <<'EOF'
@@ -187,6 +169,8 @@ jobs:
                   NEXT_PUBLIC_ONESIGNAL_APP_ID=${{ secrets.NEXT_PUBLIC_ONESIGNAL_APP_ID }}
                   NEXT_PUBLIC_SAFARI_WEB_ID=${{ vars.NEXT_PUBLIC_SAFARI_WEB_ID }}
                   NEXT_PUBLIC_ONESIGNAL_WEBHOOK=${{ vars.NEXT_PUBLIC_ONESIGNAL_WEBHOOK }}
+                  NEXT_PUBLIC_OTA_FLOOR_ANDROID=${{ steps.ota_floors.outputs.android }}
+                  NEXT_PUBLIC_OTA_FLOOR_IOS=${{ steps.ota_floors.outputs.ios }}
                   EOF
 
             - name: Build native static export
@@ -232,17 +216,38 @@ jobs:
                   node scripts/check-native-capabilities.mjs "v$FLOOR"
                   node scripts/check-native-ota-surface.mjs "v$FLOOR" --platform android
 
+            - name: Prepare disabled candidate channel
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+              run: node scripts/capgo-release-guard.mjs prepare-candidate
+
             - name: Upload bundle to Capgo
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
                   CAPGO_PRIVATE_KEY: ${{ secrets.CAPGO_PRIVATE_KEY }}
                   COMMIT_MSG: ${{ github.event.head_commit.message }}
-                  CHANNEL: production
+                  CHANNEL: ota-candidate
                   VERSION: ${{ steps.version.outputs.name }}
-                  NATIVE_FLOOR: ${{ steps.native_floor.outputs.name }}
+                  # The lower of the two platform floors. One bundle serves both
+                  # platforms and Capgo carries one min_update_version, so the
+                  # server takes the permissive bound and the on-device gate
+                  # applies each platform's own — the newest native release would
+                  # have the server refuse the population the floors exist to keep
+                  # served (iOS 1.5.0, while every input that moved was android/).
+                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
+                  FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
+                  FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
               run: |
                   echo "Uploading bundle $VERSION to channel $CHANNEL"
-                  COMMENT="${GITHUB_SHA:0:7} — $(printf '%s' "${COMMIT_MSG:-Manual deploy}" | head -n1)"
+                  # The floors ride the comment because nothing else on the wire
+                  # carries them: getLatest() has no min_update_version field, and a
+                  # device judging a candidate by the floors baked into the bundle it
+                  # is already RUNNING would accept JS built after a native release
+                  # it knows nothing about. `comment` is round-tripped from here onto
+                  # the getLatest() result, so the candidate's own numbers arrive
+                  # before the download. Marker shape is parsed by
+                  # parseCandidateFloors — keep the two in lockstep.
+                  COMMENT="${GITHUB_SHA:0:7} — $(printf '%s' "${COMMIT_MSG:-Manual deploy}" | head -n1) [ota-floors: android=$FLOOR_ANDROID ios=$FLOOR_IOS]"
                   npx @capgo/cli@8.42.4 bundle upload \
                     --channel "$CHANNEL" \
                     --apikey "$CAPGO_API_KEY" \
@@ -250,24 +255,38 @@ jobs:
                     --path ./out \
                     --bundle "$VERSION" \
                     --min-update-version "$NATIVE_FLOOR" \
-                    --version-exists-ok \
-                    --comment "$COMMENT"
+                    --comment "$COMMENT" \
+                    --link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"
 
-            # --version-exists-ok makes re-running the same resolved release safe;
-            # this assertion still fails if that run did not actually serve it.
+            # Upload must finish successfully in this run. Do not use
+            # --version-exists-ok: a failed upload can leave metadata behind
+            # without a usable artifact. Version collisions require investigation.
+            # Verify the exact record before production can serve the candidate.
+            - name: Verify the floors reached the bundle
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  VERSION: ${{ steps.version.outputs.name }}
+                  FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
+                  FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
+                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
+              run: node scripts/capgo-release-guard.mjs verify-bundle
+
+            - name: Promote verified bundle to production
+              env:
+                  CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
+                  VERSION: ${{ steps.version.outputs.name }}
+              run: |
+                  npx @capgo/cli@8.42.4 channel set production \
+                    --apikey "$CAPGO_API_KEY" --bundle "$VERSION"
+
             - name: Verify channel serves the new bundle
               env:
                   CAPGO_API_KEY: ${{ secrets.CAPGO_API_KEY }}
-                  CHANNEL: production
-                  EXPECTED: ${{ steps.version.outputs.name }}
-              run: |
-                  CURRENT="$(npx @capgo/cli@8.42.4 channel currentBundle "$CHANNEL" \
-                    --apikey "$CAPGO_API_KEY" --quiet | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?' | tail -n1 || true)"
-                  if [ "$CURRENT" != "$EXPECTED" ]; then
-                    echo "ERROR: channel $CHANNEL serves '${CURRENT:-<none>}', expected $EXPECTED — nothing shipped" >&2
-                    exit 1
-                  fi
-                  echo "Channel $CHANNEL now serves $EXPECTED"
+                  VERSION: ${{ steps.version.outputs.name }}
+                  FLOOR_ANDROID: ${{ steps.ota_floors.outputs.android }}
+                  FLOOR_IOS: ${{ steps.ota_floors.outputs.ios }}
+                  NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}
+              run: node scripts/capgo-release-guard.mjs verify-production
 
             - name: Deployment summary
               run: |

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -230,8 +230,8 @@ Use the workflow that matches the release:
 | | button | what it does |
 |-|--------|--------------|
 | native | **App Release Android & iOS** | resolves `<major>.<build+1>.0` → builds iOS + Android from that one number → TestFlight + Play `internal` → tags `v<version>` |
-| Android replacement | **App Release Android** | leave `versionName` blank on the selected supported branch → rebuilds the current tagged Android version with a new Play `versionCode`; refuses iOS/shared native changes and does not move the shared OTA floor |
-| OTA | **App Release OTA** | manually resolves `<major>.<build>.<ota+1>` off production → uploads and verifies an inactive candidate → promotes it → tags `ota-<version>` |
+| Android replacement | **App Release Android** | leave `versionName` blank on the selected supported branch → rebuilds the current tagged Android version with a new Play `versionCode`; refuses iOS/shared native changes and does not move the iOS OTA floor |
+| OTA | **App Release OTA** | resolves the next version across platform channels and reserved uploads → verifies two inactive candidates → promotes each platform → tags `ota-<version>` |
 
 All three lanes require a manual dispatch. A push or merge does not release an app or OTA.
 The workflow resolves the version; do not create release tags by hand.
@@ -261,7 +261,7 @@ wrapper must return on Android before the lazy import. This prevents a later JS-
 change from reintroducing the native crash on the original same-version population.
 Adding a new permission-bearing plugin changes the native fingerprint and is rejected
 independently. Any native drift or legacy-permission violation blocks OTA. The guard is
-retired naturally when a coordinated native release advances the shared floor beyond
+retired naturally when a coordinated native release advances the Android floor beyond
 the original binary. The tag is created after the Play upload, so a failed or
 never-launched replacement cannot prematurely relax the OTA guard.
 
@@ -386,7 +386,7 @@ PR #3111 while preserving the existing release refs and manual trigger.
 
 | trigger | channel | bundle version |
 | ------- | ------- | -------------- |
-| **App Release OTA** — manual, approved release ref | `production` | `<major>.<build>.<ota+1>` |
+| **App Release OTA** — manual, approved release ref | `ios-mobile-release` and `android-mobile-release` | `<major>.<build>.<ota+1>-ios` / `-android` |
 | **App Staging OTA** — manual, `dev` source | `staging` | `<major>.<build>.<commit count>` |
 
 For an OTA from `dev`:
@@ -399,9 +399,10 @@ For an OTA from `dev`:
    mechanisms but do not replace tests on the installed binaries.
 3. Open Actions → **App Release OTA** → **Run workflow** and select `dev`. The CLI equivalent
    is `gh workflow run release-ota.yml --repo peanutprotocol/peanut-ui --ref dev`.
-4. Verify the run's source SHA, compatibility checks, exact candidate metadata, production
-   channel and `ota-<version>` tag. The version is resolved from the live channel; never
-   force a lower version or reuse a previously failed candidate.
+4. Verify the run's source SHA, compatibility checks, both exact candidate records and
+   platform channels, and the `ota-<version>` tag. The next version exceeds both channels,
+   previous OTA tags and reserved platform upload names (including partial/deleted uploads).
+   `builtin` is a valid initial channel state; never overwrite a failed candidate.
 
 Dispatching publishes to production after the automated checks; this workflow does not
 pause for device QA between upload and promotion. The reserved `ota-candidate` channel has
@@ -422,8 +423,10 @@ cannot be marked healthy merely because the UI rendered. It resets to the builti
 on the launch after three incomplete boots. Network access is not part of this readiness
 condition, so offline launches can still complete normally.
 
-The native release workflow also publishes its matching production bundle when required;
-that path is unchanged except for the stronger native-release provenance guard.
+Native release workflows check and publish only their platform channel. Their plain `.0`
+record carries both floors equal to the binary version; it may be reused by the other
+native job only after exact source, floor and artifact verification. OTA `.1+` records
+use platform suffixes because their server floors can differ.
 
 ### Per-platform delivery floors
 
@@ -457,9 +460,11 @@ use a scoped dependency digest.
 - **The floors only ever widen delivery.** The publish gate is unchanged: a tree whose
   surface differs from the newest release still fails `check-native-ota-surface` and still
   needs a coordinated native release.
-- **The server gets the lower of the two.** Capgo carries one `min_update_version` per
-  bundle and one bundle serves both platforms, so `--min-update-version` is the permissive
-  bound and the device applies its own platform's.
+- **Each platform gets its own server floor.** The same web export is uploaded as two
+  signed bundle records: `1.6.N-ios` with minimum `1.5.0`, and `1.6.N-android` with minimum
+  `1.6.0`. Channels are platform-exclusive defaults using Metadata targeting. Android
+  1.5.0 is rejected by Capgo before its old updater can download the first floor-aware
+  bundle. Android 1.6.0 can update immediately without waiting for iOS adoption.
 
 #### The floors travel with the candidate, not with the running bundle
 
@@ -468,7 +473,8 @@ bundle it is *running* are the wrong numbers for that: a candidate built after a
 release has a higher floor than anything the running JS knows about, so trusting the local
 value accepts JS the binary cannot execute. Nothing in Capgo's `LatestVersion` carries
 `min_update_version` — but `comment` is round-tripped from the upload onto the
-`getLatest()` result (verified in both native implementations), so the publish step writes
+`getLatest()` result when the app setting **Expose bundle metadata to plugin** is enabled,
+so the publish step writes
 the numbers there:
 
 ```
@@ -496,17 +502,20 @@ fails the run before production changes.
 `scripts/capgo-release-guard.mjs` reads structured Capgo API records and selects the exact
 `name` field. The pinned CLI's human bundle table does not expose comments and cannot be
 used for this check. Before promotion, the guard requires the expected candidate marker at
-the end of that record's comment, the shared minimum native version, a link to the full
+the end of each record's comment, its platform's minimum native version, a link to the full
 source commit, and artifact metadata. HTTP errors, malformed responses and missing
 metadata stop the run. Uploads must finish successfully in that run: the production OTA
 lane no longer uses `--version-exists-ok`, because a failed upload can leave a record before
 its bytes are available. Version collisions require investigation, including interrupted
 candidate uploads; never delete or overwrite a served bundle to bypass this guard.
 
-Only then does the workflow point `production` to the verified version, and it reads back
-the production channel and artifact before tagging. Failed pre-promotion verification
-leaves production on its prior bundle. This is publication validation, not evidence that the bundle boots on
-real devices; the staging and device recovery checks remain necessary.
+Both artifacts must upload and verify before either platform channel moves. Immediately
+before each promotion, the guard checks both default channels, exclusive platform flags,
+Metadata targeting, anti-downgrade, disabled self-assignment and rollout, and metadata
+exposure. It rejects overlapping mobile defaults. Channel and artifact readback precede
+tagging. Promotions are separate API operations: if the second fails, one platform may
+advance while the other keeps its prior bundle. Fix the cause and rerun; reserved bundle
+names force a fresh version. This verifies publication, not boot behavior on real devices.
 
 **The floors are kept next to the staged bundle id.** A bundle is admitted at check time,
 when the comment is in hand, but applied on a *later launch* — and the plugin's queue
@@ -528,21 +537,36 @@ honestly — `runningBundleOutranksBinary()`, "is this install running JS built 
 contract it does not have", which is what the store row should reflect whether or not a new
 bundle exists.
 
-#### Two limits to know
+#### Channel migration and existing devices
 
-1. **A pre-floor install cannot be rescued over the air.** A device running a bundle that
-   has the gate but no floor-reading code judges candidates by version alone, so an iOS
-   1.5.0 install on bundle 1.6.2 refuses every 1.6.x — including the bundle that would
-   teach it about floors. Nothing shippable reaches it; it needs a new binary (TestFlight,
-   no review). The window was one bundle wide, between #3085 landing and this change, and
-   it is the concrete argument for **two production channels, one per platform**
-   (`--ios` / `--android` targeting, each with its own `min_update_version`): iOS would
-   have stayed on a 1.5.x line and never met a 1.6.x candidate at all.
-2. **The native release lanes bake and emit no floors.** At the point
-   `android-release.yml` / `ios-release.yml` publish their matching bundle, the release's
-   own tag does not exist yet, so floors cannot be resolved against it. Those bundles fall
-   back to the candidate-version rule, so a platform the release did not touch can stay
-   frozen until the next production OTA carries floors.
+Use the existing `ios-mobile-release` and `android-mobile-release` channels. Before
+changing defaults, clear the old iOS preview to `builtin`; keep Android on `builtin`.
+These are empty delivery baselines until the first verified release, not a device reset.
+Configure each channel for only its platform, with Electron off, Metadata targeting,
+anti-downgrade on, rollout off and self-assignment off. Keep production and physical-device
+audiences enabled. Enable app-level bundle metadata exposure, then select those channels
+as the respective default download channels. Remove iOS and Android flags from the
+retired `production` channel before saving defaults; it can remain the Electron default
+without overlapping mobile routing.
+
+Shipped v1.5.0 binaries have no configured default channel, so unassigned devices pick up
+the new server defaults on their next check. A local beta subscription or dashboard
+assignment overrides defaults; inspect those separately. Updated beta exit calls
+`unsetChannel()`, verifies the platform default and resets to builtin. It never assigns
+an explicit `production` override. A surviving dashboard override requires admin removal.
+
+There are two distinct legacy states:
+
+- Original v1.5.0 updater code downloads candidates without a floor gate. The platform
+  server floor protects Android 1.5.0 while allowing compatible iOS 1.5.0 to bootstrap.
+- An iOS 1.5.0 device already running an intermediate version-only gate can refuse every
+  1.6.x candidate before parsing metadata. Changing channels cannot repair that client
+  behavior. Such a device needs a reset to its builtin bundle or a newer native install.
+  Do not assume the routing change fixes every device already affected by an older OTA.
+
+Android 1.5.0 remains excluded from this 1.6.x native surface and needs its store update.
+Android 1.6.0 and compatible iOS 1.5.0 can receive subsequent platform OTA versions
+independently. Verify the current-to-next-to-next transition on real binaries before release.
 
 ### Provenance: the ref must contain the newest native release
 
@@ -583,50 +607,26 @@ build, and reported as `v1.6.0 is not an ancestor of HEAD`. The explicit guard f
 seconds and says what the consequence would have been. A stale ref whose native surface
 happened to match would have passed the fingerprint diff entirely.
 
-A second path publishes to `production`: a **native release
-auto-publishes a matching production bundle** when its versionName is ahead of the newest
-production bundle. `release-native.yml` accepts `dev`, `main` and `release/android-kyc`, so
-a native release can also deliver `dev` code to production. Capgo refuses on-device any bundle sorting below the installed native version
-(`disable_auto_update_under_native`), so a binary that outruns the bundles strands its
-whole fleet with green CI — that was TASK-21793 (102 devices refused OTA for a month
-because internal builds shipped 1.0.53 while the newest bundle was 1.0.51). The release
-workflows check the floor before building (`scripts/semver-newer.mjs` against
-`channel currentBundle production`) and, after the store upload, publish the release's
-own `out/` under the binary's versionName, then assert the channel serves it.
+Native releases also publish the matching `.0` bundle to their own platform channel when
+needed. The channel version is read through structured Capgo APIs before the native build;
+`builtin` requires a matching upload. After store upload, `publish-native-ota.sh` prepares
+an inactive candidate and verifies the exact source, both binary-equal floors and artifact
+before promotion. An existing `.0` record with incomplete metadata fails closed.
 
-- **The `production` channel** must exist in the Capgo dashboard and be bound to the prod
-  app. It does — bundle 1.0.48 shipped to it on 2026-08-06.
-- **No second approver yet.** The job declares the `Production` environment, but that
-  environment has no required reviewers, so the run ships immediately. Adding required
-  reviewers under Settings → Environments → Production makes it queue for approval with no
-  workflow change (needs repo admin).
-- **Native-version gating:** every upload passes an explicit `--min-update-version`, so a
-  JS bundle built against new plugins stays off older native shells. The release lanes pin
-  it to the binary they ship; `App Release OTA` uses the lower verified platform floor
-  (`scripts/ota-platform-floor.mjs --lowest`) and fails if no compatible release is visible.
-  It replaced `--auto-min-update-version`, which only copies the previous bundle's floor forward — with no
-  native version stamped on the `dev` checkout (package.json says 1.0.53) the floor never
-  rose past the first upload, and the CLI refuses the two flags together.
-  **Bump the native version whenever you change plugins/native code**, then ship that via
-  Play — OTA can't.
+- **Channel configuration is checked by CI.** Both platform defaults must satisfy the
+  policies above. Public API artifact reads are combined with the same authenticated
+  channel-policy interface used by Capgo CLI, since the public channel response omits
+  platform flags. Unreadable policies or missing metadata exposure stop publication.
+- **Manual dispatch publishes after checks.** The workflow uses the `Production` GitHub
+  environment; adding required reviewers there is a separate repository policy decision.
+- **Native-version gating:** every record has an explicit `--min-update-version`, enforced
+  by the channel's Metadata strategy. Each OTA uses its own platform floor; native `.0`
+  records use their binary version. Never use the lower platform floor for a shared record.
+  New native/plugin contracts require a native release before an OTA can use them.
 
-  Capgo enforces that floor only under the channel's `metadata` "disable auto update"
-  strategy. The production channel was not on it, and the default (`major`) reads a
-  `<major>.<build>` bump as a permitted minor: a v1.6.0 native release auto-published its
-  matching 1.6.0 bundle and every install on the 1.5.0 binary downloaded it, staged it and
-  offered a restart — a restart that installs JS built against the newer binary's native
-  surface. Set it once, per channel, with repo-admin Capgo credentials:
-
-  ```
-  npx @capgo/cli@8.42.4 channel set production --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
-  npx @capgo/cli@8.42.4 channel set staging --disable-auto-update metadata --apikey "$CAPGO_API_KEY"
-  ```
-
-  Deliberately not written by CI: the strategy is one fleet-wide switch, and a wrong value
-  takes OTA out for everyone — the TASK-21793 shape. It is an operator decision, made once.
 - **Native-version gating, on the device:** `src/utils/ota-native-gate.ts` re-derives the
-  same rule client-side, because the dashboard strategy above is invisible to both CI and
-  the app and nothing on the device noticed when it was wrong. Under the
+  same rule client-side, as a second check after server targeting. It uses candidate platform floors when
+  present and conservatively falls back to candidate version when they are missing. Under the
   `<major>.<build>.<ota>` scheme a bundle's first two segments name the binary it was built
   against, so a bundle whose `<major>.<build>` outranks `App.getInfo().version` is never
   downloaded, never staged, and reported as store-update-required instead. A bundle already
@@ -681,13 +681,14 @@ own `out/` under the binary's versionName, then assert the channel serves it.
   `CURRENT_PROJECT_VERSION` are normalised out — `native-ios-postsync.js` stamps them on
   every sync, and leaving them in would refuse an OTA after every release.
   **Why it exists:** `min_update_version` only blocks *delivery*, only under the
-  `metadata` channel strategy, and lives in a dashboard CI cannot read, so nothing
-  previously reported that an incompatible bundle had been *built* — the mismatch first
+  `metadata` channel strategy, and does not itself prove source compatibility. Previously nothing
+  reported that an incompatible bundle had been *built* — the mismatch first
   appeared on a user's device. The remedy for a failure is a coordinated native release
   or the narrowly gated same-version Android replacement lane—never widening or
   skipping the check.
-- **Staged rollout:** roll production OTA to ~10% → watch Sentry/crash + error rates →
-  100%. Don't 100% every merge.
+- **Rollout:** this workflow requires progressive rollout disabled and promotes both
+  stable channels after checks. Device QA must happen before dispatch; a separate reviewed
+  rollout process is required for percentage-based delivery.
 - **Rollback** is configured in `capacitor.config.ts` (`appReadyTimeout: 15000` +
   `autoDeleteFailed` + `autoDeletePrevious`): a bundle that never calls
   `notifyAppReady()` auto-reverts. **Verify once** with a deliberately-broken bundle.
@@ -697,7 +698,7 @@ own `out/` under the binary's versionName, then assert the channel serves it.
 ### Internal testing (the `staging` channel on a real device)
 
 Run **App Staging OTA** manually from `dev` to publish a beta bundle to `staging`;
-**App Release OTA** only targets `production`. Five taps on the version line in
+**App Release OTA** targets the two platform production channels. Five taps on the version line in
 **Profile → About** reveal a
 Beta-updates switch that calls `setChannel('staging')` — no dashboard work per tester, and
 the row also prints the device ID for the times someone has to be forced onto a channel
@@ -722,7 +723,7 @@ Three prerequisites, all one-time:
   commit-count band sits far above production's, so this only bites right after a native
   release.
 
-Leaving the channel unsets it **and** calls `reset()` back to the store bundle: staging
+Leaving the channel unsets it, verifies the platform default, **and** calls `reset()` back to the store bundle: staging
 versions outrank every production one, so no production OTA could ever replace a beta
 bundle on its own.
 

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -409,6 +409,12 @@ all device audiences disabled. Existing staging builds use a different version s
 and do not emit the new floor marker: do not promote a staging bundle to production or
 use it as proof of per-platform production delivery.
 
+An active or unreadable progressive rollout stops the release before version resolution
+and is checked again immediately before production promotion. The stable bundle and
+rollout target are separate channel state; changing one does not clear the other. The
+workflow leaves an existing rollout untouched. Avoid concurrent dashboard/channel edits
+during publication: the preflight read and promotion are separate API operations.
+
 The early inline `notifyAppReady()` avoids false rollbacks when the OS freezes an app in
 the background. The custom incomplete-boot counter stays armed until React has rendered
 and the local updater has initialized. A failed updater import or initialization therefore
@@ -433,6 +439,12 @@ walks the `v<major>.<build>.0` tags newest-first while that platform's half of t
 fingerprint is unchanged; the last release that still matches is the floor — the oldest
 binary of that platform whose native contract is the one this tree was built against. For
 the tree above that is `android 1.6.0, ios 1.5.0`.
+
+Resolved `@capacitor/android` and `@capacitor/ios` versions affect only their own platform's
+floor. Core, cross-platform plugins, and unclassified native dependencies still affect
+both. The complete native fingerprint keeps its existing combined dependency digest so
+stored same-version replacement attestations remain valid; only per-platform comparisons
+use a scoped dependency digest.
 
 - **`shared` inputs count for both platforms.** `capacitor.config.ts`, `patches/` and the
   resolved plugin versions sit outside `android/` and `ios/` while describing the native

--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -213,9 +213,9 @@ and it is fine for it to lag behind what ships.
 > filter cannot ship over the air, so on their own they block OTA again for no user-visible
 > gain. `native-routes.ts` still maps `/app/*` → `/app`, so nothing else needs touching.
 
-All three manual workflows accept `dev`, `main`, and `release/android-kyc`.
-Select the source branch before dispatch. A supported branch name does not prove
-that its current commit is ready to ship.
+The native and production OTA workflows are manual and accept `dev`, `main`, and
+`release/android-kyc`. Select the source branch before dispatch — a supported branch name
+does not prove that its current commit is ready to ship.
 
 1. Inspect the selected branch's current commit and confirm its release QA is complete.
 2. Before dispatching from `main`, verify it contains the reviewed native changes and
@@ -231,13 +231,10 @@ Use the workflow that matches the release:
 |-|--------|--------------|
 | native | **App Release Android & iOS** | resolves `<major>.<build+1>.0` → builds iOS + Android from that one number → TestFlight + Play `internal` → tags `v<version>` |
 | Android replacement | **App Release Android** | leave `versionName` blank on the selected supported branch → rebuilds the current tagged Android version with a new Play `versionCode`; refuses iOS/shared native changes and does not move the shared OTA floor |
-| OTA | **App Release OTA** | resolves `<major>.<build>.<ota+1>` off the production channel → uploads the bundle → tags `ota-<version>` |
+| OTA | **App Release OTA** | manually resolves `<major>.<build>.<ota+1>` off production → uploads and verifies an inactive candidate → promotes it → tags `ota-<version>` |
 
-For production OTA, use **App Release OTA** so it resolves the version before calling Capgo.
-Do not dispatch the Capgo production workflow directly without a resolved version.
-
-None is automatic: no push, merge or commit reaches them. They are the same deliberate
-act as the `git tag … && git push` they replace, minus the hand-picked number.
+All three lanes require a manual dispatch. A push or merge does not release an app or OTA.
+The workflow resolves the version; do not create release tags by hand.
 
 Use the Android replacement lane only for an Android-only native correction to the
 currently shipped build. It verifies the existing native tag attests both platforms,
@@ -355,7 +352,7 @@ the build is reproducible, the AAB lands on a Play track.
   write `keystore.properties` → write prod `NEXT_PUBLIC_*` → `pnpm native:release`
   (`versionCode = github.run_number`) → upload AAB to Play (`internal` by default).
 - **Gate** with a `production` GitHub Environment + required reviewers — not configured
-  yet: the environment has no protection rules today, so runs ship without a second
+  yet: the environment has no required reviewers today, so runs ship without a second
   approval (see §9, "No second approver yet").
 - **Track promotion:** internal → closed/beta → production with **staged rollout**
   (`status: inProgress` + `userFraction: 0.1`, promote after metrics look clean).
@@ -383,26 +380,169 @@ the build is reproducible, the AAB lands on a Play track.
 
 ## 9. OTA updates (Capgo)
 
-`App Release OTA` builds the static export and uploads it. Production is **opt-in per
-release**, never a side effect of pushing code:
+`App Release OTA` builds and publishes a production static export after a manual dispatch
+from `dev`, `main`, or `release/android-kyc`. This backport includes the protections from
+PR #3111 while preserving the existing release refs and manual trigger.
 
-| trigger                        | channel      | bundle version            |
-| ----------------------------- | ------------ | ------------------------- |
-| **App Release OTA** from `dev`, `main`, or `release/android-kyc` | `production` | `<major>.<build>.<ota+1>` |
-| **App Staging OTA** from `dev` | `staging`    | `<major>.<build>.<commit count>` |
+| trigger | channel | bundle version |
+| ------- | ------- | -------------- |
+| **App Release OTA** — manual, approved release ref | `production` | `<major>.<build>.<ota+1>` |
+| **App Staging OTA** — manual, `dev` source | `staging` | `<major>.<build>.<commit count>` |
 
-Shipping an OTA to everyone is therefore two steps — land the code, then run **App Release
-OTA** (§6). The workflow only accepts a dispatch from `dev`, `main`, or
-`release/android-kyc`; it resolves the next production bundle version from the current
-production channel and refuses other refs.
-Staging is published separately and manually through **App Staging OTA**; there is no
-automatic staging publish or `ota-*` break-glass workflow.
+For an OTA from `dev`:
+
+1. Merge the reviewed protections and desired app changes into `dev`. Record its exact
+   commit and wait for its required checks. Verify the installed native versions in scope.
+2. Validate on representative real devices that the current OTA accepts the candidate and
+   the candidate can receive a subsequent compatible OTA. Include cold starts, offline
+   launches, and recovery after an updater initialization failure. Unit tests cover these
+   mechanisms but do not replace tests on the installed binaries.
+3. Open Actions → **App Release OTA** → **Run workflow** and select `dev`. The CLI equivalent
+   is `gh workflow run release-ota.yml --repo peanutprotocol/peanut-ui --ref dev`.
+4. Verify the run's source SHA, compatibility checks, exact candidate metadata, production
+   channel and `ota-<version>` tag. The version is resolved from the live channel; never
+   force a lower version or reuse a previously failed candidate.
+
+Dispatching publishes to production after the automated checks; this workflow does not
+pause for device QA between upload and promotion. The reserved `ota-candidate` channel has
+all device audiences disabled. Existing staging builds use a different version sequence
+and do not emit the new floor marker: do not promote a staging bundle to production or
+use it as proof of per-platform production delivery.
+
+The early inline `notifyAppReady()` avoids false rollbacks when the OS freezes an app in
+the background. The custom incomplete-boot counter stays armed until React has rendered
+and the local updater has initialized. A failed updater import or initialization therefore
+cannot be marked healthy merely because the UI rendered. It resets to the builtin bundle
+on the launch after three incomplete boots. Network access is not part of this readiness
+condition, so offline launches can still complete normally.
+
+The native release workflow also publishes its matching production bundle when required;
+that path is unchanged except for the stronger native-release provenance guard.
+
+### Per-platform delivery floors
+
+One release tag names two binaries, and the field does not keep them in step: TestFlight
+has no auto-update, so iOS sat on **1.5.0** while Android moved to **1.6.0** — and every
+native input that changed between those releases was under `android/`. A version number
+cannot express that. Read numerically, bundle 1.6.x "needs a 1.6 binary" and the entire
+iOS population is refused JS its binary runs perfectly, *silently*, because the store row
+is hidden while the App Store listing is not live.
+
+`scripts/ota-platform-floor.mjs` answers it from the surface instead. Per platform it
+walks the `v<major>.<build>.0` tags newest-first while that platform's half of the
+fingerprint is unchanged; the last release that still matches is the floor — the oldest
+binary of that platform whose native contract is the one this tree was built against. For
+the tree above that is `android 1.6.0, ios 1.5.0`.
+
+- **`shared` inputs count for both platforms.** `capacitor.config.ts`, `patches/` and the
+  resolved plugin versions sit outside `android/` and `ios/` while describing the native
+  half of both, so this is not a path-prefix filter. Every `NATIVE_INPUTS` entry carries an
+  explicit `platform` and a test pins it, so a newly added input cannot default to the
+  lenient side.
+- **Contiguous from the newest.** A native change made and then reverted does not make the
+  binaries in between able to run this JS — they are precisely the binaries the change was
+  made for.
+- **The floors only ever widen delivery.** The publish gate is unchanged: a tree whose
+  surface differs from the newest release still fails `check-native-ota-surface` and still
+  needs a coordinated native release.
+- **The server gets the lower of the two.** Capgo carries one `min_update_version` per
+  bundle and one bundle serves both platforms, so `--min-update-version` is the permissive
+  bound and the device applies its own platform's.
+
+#### The floors travel with the candidate, not with the running bundle
+
+A device has to judge the bundle it is being *offered*, and the floors baked into the
+bundle it is *running* are the wrong numbers for that: a candidate built after a native
+release has a higher floor than anything the running JS knows about, so trusting the local
+value accepts JS the binary cannot execute. Nothing in Capgo's `LatestVersion` carries
+`min_update_version` — but `comment` is round-tripped from the upload onto the
+`getLatest()` result (verified in both native implementations), so the publish step writes
+the numbers there:
+
+```
+<sha> — <commit subject> [ota-floors: android=1.6.0 ios=1.5.0]
+```
+
+`parseCandidateFloors` reads that marker **anchored to the end of the comment**, and
+nothing looser: both platforms or neither, plain `X.Y.Z` only. The anchor is load-bearing.
+The comment also carries the commit subject — arbitrary text a contributor writes — and an
+unanchored match let a subject reading `fix: ota-floors: android=9.9.9 ios=9.9.9 was wrong`
+win over the real numbers appended after it. A floor of `9.9.9` refuses every bundle on
+every binary, so that is fleet-wide OTA death by commit message. The lane always appends
+its marker last; `$` is what guarantees the lane's numbers are the ones read.
+`scripts/__tests__/ota-floor-marker-contract.test.js` executes the contract rather than
+restating it — the workflow's own shell builds the string and the app's own regex reads it,
+so the two cannot drift.
+
+A bundle whose comment has no marker falls back to comparing the candidate's own version,
+which is the conservative direction. The production OTA lane uploads to `ota-candidate`
+first. It creates or updates that reserved channel with public/default access, self-assignment,
+and every device audience disabled, then reads those settings back before uploading. The
+Capgo key needs channel creation/settings permission for this step; missing permission
+fails the run before production changes.
+
+`scripts/capgo-release-guard.mjs` reads structured Capgo API records and selects the exact
+`name` field. The pinned CLI's human bundle table does not expose comments and cannot be
+used for this check. Before promotion, the guard requires the expected candidate marker at
+the end of that record's comment, the shared minimum native version, a link to the full
+source commit, and artifact metadata. HTTP errors, malformed responses and missing
+metadata stop the run. Uploads must finish successfully in that run: the production OTA
+lane no longer uses `--version-exists-ok`, because a failed upload can leave a record before
+its bytes are available. Version collisions require investigation, including interrupted
+candidate uploads; never delete or overwrite a served bundle to bypass this guard.
+
+Only then does the workflow point `production` to the verified version, and it reads back
+the production channel and artifact before tagging. Failed pre-promotion verification
+leaves production on its prior bundle. This is publication validation, not evidence that the bundle boots on
+real devices; the staging and device recovery checks remain necessary.
+
+**The floors are kept next to the staged bundle id.** A bundle is admitted at check time,
+when the comment is in hand, but applied on a *later launch* — and the plugin's queue
+carries only an id and a version (`BundleInfo` has no comment field). Without that, the
+launch-time gate re-asks with nothing to answer from, falls back to the version rule, and
+disarms the bundle the check just approved: an iOS 1.5.0 install would download 1.6.3 and
+throw it away on every launch. Only one bundle is ever queued, so it is one entry, replaced
+before native queueing on each stage and dropped when the queue is. A mismatched id reads
+as "no floors", which is also what a bundle staged before any of this existed gets.
+
+The scan that produces a floor **stops at the major boundary**, even where the surface
+matches across it. A major is a deliberate app-generation break: `release-version.mjs`
+keeps a bundle's floor inside one major band, and the on-device comparison checks majors
+before builds — so a floor of `1.6.0` published from a `2.x` tree would have every `1.6`
+binary accept a `2.x` bundle.
+
+The baked `NEXT_PUBLIC_OTA_FLOOR_*` constants stay, for the one question they can answer
+honestly — `runningBundleOutranksBinary()`, "is this install running JS built for a native
+contract it does not have", which is what the store row should reflect whether or not a new
+bundle exists.
+
+#### Two limits to know
+
+1. **A pre-floor install cannot be rescued over the air.** A device running a bundle that
+   has the gate but no floor-reading code judges candidates by version alone, so an iOS
+   1.5.0 install on bundle 1.6.2 refuses every 1.6.x — including the bundle that would
+   teach it about floors. Nothing shippable reaches it; it needs a new binary (TestFlight,
+   no review). The window was one bundle wide, between #3085 landing and this change, and
+   it is the concrete argument for **two production channels, one per platform**
+   (`--ios` / `--android` targeting, each with its own `min_update_version`): iOS would
+   have stayed on a 1.5.x line and never met a 1.6.x candidate at all.
+2. **The native release lanes bake and emit no floors.** At the point
+   `android-release.yml` / `ios-release.yml` publish their matching bundle, the release's
+   own tag does not exist yet, so floors cannot be resolved against it. Those bundles fall
+   back to the candidate-version rule, so a platform the release did not touch can stay
+   frozen until the next production OTA carries floors.
 
 ### Provenance: the ref must contain the newest native release
 
-Both release workflows assert that the dispatched commit contains the newest
-`v<major>.<build>.0` tag, before anything is built. Neither resolver can tell on its own:
-`ota` lands the next bundle inside the newest native build's range and `native` returns
+Both release workflows assert that the selected commit contains the newest attested
+`v<major>.<build>.0` release across all majors, before anything is built. Release tags must
+be annotated with the exact `Native release X.Y.0` subject written by `release-native.yml`;
+this recognizes the existing 1.1.0–1.6.0 releases and excludes unrelated date/snapshot tags.
+The checked-out package major never hides a newer release. The native workflow permits an
+empty registry explicitly via `newest-native --allow-none`; Git, shallow-history and
+resolver failures abort instead of being treated as the first release.
+
+Neither version-numbering mode proves ancestry on its own: `ota` lands the next bundle inside the newest native build's range and `native` returns
 `latestBuild + 1`, so **both produce a number that outranks the binary whether or not the
 commit contains it**. A bundle numbered above the binary is accepted by every device, and
 an OTA carrying pre-release code is therefore a silent downgrade of the JS the binary
@@ -423,7 +563,7 @@ own. Two things had to line up:
   surface check and `--auto-min-update-version`. Retiring a workflow on `dev`/`main` does
   **not** retire it at older commits, and the same trap applies to the `v*` prefix. Treat
   every `ota-*` / `v*` tag push as running last month's pipeline, and ship through the
-  dispatch workflows instead.
+  current manual OTA and native workflows instead.
 
 `check-native-ota-surface.mjs` already asserted the same ancestry, but only as a
 precondition of its fingerprint diff — in the deploy job, after a full install and native
@@ -431,9 +571,10 @@ build, and reported as `v1.6.0 is not an ancestor of HEAD`. The explicit guard f
 seconds and says what the consequence would have been. A stale ref whose native surface
 happened to match would have passed the fingerprint diff entirely.
 
-One deliberate exception to "opt-in per release": a **native release auto-publishes a
-matching production bundle** when its versionName is ahead of the newest production
-bundle. Capgo refuses on-device any bundle sorting below the installed native version
+A second path publishes to `production`: a **native release
+auto-publishes a matching production bundle** when its versionName is ahead of the newest
+production bundle. `release-native.yml` accepts `dev`, `main` and `release/android-kyc`, so
+a native release can also deliver `dev` code to production. Capgo refuses on-device any bundle sorting below the installed native version
 (`disable_auto_update_under_native`), so a binary that outruns the bundles strands its
 whole fleet with green CI — that was TASK-21793 (102 devices refused OTA for a month
 because internal builds shipped 1.0.53 while the newest bundle was 1.0.51). The release
@@ -444,14 +585,14 @@ own `out/` under the binary's versionName, then assert the channel serves it.
 - **The `production` channel** must exist in the Capgo dashboard and be bound to the prod
   app. It does — bundle 1.0.48 shipped to it on 2026-08-06.
 - **No second approver yet.** The job declares the `Production` environment, but that
-  environment has no protection rules, so the run ships immediately. Adding required
+  environment has no required reviewers, so the run ships immediately. Adding required
   reviewers under Settings → Environments → Production makes it queue for approval with no
   workflow change (needs repo admin).
 - **Native-version gating:** every upload passes an explicit `--min-update-version`, so a
   JS bundle built against new plugins stays off older native shells. The release lanes pin
-  it to the binary they ship; `App Release OTA` resolves it from the newest `v<major>.<build>.0`
-  tag (`scripts/release-version.mjs native-floor`) and fails if none is visible. It replaced
-  `--auto-min-update-version`, which only copies the previous bundle's floor forward — with no
+  it to the binary they ship; `App Release OTA` uses the lower verified platform floor
+  (`scripts/ota-platform-floor.mjs --lowest`) and fails if no compatible release is visible.
+  It replaced `--auto-min-update-version`, which only copies the previous bundle's floor forward — with no
   native version stamped on the `dev` checkout (package.json says 1.0.53) the floor never
   rose past the first upload, and the CLI refuses the two flags together.
   **Bump the native version whenever you change plugins/native code**, then ship that via

--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -1,0 +1,180 @@
+/** @jest-environment node */
+const fs = require('node:fs')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+const { spawnSync } = require('node:child_process')
+const ROOT = path.join(__dirname, '../..')
+const SCRIPT = pathToFileURL(path.join(ROOT, 'scripts/capgo-release-guard.mjs')).href
+const SHA = 'a'.repeat(40)
+const MARKER = '[ota-floors: android=1.6.0 ios=1.5.0]'
+const env = {
+    CAPGO_APP_ID: 'me.peanut.wallet',
+    CAPGO_API_KEY: 'test-key',
+    VERSION: '1.6.3',
+    FLOOR_ANDROID: '1.6.0',
+    FLOOR_IOS: '1.5.0',
+    NATIVE_FLOOR: '1.5.0',
+    GITHUB_SHA: SHA,
+}
+const goodBundle = {
+    app_id: env.CAPGO_APP_ID,
+    name: '1.6.3',
+    deleted: false,
+    comment: `commit ${MARKER}`,
+    minUpdateVersion: '1.5.0',
+    link: `https://github.com/peanutprotocol/peanut-ui/commit/${SHA}`,
+    checksum: 'signed-checksum',
+    storage_provider: 'r2',
+    r2_path: 'org/app/1.6.3.zip',
+}
+const candidate = {
+    app_id: env.CAPGO_APP_ID,
+    name: 'ota-candidate',
+    public: false,
+    allow_device_self_set: false,
+    allow_emulator: false,
+    allow_device: false,
+    allow_dev: false,
+    allow_prod: false,
+}
+
+// Exercise the actual ESM entry point with recorded HTTP responses. No API key,
+// network or publication happens in these tests; unexpected requests fail.
+function invoke(mode, responses, overrides = {}) {
+    const driver = `
+      import { run } from ${JSON.stringify(SCRIPT)};
+      import { readFileSync } from 'node:fs';
+      const input = JSON.parse(readFileSync(0, 'utf8'));
+      const requests = [];
+      try {
+        const result = await run(input.mode, { env: input.env, fetchImpl: async (url, init) => {
+          requests.push({ url: String(url), method: init.method, body: init.body && JSON.parse(init.body) });
+          const response = input.responses.shift();
+          if (!response) throw new Error('unexpected request');
+          if (response.networkError) throw new Error('network failure');
+          return { ok: !response.status || response.status === 200, status: response.status || 200,
+            json: async () => { if (response.invalidJson) throw new Error('invalid JSON'); return response.body; } };
+        }});
+        console.log(JSON.stringify({ result, requests }));
+      } catch (error) { console.log(JSON.stringify({ error: error.message, requests })); process.exitCode = 1; }
+    `
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', driver], {
+        input: JSON.stringify({ mode, env: { ...env, ...overrides }, responses }),
+        encoding: 'utf8',
+    })
+    return { status: result.status, ...JSON.parse(result.stdout) }
+}
+function verify(rows, overrides) {
+    return invoke('verify-bundle', [{ body: candidate }, { body: rows }], overrides)
+}
+
+it('verifies the exact structured bundle record', () => {
+    expect(verify([goodBundle]).status).toBe(0)
+    expect(verify({ data: [goodBundle] }).status).toBe(0)
+})
+it.each(['1.6.2', '1.6.30', '11.6.3', '1.6.3-rc1', '1.6.3.1'])(
+    'cannot use %s even when its subject names the requested version',
+    (name) => {
+        const rows = [
+            { ...goodBundle, name, comment: `fix 1.6.3 rollout ${MARKER}` },
+            { ...goodBundle, comment: 'no floors' },
+        ]
+        expect(verify(rows).status).toBe(1)
+    }
+)
+it.each([
+    { comment: null },
+    { comment: `${MARKER} trailing text` },
+    { comment: '[ota-floors: android=1.5.0 ios=1.5.0]' },
+    { minUpdateVersion: '1.4.0' },
+    { app_id: 'wrong.app' },
+    { deleted: true },
+    { link: 'https://github.com/peanutprotocol/peanut-ui/commit/other' },
+    { checksum: null },
+    { storage_provider: 'supabase' },
+    { r2_path: null },
+])('refuses stale or incomplete artifact metadata: %j', (change) => {
+    expect(verify([{ ...goodBundle, ...change }]).status).toBe(1)
+})
+it('rejects missing, ambiguous and malformed bundle records', () => {
+    for (const response of [[], [goodBundle, goodBundle], { error: 'bad' }, 'CLI error 1.6.3']) {
+        expect(verify(response).status).toBe(1)
+    }
+})
+it('follows pagination using exact names', () => {
+    const older = Array.from({ length: 50 }, (_, i) => ({ name: `1.6.${i + 100}`, comment: MARKER }))
+    const result = invoke('verify-bundle', [{ body: candidate }, { body: older }, { body: [goodBundle] }])
+    expect(result.status).toBe(0)
+    expect(result.requests[2].url).toContain('page=1')
+})
+it.each([{ status: 401 }, { status: 500 }, { networkError: true }, { invalidJson: true }])(
+    'fails closed on API failure: %j',
+    (response) => {
+        expect(invoke('verify-bundle', [{ body: candidate }, response]).status).toBe(1)
+    }
+)
+it.each(['public', 'allow_device_self_set', 'allow_emulator', 'allow_device', 'allow_dev', 'allow_prod'])(
+    'rejects a candidate channel with %s enabled',
+    (field) => {
+        const result = invoke('verify-bundle', [{ body: { ...candidate, [field]: true } }, { body: [goodBundle] }])
+        expect(result.status).toBe(1)
+        expect(result.requests).toHaveLength(1)
+    }
+)
+it('prepares the disabled channel and reads the persisted settings back', () => {
+    const result = invoke('prepare-candidate', [{ body: { status: 'success' } }, { body: candidate }])
+    expect(result.status).toBe(0)
+    expect(result.requests[0].body).toMatchObject({
+        ...Object.fromEntries(Object.entries(candidate).filter(([key]) => key !== 'name')),
+        channel: 'ota-candidate',
+        ios: false,
+        android: false,
+        electron: false,
+        rolloutEnabled: false,
+    })
+    expect(result.requests[1].method).toBe('GET')
+})
+it('rejects preparation when the server did not persist the audience restrictions', () => {
+    expect(invoke('prepare-candidate', [{ body: {} }, { body: { ...candidate, allow_prod: true } }]).status).toBe(1)
+})
+it('reads the production version field without matching versions in arbitrary text', () => {
+    const production = { app_id: env.CAPGO_APP_ID, name: 'production', version: { name: '1.6.2' } }
+    expect(invoke('current-version', [{ body: production }]).result).toBe('1.6.2')
+    expect(
+        invoke('current-version', [{ body: { ...production, version: null, comment: 'version 1.6.2' } }]).status
+    ).toBe(1)
+})
+it('verifies production and the promoted artifact, and rejects an active alternate rollout', () => {
+    const production = {
+        app_id: env.CAPGO_APP_ID,
+        name: 'production',
+        version: { name: '1.6.3' },
+        rolloutEnabled: false,
+    }
+    expect(invoke('verify-production', [{ body: production }, { body: [goodBundle] }]).status).toBe(0)
+    for (const change of [{ rolloutEnabled: true }, { version: { name: '1.6.2' } }]) {
+        expect(invoke('verify-production', [{ body: { ...production, ...change } }]).status).toBe(1)
+    }
+})
+it.each([{ FLOOR_ANDROID: '2.1.0' }, { FLOOR_IOS: '1.7.0' }, { NATIVE_FLOOR: '1.6.0' }, { FLOOR_IOS: '1.5.1' }])(
+    'rejects invalid floor expectations: %j',
+    (overrides) => {
+        expect(verify([goodBundle], overrides).status).toBe(1)
+    }
+)
+it('keeps production promotion after successful verification and upload isolated', () => {
+    const source = fs.readFileSync(path.join(ROOT, '.github/workflows/release-ota.yml'), 'utf8')
+    const upload = source.slice(source.indexOf('- name: Upload bundle'), source.indexOf('- name: Verify the floors'))
+    expect(upload).toContain('CHANNEL: ota-candidate')
+    expect(upload).toContain('--channel "$CHANNEL"')
+    expect(upload).not.toMatch(/^\s+--version-exists-ok\b/m)
+    expect(upload).toContain('--link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"')
+    const prepare = source.indexOf('node scripts/capgo-release-guard.mjs prepare-candidate')
+    const verify = source.indexOf('node scripts/capgo-release-guard.mjs verify-bundle')
+    const promote = source.indexOf('channel set production')
+    expect(prepare).toBeLessThan(source.indexOf('- name: Upload bundle'))
+    expect(verify).toBeLessThan(promote)
+    expect(source.slice(verify, promote)).not.toMatch(/continue-on-error|always\(\)/)
+    expect(source).toContain('CAPGO_APP_ID: me.peanut.wallet')
+    expect(fs.readFileSync(path.join(ROOT, 'capacitor.config.ts'), 'utf8')).toContain("appId: 'me.peanut.wallet'")
+})

--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -11,7 +11,8 @@ const MARKER = '[ota-floors: android=1.6.0 ios=1.5.0]'
 const env = {
     CAPGO_APP_ID: 'me.peanut.wallet',
     CAPGO_API_KEY: 'test-key',
-    VERSION: '1.6.3',
+    VERSION: '1.6.3-ios',
+    PLATFORM: 'ios',
     FLOOR_ANDROID: '1.6.0',
     FLOOR_IOS: '1.5.0',
     NATIVE_FLOOR: '1.5.0',
@@ -19,7 +20,7 @@ const env = {
 }
 const goodBundle = {
     app_id: env.CAPGO_APP_ID,
-    name: '1.6.3',
+    name: '1.6.3-ios',
     deleted: false,
     comment: `commit ${MARKER}`,
     minUpdateVersion: '1.5.0',
@@ -31,6 +32,7 @@ const goodBundle = {
 const candidate = {
     app_id: env.CAPGO_APP_ID,
     name: 'ota-candidate',
+    rolloutEnabled: false,
     public: false,
     allow_device_self_set: false,
     allow_emulator: false,
@@ -138,55 +140,138 @@ it('prepares the disabled channel and reads the persisted settings back', () => 
 it('rejects preparation when the server did not persist the audience restrictions', () => {
     expect(invoke('prepare-candidate', [{ body: {} }, { body: { ...candidate, allow_prod: true } }]).status).toBe(1)
 })
-it('reads the production version field without matching versions in arbitrary text', () => {
-    const production = {
-        app_id: env.CAPGO_APP_ID,
-        name: 'production',
-        version: { name: '1.6.2' },
-        rolloutEnabled: false,
-    }
-    expect(invoke('current-version', [{ body: production }]).result).toBe('1.6.2')
-    expect(
-        invoke('current-version', [{ body: { ...production, version: null, comment: 'version 1.6.2' } }]).status
-    ).toBe(1)
+
+const app = { app_id: env.CAPGO_APP_ID, expose_metadata: true }
+const config = { supaHost: 'https://sb.capgo.app', supaKey: 'public-anon-key' }
+const channelPolicy = (platform, version = 'builtin') => ({
+    app_id: env.CAPGO_APP_ID,
+    name: `${platform}-mobile-release`,
+    public: true,
+    ios: platform === 'ios',
+    android: platform === 'android',
+    electron: false,
+    disable_auto_update: 'version_number',
+    disable_auto_update_under_native: true,
+    allow_device_self_set: false,
+    allow_prod: true,
+    allow_device: true,
+    rollout_enabled: false,
+    version: { name: version },
 })
-it('refuses to resolve a release while production has an active rollout', () => {
-    const production = {
-        app_id: env.CAPGO_APP_ID,
-        name: 'production',
-        version: { name: '1.6.2' },
-        rolloutEnabled: true,
-    }
-    const result = invoke('current-version', [{ body: production }])
+const channels = [channelPolicy('ios'), channelPolicy('android')]
+const policyResponses = (rows = channels) => [{ body: app }, { body: config }, { body: rows }]
+
+it('reads builtin as a legitimate starting state, but rejects a missing version', () => {
+    expect(invoke('current-version', policyResponses()).result).toBe('builtin')
+    expect(invoke('current-version', policyResponses([{ ...channels[0], version: null }, channels[1]])).status).toBe(1)
+})
+it.each([
+    { android: true },
+    { ios: false },
+    { electron: true },
+    { public: false },
+    { disable_auto_update: 'major' },
+    { disable_auto_update_under_native: false },
+    { allow_device_self_set: true },
+    { allow_prod: false },
+    { allow_device: false },
+    { rollout_enabled: true },
+    { rollout_enabled: null },
+    { rollout_enabled: undefined },
+])('rejects unsafe iOS policy before promotion: %j', (change) => {
+    const result = invoke('verify-promotion', policyResponses([{ ...channels[0], ...change }, channels[1]]))
     expect(result.status).toBe(1)
     expect(result.requests.every((request) => request.method === 'GET')).toBe(true)
 })
+it('requires an exclusive Android default too, even when promoting iOS', () => {
+    expect(invoke('verify-promotion', policyResponses([channels[0], { ...channels[1], ios: true }])).status).toBe(1)
+    expect(
+        invoke('verify-promotion', policyResponses([...channels, { ...channels[0], name: 'production' }])).status
+    ).toBe(1)
+})
+it.each([false, null, undefined])('blocks releases when metadata exposure is %s', (expose_metadata) => {
+    const result = invoke('verify-promotion', [{ body: { ...app, expose_metadata } }])
+    expect(result.status).toBe(1)
+    expect(result.requests).toHaveLength(1)
+})
+it('never sends credentials to an unexpected configuration host', () => {
+    const result = invoke('verify-promotion', [
+        { body: app },
+        { body: { ...config, supaHost: 'https://untrusted.test' } },
+    ])
+    expect(result.status).toBe(1)
+    expect(result.requests).toHaveLength(2)
+})
+it('accepts validated metadata routing and fails closed on API failure', () => {
+    expect(invoke('verify-promotion', policyResponses()).status).toBe(0)
+    expect(invoke('verify-promotion', [{ body: app }, { body: config }, { status: 503 }]).status).toBe(1)
+})
+it('keeps a partial or deleted upload reserved, and ignores the staging counter', () => {
+    const result = invoke('current-release', [
+        ...policyResponses(),
+        { body: [{ name: '1.6.3-ios', deleted: true }, { name: '1.6.11913' }, { name: '1.6.2-android' }] },
+    ])
+    expect(result.result).toBe('1.6.3')
+    expect(invoke('current-release', [...policyResponses(), { body: [] }]).result).toBe('builtin')
+})
+it('verifies the selected production artifact after promotion', () => {
+    const rows = [channelPolicy('ios', env.VERSION), channels[1]]
+    expect(invoke('verify-production', [...policyResponses(rows), { body: [goodBundle] }]).status).toBe(0)
+    expect(invoke('verify-production', policyResponses()).status).toBe(1)
+})
+it('rejects the lower iOS floor on an Android delivery record', () => {
+    const result = verify([{ ...goodBundle, name: '1.6.3-android' }], { PLATFORM: 'android', VERSION: '1.6.3-android' })
+    expect(result.status).toBe(1)
+    expect(result.error).toContain('server floor must match the delivery platform')
+})
+it.each(['ios', 'android'])('verifies a distinct %s artifact with its own native floor', (platform) => {
+    const nativeFloor = platform === 'ios' ? '1.5.0' : '1.6.0'
+    const version = `1.6.3-${platform}`
+    expect(
+        verify([{ ...goodBundle, name: version, minUpdateVersion: nativeFloor }], {
+            PLATFORM: platform,
+            VERSION: version,
+            NATIVE_FLOOR: nativeFloor,
+        }).status
+    ).toBe(0)
+})
+it('allows reuse only of a verified native .0 record from the exact source', () => {
+    const native = {
+        ...goodBundle,
+        name: '1.7.0',
+        minUpdateVersion: '1.7.0',
+        comment: '[ota-floors: android=1.7.0 ios=1.7.0]',
+    }
+    const overrides = { VERSION: '1.7.0', FLOOR_ANDROID: '1.7.0', FLOOR_IOS: '1.7.0', NATIVE_FLOOR: '1.7.0' }
+    expect(invoke('existing-native', [{ body: [] }], overrides).result).toBe('missing')
+    expect(invoke('existing-native', [{ body: [native] }], overrides).result).toBe('1.7.0')
+    expect(invoke('existing-native', [{ body: [{ ...native, checksum: null }] }], overrides).status).toBe(1)
+    expect(invoke('existing-native', [{ body: [{ ...native, link: 'wrong-source' }] }], overrides).status).toBe(1)
+    expect(invoke('existing-native', [], { VERSION: '1.7.1-ios' }).status).toBe(1)
+})
 
-// Execute the workflow's actual promotion shell. Replace only its executables:
-// node runs the real guard with an HTTP fixture, and npx records whether the
-// production mutation would have happened. No deployment or network is possible.
-function promotion(rolloutEnabled, apiFails = false) {
+// Run the actual promotion shell; only executables are replaced. The real
+// preflight consumes recorded API responses. Post-promotion verification has
+// separate exact-artifact cases above. No network or publication is possible.
+function promotion(change = {}, apiFails = false) {
     const source = fs.readFileSync(path.join(ROOT, '.github/workflows/release-ota.yml'), 'utf8')
     const step = source.slice(
-        source.indexOf('- name: Promote verified bundle'),
-        source.indexOf('- name: Verify channel serves')
+        source.indexOf('- name: Promote verified bundles'),
+        source.indexOf('- name: Deployment summary')
     )
     const shell = step.match(/run: \|\n([\s\S]*)/)[1]
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ota-promotion-'))
     const marker = path.join(dir, 'production-mutated')
     const driver = `
-      const mode = process.argv[2];
-      // This wrapper receives the real CLI arguments, but must not activate
-      // the imported module's separate CLI entry point or its real fetch.
-      process.argv[1] = process.execPath;
+      const mode = process.argv[2]; process.argv[1] = process.execPath;
       globalThis.fetch = () => { throw new Error('unexpected live request'); };
+      if (mode !== 'verify-promotion') process.exit(0);
       const { run } = await import(${JSON.stringify(SCRIPT)});
-      try {
-        await run(mode, { fetchImpl: async () => ({
-          ok: process.env.TEST_API_FAILS !== 'true', status: 503,
-          json: async () => JSON.parse(process.env.TEST_PRODUCTION)
-        }) });
-      } catch (error) { console.error(error.message); process.exitCode = 1; }
+      const responses = JSON.parse(process.env.TEST_RESPONSES);
+      try { await run(mode, { fetchImpl: async () => ({
+        ok: process.env.TEST_API_FAILS !== 'true', status: 503,
+        json: async () => responses.shift().body
+      }) }); } catch (error) { console.error(error.message); process.exitCode = 1; }
     `
     try {
         const result = spawnSync(
@@ -197,7 +282,7 @@ function promotion(rolloutEnabled, apiFails = false) {
                 '-c',
                 `
           node() { "$NODE_BINARY" --input-type=module -e "$GUARD_DRIVER" "$@"; }
-          npx() { printf 'promoted' > "$PROMOTED_FILE"; }
+          npx() { printf 'promoted' >> "$PROMOTED_FILE"; }
           ${shell}
         `,
             ],
@@ -206,72 +291,114 @@ function promotion(rolloutEnabled, apiFails = false) {
                 env: {
                     ...process.env,
                     ...env,
+                    RELEASE_VERSION: '1.6.3',
                     NODE_BINARY: process.execPath,
                     GUARD_DRIVER: driver,
                     PROMOTED_FILE: marker,
                     TEST_API_FAILS: String(apiFails),
-                    TEST_PRODUCTION: JSON.stringify({
-                        app_id: env.CAPGO_APP_ID,
-                        name: 'production',
-                        version: { name: '1.6.2' },
-                        rolloutEnabled,
-                    }),
+                    TEST_RESPONSES: JSON.stringify(policyResponses([{ ...channels[0], ...change }, channels[1]])),
                 },
             }
         )
-        return { status: result.status, stderr: result.stderr, mutated: fs.existsSync(marker) }
+        return { status: result.status, promoted: fs.existsSync(marker) }
     } finally {
         fs.rmSync(dir, { recursive: true, force: true })
     }
 }
-
-it.each([true, null, undefined, 'false'])(
-    'never changes production when rollout state is %s before promotion',
-    (state) => {
-        const result = promotion(state)
-        expect(result.status).not.toBe(0)
-        expect(result.mutated).toBe(false)
+it.each([{ rollout_enabled: true }, { rollout_enabled: null }, { android: true }, { disable_auto_update: 'major' }])(
+    'the actual workflow cannot mutate either channel after rejected preflight %j',
+    (change) => {
+        expect(promotion(change)).toEqual({ status: 1, promoted: false })
     }
 )
-it('never changes production when its pre-promotion read fails', () => {
-    const result = promotion(false, true)
-    expect(result.status).not.toBe(0)
-    expect(result.mutated).toBe(false)
+it('the actual workflow stops before mutation on API failure', () => {
+    expect(promotion({}, true)).toEqual({ status: 1, promoted: false })
 })
-it('allows promotion only after confirming production has no active rollout', () => {
-    expect(promotion(false)).toEqual({ status: 0, mutated: true, stderr: '' })
+it('the actual workflow promotes only after both platform policies pass', () => {
+    expect(promotion()).toEqual({ status: 0, promoted: true })
 })
-it('verifies production and the promoted artifact, and rejects an active alternate rollout', () => {
-    const production = {
-        app_id: env.CAPGO_APP_ID,
-        name: 'production',
-        version: { name: '1.6.3' },
-        rolloutEnabled: false,
-    }
-    expect(invoke('verify-production', [{ body: production }, { body: [goodBundle] }]).status).toBe(0)
-    for (const change of [{ rolloutEnabled: true }, { version: { name: '1.6.2' } }]) {
-        expect(invoke('verify-production', [{ body: { ...production, ...change } }]).status).toBe(1)
-    }
-})
-it.each([{ FLOOR_ANDROID: '2.1.0' }, { FLOOR_IOS: '1.7.0' }, { NATIVE_FLOOR: '1.6.0' }, { FLOOR_IOS: '1.5.1' }])(
-    'rejects invalid floor expectations: %j',
-    (overrides) => {
-        expect(verify([goodBundle], overrides).status).toBe(1)
-    }
-)
-it('keeps production promotion after successful verification and upload isolated', () => {
+it('uploads and verifies both artifacts before any production promotion', () => {
     const source = fs.readFileSync(path.join(ROOT, '.github/workflows/release-ota.yml'), 'utf8')
-    const upload = source.slice(source.indexOf('- name: Upload bundle'), source.indexOf('- name: Verify the floors'))
-    expect(upload).toContain('CHANNEL: ota-candidate')
-    expect(upload).toContain('--channel "$CHANNEL"')
-    expect(upload).not.toMatch(/^\s+--version-exists-ok\b/m)
-    expect(upload).toContain('--link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"')
-    const prepare = source.indexOf('node scripts/capgo-release-guard.mjs prepare-candidate')
-    const verify = source.indexOf('node scripts/capgo-release-guard.mjs verify-bundle')
-    const promote = source.indexOf('channel set production')
-    expect(prepare).toBeLessThan(source.indexOf('- name: Upload bundle'))
-    expect(verify).toBeLessThan(promote)
-    expect(source.slice(verify, promote)).not.toMatch(/continue-on-error|always\(\)/)
-    expect(source).toContain('CAPGO_APP_ID: me.peanut.wallet')
-    expect(fs.readFileSync(path.join(ROOT, 'capacitor.config.ts'), 'utf8')).toContain("appId: 'me.peanut.wallet'")
+    expect(source.indexOf('- name: Upload bundles')).toBeLessThan(source.indexOf('- name: Verify the floors'))
+    expect(source.indexOf('- name: Verify the floors')).toBeLessThan(source.indexOf('- name: Promote verified bundles'))
+    expect(source).not.toContain('--version-exists-ok')
+    expect(source).toContain('--channel ota-candidate')
+    expect(source).not.toContain('channel set production')
 })
+
+it('never assigns a prerelease .0 identity that sorts below its native binary', () => {
+    expect(verify([{ ...goodBundle, name: '1.6.0-ios' }], { VERSION: '1.6.0-ios' }).status).toBe(1)
+})
+
+// Execute the native publisher with deterministic command responses. Assertions
+// cover the ordering and failures that can otherwise promote an absent artifact.
+function publishNative({ existing = 'missing', failure = '', platform = 'ios' } = {}) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'native-ota-publish-'))
+    const log = path.join(dir, 'calls')
+    fs.mkdirSync(path.join(dir, 'out'))
+    fs.writeFileSync(path.join(dir, 'out/index.html'), '<html></html>')
+    try {
+        const result = spawnSync(
+            'bash',
+            [
+                '-c',
+                `
+          node() {
+            printf '%s\\n' "$2" >> "$CALL_LOG"
+            [ "$FAILURE" != "$2" ] || return 1
+            if [ "$2" = existing-native ]; then printf '%s' "$EXISTING"; fi
+          }
+          npx() {
+            printf '%s\\n' "$*" >> "$CALL_LOG"
+            [ "$FAILURE" != upload ] || return 1
+          }
+          source "$PUBLISH_SCRIPT"
+        `,
+            ],
+            {
+                cwd: dir,
+                encoding: 'utf8',
+                env: {
+                    ...process.env,
+                    ...env,
+                    VERSION: '1.7.0',
+                    PLATFORM: platform,
+                    CAPGO_PRIVATE_KEY: 'test-private-key',
+                    CALL_LOG: log,
+                    EXISTING: existing,
+                    FAILURE: failure,
+                    PUBLISH_SCRIPT: path.join(ROOT, 'scripts/publish-native-ota.sh'),
+                },
+            }
+        )
+        return { status: result.status, calls: fs.readFileSync(log, 'utf8').trim().split('\n') }
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+    }
+}
+it.each(['ios', 'android'])('native publisher verifies before promoting %s', (platform) => {
+    const { status, calls } = publishNative({ platform })
+    expect(status).toBe(0)
+    const upload = calls.findIndex((line) => line.includes('bundle upload'))
+    const promote = calls.findIndex((line) => line.includes('channel set'))
+    expect(upload).toBeGreaterThan(calls.indexOf('existing-native'))
+    expect(calls[upload]).toContain('--min-update-version 1.7.0')
+    expect(calls[upload]).toContain('[ota-floors: android=1.7.0 ios=1.7.0]')
+    expect(promote).toBeGreaterThan(calls.indexOf('verify-bundle'))
+    expect(calls[promote]).toContain(`channel set ${platform}-mobile-release`)
+    expect(calls.at(-1)).toBe('verify-production')
+})
+it('native publisher skips uploading only an already verified record', () => {
+    const { status, calls } = publishNative({ existing: '1.7.0' })
+    expect(status).toBe(0)
+    expect(calls.some((line) => line.includes('bundle upload'))).toBe(false)
+    expect(calls).toContain('verify-bundle')
+})
+it.each(['existing-native', 'upload', 'verify-bundle', 'verify-promotion'])(
+    'native publisher cannot promote after %s fails',
+    (failure) => {
+        const { status, calls } = publishNative({ failure })
+        expect(status).toBe(1)
+        expect(calls.some((line) => line.includes('channel set'))).toBe(false)
+    }
+)

--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 const fs = require('node:fs')
 const path = require('node:path')
+const os = require('node:os')
 const { pathToFileURL } = require('node:url')
 const { spawnSync } = require('node:child_process')
 const ROOT = path.join(__dirname, '../..')
@@ -138,11 +139,107 @@ it('rejects preparation when the server did not persist the audience restriction
     expect(invoke('prepare-candidate', [{ body: {} }, { body: { ...candidate, allow_prod: true } }]).status).toBe(1)
 })
 it('reads the production version field without matching versions in arbitrary text', () => {
-    const production = { app_id: env.CAPGO_APP_ID, name: 'production', version: { name: '1.6.2' } }
+    const production = {
+        app_id: env.CAPGO_APP_ID,
+        name: 'production',
+        version: { name: '1.6.2' },
+        rolloutEnabled: false,
+    }
     expect(invoke('current-version', [{ body: production }]).result).toBe('1.6.2')
     expect(
         invoke('current-version', [{ body: { ...production, version: null, comment: 'version 1.6.2' } }]).status
     ).toBe(1)
+})
+it('refuses to resolve a release while production has an active rollout', () => {
+    const production = {
+        app_id: env.CAPGO_APP_ID,
+        name: 'production',
+        version: { name: '1.6.2' },
+        rolloutEnabled: true,
+    }
+    const result = invoke('current-version', [{ body: production }])
+    expect(result.status).toBe(1)
+    expect(result.requests.every((request) => request.method === 'GET')).toBe(true)
+})
+
+// Execute the workflow's actual promotion shell. Replace only its executables:
+// node runs the real guard with an HTTP fixture, and npx records whether the
+// production mutation would have happened. No deployment or network is possible.
+function promotion(rolloutEnabled, apiFails = false) {
+    const source = fs.readFileSync(path.join(ROOT, '.github/workflows/release-ota.yml'), 'utf8')
+    const step = source.slice(
+        source.indexOf('- name: Promote verified bundle'),
+        source.indexOf('- name: Verify channel serves')
+    )
+    const shell = step.match(/run: \|\n([\s\S]*)/)[1]
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ota-promotion-'))
+    const marker = path.join(dir, 'production-mutated')
+    const driver = `
+      const mode = process.argv[2];
+      // This wrapper receives the real CLI arguments, but must not activate
+      // the imported module's separate CLI entry point or its real fetch.
+      process.argv[1] = process.execPath;
+      globalThis.fetch = () => { throw new Error('unexpected live request'); };
+      const { run } = await import(${JSON.stringify(SCRIPT)});
+      try {
+        await run(mode, { fetchImpl: async () => ({
+          ok: process.env.TEST_API_FAILS !== 'true', status: 503,
+          json: async () => JSON.parse(process.env.TEST_PRODUCTION)
+        }) });
+      } catch (error) { console.error(error.message); process.exitCode = 1; }
+    `
+    try {
+        const result = spawnSync(
+            'bash',
+            [
+                '-euo',
+                'pipefail',
+                '-c',
+                `
+          node() { "$NODE_BINARY" --input-type=module -e "$GUARD_DRIVER" "$@"; }
+          npx() { printf 'promoted' > "$PROMOTED_FILE"; }
+          ${shell}
+        `,
+            ],
+            {
+                encoding: 'utf8',
+                env: {
+                    ...process.env,
+                    ...env,
+                    NODE_BINARY: process.execPath,
+                    GUARD_DRIVER: driver,
+                    PROMOTED_FILE: marker,
+                    TEST_API_FAILS: String(apiFails),
+                    TEST_PRODUCTION: JSON.stringify({
+                        app_id: env.CAPGO_APP_ID,
+                        name: 'production',
+                        version: { name: '1.6.2' },
+                        rolloutEnabled,
+                    }),
+                },
+            }
+        )
+        return { status: result.status, stderr: result.stderr, mutated: fs.existsSync(marker) }
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+    }
+}
+
+it.each([true, null, undefined, 'false'])(
+    'never changes production when rollout state is %s before promotion',
+    (state) => {
+        const result = promotion(state)
+        expect(result.status).not.toBe(0)
+        expect(result.mutated).toBe(false)
+    }
+)
+it('never changes production when its pre-promotion read fails', () => {
+    const result = promotion(false, true)
+    expect(result.status).not.toBe(0)
+    expect(result.mutated).toBe(false)
+})
+it('allows promotion only after confirming production has no active rollout', () => {
+    expect(promotion(false)).toEqual({ status: 0, mutated: true, stderr: '' })
 })
 it('verifies production and the promoted artifact, and rejects an active alternate rollout', () => {
     const production = {

--- a/scripts/__tests__/native-fingerprint.test.js
+++ b/scripts/__tests__/native-fingerprint.test.js
@@ -381,3 +381,48 @@ describe('native-fingerprint', () => {
         expect(result.stderr).toContain('needs a directory')
     })
 })
+
+/*
+ * Every native input must say which platform's binary carries it. A new input
+ * with no `platform` would be skipped by platformDiff for both platforms — the
+ * lenient direction, which is how an unnoticed native change reaches an older
+ * binary. `shared` is a deliberate answer, not a default: capacitor.config.ts,
+ * patches/ and the resolved plugin versions sit outside android/ and ios/ while
+ * describing the native half of both.
+ */
+describe('platform classification', () => {
+    const inputs = () => {
+        const result = spawnSync(process.execPath, [SCRIPT_PATH, '--inputs'], { encoding: 'utf-8' })
+        expect(result.status).toBe(0)
+        return JSON.parse(result.stdout)
+    }
+
+    it('classifies every native input', () => {
+        const unclassified = inputs().filter((input) => !['android', 'ios', 'shared'].includes(input.platform))
+        expect(unclassified.map((input) => input.id)).toEqual([])
+    })
+
+    it('agrees with the path prefix wherever there is one', () => {
+        const mismatched = inputs().filter(
+            (input) =>
+                (input.id.startsWith('android/') && input.platform !== 'android') ||
+                (input.id.startsWith('ios/') && input.platform !== 'ios')
+        )
+        expect(mismatched.map((input) => input.id)).toEqual([])
+    })
+
+    // Shared inputs are the reason platformDiff is not a path-prefix filter.
+    it('keeps the shared inputs shared', () => {
+        const shared = inputs()
+            .filter((input) => input.platform === 'shared')
+            .map((input) => input.id)
+        expect(shared).toEqual(expect.arrayContaining(['capacitor.config.ts', 'patches/**', 'native-plugin-versions']))
+    })
+
+    // Named for iOS but not under ios/ — it pins iOS native SDK versions after
+    // `cap sync`, so a prefix rule would have called it shared.
+    it('classifies the iOS post-sync script as iOS', () => {
+        const entry = inputs().find((input) => input.id === 'scripts/native-ios-postsync.js')
+        expect(entry.platform).toBe('ios')
+    })
+})

--- a/scripts/__tests__/ota-floor-marker-contract.test.js
+++ b/scripts/__tests__/ota-floor-marker-contract.test.js
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+
+/*
+ * The publish lane writes the per-platform floors into the bundle comment and the
+ * app parses them back out of getLatest(). Two files, one format, and no runtime
+ * error if they disagree — a mismatched marker just means every device silently
+ * falls back to the candidate-version rule, which is the state that froze the
+ * iOS population. So the contract is executed here rather than eyeballed: the
+ * workflow's own shell builds the string, and the app's own regex reads it.
+ */
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const REPO_ROOT = path.join(__dirname, '..', '..')
+const WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'release-ota.yml')
+const GATE = path.join(REPO_ROOT, 'src', 'utils', 'ota-native-gate.ts')
+
+// The assignment as the workflow writes it, not a copy of it. Read as text
+// rather than parsed YAML — the suite has no yaml dependency, and the rest of
+// the workflow tests here assert on the source the same way.
+const workflowSource = fs.readFileSync(WORKFLOW, 'utf8')
+
+function commentAssignment() {
+    const line = workflowSource.split('\n').find((l) => l.trim().startsWith('COMMENT='))
+    expect(line).toBeDefined()
+    return line.trim()
+}
+
+// The regex as the app declares it, not a copy of it.
+function markerRegex() {
+    const source = fs.readFileSync(GATE, 'utf8')
+    const declared = source.match(/const FLOOR_MARKER = \/(.+)\/\n/)
+    expect(declared).not.toBeNull()
+    return new RegExp(declared[1])
+}
+
+function buildComment({ android, ios, commitMsg = 'fix: something\nsecond line' }) {
+    const result = spawnSync('bash', ['-c', `${commentAssignment()}; printf '%s' "$COMMENT"`], {
+        env: {
+            ...process.env,
+            GITHUB_SHA: 'abc1234567890abcdef',
+            COMMIT_MSG: commitMsg,
+            FLOOR_ANDROID: android,
+            FLOOR_IOS: ios,
+        },
+        encoding: 'utf8',
+    })
+    expect(result.status).toBe(0)
+    return result.stdout
+}
+
+it('the comment the lane writes is the comment the app can parse', () => {
+    const comment = buildComment({ android: '1.6.0', ios: '1.5.0' })
+    const match = markerRegex().exec(comment)
+    expect(match).not.toBeNull()
+    expect([match[1], match[2]]).toEqual(['1.6.0', '1.5.0'])
+})
+
+// Only the first line of the commit message is taken, so a multi-line message
+// cannot push the marker onto a line the parser never sees.
+it('keeps the marker on the first line, past a multi-line commit message', () => {
+    const comment = buildComment({ android: '1.7.0', ios: '1.5.0' })
+    expect(comment.split('\n')).toHaveLength(1)
+    expect(markerRegex().test(comment)).toBe(true)
+})
+
+// A commit subject is arbitrary text. It must not be able to forge or break the
+// marker that follows it.
+it.each([
+    ['a version-shaped subject', 'chore: bump to 9.9.9'],
+    ['a subject naming the marker', 'fix: ota-floors: android=9.9.9 ios=9.9.9 was wrong'],
+    ['quotes and brackets', 'fix: handle "[ota-floors]" in $COMMENT'],
+])('reads the real floors past %s', (_label, commitMsg) => {
+    const comment = buildComment({ android: '1.6.0', ios: '1.5.0', commitMsg })
+    const match = markerRegex().exec(comment)
+    expect(match).not.toBeNull()
+    // The lane appends its marker last, and the regex is end-anchored, so the
+    // lane's numbers are the ones read — a subject cannot forge a floor. An
+    // unanchored match read 9.9.9 here, which refuses every bundle on every
+    // binary: fleet-wide OTA death by commit message.
+    expect([match[1], match[2]]).toEqual(['1.6.0', '1.5.0'])
+})
+
+it('ignores a marker that is not at the end, however well-formed', () => {
+    const forged = '[ota-floors: android=9.9.9 ios=9.9.9] abc1234 — a subject'
+    expect(markerRegex().test(forged)).toBe(false)
+})
+
+it('the verify step checks for the same string the upload writes', () => {
+    const marker = '[ota-floors: android=$FLOOR_ANDROID ios=$FLOOR_IOS]'
+    expect(workflowSource).toContain('Verify the floors reached the bundle')
+    expect(workflowSource).toContain('node scripts/capgo-release-guard.mjs verify-bundle')
+    expect(commentAssignment()).toContain(marker)
+})
+
+/*
+ * --lowest is what the channel's single min_update_version is set from. A
+ * refactor that leaves the resolver's unit cases green can still hand production
+ * the wrong shared floor if this handoff moves.
+ */
+it('passes the shared floor to --min-update-version, and the per-platform ones to the export', () => {
+    expect(workflowSource).toContain('NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}')
+    expect(workflowSource).toContain('--min-update-version "$NATIVE_FLOOR"')
+    expect(workflowSource).toContain('NEXT_PUBLIC_OTA_FLOOR_ANDROID=${{ steps.ota_floors.outputs.android }}')
+    expect(workflowSource).toContain('NEXT_PUBLIC_OTA_FLOOR_IOS=${{ steps.ota_floors.outputs.ios }}')
+    expect(workflowSource).toContain('node scripts/ota-platform-floor.mjs --lowest')
+})

--- a/scripts/__tests__/ota-floor-marker-contract.test.js
+++ b/scripts/__tests__/ota-floor-marker-contract.test.js
@@ -94,15 +94,12 @@ it('the verify step checks for the same string the upload writes', () => {
     expect(commentAssignment()).toContain(marker)
 })
 
-/*
- * --lowest is what the channel's single min_update_version is set from. A
- * refactor that leaves the resolver's unit cases green can still hand production
- * the wrong shared floor if this handoff moves.
- */
-it('passes the shared floor to --min-update-version, and the per-platform ones to the export', () => {
-    expect(workflowSource).toContain('NATIVE_FLOOR: ${{ steps.ota_floors.outputs.lowest }}')
+it('uses the delivery platform floor, independently of the other platform', () => {
+    expect(workflowSource).not.toContain('outputs.lowest')
+    expect(workflowSource).not.toContain('ota-platform-floor.mjs --lowest')
+    expect(workflowSource).toContain('NATIVE_FLOOR="$FLOOR_IOS"')
+    expect(workflowSource).toContain('NATIVE_FLOOR="$FLOOR_ANDROID"')
     expect(workflowSource).toContain('--min-update-version "$NATIVE_FLOOR"')
     expect(workflowSource).toContain('NEXT_PUBLIC_OTA_FLOOR_ANDROID=${{ steps.ota_floors.outputs.android }}')
     expect(workflowSource).toContain('NEXT_PUBLIC_OTA_FLOOR_IOS=${{ steps.ota_floors.outputs.ios }}')
-    expect(workflowSource).toContain('node scripts/ota-platform-floor.mjs --lowest')
 })

--- a/scripts/__tests__/ota-platform-floor.test.js
+++ b/scripts/__tests__/ota-platform-floor.test.js
@@ -70,6 +70,48 @@ function floorsFail(dir, platform) {
     return { status: res.status, stderr: res.stderr }
 }
 
+it.each([
+    ['@capacitor/android', '1.6.0', '1.5.0'],
+    ['@capacitor/ios', '1.5.0', '1.6.0'],
+    ['@capacitor/core', '1.6.0', '1.6.0'],
+    ['@capacitor-community/example-plugin', '1.6.0', '1.6.0'],
+])('a %s dependency bump raises only the affected native floors', (dependency, android, ios) => {
+    const repo = makeRepo()
+    const dependencies = {
+        '@capacitor/android': '8.2.0',
+        '@capacitor/ios': '8.2.0',
+        '@capacitor/core': '8.2.0',
+        '@capacitor-community/example-plugin': '8.2.0',
+    }
+    write(repo.dir, 'package.json', JSON.stringify({ version: '1.0.0', dependencies }))
+    const lockfile = () =>
+        'packages:\n' +
+        Object.entries(dependencies)
+            .map(([name, version]) => `  '${name}@${version}': {}`)
+            .join('\n')
+    write(repo.dir, 'pnpm-lock.yaml', lockfile())
+    release(repo, 'v1.5.0')
+    // The declared range and generated manifests can remain unchanged; the
+    // resolved lockfile version is the contract the next build actually uses.
+    dependencies[dependency] = '8.3.0'
+    write(repo.dir, 'pnpm-lock.yaml', lockfile())
+    release(repo, 'v1.6.0')
+
+    expect(floors(repo.dir)).toEqual({
+        NEXT_PUBLIC_OTA_FLOOR_ANDROID: android,
+        NEXT_PUBLIC_OTA_FLOOR_IOS: ios,
+    })
+    // The complete surface must still detect every dependency bump. Only the
+    // platform floor comparison narrows the dependency set.
+    const complete = require('child_process').spawnSync(
+        'node',
+        [path.join(REPO_ROOT, 'scripts/native-fingerprint.mjs'), '--root', repo.dir, '--diff', 'v1.5.0'],
+        { encoding: 'utf8' }
+    )
+    expect(complete.status).toBe(1)
+    expect(complete.stdout).toContain('native-plugin-versions')
+})
+
 it('lets an untouched platform keep its older binaries', () => {
     const repo = makeRepo()
     release(repo, 'v1.4.0')

--- a/scripts/__tests__/ota-platform-floor.test.js
+++ b/scripts/__tests__/ota-platform-floor.test.js
@@ -1,0 +1,238 @@
+/**
+ * Per-platform OTA floors. One release tag names two binaries and the field does
+ * not keep them in step, so "which binaries may receive this bundle" is a
+ * question about each platform's native surface, not about a version number.
+ */
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const REPO_ROOT = path.join(__dirname, '..', '..')
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'ota-platform-floor.mjs')
+
+// Its own repo per case: the tag list and the native surface at each tag are the
+// whole input, so asserting against this checkout would pin the suite to
+// whatever release history happens to exist.
+function makeRepo() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ota-floor-'))
+    for (const rel of ['scripts', 'android/app/src/main', 'ios/App/App.xcodeproj', 'patches']) {
+        fs.mkdirSync(path.join(dir, rel), { recursive: true })
+    }
+    for (const name of ['ota-platform-floor.mjs', 'native-fingerprint.mjs', 'release-version.mjs']) {
+        fs.copyFileSync(path.join(REPO_ROOT, 'scripts', name), path.join(dir, 'scripts', name))
+    }
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ version: '1.0.0' }))
+    write(dir, 'capacitor.config.ts', 'shared v1\n')
+    write(dir, 'android/app/src/main/AndroidManifest.xml', 'android v1\n')
+    write(dir, 'ios/App/App.xcodeproj/project.pbxproj', 'ios v1\n')
+
+    const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
+    git('init', '-q')
+    // Hermetic against a developer's global signing config.
+    git('config', 'commit.gpgsign', 'false')
+    git('config', 'tag.gpgsign', 'false')
+    git('config', 'user.email', 't@t.t')
+    git('config', 'user.name', 't')
+    return { dir, git }
+}
+
+function write(dir, rel, contents) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true })
+    fs.writeFileSync(path.join(dir, rel), contents)
+}
+
+function release({ dir, git }, tag) {
+    git('add', '-A')
+    git('commit', '-q', '-m', tag, '--allow-empty')
+    git('tag', '-a', tag, '-m', `Native release ${tag.slice(1)}`)
+}
+
+function floors(dir, ref = 'HEAD') {
+    const out = execFileSync('node', [SCRIPT, '--root', dir, '--ref', ref], { cwd: dir, encoding: 'utf8' })
+    return Object.fromEntries(
+        out
+            .trim()
+            .split('\n')
+            .map((line) => line.split('='))
+    )
+}
+
+function lowest(dir) {
+    return execFileSync('node', [SCRIPT, '--root', dir, '--lowest'], { cwd: dir, encoding: 'utf8' }).trim()
+}
+
+function floorsFail(dir, platform) {
+    const res = require('child_process').spawnSync('node', [SCRIPT, '--root', dir, '--platform', platform], {
+        cwd: dir,
+        encoding: 'utf8',
+    })
+    return { status: res.status, stderr: res.stderr }
+}
+
+it('lets an untouched platform keep its older binaries', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.4.0')
+    release(repo, 'v1.5.0')
+    // The v1.6.0 shape from the real incident: Android-only native change.
+    write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android v2\n')
+    release(repo, 'v1.6.0')
+
+    expect(floors(repo.dir)).toEqual({
+        NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.6.0',
+        NEXT_PUBLIC_OTA_FLOOR_IOS: '1.4.0',
+    })
+})
+
+it('raises both floors for a shared input, which describes both binaries', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.4.0')
+    write(repo.dir, 'capacitor.config.ts', 'shared v2\n')
+    release(repo, 'v1.5.0')
+
+    expect(floors(repo.dir)).toEqual({
+        NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.5.0',
+        NEXT_PUBLIC_OTA_FLOOR_IOS: '1.5.0',
+    })
+})
+
+it('raises only the iOS floor for an iOS-only change', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.4.0')
+    write(repo.dir, 'ios/App/App.xcodeproj/project.pbxproj', 'ios v2\n')
+    release(repo, 'v1.5.0')
+
+    expect(floors(repo.dir)).toEqual({
+        NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.4.0',
+        NEXT_PUBLIC_OTA_FLOOR_IOS: '1.5.0',
+    })
+})
+
+// A native change made and then reverted does not make the binaries in between
+// able to run this JS — they are exactly the binaries the change was made for.
+it('stops at the first mismatch instead of reaching past it', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.3.0')
+    write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android interim\n')
+    release(repo, 'v1.4.0')
+    write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android v1\n')
+    release(repo, 'v1.5.0')
+
+    expect(floors(repo.dir).NEXT_PUBLIC_OTA_FLOOR_ANDROID).toBe('1.5.0')
+})
+
+it('refuses when no shipped binary of that platform carries this surface', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.5.0')
+    write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'unreleased\n')
+    repo.git('add', '-A')
+    repo.git('commit', '-q', '-m', 'drift')
+
+    const { status, stderr } = floorsFail(repo.dir, 'android')
+    expect(status).toBe(1)
+    expect(stderr).toContain("no shipped android binary carries this tree's native contract")
+    // iOS is untouched, so it still resolves — the platforms are independent.
+    expect(
+        execFileSync('node', [SCRIPT, '--root', repo.dir, '--platform', 'ios'], {
+            cwd: repo.dir,
+            encoding: 'utf8',
+        }).trim()
+    ).toBe('1.5.0')
+})
+
+it('refuses a repository with no native release at all', () => {
+    const repo = makeRepo()
+    repo.git('add', '-A')
+    repo.git('commit', '-q', '-m', 'no releases')
+
+    const { status, stderr } = floorsFail(repo.dir, 'android')
+    expect(status).toBe(1)
+    expect(stderr).toMatch(/no v\*? ?tags?|no v<major>/)
+})
+
+it('rejects an unknown platform', () => {
+    const repo = makeRepo()
+    release(repo, 'v1.5.0')
+    const { status, stderr } = floorsFail(repo.dir, 'windows')
+    expect(status).toBe(1)
+    expect(stderr).toContain('platform must be android or ios')
+})
+
+/*
+ * --lowest is the single number Capgo gets, because one bundle serves both
+ * platforms and a channel carries one min_update_version. Every install's
+ * eligibility goes through it, and the per-platform cases above would stay green
+ * if it picked the wrong side.
+ */
+describe('--lowest, the shared server floor', () => {
+    it('takes the iOS side when iOS is lower', () => {
+        const repo = makeRepo()
+        release(repo, 'v1.4.0')
+        release(repo, 'v1.5.0')
+        write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android v2\n')
+        release(repo, 'v1.6.0')
+
+        expect(floors(repo.dir)).toEqual({
+            NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.6.0',
+            NEXT_PUBLIC_OTA_FLOOR_IOS: '1.4.0',
+        })
+        expect(lowest(repo.dir)).toBe('1.4.0')
+    })
+
+    it('takes the Android side when Android is lower', () => {
+        const repo = makeRepo()
+        release(repo, 'v1.4.0')
+        release(repo, 'v1.5.0')
+        write(repo.dir, 'ios/App/App.xcodeproj/project.pbxproj', 'ios v2\n')
+        release(repo, 'v1.6.0')
+
+        expect(floors(repo.dir)).toEqual({
+            NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.4.0',
+            NEXT_PUBLIC_OTA_FLOOR_IOS: '1.6.0',
+        })
+        expect(lowest(repo.dir)).toBe('1.4.0')
+    })
+
+    it('compares builds numerically, not lexically', () => {
+        const repo = makeRepo()
+        release(repo, 'v1.9.0')
+        write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android v2\n')
+        release(repo, 'v1.10.0')
+
+        expect(floors(repo.dir)).toEqual({
+            NEXT_PUBLIC_OTA_FLOOR_ANDROID: '1.10.0',
+            NEXT_PUBLIC_OTA_FLOOR_IOS: '1.9.0',
+        })
+        expect(lowest(repo.dir)).toBe('1.9.0')
+    })
+})
+
+/*
+ * A major is a deliberate app-generation break. release-version.mjs keeps a
+ * bundle's floor inside one major band, and the on-device comparison checks
+ * majors before builds — so a floor reaching back across the boundary would have
+ * every 1.x binary accept a 2.x bundle.
+ */
+describe('major boundary', () => {
+    const acrossMajors = () => {
+        const repo = makeRepo()
+        release(repo, 'v1.5.0')
+        release(repo, 'v1.6.0')
+        // A new generation whose iOS surface is untouched all the way back.
+        write(repo.dir, 'android/app/src/main/AndroidManifest.xml', 'android v2\n')
+        release(repo, 'v2.1.0')
+        return repo
+    }
+
+    it('does not reach past the newest major, even when the surface matches', () => {
+        const repo = acrossMajors()
+        expect(floors(repo.dir)).toEqual({
+            NEXT_PUBLIC_OTA_FLOOR_ANDROID: '2.1.0',
+            NEXT_PUBLIC_OTA_FLOOR_IOS: '2.1.0',
+        })
+    })
+
+    it('keeps the shared server floor inside the same band', () => {
+        expect(lowest(acrossMajors().dir)).toBe('2.1.0')
+    })
+})

--- a/scripts/__tests__/release-branch-guards.test.js
+++ b/scripts/__tests__/release-branch-guards.test.js
@@ -4,24 +4,52 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 
+const workflowsDir = path.join(__dirname, '..', '..', '.github', 'workflows')
+
 // Execute only the branch guard, never the version resolver or deployment steps.
-describe.each(['release-ota.yml', 'release-native.yml', 'android-release.yml'])('%s release branches', (file) => {
-    const workflow = fs.readFileSync(path.join(__dirname, '..', '..', '.github', 'workflows', file), 'utf8')
-    const guard = workflow.match(/if \[ "\$GITHUB_REF_NAME"[^\n]+; then\n[\s\S]*?\n\s+fi/)[0]
+function guardOf(file) {
+    const workflow = fs.readFileSync(path.join(workflowsDir, file), 'utf8')
+    return workflow.match(/if \[ "\$GITHUB_REF_NAME"[^\n]+; then\n[\s\S]*?\n\s+fi/)[0]
+}
+
+function run(guard, branch) {
+    return spawnSync('bash', ['-eu', '-c', guard], {
+        env: { ...process.env, GITHUB_REF_NAME: branch },
+        encoding: 'utf8',
+    })
+}
+
+// Backport the OTA protections without changing the existing manual refs.
+describe('release-ota.yml manual release branches', () => {
+    const guard = guardOf('release-ota.yml')
 
     it.each(['dev', 'main', 'release/android-kyc'])('accepts %s', (branch) => {
-        const result = spawnSync('bash', ['-eu', '-c', guard], {
-            env: { ...process.env, GITHUB_REF_NAME: branch },
-            encoding: 'utf8',
-        })
-        expect(result.status).toBe(0)
+        expect(run(guard, branch).status).toBe(0)
+    })
+
+    it.each(['feature/kyc', 'release/other', 'main-fix', ''])('refuses %s', (branch) => {
+        const result = run(guard, branch)
+        expect(result.status).toBe(1)
+        expect(result.stderr).toContain('::error::')
+    })
+
+    it('requires a manual dispatch, never a push or tag', () => {
+        const workflow = fs.readFileSync(path.join(workflowsDir, 'release-ota.yml'), 'utf8')
+        const triggers = workflow.match(/^on:\n([\s\S]*?)(?=^\S)/m)[1]
+        expect(triggers.trim()).toBe('workflow_dispatch:')
+    })
+})
+
+// The native lanes still cut releases from dev; unchanged, and deliberately so.
+describe.each(['release-native.yml', 'android-release.yml'])('%s release branches', (file) => {
+    const guard = guardOf(file)
+
+    it.each(['dev', 'main', 'release/android-kyc'])('accepts %s', (branch) => {
+        expect(run(guard, branch).status).toBe(0)
     })
 
     it.each(['feature/kyc', 'release/other', 'main-fix', ''])('rejects unrelated branch %s', (branch) => {
-        const result = spawnSync('bash', ['-eu', '-c', guard], {
-            env: { ...process.env, GITHUB_REF_NAME: branch },
-            encoding: 'utf8',
-        })
+        const result = run(guard, branch)
         expect(result.status).toBe(1)
         expect(result.stderr).toContain('::error::')
     })

--- a/scripts/__tests__/release-version.test.js
+++ b/scripts/__tests__/release-version.test.js
@@ -93,6 +93,17 @@ describe('release version resolver', () => {
     })
 
     describe('ota', () => {
+        it('advances beyond shipped tags after channels are reset to builtin', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.6.0', 'ota-1.6.2'] }), ['ota', '--current', 'builtin'])
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.6.3')
+        })
+        it('advances after a partial platform upload', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.6.0', 'ota-1.6.2'] }), ['ota', '--current', '1.6.3-ios'])
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.6.4')
+        })
+
         it('increments the OTA component within the current build', () => {
             const result = run(repo('1.0.53', { tags: ['v1.5.0'] }), ['ota', '--current', '1.5.3'])
 

--- a/scripts/__tests__/release-version.test.js
+++ b/scripts/__tests__/release-version.test.js
@@ -25,7 +25,11 @@ function makeRepo(version, { commits = 3, tags = [] } = {}) {
     for (let i = 0; i < commits; i++) {
         git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '--allow-empty', '-m', `c${i}`)
     }
-    tags.forEach((tag) => git('tag', tag))
+    tags.forEach((tag) => {
+        if (/^v\d+\.[1-9]\d*\.0$/.test(tag)) {
+            git('-c', 'user.email=t@t', '-c', 'user.name=t', 'tag', '-a', tag, '-m', `Native release ${tag.slice(1)}`)
+        } else git('tag', tag)
+    })
     return dir
 }
 
@@ -164,6 +168,135 @@ describe('release version resolver', () => {
 
             expect(result.status).toBe(1)
             expect(result.stderr).toMatch(/cut a native release/)
+        })
+    })
+
+    /*
+     * newest-native is the provenance input for both production release
+     * workflows: it answers "the release this commit must contain". Unlike
+     * native-floor it deliberately ignores package.json's major, because the
+     * first release of a new major has no floor and skipping the check there is
+     * what would let a lagging ref build 2.1.0 without containing v1.6.0.
+     */
+    describe('newest-native', () => {
+        it('does not hide a newer major from a stale release ref', () => {
+            const dir = repo('1.0.53', { tags: ['v1.6.0'] })
+            const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' })
+            git('-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '--allow-empty', '-m', 'new major')
+            git('-c', 'user.email=t@t', '-c', 'user.name=t', 'tag', '-a', 'v2.1.0', '-m', 'Native release 2.1.0')
+            git('checkout', '--detach', 'HEAD~1')
+            const result = run(dir, ['newest-native'])
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('2.1.0')
+            expect(
+                spawnSync('git', ['merge-base', '--is-ancestor', `v${result.stdout.trim()}`, 'HEAD'], { cwd: dir })
+                    .status
+            ).toBe(1)
+        })
+
+        it('picks the newest attested native release across majors', () => {
+            const result = run(repo('2.0.0', { tags: ['v1.4.0', 'v1.6.0', 'v1.5.0', 'v2.1.0'] }), ['newest-native'])
+
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('2.1.0')
+        })
+
+        // The load-bearing case: package.json has moved to a major with no tag
+        // yet. native-floor has no answer here and the guard would skip; this
+        // must still name v1.6.0 as the release the commit has to contain.
+        it('answers for a major that has no release of its own yet', () => {
+            const result = run(repo('2.0.0', { tags: ['v1.5.0', 'v1.6.0'] }), ['newest-native'])
+
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.6.0')
+        })
+
+        it('orders builds numerically, not lexically', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.9.0', 'v1.10.0'] }), ['newest-native'])
+
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.10.0')
+        })
+
+        // Same exclusions as native-floor: an OTA tag and the date-shaped
+        // v2026.02.26 that really is on main are not native releases.
+        it('ignores tags that are not native releases', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.6.0', 'v1.6.3', 'v2026.02.26'] }), ['newest-native'])
+
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.6.0')
+        })
+
+        // `v*` is loose enough that a date-shaped tag can match the release
+        // pattern exactly. Unbounded, v2026.02.0 would become the newest release
+        // and demand every ref contain a tag that never shipped a binary.
+        it('ignores a date-shaped tag that does match the release pattern', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.6.0', 'v2026.02.0'] }), ['newest-native'])
+
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('1.6.0')
+        })
+
+        it('ignores an unrelated canonical-looking tag without release metadata', () => {
+            const dir = repo('1.0.53', { tags: ['v1.6.0'] })
+            execFileSync(
+                'git',
+                ['-c', 'user.email=t@t', '-c', 'user.name=t', 'tag', '-a', 'v2026.2.0', '-m', 'Website snapshot'],
+                { cwd: dir }
+            )
+            expect(run(dir, ['newest-native']).stdout.trim()).toBe('1.6.0')
+        })
+
+        it('returns an empty success only for an explicitly allowed empty registry', () => {
+            const result = run(repo('1.0.53'), ['newest-native', '--allow-none'])
+            expect(result.status).toBe(0)
+            expect(result.stdout.trim()).toBe('')
+        })
+
+        it('does not mistake an unreadable registry for the first release', () => {
+            const dir = repo('1.0.53', { tags: ['v1.6.0'] })
+            fs.renameSync(path.join(dir, '.git'), path.join(dir, 'hidden-git'))
+            expect(run(dir, ['newest-native', '--allow-none']).status).toBe(1)
+        })
+
+        it('rejects shallow history even when no prior release is allowed', () => {
+            const dir = makeShallowClone(repo('1.0.53', { tags: ['v1.6.0'] }), 1)
+            repos.push(dir)
+            const result = run(dir, ['newest-native', '--allow-none'])
+            expect(result.status).toBe(1)
+            expect(result.stderr).toMatch(/fetch-depth/)
+        })
+
+        it('fails when the repository has no native release at all', () => {
+            const result = run(repo('1.0.53', { tags: ['v1.0.1', 'v1.0.2'] }), ['newest-native'])
+
+            expect(result.status).toBe(1)
+            expect(result.stderr).toMatch(/no attested v<major>\.<build>\.0 native release/)
+        })
+    })
+
+    describe('native workflow provenance guard', () => {
+        const workflow = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/release-native.yml'), 'utf8')
+        const guard = workflow
+            .split('- name: Guard release provenance')[1]
+            .split('- name: Resolve next build version')[0]
+            .split('run: |')[1]
+            .split('\n')
+            .map((line) => line.replace(/^ {18}/, ''))
+            .join('\n')
+        const execute = (dir) =>
+            spawnSync('bash', ['-euo', 'pipefail', '-c', guard], {
+                cwd: dir,
+                env: { ...process.env, GITHUB_REF_NAME: 'dev', GITHUB_SHA: 'a'.repeat(40) },
+                encoding: 'utf8',
+            })
+        it('accepts a verified empty release registry for the first native release', () => {
+            expect(execute(repo('1.0.53')).status).toBe(0)
+        })
+        it('does not turn a broken resolver into permission to publish', () => {
+            const dir = repo('1.0.53', { tags: ['v1.6.0'] })
+            fs.writeFileSync(path.join(dir, 'package.json'), 'invalid JSON')
+            expect(execute(dir).status).not.toBe(0)
         })
     })
 

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
-// Structured release checks. The pinned CLI's human bundle table omits comments.
-// API contracts: https://capgo.app/docs/public-api/bundles/ and /channels/.
-// Keep the upload on a channel with every device audience disabled until the
-// exact version, source commit and compatibility metadata have been verified.
+// Public API for artifacts; the CLI's authenticated PostgREST interface for
+// channel policies, because public/channel/get.ts omits ios/android/electron.
 import { realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 export const CANDIDATE_CHANNEL = 'ota-candidate'
+export const PRODUCTION_CHANNELS = { ios: 'ios-mobile-release', android: 'android-mobile-release' }
 const DISABLED_AUDIENCES = {
     public: false,
     allow_device_self_set: false,
@@ -15,31 +14,49 @@ const DISABLED_AUDIENCES = {
     allow_dev: false,
     allow_prod: false,
 }
-const VERSION = /^(0|[1-9]\d*)\.([1-9]\d*)\.(0|[1-9]\d*)$/
+const CORE = /^(0|[1-9]\d*)\.([1-9]\d*)\.(0|[1-9]\d*)$/
+const CHANNEL_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/
 
 function required(env, name) {
     if (!env[name]) throw new Error(`${name} is required`)
     return env[name]
 }
-
+function platform(env) {
+    const value = required(env, 'PLATFORM')
+    if (!Object.hasOwn(PRODUCTION_CHANNELS, value)) throw new Error('PLATFORM must be ios or android')
+    return value
+}
 export function verifyBundle(bundle, env) {
+    const target = platform(env)
     const version = required(env, 'VERSION')
+    const core = version.replace(/-(ios|android)$/, '')
     const android = required(env, 'FLOOR_ANDROID')
     const ios = required(env, 'FLOOR_IOS')
     const nativeFloor = required(env, 'NATIVE_FLOOR')
     const sha = required(env, 'GITHUB_SHA')
-    if (!VERSION.test(version) || !/^[a-f0-9]{40}$/.test(sha)) throw new Error('invalid release identity')
+    // Native .0 records may be shared: both floors must equal that binary.
+    // OTA records are distinct even when their web assets are identical.
+    const native = CORE.test(version) && version.endsWith('.0')
+    if (
+        !CORE.test(core) ||
+        (!native && (core.endsWith('.0') || version !== `${core}-${target}`)) ||
+        !/^[a-f0-9]{40}$/.test(sha)
+    ) {
+        throw new Error('invalid release identity')
+    }
     for (const floor of [android, ios]) {
         if (
-            !VERSION.test(floor) ||
+            !CORE.test(floor) ||
             !floor.endsWith('.0') ||
-            floor.split('.')[0] !== version.split('.')[0] ||
-            Number(floor.split('.')[1]) > Number(version.split('.')[1])
+            floor.split('.')[0] !== core.split('.')[0] ||
+            Number(floor.split('.')[1]) > Number(core.split('.')[1])
         )
             throw new Error('invalid native floor')
     }
-    const lowest = [android, ios].sort((a, b) => Number(a.split('.')[1]) - Number(b.split('.')[1]))[0]
-    if (nativeFloor !== lowest) throw new Error('shared native floor must equal the lower platform floor')
+    if (native && (android !== version || ios !== version))
+        throw new Error('native bundle floors must match the binary')
+    if (nativeFloor !== (target === 'ios' ? ios : android))
+        throw new Error('server floor must match the delivery platform')
     if (bundle?.name !== version || bundle.app_id !== required(env, 'CAPGO_APP_ID') || bundle.deleted !== false) {
         throw new Error(`bundle identity mismatch for ${version}`)
     }
@@ -51,9 +68,6 @@ export function verifyBundle(bundle, env) {
     if (bundle.link !== `https://github.com/peanutprotocol/peanut-ui/commit/${sha}`) {
         throw new Error(`bundle ${version} belongs to a different or unverified source commit`)
     }
-    // Require artifact metadata as well as compatibility data. This does not
-    // prove the remote bytes exist: the workflow also requires a successful fresh
-    // upload and forbids --version-exists-ok for incomplete prior attempts.
     if (
         typeof bundle.checksum !== 'string' ||
         !bundle.checksum ||
@@ -65,56 +79,116 @@ export function verifyBundle(bundle, env) {
     return version
 }
 
+export function verifyPolicies(channels, appId) {
+    if (!Array.isArray(channels) || channels.length >= 1000 || channels.some((row) => row.app_id !== appId)) {
+        throw new Error('invalid channel policy response')
+    }
+    for (const [target, name] of Object.entries(PRODUCTION_CHANNELS)) {
+        const matches = channels.filter((row) => row.name === name)
+        if (matches.length !== 1) throw new Error(`missing or ambiguous channel ${name}`)
+        const row = matches[0]
+        const expected = {
+            public: true,
+            ios: target === 'ios',
+            android: target === 'android',
+            electron: false,
+            disable_auto_update: 'version_number',
+            disable_auto_update_under_native: true,
+            allow_device_self_set: false,
+            allow_prod: true,
+            allow_device: true,
+            rollout_enabled: false,
+        }
+        for (const [field, value] of Object.entries(expected)) {
+            if (row[field] !== value) throw new Error(`${name} must have ${field}=${value}`)
+        }
+        if (row.version?.name !== 'builtin' && !CHANNEL_VERSION.test(row.version?.name ?? '')) {
+            throw new Error(`${name} has no valid current bundle version`)
+        }
+    }
+    if (
+        channels.some(
+            (row) => row.public && (row.ios || row.android) && !Object.values(PRODUCTION_CHANNELS).includes(row.name)
+        )
+    ) {
+        throw new Error('another default channel overlaps mobile production routing')
+    }
+    return channels
+}
+
 export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
     const appId = required(env, 'CAPGO_APP_ID')
     const apiKey = required(env, 'CAPGO_API_KEY')
+    const json = async (url, init = {}) => {
+        const response = await fetchImpl(url, { ...init, signal: AbortSignal.timeout(30000), redirect: 'error' })
+        if (!response.ok) throw new Error(`Capgo request failed (HTTP ${response.status})`)
+        return response.json()
+    }
     const request = async (resource, { query = {}, body } = {}) => {
         const url = new URL(`https://api.capgo.app/${resource}`)
         if (!body) url.search = new URLSearchParams({ app_id: appId, ...query }).toString()
-        const response = await fetchImpl(url, {
+        return json(url, {
             method: body ? 'POST' : 'GET',
             headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
             ...(body ? { body: JSON.stringify({ app_id: appId, ...body }) } : {}),
-            signal: AbortSignal.timeout(30000),
-            redirect: 'error',
         })
-        if (!response.ok) throw new Error(`Capgo ${resource} request failed (HTTP ${response.status})`)
-        return response.json()
     }
-    const channel = async (name) => {
-        const result = await request('channel', { query: { channel: name } })
-        if (result?.app_id !== appId || result.name !== name) throw new Error('channel identity mismatch')
-        return result
-    }
-    const productionWithoutRollout = async () => {
-        const production = await channel('production')
-        if (production.rolloutEnabled !== false) {
-            throw new Error('production rollout must be explicitly disabled before releasing')
+    const policies = async () => {
+        const app = await request('app')
+        if (app?.app_id !== appId || app.expose_metadata !== true)
+            throw new Error('app must expose bundle metadata to the plugin')
+        // Same public configuration and capgkey authentication as Capgo CLI's
+        // createSupabaseClient(). Pin the host before sending the release key.
+        const config = await json('https://api.capgo.app/private/config', { method: 'GET' })
+        if (config?.supaHost !== 'https://sb.capgo.app' || typeof config.supaKey !== 'string' || !config.supaKey) {
+            throw new Error('unexpected Capgo database configuration')
         }
-        return production
+        const url = new URL('https://sb.capgo.app/rest/v1/channels')
+        url.search = new URLSearchParams({
+            app_id: `eq.${appId}`,
+            limit: '1000',
+            select: 'name,app_id,public,ios,android,electron,disable_auto_update,disable_auto_update_under_native,allow_device_self_set,allow_prod,allow_device,rollout_enabled,version:app_versions!channels_version_fkey(name,id)',
+        }).toString()
+        return verifyPolicies(
+            await json(url, {
+                method: 'GET',
+                headers: {
+                    apikey: config.supaKey,
+                    Authorization: `Bearer ${config.supaKey}`,
+                    capgkey: apiKey,
+                },
+            }),
+            appId
+        )
     }
     const verifyCandidate = async () => {
-        const candidate = await channel(CANDIDATE_CHANNEL)
+        const candidate = await request('channel', { query: { channel: CANDIDATE_CHANNEL } })
+        if (candidate?.app_id !== appId || candidate.name !== CANDIDATE_CHANNEL)
+            throw new Error('channel identity mismatch')
         for (const [field, expected] of Object.entries(DISABLED_AUDIENCES)) {
             if (candidate[field] !== expected) throw new Error(`candidate channel must have ${field}=false`)
         }
+        if (candidate.rolloutEnabled !== false) throw new Error('candidate rollout must be disabled')
     }
-    const bundle = async () => {
-        const version = required(env, 'VERSION')
-        // The API pages by 50 and does not implement its optional version filter.
-        // Search the actual name field; never search a serialized record or log.
+    const bundles = async () => {
+        const rows = []
         for (let page = 0; page < 100; page++) {
             const response = await request('bundle', { query: { page: String(page) } })
-            const rows = Array.isArray(response) ? response : response?.data
-            if (!Array.isArray(rows)) throw new Error('invalid bundle-list response')
-            const matches = rows.filter((row) => row?.name === version)
-            if (matches.length > 1) throw new Error(`ambiguous bundle ${version}`)
-            if (matches.length === 1) return verifyBundle(matches[0], env)
-            if (rows.length < 50) break
+            const batch = Array.isArray(response) ? response : response?.data
+            if (!Array.isArray(batch)) throw new Error('invalid bundle-list response')
+            rows.push(...batch)
+            if (batch.length < 50) return rows
         }
+        throw new Error('bundle-list pagination limit reached')
+    }
+    const bundle = async ({ allowMissing = false } = {}) => {
+        const version = required(env, 'VERSION')
+        const matches = (await bundles()).filter((row) => row?.name === version)
+        if (matches.length > 1) throw new Error(`ambiguous bundle ${version}`)
+        if (matches.length === 1) return verifyBundle(matches[0], env)
+        if (allowMissing) return 'missing'
         throw new Error(`bundle ${version} was not found`)
     }
-
     switch (mode) {
         case 'prepare-candidate':
             await request('channel', {
@@ -132,28 +206,46 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         case 'verify-bundle':
             await verifyCandidate()
             return `Verified bundle ${await bundle()}`
+        case 'existing-native':
+            if (!CORE.test(env.VERSION ?? '') || !env.VERSION.endsWith('.0'))
+                throw new Error('expected native .0 version')
+            return bundle({ allowMissing: true })
         case 'current-version': {
-            const current = (await productionWithoutRollout()).version?.name
-            if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(current ?? '')) {
-                throw new Error('production has no valid current bundle version')
-            }
-            return current
+            const name = PRODUCTION_CHANNELS[platform(env)]
+            return (await policies()).find((row) => row.name === name).version.name
+        }
+        case 'current-release': {
+            const current = (await policies())
+                .filter((row) => Object.values(PRODUCTION_CHANNELS).includes(row.name))
+                .map((row) => row.version.name)
+                .filter((name) => name !== 'builtin')
+            // Include failed/partial and deleted platform uploads: their names
+            // remain reserved. Exclude staging's commit-count version sequence.
+            current.push(
+                ...(await bundles()).map((row) => row.name).filter((name) => /^\d+\.\d+\.\d+-(ios|android)$/.test(name))
+            )
+            const cores = current.map((name) => name.split('-')[0])
+            cores.sort((a, b) => {
+                const x = a.split('.').map(Number),
+                    y = b.split('.').map(Number)
+                return y[0] - x[0] || y[1] - x[1] || y[2] - x[2]
+            })
+            return cores[0] ?? 'builtin'
         }
         case 'verify-promotion':
-            await productionWithoutRollout()
-            return 'Production has no active rollout; promotion may proceed'
+            await policies()
+            return 'Platform production policies verified'
         case 'verify-production': {
-            const production = await channel('production')
-            if (production.version?.name !== required(env, 'VERSION') || production.rolloutEnabled !== false) {
-                throw new Error('production does not exclusively serve the expected version')
-            }
-            return `Production serves verified bundle ${await bundle()}`
+            const name = PRODUCTION_CHANNELS[platform(env)]
+            const row = (await policies()).find((entry) => entry.name === name)
+            if (row.version.name !== required(env, 'VERSION'))
+                throw new Error(`${name} does not exclusively serve the expected version`)
+            return `${name} serves verified bundle ${await bundle()}`
         }
         default:
             throw new Error(`unknown release-guard mode: ${mode}`)
     }
 }
-
 if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
     try {
         console.log(await run(process.argv[2]))

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Structured release checks. The pinned CLI's human bundle table omits comments.
+// API contracts: https://capgo.app/docs/public-api/bundles/ and /channels/.
+// Keep the upload on a channel with every device audience disabled until the
+// exact version, source commit and compatibility metadata have been verified.
+import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export const CANDIDATE_CHANNEL = 'ota-candidate'
+const DISABLED_AUDIENCES = {
+    public: false,
+    allow_device_self_set: false,
+    allow_emulator: false,
+    allow_device: false,
+    allow_dev: false,
+    allow_prod: false,
+}
+const VERSION = /^(0|[1-9]\d*)\.([1-9]\d*)\.(0|[1-9]\d*)$/
+
+function required(env, name) {
+    if (!env[name]) throw new Error(`${name} is required`)
+    return env[name]
+}
+
+export function verifyBundle(bundle, env) {
+    const version = required(env, 'VERSION')
+    const android = required(env, 'FLOOR_ANDROID')
+    const ios = required(env, 'FLOOR_IOS')
+    const nativeFloor = required(env, 'NATIVE_FLOOR')
+    const sha = required(env, 'GITHUB_SHA')
+    if (!VERSION.test(version) || !/^[a-f0-9]{40}$/.test(sha)) throw new Error('invalid release identity')
+    for (const floor of [android, ios]) {
+        if (
+            !VERSION.test(floor) ||
+            !floor.endsWith('.0') ||
+            floor.split('.')[0] !== version.split('.')[0] ||
+            Number(floor.split('.')[1]) > Number(version.split('.')[1])
+        )
+            throw new Error('invalid native floor')
+    }
+    const lowest = [android, ios].sort((a, b) => Number(a.split('.')[1]) - Number(b.split('.')[1]))[0]
+    if (nativeFloor !== lowest) throw new Error('shared native floor must equal the lower platform floor')
+    if (bundle?.name !== version || bundle.app_id !== required(env, 'CAPGO_APP_ID') || bundle.deleted !== false) {
+        throw new Error(`bundle identity mismatch for ${version}`)
+    }
+    const expected = `[ota-floors: android=${android} ios=${ios}]`
+    if (typeof bundle.comment !== 'string' || !bundle.comment.trimEnd().endsWith(expected)) {
+        throw new Error(`bundle ${version} does not carry the expected candidate floors`)
+    }
+    if (bundle.minUpdateVersion !== nativeFloor) throw new Error(`bundle ${version} has the wrong server floor`)
+    if (bundle.link !== `https://github.com/peanutprotocol/peanut-ui/commit/${sha}`) {
+        throw new Error(`bundle ${version} belongs to a different or unverified source commit`)
+    }
+    // Require artifact metadata as well as compatibility data. This does not
+    // prove the remote bytes exist: the workflow also requires a successful fresh
+    // upload and forbids --version-exists-ok for incomplete prior attempts.
+    if (
+        typeof bundle.checksum !== 'string' ||
+        !bundle.checksum ||
+        bundle.storage_provider !== 'r2' ||
+        !bundle.r2_path
+    ) {
+        throw new Error(`bundle ${version} has incomplete artifact metadata`)
+    }
+    return version
+}
+
+export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
+    const appId = required(env, 'CAPGO_APP_ID')
+    const apiKey = required(env, 'CAPGO_API_KEY')
+    const request = async (resource, { query = {}, body } = {}) => {
+        const url = new URL(`https://api.capgo.app/${resource}`)
+        if (!body) url.search = new URLSearchParams({ app_id: appId, ...query }).toString()
+        const response = await fetchImpl(url, {
+            method: body ? 'POST' : 'GET',
+            headers: { Authorization: apiKey, 'Content-Type': 'application/json' },
+            ...(body ? { body: JSON.stringify({ app_id: appId, ...body }) } : {}),
+            signal: AbortSignal.timeout(30000),
+            redirect: 'error',
+        })
+        if (!response.ok) throw new Error(`Capgo ${resource} request failed (HTTP ${response.status})`)
+        return response.json()
+    }
+    const channel = async (name) => {
+        const result = await request('channel', { query: { channel: name } })
+        if (result?.app_id !== appId || result.name !== name) throw new Error('channel identity mismatch')
+        return result
+    }
+    const verifyCandidate = async () => {
+        const candidate = await channel(CANDIDATE_CHANNEL)
+        for (const [field, expected] of Object.entries(DISABLED_AUDIENCES)) {
+            if (candidate[field] !== expected) throw new Error(`candidate channel must have ${field}=false`)
+        }
+    }
+    const bundle = async () => {
+        const version = required(env, 'VERSION')
+        // The API pages by 50 and does not implement its optional version filter.
+        // Search the actual name field; never search a serialized record or log.
+        for (let page = 0; page < 100; page++) {
+            const response = await request('bundle', { query: { page: String(page) } })
+            const rows = Array.isArray(response) ? response : response?.data
+            if (!Array.isArray(rows)) throw new Error('invalid bundle-list response')
+            const matches = rows.filter((row) => row?.name === version)
+            if (matches.length > 1) throw new Error(`ambiguous bundle ${version}`)
+            if (matches.length === 1) return verifyBundle(matches[0], env)
+            if (rows.length < 50) break
+        }
+        throw new Error(`bundle ${version} was not found`)
+    }
+
+    switch (mode) {
+        case 'prepare-candidate':
+            await request('channel', {
+                body: {
+                    channel: CANDIDATE_CHANNEL,
+                    ...DISABLED_AUDIENCES,
+                    ios: false,
+                    android: false,
+                    electron: false,
+                    rolloutEnabled: false,
+                },
+            })
+            await verifyCandidate()
+            return 'Candidate channel has no enabled device audience'
+        case 'verify-bundle':
+            await verifyCandidate()
+            return `Verified bundle ${await bundle()}`
+        case 'current-version': {
+            const current = (await channel('production')).version?.name
+            if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(current ?? '')) {
+                throw new Error('production has no valid current bundle version')
+            }
+            return current
+        }
+        case 'verify-production': {
+            const production = await channel('production')
+            if (production.version?.name !== required(env, 'VERSION') || production.rolloutEnabled !== false) {
+                throw new Error('production does not exclusively serve the expected version')
+            }
+            return `Production serves verified bundle ${await bundle()}`
+        }
+        default:
+            throw new Error(`unknown release-guard mode: ${mode}`)
+    }
+}
+
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
+    try {
+        console.log(await run(process.argv[2]))
+    } catch (error) {
+        console.error(`capgo-release-guard: ${error.message}`)
+        process.exitCode = 1
+    }
+}

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -86,6 +86,13 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         if (result?.app_id !== appId || result.name !== name) throw new Error('channel identity mismatch')
         return result
     }
+    const productionWithoutRollout = async () => {
+        const production = await channel('production')
+        if (production.rolloutEnabled !== false) {
+            throw new Error('production rollout must be explicitly disabled before releasing')
+        }
+        return production
+    }
     const verifyCandidate = async () => {
         const candidate = await channel(CANDIDATE_CHANNEL)
         for (const [field, expected] of Object.entries(DISABLED_AUDIENCES)) {
@@ -126,12 +133,15 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
             await verifyCandidate()
             return `Verified bundle ${await bundle()}`
         case 'current-version': {
-            const current = (await channel('production')).version?.name
+            const current = (await productionWithoutRollout()).version?.name
             if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(current ?? '')) {
                 throw new Error('production has no valid current bundle version')
             }
             return current
         }
+        case 'verify-promotion':
+            await productionWithoutRollout()
+            return 'Production has no active rollout; promotion may proceed'
         case 'verify-production': {
             const production = await channel('production')
             if (production.version?.name !== required(env, 'VERSION') || production.rolloutEnabled !== false) {

--- a/scripts/native-fingerprint.mjs
+++ b/scripts/native-fingerprint.mjs
@@ -123,6 +123,13 @@ export const NATIVE_DEPENDENCIES = [
 // Capacitor, which costs nothing but an extra native release.
 const NATIVE_DEPENDENCY_PATTERN = /capacitor|cordova|^@onesignal\/|^@sumsub\//i
 
+// Explicit exceptions only. Core and cross-platform plugins affect both
+// binaries; an unclassified plugin stays shared until its scope is established.
+const PLATFORM_NATIVE_DEPENDENCIES = new Map([
+    ['@capacitor/android', 'android'],
+    ['@capacitor/ios', 'ios'],
+])
+
 // Every input is one line of the manifest. Adding one is a deliberate act: it
 // widens what counts as "the native surface changed" and therefore how often an
 // OTA is refused, so prefer the narrowest input that actually carries the
@@ -218,7 +225,9 @@ export const NATIVE_INPUTS = [
     { kind: 'glob', id: 'patches/**', platform: 'shared', dirs: ['patches'], extensions: [''] },
 
     // Resolved native plugin versions, from the lockfile rather than the
-    // generated manifests, which the OTA workflow never regenerates.
+    // generated manifests, which the OTA workflow never regenerates. Keep the
+    // combined digest for full-surface checks and stored replacement attestations;
+    // platformDiff computes a scoped dependency digest for this entry instead.
     { kind: 'deps', id: 'native-plugin-versions', platform: 'shared' },
 ]
 
@@ -329,7 +338,7 @@ function assertRefExists(ref) {
 // Every native dependency's resolved version(s), read from the lockfile. Names
 // come from package.json so the set is explicit; versions come from the
 // lockfile so a bump cannot hide behind a caret specifier.
-function nativeDependencyVersions(ref) {
+function nativeDependencyVersions(ref, platform) {
     const packageJson = readAtRef('package.json', ref)
     const lockfile = readAtRef('pnpm-lock.yaml', ref)
     if (!packageJson || !lockfile) return null
@@ -348,7 +357,14 @@ function nativeDependencyVersions(ref) {
     const declared = Object.keys({ ...parsed.dependencies, ...parsed.devDependencies }).filter((name) =>
         NATIVE_DEPENDENCY_PATTERN.test(name)
     )
-    const names = [...new Set([...NATIVE_DEPENDENCIES, ...declared, ...generatedPluginNames(ref)])].sort()
+    const names = [...new Set([...NATIVE_DEPENDENCIES, ...declared, ...generatedPluginNames(ref)])]
+        .filter(
+            (name) =>
+                !platform ||
+                !PLATFORM_NATIVE_DEPENDENCIES.has(name) ||
+                PLATFORM_NATIVE_DEPENDENCIES.get(name) === platform
+        )
+        .sort()
 
     // pnpm patch identity: which packages are patched and by which file.
     const patched = Object.entries(parsed.pnpm?.patchedDependencies ?? {})
@@ -371,7 +387,7 @@ function nativeDependencyVersions(ref) {
     ].join('\n')
 }
 
-export function manifest(ref) {
+export function manifest(ref, dependencyPlatform) {
     assertRefExists(ref)
     const entries = {}
     for (const input of NATIVE_INPUTS) {
@@ -397,7 +413,7 @@ export function manifest(ref) {
             continue
         }
 
-        const versions = nativeDependencyVersions(ref)
+        const versions = nativeDependencyVersions(ref, dependencyPlatform)
         entries[input.id] = versions === null ? ABSENT : sha(versions)
     }
     return entries
@@ -413,8 +429,10 @@ export function fingerprint(ref) {
 }
 
 export function diff(baseRef, headRef) {
-    const base = manifest(baseRef)
-    const head = manifest(headRef)
+    return diffManifests(manifest(baseRef), manifest(headRef))
+}
+
+function diffManifests(base, head) {
     return NATIVE_INPUTS.filter((input) => base[input.id] !== head[input.id]).map((input) => ({
         path: input.id,
         platform: input.platform,
@@ -441,7 +459,12 @@ export function diff(baseRef, headRef) {
  */
 export function platformDiff(platform, baseRef, headRef) {
     if (!['android', 'ios'].includes(platform)) throw new Error(`platform must be android or ios, got "${platform}"`)
-    return diff(baseRef, headRef).filter((change) => change.platform === platform || change.platform === 'shared')
+    // The full fingerprint format is also persisted in native replacement tags.
+    // Scope dependency versions only for floor comparisons so an Android-only
+    // runtime bump cannot raise the iOS floor or invalidate those attestations.
+    return diffManifests(manifest(baseRef, platform), manifest(headRef, platform)).filter(
+        (change) => change.platform === platform || change.platform === 'shared'
+    )
 }
 
 function flag(argv, name) {

--- a/scripts/native-fingerprint.mjs
+++ b/scripts/native-fingerprint.mjs
@@ -130,34 +130,38 @@ const NATIVE_DEPENDENCY_PATTERN = /capacitor|cordova|^@onesignal\/|^@sumsub\//i
 export const NATIVE_INPUTS = [
     // Capacitor's generated plugin manifests — the plugin set and their exact
     // resolved versions, per platform.
-    { kind: 'file', id: 'android/capacitor.settings.gradle' },
-    { kind: 'file', id: 'ios/App/CapApp-SPM/Package.swift' },
+    { kind: 'file', id: 'android/capacitor.settings.gradle', platform: 'android' },
+    { kind: 'file', id: 'ios/App/CapApp-SPM/Package.swift', platform: 'ios' },
 
     // The resolved SPM graph xcodebuild actually archives against. Package.swift
     // declares ranges; this pins the revision each native SDK is built from, so
     // a pin can move with no other file changing.
-    { kind: 'file', id: 'ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved' },
+    {
+        kind: 'file',
+        id: 'ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved',
+        platform: 'ios',
+    },
 
     // Native runtime config the JS half reads through the bridge.
-    { kind: 'file', id: 'capacitor.config.ts' },
+    { kind: 'file', id: 'capacitor.config.ts', platform: 'shared' },
 
     // The release workflow runs this after `cap sync`, and it pins native SDK
     // versions the repo has no other record of — SUMSUB_VERSION and
     // MPP_VERSION are string constants inside it, so bumping the MeaWallet SDK
     // from 2.0.0 to 2.1.0 changes what the binary links and nothing else in
     // this manifest moves.
-    { kind: 'file', id: 'scripts/native-ios-postsync.js' },
+    { kind: 'file', id: 'scripts/native-ios-postsync.js', platform: 'ios' },
 
     // Android build surface: dependencies, SDK levels, permissions, and the
     // shrinker rules that determine which native runtime metadata survives.
-    { kind: 'file', id: 'android/build.gradle' },
-    { kind: 'file', id: 'android/app/build.gradle' },
-    { kind: 'file', id: 'android/app/proguard-rules.pro' },
-    { kind: 'file', id: 'android/variables.gradle' },
-    { kind: 'file', id: 'android/app/src/main/AndroidManifest.xml' },
+    { kind: 'file', id: 'android/build.gradle', platform: 'android' },
+    { kind: 'file', id: 'android/app/build.gradle', platform: 'android' },
+    { kind: 'file', id: 'android/app/proguard-rules.pro', platform: 'android' },
+    { kind: 'file', id: 'android/variables.gradle', platform: 'android' },
+    { kind: 'file', id: 'android/app/src/main/AndroidManifest.xml', platform: 'android' },
 
     // iOS build surface: targets, deployment floor, capabilities.
-    { kind: 'file', id: 'ios/App/App.xcodeproj/project.pbxproj' },
+    { kind: 'file', id: 'ios/App/App.xcodeproj/project.pbxproj', platform: 'ios' },
 
     // Native resource contracts the config files delegate to, which nothing
     // else here moves for. On Android that is res/values — capacitor-passkey.xml
@@ -167,10 +171,17 @@ export const NATIVE_INPUTS = [
     // Extensions rather than a `**` glob: the generated web assets under
     // ios/App/App/public and android/app/src/main/assets/public are gitignored,
     // so neither ls-files nor ls-tree ever reports them.
-    { kind: 'glob', id: 'android/app/src/main/res/**.xml', dirs: ['android/app/src/main/res'], extensions: ['.xml'] },
+    {
+        kind: 'glob',
+        id: 'android/app/src/main/res/**.xml',
+        platform: 'android',
+        dirs: ['android/app/src/main/res'],
+        extensions: ['.xml'],
+    },
     {
         kind: 'glob',
         id: 'ios/App/**.{plist,entitlements}',
+        platform: 'ios',
         dirs: ['ios/App'],
         extensions: ['.plist', '.entitlements'],
     },
@@ -192,17 +203,23 @@ export const NATIVE_INPUTS = [
     //
     // The real fix is for the variant to stop depending on a CI secret; until
     // then the guard errs toward refusing an OTA.
-    { kind: 'glob', id: 'android/app/src/**.{java,kt}', dirs: ['android/app/src'], extensions: ['.java', '.kt'] },
-    { kind: 'glob', id: 'ios/App/**.swift', dirs: ['ios/App'], extensions: ['.swift'] },
+    {
+        kind: 'glob',
+        id: 'android/app/src/**.{java,kt}',
+        platform: 'android',
+        dirs: ['android/app/src'],
+        extensions: ['.java', '.kt'],
+    },
+    { kind: 'glob', id: 'ios/App/**.swift', platform: 'ios', dirs: ['ios/App'], extensions: ['.swift'] },
 
     // pnpm patches rewrite a package's JS wrapper AND its native sources with
     // no version change, so neither the lockfile version nor the generated
     // manifests move. The patch files are the only record.
-    { kind: 'glob', id: 'patches/**', dirs: ['patches'], extensions: [''] },
+    { kind: 'glob', id: 'patches/**', platform: 'shared', dirs: ['patches'], extensions: [''] },
 
     // Resolved native plugin versions, from the lockfile rather than the
     // generated manifests, which the OTA workflow never regenerates.
-    { kind: 'deps', id: 'native-plugin-versions' },
+    { kind: 'deps', id: 'native-plugin-versions', platform: 'shared' },
 ]
 
 // A file the tree does not have is still a fact about the surface — adding or
@@ -400,9 +417,31 @@ export function diff(baseRef, headRef) {
     const head = manifest(headRef)
     return NATIVE_INPUTS.filter((input) => base[input.id] !== head[input.id]).map((input) => ({
         path: input.id,
+        platform: input.platform,
         base: base[input.id],
         head: head[input.id],
     }))
+}
+
+/**
+ * The same diff, narrowed to what one platform's binary actually carries.
+ *
+ * `shared` inputs count for BOTH platforms and are the reason this is not a
+ * path-prefix filter: `capacitor.config.ts`, `patches/` and the resolved plugin
+ * versions sit outside `android/` and `ios/` while describing the native half of
+ * both, so a prefix test would quietly wave a plugin bump through for every
+ * platform. Every entry in NATIVE_INPUTS carries an explicit `platform`, and a
+ * test asserts it, so a newly added input cannot default to the lenient side.
+ *
+ * Why per-platform at all: one release tag names two binaries, and the field
+ * does not keep them in step — TestFlight does not auto-update, so iOS sat on
+ * 1.5.0 while Android moved to 1.6.0, and every native input that changed
+ * between those two releases was under `android/`. A version-number comparison
+ * cannot see that, and refuses the whole iOS population an update it could run.
+ */
+export function platformDiff(platform, baseRef, headRef) {
+    if (!['android', 'ios'].includes(platform)) throw new Error(`platform must be android or ios, got "${platform}"`)
+    return diff(baseRef, headRef).filter((change) => change.platform === platform || change.platform === 'shared')
 }
 
 function flag(argv, name) {
@@ -420,6 +459,16 @@ function main(argv) {
 
     if (argv.includes('--manifest')) {
         return JSON.stringify(manifest(ref), null, 2)
+    }
+
+    // The input set and its platform classification, for the suite that pins
+    // it. Reads nothing from git, so it answers in any checkout.
+    if (argv.includes('--inputs')) {
+        return JSON.stringify(
+            NATIVE_INPUTS.map(({ id, platform }) => ({ id, platform })),
+            null,
+            2
+        )
     }
 
     // Presence of the flag decides the mode, never the value it picked up: a

--- a/scripts/ota-platform-floor.mjs
+++ b/scripts/ota-platform-floor.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+// Resolves, per platform, the OLDEST native release a bundle may be delivered to.
+//
+// Capgo carries one `min_update_version` per bundle and one bundle serves both
+// platforms, so the server side can only express a single floor. That floor is a
+// version number, and a version number cannot say which platform's binary
+// actually changed — while the field keeps the two platforms apart on its own:
+// TestFlight does not auto-update, so iOS sat on 1.5.0 while Android moved to
+// 1.6.0, and every native input that differed between those releases was under
+// `android/`. A single numeric floor of 1.6.0 refuses the entire iOS population
+// a bundle its binary can run perfectly well.
+//
+// So the floor is computed here, per platform, from the surface rather than the
+// number: walk the native releases newest-first and keep going while that
+// platform's half of the fingerprint is unchanged. The last release that still
+// matches is the floor — the oldest binary of that platform whose native
+// contract is the one this tree was built against. The numbers are baked into
+// the bundle (NEXT_PUBLIC_OTA_FLOOR_ANDROID / _IOS) and the on-device gate
+// compares the running binary against the floor for its own platform.
+//
+// This only ever WIDENS delivery. The publish gate is unchanged: a tree whose
+// surface differs from the newest release still fails check-native-ota-surface
+// and still needs a coordinated native release.
+//
+// Usage:
+//   node scripts/ota-platform-floor.mjs                 # both, as KEY=value lines
+//   node scripts/ota-platform-floor.mjs --platform ios   # one, as a bare version
+//   node scripts/ota-platform-floor.mjs --ref <git-ref>
+
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { platformDiff, setRepoRoot } from './native-fingerprint.mjs'
+import { allNativeReleases, setRepoRoot as setVersionRepoRoot } from './release-version.mjs'
+
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+export const PLATFORMS = ['android', 'ios']
+
+/**
+ * The oldest native release of `platform` whose native surface still matches
+ * `headRef`, as a plain `<major>.<build>.0` version.
+ *
+ * Contiguous from the newest on purpose. A release further back that happens to
+ * match again — a native change made and then reverted — is not evidence that
+ * the binaries in between can run this JS, and treating it as a floor would
+ * hand a bundle to exactly the binaries the intervening change was made for.
+ *
+ * The scan also stops at the major boundary, even when the surface matches
+ * across it. A major is a deliberate app-generation break: release-version.mjs
+ * keeps a bundle's floor inside one major band, and the on-device comparison
+ * checks majors before builds — so a floor of 1.6.0 published from a 2.x tree
+ * would have every 1.6 binary accept a 2.x bundle, which is the one boundary
+ * the scheme exists to hold.
+ *
+ * Throws when even the NEWEST release differs for this platform: there is no
+ * binary in the field that carries this tree's contract, which is the state
+ * check-native-ota-surface fails the publish on.
+ */
+export function platformFloor({ platform, headRef = 'HEAD', root = defaultRoot }) {
+    if (!PLATFORMS.includes(platform)) throw new Error(`platform must be android or ios, got "${platform}"`)
+    setRepoRoot(root)
+    setVersionRepoRoot(root)
+
+    const releases = allNativeReleases()
+    if (releases.length === 0) throw new Error('no v<major>.<build>.0 tag exists in this repository')
+
+    const currentMajor = releases[0].major
+    let floor = null
+    for (const { major, build } of releases) {
+        if (major !== currentMajor) break
+        const tag = `v${major}.${build}.0`
+        if (platformDiff(platform, tag, headRef).length > 0) break
+        floor = `${major}.${build}.0`
+    }
+    if (floor === null) {
+        const newest = `v${releases[0].major}.${releases[0].build}.0`
+        const changed = platformDiff(platform, newest, headRef)
+            .map(({ path }) => `  ${path}`)
+            .join('\n')
+        throw new Error(
+            `no shipped ${platform} binary carries this tree's native contract — it differs from ${newest}:\n${changed}\n` +
+                'Cut a coordinated native release before publishing this OTA.'
+        )
+    }
+    return floor
+}
+
+export function platformFloors({ headRef = 'HEAD', root = defaultRoot } = {}) {
+    return Object.fromEntries(PLATFORMS.map((platform) => [platform, platformFloor({ platform, headRef, root })]))
+}
+
+// Numeric on (major, build); the ota segment of a floor is always 0.
+function compareVersions(a, b) {
+    const [aMajor, aBuild] = a.split('.').map(Number)
+    const [bMajor, bBuild] = b.split('.').map(Number)
+    return aMajor - bMajor || aBuild - bBuild
+}
+
+function flag(argv, name) {
+    const index = argv.indexOf(name)
+    return index === -1 ? undefined : argv[index + 1]
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+    try {
+        const argv = process.argv.slice(2)
+        const root = flag(argv, '--root') ?? defaultRoot
+        const headRef = flag(argv, '--ref') ?? 'HEAD'
+        const platform = flag(argv, '--platform')
+        for (const name of ['--root', '--ref', '--platform']) {
+            if (argv.includes(name) && !flag(argv, name)) throw new Error(`${name} needs a value`)
+        }
+        if (argv.includes('--lowest')) {
+            // Capgo carries ONE min_update_version per bundle and one bundle
+            // serves both platforms, so the server can only express the more
+            // permissive of the two floors; the on-device gate applies the
+            // platform-specific one. Picking the higher instead would have the
+            // server refuse the very population the floors exist to keep served.
+            const floors = platformFloors({ headRef, root })
+            const lowest = PLATFORMS.map((name) => floors[name]).sort(compareVersions)[0]
+            process.stdout.write(`${lowest}\n`)
+        } else if (platform) {
+            process.stdout.write(`${platformFloor({ platform, headRef, root })}\n`)
+        } else {
+            const floors = platformFloors({ headRef, root })
+            process.stdout.write(
+                `NEXT_PUBLIC_OTA_FLOOR_ANDROID=${floors.android}\nNEXT_PUBLIC_OTA_FLOOR_IOS=${floors.ios}\n`
+            )
+        }
+    } catch (err) {
+        console.error(`✗ ota-platform-floor: ${err.message}`)
+        process.exit(1)
+    }
+}

--- a/scripts/ota-platform-floor.mjs
+++ b/scripts/ota-platform-floor.mjs
@@ -2,14 +2,9 @@
 
 // Resolves, per platform, the OLDEST native release a bundle may be delivered to.
 //
-// Capgo carries one `min_update_version` per bundle and one bundle serves both
-// platforms, so the server side can only express a single floor. That floor is a
-// version number, and a version number cannot say which platform's binary
-// actually changed — while the field keeps the two platforms apart on its own:
-// TestFlight does not auto-update, so iOS sat on 1.5.0 while Android moved to
-// 1.6.0, and every native input that differed between those releases was under
-// `android/`. A single numeric floor of 1.6.0 refuses the entire iOS population
-// a bundle its binary can run perfectly well.
+// Capgo carries one min_update_version per bundle record. Production uploads
+// separate iOS/Android records so each server floor protects legacy clients
+// before their first floor-aware OTA. A lower shared floor is unsafe.
 //
 // So the floor is computed here, per platform, from the surface rather than the
 // number: walk the native releases newest-first and keep going while that
@@ -112,11 +107,8 @@ if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import
             if (argv.includes(name) && !flag(argv, name)) throw new Error(`${name} needs a value`)
         }
         if (argv.includes('--lowest')) {
-            // Capgo carries ONE min_update_version per bundle and one bundle
-            // serves both platforms, so the server can only express the more
-            // permissive of the two floors; the on-device gate applies the
-            // platform-specific one. Picking the higher instead would have the
-            // server refuse the very population the floors exist to keep served.
+            // Diagnostic only. Never use this value as a shared server floor:
+            // legacy updaters cannot enforce the stricter platform requirement.
             const floors = platformFloors({ headRef, root })
             const lowest = PLATFORMS.map((name) => floors[name]).sort(compareVersions)[0]
             process.stdout.write(`${lowest}\n`)

--- a/scripts/publish-native-ota.sh
+++ b/scripts/publish-native-ota.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# The .0 artifact can be shared only after verifying the exact source and equal
+# native floors. OTA .1+ records instead have separate -ios/-android identities.
+set -euo pipefail
+case "$PLATFORM" in ios|android) ;; *) echo 'Invalid platform' >&2; exit 1;; esac
+export FLOOR_ANDROID="$VERSION" FLOOR_IOS="$VERSION" NATIVE_FLOOR="$VERSION"
+test -f out/index.html
+node scripts/capgo-release-guard.mjs verify-promotion
+node scripts/capgo-release-guard.mjs prepare-candidate
+EXISTING="$(node scripts/capgo-release-guard.mjs existing-native)"
+if [ "$EXISTING" = missing ]; then
+  npx @capgo/cli@8.42.4 bundle upload \
+    --channel ota-candidate --apikey "$CAPGO_API_KEY" --key-data-v2 "$CAPGO_PRIVATE_KEY" \
+    --path ./out --bundle "$VERSION" --min-update-version "$VERSION" \
+    --comment "${GITHUB_SHA:0:7} — native release $VERSION [ota-floors: android=$VERSION ios=$VERSION]" \
+    --link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"
+fi
+node scripts/capgo-release-guard.mjs verify-bundle
+node scripts/capgo-release-guard.mjs verify-promotion
+npx @capgo/cli@8.42.4 channel set "$PLATFORM-mobile-release" --apikey "$CAPGO_API_KEY" --bundle "$VERSION"
+node scripts/capgo-release-guard.mjs verify-production

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -24,25 +24,46 @@
 //   node scripts/release-version.mjs ota --current <version>
 //   node scripts/release-version.mjs staging
 //   node scripts/release-version.mjs native-floor
+//   node scripts/release-version.mjs newest-native
 //   node scripts/release-version.mjs validate <version> --kind <native|ota>
 //
 // Needs full history and tags (actions/checkout with fetch-depth: 0).
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const PLAIN_SEMVER = /^(\d+)\.(\d+)\.(\d+)$/
 const CHANNEL_SEMVER = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+let repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
-try {
-    process.stdout.write(`${main(process.argv.slice(2))}\n`)
-} catch (err) {
-    console.error(`✗ release-version: ${err.message}`)
-    process.exit(1)
+export function setRepoRoot(root) {
+    repoRoot = resolve(root)
+}
+
+// Guarded so this file can be imported for its tag reader (ota-platform-floor)
+// without running the CLI and calling process.exit on a missing mode.
+// realpath, not resolve: the suite copies this script under os.tmpdir(), which on
+// macOS hands back /var/... while import.meta.url resolves to /private/var/...,
+// and a plain string compare would leave the CLI silently printing nothing.
+function invokedDirectly() {
+    if (!process.argv[1]) return false
+    try {
+        return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
+    } catch {
+        return false
+    }
+}
+
+if (invokedDirectly()) {
+    try {
+        process.stdout.write(`${main(process.argv.slice(2))}\n`)
+    } catch (err) {
+        console.error(`✗ release-version: ${err.message}`)
+        process.exit(1)
+    }
 }
 
 function main(argv) {
@@ -58,10 +79,14 @@ function main(argv) {
             return `${major}.${latestBuild(major)}.${commitCount()}`
         case 'native-floor':
             return nativeFloor(major)
+        case 'newest-native':
+            return newestNative(rest.includes('--allow-none'))
         case 'validate':
             return validate(major, rest[0], flag(rest, '--kind'))
         default:
-            throw new Error(`unknown mode "${mode ?? ''}" — expected native, ota, staging, native-floor or validate`)
+            throw new Error(
+                `unknown mode "${mode ?? ''}" — expected native, ota, staging, native-floor, newest-native or validate`
+            )
     }
 }
 
@@ -112,6 +137,44 @@ function nativeFloor(major) {
     return `${major}.${build}.0`
 }
 
+// The newest native release in the repository, ACROSS majors — which is the one
+// a release ref has to contain. `nativeFloor` deliberately scopes to the current
+// major, because a bundle's --min-update-version has to sit in the same major
+// band as the bundle. Provenance is the opposite question: the moment
+// package.json advances to a major with no tag yet, the major-scoped floor has
+// no answer, and skipping the check there is what would let a lagging ref build
+// 2.1.0 without containing v1.6.0 — a higher store version carrying older code,
+// exactly what the guard exists to stop.
+function newestNative(allowNone = false) {
+    const releases = allNativeReleases()
+    if (releases.length === 0) {
+        if (allowNone) return ''
+        throw new Error('no attested v<major>.<build>.0 native release exists in this repository')
+    }
+    const [{ major, build }] = releases
+    return `${major}.${build}.0`
+}
+
+// All app generations count for provenance, regardless of the checked-out
+// package major. The release workflow creates annotated tags with this exact
+// subject after its native jobs succeed. A date-shaped or unrelated tag is not
+// release evidence. Never infer a tag's meaning from the stale checkout's major.
+export function allNativeReleases() {
+    return readTags({ allowEmpty: true })
+        .map((tag) => /^v(0|[1-9]\d*)\.([1-9]\d*)\.0$/.exec(tag))
+        .filter(Boolean)
+        .filter(([tag, major, build]) => {
+            const metadata = execFileSync(
+                'git',
+                ['for-each-ref', '--format=%(objecttype)%00%(contents:subject)', `refs/tags/${tag}`],
+                { cwd: repoRoot, encoding: 'utf8' }
+            ).trim()
+            return metadata === `tag\0Native release ${major}.${build}.0`
+        })
+        .map(([, major, build]) => ({ major: Number(major), build: Number(build) }))
+        .sort((a, b) => b.major - a.major || b.build - a.build)
+}
+
 function validate(major, version, kind) {
     const match = PLAIN_SEMVER.exec(version ?? '')
     if (!match) throw new Error(`"${version}" is not a plain X.Y.Z version`)
@@ -140,15 +203,26 @@ function readMajor() {
 
 // Returns 0 when no native release exists for this major, so the first one is .1.
 function latestBuild(major) {
-    const tags = execFileSync('git', ['tag', '--list', 'v*'], { cwd: repoRoot, encoding: 'utf8' }).split('\n')
-    if (!tags.some((tag) => tag.trim())) {
-        throw new Error('no v* tags are visible — the resolver needs actions/checkout with fetch-depth: 0')
-    }
     const pattern = new RegExp(`^v${major}\\.(\\d+)\\.0$`)
-    return tags.reduce((highest, tag) => {
-        const match = pattern.exec(tag.trim())
+    return readTags().reduce((highest, tag) => {
+        const match = pattern.exec(tag)
         return match ? Math.max(highest, Number(match[1])) : highest
     }, 0)
+}
+
+function readTags({ allowEmpty = false } = {}) {
+    const shallow = execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    }).trim()
+    if (shallow !== 'false') throw new Error('shallow clone — release registry needs fetch-depth: 0')
+    const tags = execFileSync('git', ['tag', '--list', 'v*'], { cwd: repoRoot, encoding: 'utf8' })
+        .split('\n')
+        .map((tag) => tag.trim())
+    if (!allowEmpty && !tags.some(Boolean)) {
+        throw new Error('no v* tags are visible — the resolver needs actions/checkout with fetch-depth: 0')
+    }
+    return tags.filter(Boolean)
 }
 
 function flag(argv, name) {

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -97,7 +97,7 @@ function nextOta(major, current) {
     const build = latestBuild(major)
     if (build === 0) throw new Error(`no v${major}.<build>.0 tag exists yet — cut a native release before an OTA`)
 
-    const match = CHANNEL_SEMVER.exec(current ?? '')
+    const match = CHANNEL_SEMVER.exec(current === 'builtin' ? `${major}.${build}.0` : (current ?? ''))
     if (!match) throw new Error(`--current must be X.Y.Z or X.Y.Z-<prerelease>, got "${current}"`)
     const [, currentMajor, currentBuild, currentOta] = match.map(Number)
 
@@ -107,7 +107,16 @@ function nextOta(major, current) {
                 `refusing to guess a version that devices would refuse`
         )
     }
-    return currentBuild === build ? `${major}.${build}.${currentOta + 1}` : `${major}.${build}.1`
+    // A rollback to builtin must not reuse a version already shipped and tagged.
+    const shipped = execFileSync('git', ['tag', '--list', `ota-${major}.${build}.*`], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    })
+        .split('\n')
+        .map((tag) => new RegExp(`^ota-${major}\\.${build}\\.(\\d+)$`).exec(tag))
+        .filter(Boolean)
+        .map((match) => Number(match[1]))
+    return `${major}.${build}.${Math.max(currentBuild === build ? currentOta : 0, 0, ...shipped) + 1}`
 }
 
 // Staging deliberately keeps the commit count as its ota component. It shares one

--- a/src/context/OtaUpdateContext.tsx
+++ b/src/context/OtaUpdateContext.tsx
@@ -6,6 +6,7 @@ import { isSplashVisible } from '@/hooks/useSplashGate'
 import { isAndroidNativeBridge, isCapacitor } from '@/utils/capacitor'
 import type { OtaApplyOutcome } from '@/utils/capgo-updater'
 import { importWithChunkRetry } from '@/utils/chunk-error-recovery'
+import { runningBundleOutranksBinary } from '@/utils/ota-native-gate'
 import { markNativeBootComplete } from '@/utils/native-app-ready'
 
 /**
@@ -56,6 +57,14 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
         if (!isCapacitor()) return
         let disposed = false
         let cleanup: (() => void) | undefined
+
+        // This check describes already-running JS; it must not depend on a newer
+        // candidate existing, and failure must not prevent updater initialization.
+        runningBundleOutranksBinary()
+            .then((required) => {
+                if (!disposed && required) setStoreUpdateRequired(true)
+            })
+            .catch((err) => console.warn('[capgo] running floor read failed:', err))
 
         // a bundle staged on an earlier launch is still queued in the plugin —
         // read through the gate, which drops one built for a newer binary

--- a/src/context/OtaUpdateContext.tsx
+++ b/src/context/OtaUpdateContext.tsx
@@ -54,9 +54,6 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         if (!isCapacitor()) return
-        // The app rendered, so the running bundle boots — this is what the
-        // document-start notifyAppReady trades Capgo's rollback net for.
-        markNativeBootComplete()
         let disposed = false
         let cleanup: (() => void) | undefined
 
@@ -82,6 +79,10 @@ export function OtaUpdateProvider({ children }: { children: React.ReactNode }) {
                     return
                 }
                 cleanup = remove
+                // Rendering alone does not prove this bundle can receive its
+                // replacement. Keep boot recovery armed until the local updater
+                // works too; init schedules its network check without awaiting it.
+                markNativeBootComplete()
                 // Sequenced after init on purpose: the launch apply writes the
                 // pending-apply marker that init's reportPendingApply consumes,
                 // and racing them would report this launch's marker as a

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -37,6 +37,8 @@ jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
 jest.mock('@/utils/capacitor', () => ({
     isCapacitor: () => platform.capacitor,
     isAndroidNativeBridge: () => platform.android,
+    // the store-update gate reads it to pick which platform's floor applies
+    isIOSNative: () => !platform.android,
 }))
 jest.mock('@/hooks/useSplashGate', () => ({ isSplashVisible: () => platform.splashVisible }))
 // Null by default so the store-update gate fails open and the cases below are
@@ -47,6 +49,8 @@ jest.mock('@/utils/app-version', () => ({
 }))
 
 import { OtaUpdateProvider, useOtaUpdate } from '../OtaUpdateContext'
+import { NATIVE_APP_READY_SCRIPT } from '@/utils/native-app-ready'
+import * as chunkRecovery from '@/utils/chunk-error-recovery'
 
 const STAGED = { id: 'b-2', version: '1.2.0', downloaded: '', checksum: '', status: 'pending' as const }
 
@@ -63,6 +67,8 @@ beforeEach(() => {
     platform.capacitor = true
     platform.splashVisible = false
     platform.binaryVersion = null
+    mockUpdater.notifyAppReady.mockReset().mockResolvedValue(undefined)
+    mockUpdater.addListener.mockReset().mockResolvedValue({ remove: jest.fn() })
     mockUpdater.delete.mockReset().mockResolvedValue(undefined)
     mockUpdater.getFailedUpdate.mockReset().mockResolvedValue(null)
     mockExitApp.mockClear()
@@ -95,6 +101,69 @@ const withStagedBundle = async () => {
     await waitFor(() => expect(rendered.result.current.pendingBundle).toEqual(STAGED))
     return rendered
 }
+
+describe('native boot recovery includes the updater', () => {
+    const bootKey = 'peanutNativeBootIncomplete'
+
+    it('keeps recovery armed when the updater chunk cannot load', async () => {
+        window.localStorage.setItem(bootKey, '2')
+        jest.spyOn(chunkRecovery, 'importWithChunkRetry').mockRejectedValue(new Error('updater chunk unavailable'))
+        setup()
+        await waitFor(() => expect(warn).toHaveBeenCalledWith('[capgo] ota init failed:', expect.any(Error)))
+        expect(window.localStorage.getItem(bootKey)).toBe('2')
+        expect(mockUpdater.notifyAppReady).not.toHaveBeenCalled()
+    })
+
+    it('keeps recovery armed while local updater initialization is pending', async () => {
+        window.localStorage.setItem(bootKey, '2')
+        let ready!: () => void
+        mockUpdater.notifyAppReady.mockReturnValue(new Promise<void>((resolve) => (ready = resolve)))
+        setup()
+        await waitFor(() => expect(mockUpdater.notifyAppReady).toHaveBeenCalled())
+        expect(window.localStorage.getItem(bootKey)).toBe('2')
+        await act(async () => ready())
+        await waitFor(() => expect(window.localStorage.getItem(bootKey)).toBeNull())
+    })
+
+    it('marks a working local updater ready without waiting for network access', async () => {
+        window.localStorage.setItem(bootKey, '2')
+        mockUpdater.getLatest.mockRejectedValue(new Error('offline'))
+        setup()
+        await waitFor(() => expect(window.localStorage.getItem(bootKey)).toBeNull())
+        expect(mockUpdater.addListener).toHaveBeenCalledWith('appReloaded', expect.any(Function))
+        expect(mockUpdater.getLatest).not.toHaveBeenCalled()
+    })
+
+    it('does not acknowledge an initialization that finishes after unmount', async () => {
+        window.localStorage.setItem(bootKey, '2')
+        let ready!: () => void
+        mockUpdater.notifyAppReady.mockReturnValue(new Promise<void>((resolve) => (ready = resolve)))
+        const { unmount } = setup()
+        await waitFor(() => expect(mockUpdater.notifyAppReady).toHaveBeenCalled())
+        unmount()
+        await act(async () => ready())
+        expect(window.localStorage.getItem(bootKey)).toBe('2')
+    })
+
+    it('resets to the builtin bundle after repeated updater failures even when React renders', async () => {
+        mockUpdater.addListener.mockRejectedValue(new Error('updater initialization broken'))
+        const reset = jest.fn()
+        const bridge = { Capacitor: { Plugins: { CapacitorUpdater: { notifyAppReady: jest.fn(), reset } } } }
+        const launch = () =>
+            new Function('window', 'localStorage', NATIVE_APP_READY_SCRIPT)(bridge, window.localStorage)
+
+        for (let failures = 1; failures <= 3; failures++) {
+            launch()
+            const { unmount } = setup()
+            await waitFor(() => expect(warn).toHaveBeenCalledWith('[capgo] ota init failed:', expect.any(Error)))
+            expect(window.localStorage.getItem(bootKey)).toBe(String(failures))
+            unmount()
+            warn.mockClear()
+        }
+        launch()
+        expect(reset).toHaveBeenCalledTimes(1)
+    })
+})
 
 it('seeds the pending bundle from the plugin queue, so it survives a reload', async () => {
     const { result } = await withStagedBundle()

--- a/src/context/__tests__/OtaUpdateContext.test.tsx
+++ b/src/context/__tests__/OtaUpdateContext.test.tsx
@@ -50,6 +50,7 @@ jest.mock('@/utils/app-version', () => ({
 
 import { OtaUpdateProvider, useOtaUpdate } from '../OtaUpdateContext'
 import { NATIVE_APP_READY_SCRIPT } from '@/utils/native-app-ready'
+import * as otaGate from '@/utils/ota-native-gate'
 import * as chunkRecovery from '@/utils/chunk-error-recovery'
 
 const STAGED = { id: 'b-2', version: '1.2.0', downloaded: '', checksum: '', status: 'pending' as const }
@@ -701,4 +702,11 @@ describe('rollbacks the plugin performed while no page could report them', () =>
         })
         expect(error).not.toHaveBeenCalledWith(expect.stringContaining('[capgo-apply]'))
     })
+})
+
+it('surfaces an incompatible running bundle even without a newer or staged candidate', async () => {
+    jest.spyOn(otaGate, 'runningBundleOutranksBinary').mockResolvedValue(true)
+    const { result } = setup()
+    await waitFor(() => expect(result.current.storeUpdateRequired).toBe(true))
+    expect(result.current.pendingBundle).toBeNull()
 })

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -27,6 +27,9 @@ jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
 jest.mock('@/utils/capacitor', () => ({
     ...jest.requireActual('@/utils/capacitor'),
     isAndroidNativeBridge: () => mockPlatform.android,
+    // the gate reads it to pick which platform's floor applies; the real one
+    // answers false under jsdom, which would silently test Android everywhere
+    isIOSNative: () => !mockPlatform.android,
 }))
 // The gate asks the binary for its version; jsdom is not Capacitor, so the real
 // getBinaryInfo would answer null and fail the gate open in every case below.
@@ -36,6 +39,7 @@ jest.mock('@/utils/app-version', () => ({
 }))
 
 import { canRestartInPlace, initCapgoUpdater, readStagedBundle } from '../capgo-updater'
+import { stagedFloors } from '../ota-native-gate'
 
 let info: jest.SpyInstance
 let error: jest.SpyInstance
@@ -489,6 +493,33 @@ describe('store-update gate', () => {
         expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'b-3' })
         expect(mockUpdater.delete).toHaveBeenCalledWith({ id: 'b-6' })
         expect(error).not.toHaveBeenCalled()
+    })
+
+    // The pair that makes the candidate floors useful: admitted at check time on
+    // the candidate's own floor, and still admitted on the next launch, when the
+    // queue carries only an id and a version.
+    it('applies a bundle admitted under its candidate floor on the next launch', async () => {
+        mockPlatform.android = false
+        mockPlatform.binaryVersion = '1.5.0'
+        mockUpdater.getLatest.mockResolvedValue({
+            url: 'https://cdn.test/1.6.3.zip',
+            version: '1.6.3',
+            comment: 'abc1234 — subject [ota-floors: android=1.6.0 ios=1.5.0]',
+        })
+        mockUpdater.download.mockResolvedValue({ id: 'b-9', version: '1.6.3' })
+        let floorsAtQueueTime: string | undefined
+        mockUpdater.next.mockImplementation(async ({ id }: { id: string }) => {
+            floorsAtQueueTime = stagedFloors(id)
+        })
+        await initCapgoUpdater()
+        await jest.advanceTimersByTimeAsync(5_000)
+        expect(mockUpdater.next).toHaveBeenCalledWith({ id: 'b-9' })
+        expect(floorsAtQueueTime).toBe('[ota-floors: android=1.6.0 ios=1.5.0]')
+
+        // next launch: the queue names b-9 and nothing else
+        mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-9', version: '1.6.3' })
+        await expect(readStagedBundle()).resolves.toEqual({ id: 'b-9', version: '1.6.3' })
+        expect(mockUpdater.delete).not.toHaveBeenCalled()
     })
 
     it('reports a queued bundle this binary can run', async () => {

--- a/src/utils/__tests__/capgo-updater.test.ts
+++ b/src/utils/__tests__/capgo-updater.test.ts
@@ -252,44 +252,26 @@ describe('beta channel opt-in', () => {
         expect(mockUpdater.reset).toHaveBeenCalled()
     })
 
-    // unsetChannel() is local-only on both platforms (it drops a stored key);
-    // the device→channel assignment lives on the server and only setChannel()
-    // rewrites it. Without this the device stayed on beta server-side and the
-    // next check pulled the beta bundle straight back.
-    it('assigns the device to production on the server when leaving', async () => {
-        const { leaveBetaOtaChannel, PRODUCTION_OTA_CHANNEL } = await import('../capgo-updater')
-        await leaveBetaOtaChannel()
-        expect(mockUpdater.setChannel).toHaveBeenCalledWith({
-            channel: PRODUCTION_OTA_CHANNEL,
-            triggerAutoUpdate: false,
-        })
-        const [unsetOrder] = mockUpdater.unsetChannel.mock.invocationCallOrder
-        const [setOrder] = mockUpdater.setChannel.mock.invocationCallOrder
-        expect(unsetOrder).toBeLessThan(setOrder)
-    })
+    // Returning to cloud defaults must never pin the retired shared channel.
+    // Dashboard overrides are independent and must be detected after the unset.
+    it.each([true, false])(
+        'returns to the platform default without assigning the retired channel (Android=%s)',
+        async (android) => {
+            const { leaveBetaOtaChannel } = await import('../capgo-updater')
+            mockPlatform.android = android
+            mockUpdater.getChannel.mockResolvedValue({
+                channel: android ? 'android-mobile-release' : 'ios-mobile-release',
+            })
+            await leaveBetaOtaChannel()
+            expect(mockUpdater.unsetChannel).toHaveBeenCalled()
+            expect(mockUpdater.setChannel).not.toHaveBeenCalled()
+            expect(mockUpdater.reset).toHaveBeenCalled()
+        }
+    )
 
-    // A production channel that refuses self-assign is a valid dashboard
-    // configuration. The local unset already happened, so the exit must go on
-    // and let getChannel() decide — otherwise every retry would fail the same
-    // way and the device could never leave the beta bundle.
-    it.each([
-        ['rejects', () => mockUpdater.setChannel.mockRejectedValue(new Error('channel_self_set_not_allowed'))],
-        [
-            'answers with an error',
-            () => mockUpdater.setChannel.mockResolvedValue({ status: 'error', error: 'channel_self_set_not_allowed' }),
-        ],
-    ])('still resets when the production self-assign %s but beta no longer sticks', async (_case, arrange) => {
-        const { leaveBetaOtaChannel } = await import('../capgo-updater')
-        arrange()
-        await leaveBetaOtaChannel()
-        expect(mockUpdater.getChannel).toHaveBeenCalled()
-        expect(mockUpdater.reset).toHaveBeenCalled()
-    })
-
-    it('reports an override when the self-assign is refused and beta still sticks', async () => {
+    it('reports an override when beta still sticks after unsetting the local channel', async () => {
         const { leaveBetaOtaChannel, OtaChannelOverrideError, hasPendingBetaExit, BETA_OTA_CHANNEL } =
             await import('../capgo-updater')
-        mockUpdater.setChannel.mockRejectedValue(new Error('channel_self_set_not_allowed'))
         mockUpdater.getChannel.mockResolvedValue({ channel: BETA_OTA_CHANNEL, status: 'ok' })
         await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelOverrideError)
         expect(mockUpdater.reset).not.toHaveBeenCalled()
@@ -306,6 +288,14 @@ describe('beta channel opt-in', () => {
         mockUpdater.getChannel.mockResolvedValue({ channel: 'staging', status: 'override' })
         await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelOverrideError)
         expect(mockUpdater.reset).not.toHaveBeenCalled()
+    })
+
+    it.each(['production', 'ios-mobile-release'])('rejects an Android override to %s', async (channel) => {
+        const { leaveBetaOtaChannel, OtaChannelOverrideError } = await import('../capgo-updater')
+        mockUpdater.getChannel.mockResolvedValue({ channel, status: 'override' })
+        await expect(leaveBetaOtaChannel()).rejects.toBeInstanceOf(OtaChannelOverrideError)
+        expect(mockUpdater.reset).not.toHaveBeenCalled()
+        expect(mockUpdater.setChannel).not.toHaveBeenCalled()
     })
 
     // Resetting on an unreadable answer is the forced tester's worst case: the app
@@ -519,6 +509,29 @@ describe('store-update gate', () => {
         // next launch: the queue names b-9 and nothing else
         mockUpdater.getNextBundle.mockResolvedValue({ id: 'b-9', version: '1.6.3' })
         await expect(readStagedBundle()).resolves.toEqual({ id: 'b-9', version: '1.6.3' })
+        expect(mockUpdater.delete).not.toHaveBeenCalled()
+    })
+
+    it('iOS 1.5.0 can stage and retain two consecutive platform OTAs', async () => {
+        mockPlatform.android = false
+        mockPlatform.binaryVersion = '1.5.0'
+        for (const patch of [3, 4]) {
+            const bundle = { id: `ios-${patch}`, version: `1.6.${patch}-ios` }
+            mockUpdater.getNextBundle.mockResolvedValue(null)
+            mockUpdater.getLatest.mockResolvedValue({
+                url: `https://cdn.test/${bundle.version}.zip`,
+                version: bundle.version,
+                comment: '[ota-floors: android=1.6.0 ios=1.5.0]',
+            })
+            mockUpdater.download.mockResolvedValue(bundle)
+            const dispose = await initCapgoUpdater()
+            await jest.advanceTimersByTimeAsync(5_000)
+            dispose()
+            expect(mockUpdater.next).toHaveBeenCalledWith({ id: bundle.id })
+            mockUpdater.getNextBundle.mockResolvedValue(bundle)
+            await expect(readStagedBundle()).resolves.toEqual(bundle)
+            mockUpdater.current.mockResolvedValue({ bundle })
+        }
         expect(mockUpdater.delete).not.toHaveBeenCalled()
     })
 

--- a/src/utils/__tests__/native-app-ready.test.ts
+++ b/src/utils/__tests__/native-app-ready.test.ts
@@ -68,7 +68,7 @@ describe('NATIVE_APP_READY_SCRIPT', () => {
      * one the OS froze mid-boot and rolled back on both; a frozen boot resumes
      * and clears the counter, a broken one never does.
      */
-    it('falls back to the builtin bundle after three launches that never rendered', () => {
+    it('falls back to the builtin bundle after three incomplete app/updater launches', () => {
         const { notifyAppReady, reset, store } = bootScript({ failures: 3 })
         expect(reset).toHaveBeenCalled()
         expect(notifyAppReady).not.toHaveBeenCalled()

--- a/src/utils/__tests__/ota-native-gate.test.ts
+++ b/src/utils/__tests__/ota-native-gate.test.ts
@@ -49,3 +49,195 @@ describe('bundleNeedsNewerBinary', () => {
         expect(bundleNeedsNewerBinary('1.6.0', '')).toBe(false)
     })
 })
+
+const floors = (android: string, ios: string) => `abc1234 — some commit [ota-floors: android=${android} ios=${ios}]`
+
+/**
+ * The candidate's floors, read off the comment Capgo round-trips with it.
+ *
+ * One release tag names two binaries and the field does not keep them in step:
+ * TestFlight has no auto-update, so iOS sat on 1.5.0 while Android moved to
+ * 1.6.0, and every native input that changed between those releases was under
+ * `android/`. The floors baked into a bundle describe the bundle that is
+ * RUNNING, which is the wrong bundle to judge a candidate by — the two cases
+ * this exists for are a pre-floor install taking its first floor-bearing bundle,
+ * and a floor-bearing install refusing a candidate built after a native release
+ * it knows nothing about.
+ */
+describe('needsStoreUpdate with candidate floors', () => {
+    const load = async (platform: 'android' | 'ios', binary: string) => {
+        jest.resetModules()
+        jest.doMock('@/utils/capacitor', () => ({ isIOSNative: () => platform === 'ios' }))
+        jest.doMock('@/utils/app-version', () => ({
+            getBinaryInfo: async () => ({ appVersion: binary, appBuild: '1' }),
+        }))
+        return import('../ota-native-gate')
+    }
+
+    afterEach(() => {
+        jest.dontMock('@/utils/capacitor')
+        jest.dontMock('@/utils/app-version')
+        jest.resetModules()
+    })
+
+    // The population this exists to unfreeze.
+    it('lets an iOS 1.5.0 binary take a 1.6.x candidate whose iOS floor is 1.5.0', async () => {
+        const { needsStoreUpdate } = await load('ios', '1.5.0')
+        await expect(needsStoreUpdate('1.6.3', floors('1.6.0', '1.5.0'))).resolves.toBe(false)
+    })
+
+    it('still refuses that candidate on an Android 1.5.0 binary, whose floor is 1.6.0', async () => {
+        const { needsStoreUpdate } = await load('android', '1.5.0')
+        await expect(needsStoreUpdate('1.6.3', floors('1.6.0', '1.5.0'))).resolves.toBe(true)
+    })
+
+    // The inverse, and the reason the candidate has to be authoritative: judged
+    // against the RUNNING bundle's floor (android 1.6.0) this device would accept
+    // JS its binary cannot run.
+    it('refuses a native-changing 1.7 candidate on the 1.6.0 binary it was not built for', async () => {
+        const { needsStoreUpdate } = await load('android', '1.6.0')
+        await expect(needsStoreUpdate('1.7.1', floors('1.7.0', '1.5.0'))).resolves.toBe(true)
+    })
+
+    it('lets the same 1.7 candidate through on iOS, which that release did not touch', async () => {
+        const { needsStoreUpdate } = await load('ios', '1.5.0')
+        await expect(needsStoreUpdate('1.7.1', floors('1.7.0', '1.5.0'))).resolves.toBe(false)
+    })
+
+    it('falls back to the candidate version when the comment carries no floors', async () => {
+        const { needsStoreUpdate } = await load('ios', '1.5.0')
+        await expect(needsStoreUpdate('1.6.3', 'abc1234 — a plain commit message')).resolves.toBe(true)
+        await expect(needsStoreUpdate('1.6.3', undefined)).resolves.toBe(true)
+        await expect(needsStoreUpdate('1.5.4', undefined)).resolves.toBe(false)
+    })
+
+    // A comment is a human string, and a loose parse of one reads a commit
+    // message as a version. Both platforms or neither, plain X.Y.Z only.
+    it.each([
+        ['one platform only', 'abc1234 [ota-floors: android=1.6.0]'],
+        ['a prerelease', 'abc1234 [ota-floors: android=1.6.0-rc1 ios=1.5.0]'],
+        ['a bare mention', 'abc1234 bumped ota-floors for android'],
+    ])('ignores a malformed marker — %s', async (_label, comment) => {
+        const { parseCandidateFloors } = await load('ios', '1.5.0')
+        expect(parseCandidateFloors(comment)).toBeNull()
+    })
+
+    it('reads the marker out of a comment that also carries the commit line', async () => {
+        const { parseCandidateFloors } = await load('ios', '1.5.0')
+        expect(parseCandidateFloors(floors('1.6.0', '1.5.0'))).toEqual({ android: '1.6.0', ios: '1.5.0' })
+    })
+})
+
+/**
+ * A different question from needsStoreUpdate, and the only one the baked
+ * constants can answer honestly: this install is running JS built for a native
+ * contract it does not have, so a store update is owed whether or not any new
+ * bundle exists.
+ */
+describe('runningBundleOutranksBinary', () => {
+    const load = async (platform: 'android' | 'ios', binary: string, baked?: { android: string; ios: string }) => {
+        jest.resetModules()
+        if (baked) {
+            process.env.NEXT_PUBLIC_OTA_FLOOR_ANDROID = baked.android
+            process.env.NEXT_PUBLIC_OTA_FLOOR_IOS = baked.ios
+        }
+        jest.doMock('@/utils/capacitor', () => ({ isIOSNative: () => platform === 'ios' }))
+        jest.doMock('@/utils/app-version', () => ({
+            getBinaryInfo: async () => ({ appVersion: binary, appBuild: '1' }),
+        }))
+        return import('../ota-native-gate')
+    }
+
+    afterEach(() => {
+        delete process.env.NEXT_PUBLIC_OTA_FLOOR_ANDROID
+        delete process.env.NEXT_PUBLIC_OTA_FLOOR_IOS
+        jest.dontMock('@/utils/capacitor')
+        jest.dontMock('@/utils/app-version')
+        jest.resetModules()
+    })
+
+    it('is true when the binary is behind the running bundle floor', async () => {
+        const m = await load('android', '1.5.0', { android: '1.6.0', ios: '1.5.0' })
+        await expect(m.runningBundleOutranksBinary()).resolves.toBe(true)
+    })
+
+    it('is false when the binary clears it', async () => {
+        const m = await load('ios', '1.5.0', { android: '1.6.0', ios: '1.5.0' })
+        await expect(m.runningBundleOutranksBinary()).resolves.toBe(false)
+    })
+
+    it('is false on a bundle with no baked floors', async () => {
+        const m = await load('android', '1.5.0')
+        await expect(m.runningBundleOutranksBinary()).resolves.toBe(false)
+    })
+})
+
+/**
+ * The floors have to survive the download. A bundle is admitted at check time,
+ * when the comment is in hand, but applied on a later launch — and the plugin's
+ * queue carries only an id and a version. Without this, the launch-time gate
+ * re-asks with nothing to answer from, falls back to the version rule, and
+ * disarms the bundle the check just approved: an iOS 1.5.0 install downloads
+ * 1.6.3 and throws it away on every launch, forever.
+ */
+describe('staged floors', () => {
+    let gate: typeof import('../ota-native-gate')
+
+    beforeEach(async () => {
+        window.localStorage.clear()
+        jest.resetModules()
+        jest.doMock('@/utils/capacitor', () => ({ isIOSNative: () => true }))
+        jest.doMock('@/utils/app-version', () => ({
+            getBinaryInfo: async () => ({ appVersion: '1.5.0', appBuild: '1' }),
+        }))
+        gate = await import('../ota-native-gate')
+    })
+
+    afterEach(() => {
+        jest.dontMock('@/utils/capacitor')
+        jest.dontMock('@/utils/app-version')
+        jest.resetModules()
+    })
+
+    const marker = '[ota-floors: android=1.6.0 ios=1.5.0]'
+
+    it('carries the admitting floors from the check to the next launch', async () => {
+        // check time: admitted on the candidate's iOS floor
+        await expect(gate.needsStoreUpdate('1.6.3', `abc1234 — subject ${marker}`)).resolves.toBe(false)
+        gate.rememberStagedFloors('b-9', `abc1234 — subject ${marker}`)
+
+        // next launch: only the id and version remain, and the answer must hold
+        await expect(gate.needsStoreUpdate('1.6.3', gate.stagedFloors('b-9'))).resolves.toBe(false)
+    })
+
+    it('gives nothing back for a different bundle id', async () => {
+        gate.rememberStagedFloors('b-9', `abc1234 ${marker}`)
+        expect(gate.stagedFloors('b-other')).toBeUndefined()
+        // …so the launch gate falls back to the version rule and refuses
+        await expect(gate.needsStoreUpdate('1.6.3', gate.stagedFloors('b-other'))).resolves.toBe(true)
+    })
+
+    // A bundle staged before any of this existed has no entry, which must read as
+    // "no floors" rather than as an error.
+    it('gives nothing back when nothing was remembered', () => {
+        expect(gate.stagedFloors('b-9')).toBeUndefined()
+    })
+
+    it('replaces the entry on each stage, so only the queued bundle is described', () => {
+        gate.rememberStagedFloors('b-9', `abc1234 ${marker}`)
+        gate.rememberStagedFloors('b-10', 'abc1234 — no floors here')
+        expect(gate.stagedFloors('b-9')).toBeUndefined()
+        expect(gate.stagedFloors('b-10')).toBeUndefined()
+    })
+
+    it('drops the entry when the queue is dropped', () => {
+        gate.rememberStagedFloors('b-9', `abc1234 ${marker}`)
+        gate.forgetStagedFloors()
+        expect(gate.stagedFloors('b-9')).toBeUndefined()
+    })
+
+    it('survives unreadable storage without throwing', () => {
+        window.localStorage.setItem('capgoStagedFloors', 'not json')
+        expect(gate.stagedFloors('b-9')).toBeUndefined()
+    })
+})

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -4,7 +4,7 @@
 import type { BundleInfo, CapacitorUpdaterPlugin } from '@capgo/capacitor-updater'
 import { isAndroidNativeBridge } from '@/utils/capacitor'
 import { isDemoMode } from '@/utils/demo'
-import { needsStoreUpdate } from '@/utils/ota-native-gate'
+import { forgetStagedFloors, needsStoreUpdate, rememberStagedFloors, stagedFloors } from '@/utils/ota-native-gate'
 import { readStoredValue, removeStoredValue, writeStoredValue } from '@/utils/safe-storage'
 
 export interface OtaUpdateCallbacks {
@@ -109,7 +109,7 @@ async function checkAndStageUpdate(callbacks: OtaUpdateCallbacks = {}): Promise<
             // downloaded. Capgo's own floor is the server-side half of this rule and
             // only applies under one channel strategy, in a dashboard nothing here
             // can read — so the client decides too.
-            if (await needsStoreUpdate(latest.version)) {
+            if (await needsStoreUpdate(latest.version, latest.comment)) {
                 console.info(`[capgo] bundle ${latest.version} needs a newer binary — store update only`)
                 removeStoredValue(FAILURE_STREAK_KEY)
                 callbacks.onStoreUpdateRequired?.()
@@ -125,6 +125,10 @@ async function checkAndStageUpdate(callbacks: OtaUpdateCallbacks = {}): Promise<
             // apply on next launch (no mid-session reload — avoids yanking the
             // UI out from under the user). set() reloads IMMEDIATELY; next()
             // is the deferred variant.
+            // Persist before arming next(): the native bridge can reload the
+            // WebView as soon as it queues the bundle. A later JS write may never
+            // run, leaving the next launch without the floors that admitted it.
+            rememberStagedFloors(bundle.id, latest.comment)
             await CapacitorUpdater.next({ id: bundle.id })
             callbacks.onUpdateAvailable?.(bundle)
             removeStoredValue(FAILURE_STREAK_KEY)
@@ -359,7 +363,9 @@ export async function readStagedBundle(
         CapacitorUpdater.current().catch(() => null),
     ])
     if (!next?.version || next.id === current?.bundle?.id) return null
-    if (!(await needsStoreUpdate(next.version))) return next
+    // Asked with the floors this bundle was admitted under, not with nothing:
+    // re-deciding on the version alone would disarm a bundle the check approved.
+    if (!(await needsStoreUpdate(next.version, stagedFloors(next.id)))) return next
 
     // Say so, rather than letting the update row vanish: the launch check would
     // reach the same verdict, but only once it has reached the network.
@@ -396,6 +402,7 @@ async function disarmStagedBundle(
     runningId: string | undefined
 ): Promise<null> {
     console.info(`[capgo] dropping staged bundle ${staged.version} — it needs a newer binary`)
+    forgetStagedFloors()
     const sentinels =
         runningId && runningId !== BUILTIN_BUNDLE_ID ? [runningId, BUILTIN_BUNDLE_ID] : [BUILTIN_BUNDLE_ID]
 

--- a/src/utils/capgo-updater.ts
+++ b/src/utils/capgo-updater.ts
@@ -507,14 +507,13 @@ function recordFailureStreak(message: string): number {
 }
 
 // The channel used for opt-in beta updates. Testers opt in from the About screen;
-// every other install stays on the app's default channel (production) and never
+// every other install stays on the app's platform default channel and never
 // sees these bundles.
 export const BETA_OTA_CHANNEL = 'staging'
 
-// The app's default channel (ios-release.yml / android-release.yml / release-ota.yml).
-// Leaving beta also assigns the device here when the channel allows device
-// self-assign in the Capgo dashboard; otherwise the local unset has to do.
-export const PRODUCTION_OTA_CHANNEL = 'production'
+// Server defaults required by all production release workflows. Beta exit
+// unsets local routing and verifies the effective default without assigning one.
+export const PRODUCTION_OTA_CHANNELS = { ios: 'ios-mobile-release', android: 'android-mobile-release' } as const
 
 export interface OtaChannelStatus {
     channel: string | null
@@ -644,32 +643,26 @@ export async function leaveBetaOtaChannel(): Promise<void> {
             throw err
         }
 
-        // unsetChannel() only drops the plugin's local preference (verified in
-        // the plugin source: both platforms just remove a stored key). The
-        // device→channel assignment lives on the server, and only setChannel()
-        // rewrites it — so also assign production. Best effort: a channel that
-        // refuses self-assign must not strand a device whose beta preference is
-        // already gone; getChannel() below is what decides whether beta still
-        // sticks server-side.
-        try {
-            const reassigned = await CapacitorUpdater.setChannel({
-                channel: PRODUCTION_OTA_CHANNEL,
-                triggerAutoUpdate: false,
-            })
-            if (reassigned.error) console.info(`[capgo] production self-assign refused: ${reassigned.error}`)
-        } catch (err) {
-            console.info(`[capgo] production self-assign failed: ${err instanceof Error ? err.message : String(err)}`)
-        }
+        // unsetChannel returns to the platform's server-selected default.
+        // Assigning the retired shared production channel here would override
+        // platform routing. Explicit dashboard overrides are checked below.
 
         // getChannel() asks the backend what it will actually serve, and only a
-        // successful, channel-bearing answer licenses the reset. Offline, rate
+        // successful platform channel or explicit default answer licenses reset. Offline, rate
         // limited, or an error field means indeterminate — not "clear".
         const effective = await CapacitorUpdater.getChannel().catch(() => null)
         if (!effective || effective.error) {
             throw new OtaChannelUnknownError(effective?.error ?? 'the effective channel could not be read')
         }
-        if (effective.channel === BETA_OTA_CHANNEL) {
-            throw new OtaChannelOverrideError(`${BETA_OTA_CHANNEL} is still assigned to this device`)
+        const expected = isAndroidNativeBridge() ? PRODUCTION_OTA_CHANNELS.android : PRODUCTION_OTA_CHANNELS.ios
+        if (effective.channel && effective.channel !== expected) {
+            throw new OtaChannelOverrideError(
+                `expected ${expected}, but ${effective.channel ?? 'no channel'} is assigned`
+            )
+        }
+
+        if (!effective.channel && effective.status !== 'default') {
+            throw new OtaChannelUnknownError('the platform default could not be confirmed')
         }
 
         try {

--- a/src/utils/native-app-ready.ts
+++ b/src/utils/native-app-ready.ts
@@ -26,12 +26,13 @@
  * is marked SUCCESS before it has proved it can boot. This counter is the
  * replacement, and it is the better net — Capgo cannot tell a bundle whose JS
  * is broken from one the OS froze, and rolled back on both. A frozen boot
- * eventually finishes and clears the counter; a broken one never does.
+ * eventually initializes the app and updater and clears the counter; a broken
+ * one never does. A rendered app with a broken updater is still an incomplete boot.
  */
 const BOOT_INCOMPLETE_KEY = 'peanutNativeBootIncomplete'
 const BOOT_INCOMPLETE_LIMIT = 3
 
-/** The app rendered, so whatever bundle is running boots. Clears the counter. */
+/** Called after React renders and local OTA initialization succeeds, without waiting for network access. */
 export function markNativeBootComplete(): void {
     try {
         window.localStorage.removeItem(BOOT_INCOMPLETE_KEY)
@@ -52,8 +53,8 @@ export const NATIVE_APP_READY_SCRIPT = `
     var failures = 0;
     try { failures = Number(localStorage.getItem(KEY)) || 0; } catch (e) {}
 
-    // Three launches that never rendered: the bundle is the problem, not the
-    // scheduler. Fall back to the builtin one instead of marking this ready.
+    // Three launches that never initialized the app and updater: fall back to
+    // the builtin bundle instead of acknowledging another incomplete boot.
     if (failures >= LIMIT && typeof updater.reset === 'function') {
         try { localStorage.removeItem(KEY); } catch (e) {}
         try { updater.reset({}); } catch (e) {}

--- a/src/utils/ota-native-gate.ts
+++ b/src/utils/ota-native-gate.ts
@@ -1,4 +1,107 @@
 import { getBinaryInfo } from '@/utils/app-version'
+import { isIOSNative } from '@/utils/capacitor'
+import { readStoredValue, removeStoredValue, writeStoredValue } from '@/utils/safe-storage'
+
+/**
+ * The oldest native build of each platform this bundle may run on, baked in at
+ * publish time by `scripts/ota-platform-floor.mjs`.
+ *
+ * A bundle's own version cannot answer the question. One release tag names two
+ * binaries, and the field does not keep them in step: TestFlight has no
+ * auto-update, so iOS sat on 1.5.0 while Android moved to 1.6.0 — and every
+ * native input that changed between those releases was under `android/`. Read
+ * as a number, bundle 1.6.x "needs a 1.6 binary" and the whole iOS population
+ * is refused JS its binary runs perfectly. Read as a surface, iOS's floor is
+ * 1.5.0 and Android's is 1.6.0, which is the truth.
+ *
+ * Absent on bundles published before the floors existed, and on web. Direct
+ * member access on purpose — Next inlines `process.env.NEXT_PUBLIC_*` at build
+ * time only when it is written literally.
+ */
+const OTA_FLOOR = {
+    android: process.env.NEXT_PUBLIC_OTA_FLOOR_ANDROID,
+    ios: process.env.NEXT_PUBLIC_OTA_FLOOR_IOS,
+}
+
+/** The baked floor for the platform this install is running on, if it has one. */
+function platformFloor(): string | null {
+    const floor = isIOSNative() ? OTA_FLOOR.ios : OTA_FLOOR.android
+    return floor && nativeLine(floor) ? floor : null
+}
+
+/**
+ * The floors of the bundle being OFFERED, read off the string Capgo returns with
+ * it.
+ *
+ * The baked constants above describe the bundle that is *running*, which is the
+ * wrong bundle to judge a candidate by: a candidate built after a native release
+ * has a higher floor than anything the running JS knows about, and trusting the
+ * running value would accept JS this binary cannot execute. Nothing in
+ * `LatestVersion` carries `min_update_version`, but `comment` is round-tripped
+ * from the upload (verified in the native implementations, which copy the
+ * server's value onto the result), and the publish step writes the floors into
+ * it. So the candidate's own numbers arrive before the download does.
+ *
+ * Anchored to the END of the comment, which is the part that makes it
+ * unforgeable. The comment also carries the commit subject — arbitrary text a
+ * contributor writes — and an unanchored match let a subject reading
+ * `fix: ota-floors: android=9.9.9 ios=9.9.9 was wrong` win over the real
+ * numbers appended after it. A floor of 9.9.9 refuses every bundle on every
+ * binary, so that is fleet-wide OTA death by commit message. The publish lane
+ * always appends its marker last, so the last one is the lane's, and `$` is
+ * what guarantees we read that one.
+ *
+ * Otherwise deliberately narrow: both platforms or neither, plain X.Y.Z only. A
+ * comment is a human string, and a loose parse of one is how a commit subject
+ * gets read as a version.
+ */
+const FLOOR_MARKER = /\[ota-floors: android=(\d+\.\d+\.\d+) ios=(\d+\.\d+\.\d+)\]\s*$/
+
+export function parseCandidateFloors(comment: string | undefined): { android: string; ios: string } | null {
+    const match = FLOOR_MARKER.exec(comment ?? '')
+    return match ? { android: match[1], ios: match[2] } : null
+}
+
+/*
+ * The candidate's floors have to survive the download.
+ *
+ * A bundle is admitted at check time, when the comment is in hand, but applied
+ * on a LATER LAUNCH — and the plugin's queue carries only an id and a version
+ * (`BundleInfo` has no comment field). The launch-time gate would therefore
+ * re-ask the question with nothing to answer it from, fall back to the version
+ * rule, and disarm the very bundle the check had just approved: an iOS 1.5.0
+ * install would download 1.6.3 and then throw it away on every launch, forever.
+ *
+ * So the marker is kept next to the staged id. Only one bundle is ever queued,
+ * so this is one entry, replaced on each stage and dropped when the queue is.
+ * An id that does not match means no floors, which is the conservative fallback
+ * — including for a bundle staged before any of this existed.
+ */
+const STAGED_FLOORS_KEY = 'capgoStagedFloors'
+
+export function rememberStagedFloors(bundleId: string, comment: string | undefined): void {
+    const match = FLOOR_MARKER.exec(comment ?? '')
+    if (!match) {
+        removeStoredValue(STAGED_FLOORS_KEY)
+        return
+    }
+    // The matched text, not the parsed values: one format, one parser, no second
+    // shape to keep in step with the first.
+    writeStoredValue(STAGED_FLOORS_KEY, JSON.stringify({ id: bundleId, marker: match[0] }))
+}
+
+export function stagedFloors(bundleId: string): string | undefined {
+    try {
+        const stored = JSON.parse(readStoredValue(STAGED_FLOORS_KEY) ?? '')
+        return stored?.id === bundleId && typeof stored.marker === 'string' ? stored.marker : undefined
+    } catch {
+        return undefined
+    }
+}
+
+export function forgetStagedFloors(): void {
+    removeStoredValue(STAGED_FLOORS_KEY)
+}
 
 /**
  * Which binary a release version belongs to.
@@ -40,12 +143,45 @@ export function bundleNeedsNewerBinary(bundleVersion: string, binaryVersion: str
 }
 
 /**
- * Same question, against the binary this install is actually running. False on
- * web and whenever the binary's own version cannot be read — see the fail-open
- * reasoning above.
+ * Whether this install needs a store update before it can run the JS on offer.
+ *
+ * Uses the offered candidate's own platform floor from its comment. Without a
+ * valid marker, compares the candidate version conservatively. The running
+ * bundle's baked floor is never authority for admitting a different bundle.
+ *
+ * False on web and whenever the binary's own version cannot be read — see the
+ * fail-open reasoning above.
  */
-export async function needsStoreUpdate(bundleVersion: string): Promise<boolean> {
+export async function needsStoreUpdate(bundleVersion: string, candidateComment?: string): Promise<boolean> {
     const binary = await getBinaryInfo()
     if (!binary?.appVersion) return false
+
+    // Best answer first: the candidate's own floor for this platform.
+    const candidate = parseCandidateFloors(candidateComment)
+    if (candidate) {
+        const floor = isIOSNative() ? candidate.ios : candidate.android
+        return bundleNeedsNewerBinary(floor, binary.appVersion)
+    }
+
+    // No floors on the candidate — a bundle published before they existed, or a
+    // server that did not return the comment. Compare its version, exactly as
+    // before the floors: conservative, and the direction that cannot hand a
+    // binary JS built against a native surface it lacks.
     return bundleNeedsNewerBinary(bundleVersion, binary.appVersion)
+}
+
+/**
+ * Whether the binary is behind the floor of the JS it is ALREADY running.
+ *
+ * A different question from `needsStoreUpdate`, and the only one the baked
+ * constants can answer honestly. It is what the profile's store row should
+ * reflect: this install is running JS built for a newer native contract than it
+ * has, so a store update is owed whether or not any new bundle exists.
+ */
+export async function runningBundleOutranksBinary(): Promise<boolean> {
+    const floor = platformFloor()
+    if (!floor) return false
+    const binary = await getBinaryInfo()
+    if (!binary?.appVersion) return false
+    return bundleNeedsNewerBinary(floor, binary.appVersion)
 }


### PR DESCRIPTION
Legacy Android 1.5.0 updaters do not parse candidate floor markers. Giving a shared bundle the iOS 1.5.0 minimum therefore lets Android install JS whose Android floor is 1.6.0. This PR preserves manual OTA releases from `dev`, `main`, and `release/android-kyc`, and enforces compatibility on the server before that first floor-aware update.

- Publish the same export as distinct `X.Y.N-ios` and `X.Y.N-android` records, with their respective native floors. Upload and verify both in an inactive candidate channel before promoting `ios-mobile-release` and `android-mobile-release`.
- Fail closed on missing metadata exposure, overlapping defaults, incorrect platform flags, wrong targeting strategy, active rollout, artifact/source mismatch, or incomplete uploads. Recheck policy before each promotion and read back the published artifact. Partial/deleted platform uploads and prior OTA tags reserve version numbers; `builtin` is a supported migration baseline.
- Preserve native-release ancestry, native fingerprint and Android legacy-surface guards, candidate/staged floor persistence, updater initialization retry, and incomplete-boot recovery. Evaluate the running bundle floor during provider startup even when no newer candidate exists.
- Move native publication to the appropriate platform channel with verified `.0` reuse. Beta exit unsets its override and verifies the platform default instead of assigning the retired shared channel. Update the release runbook.

Capgo configuration was updated and reloaded in Chrome: iOS and Android use their respective platform-exclusive default channels, Metadata targeting, anti-downgrade, disabled rollout and disabled self-assignment. Bundle metadata exposure is enabled. The old iOS preview was cleared to `builtin`; both mobile channels remain on `builtin`. The old `production` channel is Electron-only. No OTA or native release was dispatched.

Validation at `4dda3fc5034c3b3e2b39fca8fa9a58661340919d`: 328 tests across 13 focused suites, TypeScript, scoped ESLint, formatting, shell syntax and native compatibility/legacy permission guards pass. Native fingerprint remains `48586271a56340ed`; computed floors are iOS 1.5.0 / Android 1.6.0. Actionlint adds no diagnostics; two existing iOS SC2016 notices are unchanged. GitHub native export, full unit tests, TypeScript, formatting, ESLint, design-system lint and the required `ci-success` check pass ([run](https://github.com/peanutprotocol/peanut-ui/actions/runs/34550124599)). Screenshot and asynchronous review checks are still running; no unresolved review threads remain at this check.

Before release, verify the current-to-next-to-next OTA transition on real iOS 1.5.0 and Android 1.6.0 devices. Unit tests simulate this but do not prove device behavior. A device already stuck on an intermediate version-only client gate may need a builtin reset or newer native install. The two promotions are separate operations: a second-platform failure can leave one platform advanced; rerun with a fresh version after fixing the cause. Merge into `dev` after checks, then manually run **App Release OTA** on `dev`.
