### PR TITLE
fix: reset disabled OTA candidate before uploads

### DIFF
--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -125,18 +125,26 @@ it.each(['public', 'allow_device_self_set', 'allow_emulator', 'allow_device', 'a
         expect(result.requests).toHaveLength(1)
     }
 )
-it('prepares the disabled channel and reads the persisted settings back', () => {
-    const result = invoke('prepare-candidate', [{ body: { status: 'success' } }, { body: candidate }])
+it('prepares the disabled channel, clears a partial bundle and reads the settings back', () => {
+    const result = invoke('prepare-candidate', [
+        { body: { status: 'success' } },
+        { body: candidate },
+        { body: app },
+        { body: config },
+        { body: [...channels, candidatePolicy()] },
+    ])
     expect(result.status).toBe(0)
     expect(result.requests[0].body).toMatchObject({
         ...Object.fromEntries(Object.entries(candidate).filter(([key]) => key !== 'name')),
         channel: 'ota-candidate',
+        version: null,
         ios: false,
         android: false,
         electron: false,
         rolloutEnabled: false,
     })
     expect(result.requests[1].method).toBe('GET')
+    expect(result.requests.slice(2).every((request) => request.method === 'GET')).toBe(true)
 })
 it('rejects preparation when the server did not persist the audience restrictions', () => {
     expect(invoke('prepare-candidate', [{ body: {} }, { body: { ...candidate, allow_prod: true } }]).status).toBe(1)
@@ -160,8 +168,26 @@ const channelPolicy = (platform, version = 'builtin') => ({
     version_id: version === 'builtin' ? null : 42,
     version: version === 'builtin' ? null : { id: 42, name: version },
 })
+const candidatePolicy = (version = 'builtin') => ({
+    ...channelPolicy('ios', version),
+    name: 'ota-candidate',
+    public: false,
+    ios: false,
+    allow_prod: false,
+    allow_device: false,
+})
 const channels = [channelPolicy('ios'), channelPolicy('android')]
 const policyResponses = (rows = channels) => [{ body: app }, { body: config }, { body: rows }]
+
+it('stops before upload when Capgo did not clear the partial candidate bundle', () => {
+    const result = invoke('prepare-candidate', [
+        { body: { status: 'success' } },
+        { body: candidate },
+        ...policyResponses([...channels, candidatePolicy('1.6.3-ios')]),
+    ])
+    expect(result.status).toBe(1)
+    expect(result.error).toBe('candidate channel must be reset to builtin')
+})
 
 // Capgo routes GET /app to getAll(), regardless of an app_id query.
 // Only GET /app/:id returns the single app required by the metadata check.

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -186,6 +186,12 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
         }
         if (candidate.rolloutEnabled !== false) throw new Error('candidate rollout must be disabled')
     }
+    const verifyCandidateReset = async () => {
+        const matches = (await policies()).filter((row) => row.name === CANDIDATE_CHANNEL)
+        if (matches.length !== 1 || channelVersion(matches[0], CANDIDATE_CHANNEL) !== 'builtin') {
+            throw new Error('candidate channel must be reset to builtin')
+        }
+    }
     const bundles = async () => {
         const rows = []
         for (let page = 0; page < 100; page++) {
@@ -210,6 +216,10 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
             await request('channel', {
                 body: {
                     channel: CANDIDATE_CHANNEL,
+                    // A failed run can leave its first platform bundle attached.
+                    // Reset the disabled channel so the next run retains the
+                    // checksum guard on its first upload.
+                    version: null,
                     ...DISABLED_AUDIENCES,
                     ios: false,
                     android: false,
@@ -218,7 +228,8 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
                 },
             })
             await verifyCandidate()
-            return 'Candidate channel has no enabled device audience'
+            await verifyCandidateReset()
+            return 'Candidate channel is disabled and reset to builtin'
         case 'verify-bundle':
             await verifyCandidate()
             return `Verified bundle ${await bundle()}`


### PR DESCRIPTION
The production OTA run uploaded `1.6.3-ios` to the disabled candidate channel, then Capgo rejected `1.6.3-android` because both platform records deliberately contain identical web assets. Production channels were never promoted and the tag job was skipped.

This makes paired uploads and retries safe:

- preparation resets the disabled `ota-candidate` channel to Capgo's builtin bundle and reads the persisted state back before any upload;
- iOS retains Capgo's duplicate-content checksum guard;
- only the second Android record uses Capgo's documented `--ignore-checksum-check` override so it can store identical web assets with its independent native floor;
- both exact artifact records must still pass the existing checksum, storage, source-commit, floor-marker and platform-floor checks before either production channel is promoted.

The next run will reserve `1.6.4` because the partial `1.6.3-ios` record already exists. No cleanup or reuse of `1.6.3` is required.

Validation:

- `pnpm exec jest scripts/__tests__/capgo-release-guard.test.js scripts/__tests__/release-version.test.js scripts/__tests__/ota-floor-marker-contract.test.js scripts/__tests__/release-branch-guards.test.js --runInBand` (143 tests)
- `pnpm exec prettier --check .github/workflows/release-ota.yml scripts/capgo-release-guard.mjs scripts/__tests__/capgo-release-guard.test.js`
- `git diff --check`
