### PR TITLE
fix: reset OTA candidate with builtin marker

### DIFF
--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -137,7 +137,7 @@ it('prepares the disabled channel, clears a partial bundle and reads the setting
     expect(result.requests[0].body).toMatchObject({
         ...Object.fromEntries(Object.entries(candidate).filter(([key]) => key !== 'name')),
         channel: 'ota-candidate',
-        version: null,
+        version: 'builtin',
         ios: false,
         android: false,
         electron: false,

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -219,7 +219,10 @@ export async function run(mode, { env = process.env, fetchImpl = fetch } = {}) {
                     // A failed run can leave its first platform bundle attached.
                     // Reset the disabled channel so the next run retains the
                     // checksum guard on its first upload.
-                    version: null,
+                    // The hosted endpoint returned HTTP 400 for a JSON null.
+                    // "builtin" is Capgo's public wire name for the same unlinked
+                    // database state.
+                    version: 'builtin',
                     ...DISABLED_AUDIENCES,
                     ios: false,
                     android: false,


### PR DESCRIPTION
Run [34557635511](https://github.com/peanutprotocol/peanut-ui/actions/runs/34557635511) stopped safely while preparing the disabled candidate channel: Capgo returned HTTP 400 for the literal JSON `null` used to unlink the partial `1.6.3-ios` bundle. No upload, promotion, or tag occurred.

Send Capgo's internal wire name `"builtin"` instead. Capgo normalizes that value to the same null channel-version state, and the existing PostgREST readback still requires the persisted candidate version to be null before uploads can begin.

Validation:

- `pnpm exec jest scripts/__tests__/capgo-release-guard.test.js scripts/__tests__/release-version.test.js scripts/__tests__/ota-floor-marker-contract.test.js scripts/__tests__/release-branch-guards.test.js --runInBand` (143 tests)
- `pnpm exec prettier --check scripts/capgo-release-guard.mjs scripts/__tests__/capgo-release-guard.test.js`
- `git diff --check`
