### PR TITLE
fix: accept Capgo builtin channel state

### DIFF
--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -157,7 +157,8 @@ const channelPolicy = (platform, version = 'builtin') => ({
     allow_prod: true,
     allow_device: true,
     rollout_enabled: false,
-    version: { name: version },
+    version_id: version === 'builtin' ? null : 42,
+    version: version === 'builtin' ? null : { id: 42, name: version },
 })
 const channels = [channelPolicy('ios'), channelPolicy('android')]
 const policyResponses = (rows = channels) => [{ body: app }, { body: config }, { body: rows }]
@@ -188,7 +189,19 @@ it.each([{ body: [app] }, { body: { ...app, app_id: 'another.app' } }, { body: n
 
 it('reads builtin as a legitimate starting state, but rejects a missing version', () => {
     expect(invoke('current-version', policyResponses()).result).toBe('builtin')
-    expect(invoke('current-version', policyResponses([{ ...channels[0], version: null }, channels[1]])).status).toBe(1)
+    expect(
+        invoke('current-version', policyResponses([{ ...channels[0], version_id: 42, version: null }, channels[1]]))
+            .status
+    ).toBe(1)
+})
+it.each([
+    { version_id: undefined, version: null },
+    { version_id: null, version: { id: 42, name: '1.6.2-ios' } },
+    { version_id: 42, version: null },
+    { version_id: 42, version: { id: 41, name: '1.6.2-ios' } },
+    { version_id: 42, version: { id: 42, name: 'invalid' } },
+])('rejects an inconsistent channel version response: %j', (change) => {
+    expect(invoke('current-version', policyResponses([{ ...channels[0], ...change }, channels[1]])).status).toBe(1)
 })
 it.each([
     { android: true },

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -17,6 +17,23 @@ const DISABLED_AUDIENCES = {
 const CORE = /^(0|[1-9]\d*)\.([1-9]\d*)\.(0|[1-9]\d*)$/
 const CHANNEL_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/
 
+function channelVersion(row, channelName) {
+    // Capgo represents the builtin bundle as a null channels.version foreign
+    // key, so the embedded app_versions relation is null too. Check both the
+    // raw key and relation to distinguish that legitimate state from a broken
+    // or incomplete PostgREST response.
+    if (row?.version_id === null && row.version === null) return 'builtin'
+    if (
+        !Number.isInteger(row?.version_id) ||
+        row.version_id <= 0 ||
+        row.version?.id !== row.version_id ||
+        !CHANNEL_VERSION.test(row.version?.name ?? '')
+    ) {
+        throw new Error(`${channelName} has no valid current bundle version`)
+    }
+    return row.version.name
+}
+
 function required(env, name) {
     if (!env[name]) throw new Error(`${name} is required`)
     return env[name]
@@ -102,9 +119,7 @@ export function verifyPolicies(channels, appId) {
         for (const [field, value] of Object.entries(expected)) {
             if (row[field] !== value) throw new Error(`${name} must have ${field}=${value}`)
         }
-        if (row.version?.name !== 'builtin' && !CHANNEL_VERSION.test(row.version?.name ?? '')) {
-            throw new Error(`${name} has no valid current bundle version`)
-        }
+        channelVersion(row, name)
     }
     if (
         channels.some(
@@ -148,7 +163,7 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         url.search = new URLSearchParams({
             app_id: `eq.${appId}`,
             limit: '1000',
-            select: 'name,app_id,public,ios,android,electron,disable_auto_update,disable_auto_update_under_native,allow_device_self_set,allow_prod,allow_device,rollout_enabled,version:app_versions!channels_version_fkey(name,id)',
+            select: 'name,app_id,public,ios,android,electron,disable_auto_update,disable_auto_update_under_native,allow_device_self_set,allow_prod,allow_device,rollout_enabled,version_id:version,version:app_versions!channels_version_fkey(name,id)',
         }).toString()
         return verifyPolicies(
             await json(url, {
@@ -213,12 +228,15 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
             return bundle({ allowMissing: true })
         case 'current-version': {
             const name = PRODUCTION_CHANNELS[platform(env)]
-            return (await policies()).find((row) => row.name === name).version.name
+            return channelVersion(
+                (await policies()).find((row) => row.name === name),
+                name
+            )
         }
         case 'current-release': {
             const current = (await policies())
                 .filter((row) => Object.values(PRODUCTION_CHANNELS).includes(row.name))
-                .map((row) => row.version.name)
+                .map((row) => channelVersion(row, row.name))
                 .filter((name) => name !== 'builtin')
             // Include failed/partial and deleted platform uploads: their names
             // remain reserved. Exclude staging's commit-count version sequence.
@@ -239,7 +257,7 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         case 'verify-production': {
             const name = PRODUCTION_CHANNELS[platform(env)]
             const row = (await policies()).find((entry) => entry.name === name)
-            if (row.version.name !== required(env, 'VERSION'))
+            if (channelVersion(row, name) !== required(env, 'VERSION'))
                 throw new Error(`${name} does not exclusively serve the expected version`)
             return `${name} serves verified bundle ${await bundle()}`
         }


### PR DESCRIPTION
The OTA resolver fails before deployment when both new platform channels still serve the builtin bundle. Capgo stores that state with a null `channels.version` foreign key and renders it as `builtin`, while the guard expected an embedded `{ name: "builtin" }` record.

This reads the raw version foreign key alongside the embedded bundle and accepts builtin only when both are null. Uploaded bundle states must still contain a matching numeric ID and a valid version name, preserving fail-closed checks for malformed or incomplete responses.

Validation:

- `pnpm exec jest scripts/__tests__/capgo-release-guard.test.js scripts/__tests__/release-version.test.js scripts/__tests__/ota-floor-marker-contract.test.js scripts/__tests__/release-branch-guards.test.js --runInBand` (141 tests)
- `pnpm exec prettier --check scripts/capgo-release-guard.mjs scripts/__tests__/capgo-release-guard.test.js`
- `node --check scripts/capgo-release-guard.mjs`
- `git diff --check`
