### PR TITLE
fix: read Capgo app metadata by app id

### DIFF
--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -52,7 +52,8 @@ function invoke(mode, responses, overrides = {}) {
       try {
         const result = await run(input.mode, { env: input.env, fetchImpl: async (url, init) => {
           requests.push({ url: String(url), method: init.method, body: init.body && JSON.parse(init.body) });
-          const response = input.responses.shift();
+          let response = input.responses.shift();
+          if (response?.routes) response = response.routes[new URL(url).pathname];
           if (!response) throw new Error('unexpected request');
           if (response.networkError) throw new Error('network failure');
           return { ok: !response.status || response.status === 200, status: response.status || 200,
@@ -160,6 +161,30 @@ const channelPolicy = (platform, version = 'builtin') => ({
 })
 const channels = [channelPolicy('ios'), channelPolicy('android')]
 const policyResponses = (rows = channels) => [{ body: app }, { body: config }, { body: rows }]
+
+// Capgo routes GET /app to getAll(), regardless of an app_id query.
+// Only GET /app/:id returns the single app required by the metadata check.
+it('resolves a release through the app-specific endpoint when the app list is enabled', () => {
+    const result = invoke('current-release', [
+        { routes: { '/app': { body: [app] }, [`/app/${env.CAPGO_APP_ID}`]: { body: app } } },
+        { body: config },
+        { body: channels },
+        { body: [] },
+    ])
+    expect(result.status).toBe(0)
+    expect(result.result).toBe('builtin')
+    expect(new URL(result.requests[0].url).pathname).toBe(`/app/${env.CAPGO_APP_ID}`)
+    expect(result.requests.every((request) => request.method === 'GET')).toBe(true)
+})
+it.each([{ body: [app] }, { body: { ...app, app_id: 'another.app' } }, { body: null }])(
+    'identifies an invalid app response separately from disabled metadata: %j',
+    ({ body }) => {
+        const result = invoke('verify-promotion', [{ body }])
+        expect(result.status).toBe(1)
+        expect(result.error).toBe('Capgo app response does not match the requested app')
+        expect(result.requests).toHaveLength(1)
+    }
+)
 
 it('reads builtin as a legitimate starting state, but rejects a missing version', () => {
     expect(invoke('current-version', policyResponses()).result).toBe('builtin')

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -134,9 +134,10 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         })
     }
     const policies = async () => {
-        const app = await request('app')
-        if (app?.app_id !== appId || app.expose_metadata !== true)
-            throw new Error('app must expose bundle metadata to the plugin')
+        // GET /app lists apps; app_id in its query does not select one record.
+        const app = await request(`app/${encodeURIComponent(appId)}`)
+        if (app?.app_id !== appId) throw new Error('Capgo app response does not match the requested app')
+        if (app.expose_metadata !== true) throw new Error('app must expose bundle metadata to the plugin')
         // Same public configuration and capgkey authentication as Capgo CLI's
         // createSupabaseClient(). Pin the host before sending the release key.
         const config = await json('https://api.capgo.app/private/config', { method: 'GET' })


### PR DESCRIPTION
The OTA release stopped during version resolution even though Capgo metadata exposure is enabled. The guard called `GET /app?app_id=...`; Capgo routes that endpoint to the paginated app list, so the returned array failed the single-app assertion and produced the misleading "metadata disabled" error.

Use Capgo's app-specific `GET /app/:id` endpoint, keep the metadata check fail-closed, and report an invalid app response separately from a disabled setting. A routing regression records both endpoint shapes and proves the resolver uses only the app-specific read.

Validation:

- 136 tests passed across the Capgo guard, OTA marker contract, release version, and release branch suites
- Prettier, Node syntax, and `git diff --check` passed
- Failed run 34552187740 stopped in `resolve`; `deploy` and `tag` were skipped, so it uploaded and promoted nothing
