### PR TITLE
fix: make paired OTA uploads retry-safe

### DIFF
--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -225,9 +225,18 @@ jobs:
                   # not the channel. Old clients are protected by the server.
                   for PLATFORM in ios android; do
                     VERSION="$RELEASE_VERSION-$PLATFORM"
-                    if [ "$PLATFORM" = ios ]; then NATIVE_FLOOR="$FLOOR_IOS"; else NATIVE_FLOOR="$FLOOR_ANDROID"; fi
+                    UPLOAD_GUARD_ARGS=(--channel ota-candidate)
+                    if [ "$PLATFORM" = ios ]; then
+                      NATIVE_FLOOR="$FLOOR_IOS"
+                    else
+                      NATIVE_FLOOR="$FLOOR_ANDROID"
+                      # Both platform records deliberately contain the same web
+                      # assets. Keep the duplicate check for the first upload,
+                      # then allow the second record with its Android floor.
+                      UPLOAD_GUARD_ARGS+=(--ignore-checksum-check)
+                    fi
                     npx @capgo/cli@8.42.4 bundle upload \
-                      --channel ota-candidate \
+                      "${UPLOAD_GUARD_ARGS[@]}" \
                       --apikey "$CAPGO_API_KEY" --key-data-v2 "$CAPGO_PRIVATE_KEY" \
                       --path ./out --bundle "$VERSION" --min-update-version "$NATIVE_FLOOR" \
                       --comment "$COMMENT" --link "https://github.com/peanutprotocol/peanut-ui/commit/$GITHUB_SHA"

--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -361,7 +361,55 @@ it('uploads and verifies both artifacts before any production promotion', () => 
     expect(source.indexOf('- name: Verify the floors')).toBeLessThan(source.indexOf('- name: Promote verified bundles'))
     expect(source).not.toContain('--version-exists-ok')
     expect(source).toContain('--channel ota-candidate')
+    expect(source).toContain('UPLOAD_GUARD_ARGS+=(--ignore-checksum-check)')
+    expect(source).toContain('"${UPLOAD_GUARD_ARGS[@]}"')
     expect(source).not.toContain('channel set production')
+})
+
+it('bypasses the candidate checksum collision only for the second platform record', () => {
+    const source = fs.readFileSync(path.join(ROOT, '.github/workflows/release-ota.yml'), 'utf8')
+    const step = source.slice(source.indexOf('- name: Upload bundles'), source.indexOf('- name: Verify the floors'))
+    const shell = step.match(/run: \|\n([\s\S]*)/)[1]
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ota-platform-uploads-'))
+    const calls = path.join(dir, 'calls')
+    try {
+        const result = spawnSync(
+            'bash',
+            [
+                '-euo',
+                'pipefail',
+                '-c',
+                `
+          npx() { printf '%s\\n' "$*" >> "$CALLS_FILE"; }
+          ${shell}
+        `,
+            ],
+            {
+                encoding: 'utf8',
+                env: {
+                    ...process.env,
+                    CAPGO_API_KEY: 'api-key',
+                    CAPGO_PRIVATE_KEY: 'private-key',
+                    COMMIT_MSG: 'release',
+                    RELEASE_VERSION: '1.6.4',
+                    FLOOR_ANDROID: '1.6.0',
+                    FLOOR_IOS: '1.5.0',
+                    GITHUB_SHA: SHA,
+                    CALLS_FILE: calls,
+                },
+            }
+        )
+        expect(result.status).toBe(0)
+        const [ios, android] = fs.readFileSync(calls, 'utf8').trim().split('\n')
+        expect(ios).toContain('--bundle 1.6.4-ios')
+        expect(ios).toContain('--min-update-version 1.5.0')
+        expect(ios).not.toContain('--ignore-checksum-check')
+        expect(android).toContain('--bundle 1.6.4-android')
+        expect(android).toContain('--min-update-version 1.6.0')
+        expect(android).toContain('--ignore-checksum-check')
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+    }
 })
 
 it('never assigns a prerelease .0 identity that sorts below its native binary', () => {


### PR DESCRIPTION
The production OTA run uploaded `1.6.3-ios` to the disabled candidate channel, then Capgo rejected `1.6.3-android` because both platform records deliberately contain identical web assets. Production channels were never promoted and the tag job was skipped.

This makes paired uploads and retries safe:

- preparation resets the disabled `ota-candidate` channel to Capgo's builtin bundle and reads the persisted state back before any upload;
- iOS retains Capgo's duplicate-content checksum guard;
- only the second Android record uses Capgo's documented `--ignore-checksum-check` override so it can store identical web assets with its independent native floor;
- both exact artifact records must still pass the existing checksum, storage, source-commit, floor-marker and platform-floor checks before either production channel is promoted.

The next run will reserve `1.6.4` because the partial `1.6.3-ios` record already exists. No cleanup or reuse of `1.6.3` is required.

Validation:

- `pnpm exec jest scripts/__tests__/capgo-release-guard.test.js scripts/__tests__/release-version.test.js scripts/__tests__/ota-floor-marker-contract.test.js scripts/__tests__/release-branch-guards.test.js --runInBand` (143 tests)
- `pnpm exec prettier --check .github/workflows/release-ota.yml scripts/capgo-release-guard.mjs scripts/__tests__/capgo-release-guard.test.js`
- `git diff --check`
