### PR TITLE
fix: verify Capgo OTA floor response

### DIFF
--- a/scripts/__tests__/capgo-release-guard.test.js
+++ b/scripts/__tests__/capgo-release-guard.test.js
@@ -23,7 +23,7 @@ const goodBundle = {
     name: '1.6.3-ios',
     deleted: false,
     comment: `commit ${MARKER}`,
-    minUpdateVersion: '1.5.0',
+    min_update_version: '1.5.0',
     link: `https://github.com/peanutprotocol/peanut-ui/commit/${SHA}`,
     checksum: 'signed-checksum',
     storage_provider: 'r2',
@@ -90,7 +90,8 @@ it.each([
     { comment: null },
     { comment: `${MARKER} trailing text` },
     { comment: '[ota-floors: android=1.5.0 ios=1.5.0]' },
-    { minUpdateVersion: '1.4.0' },
+    { min_update_version: '1.4.0' },
+    { min_update_version: undefined, minUpdateVersion: '1.5.0' },
     { app_id: 'wrong.app' },
     { deleted: true },
     { link: 'https://github.com/peanutprotocol/peanut-ui/commit/other' },
@@ -292,7 +293,7 @@ it.each(['ios', 'android'])('verifies a distinct %s artifact with its own native
     const nativeFloor = platform === 'ios' ? '1.5.0' : '1.6.0'
     const version = `1.6.3-${platform}`
     expect(
-        verify([{ ...goodBundle, name: version, minUpdateVersion: nativeFloor }], {
+        verify([{ ...goodBundle, name: version, min_update_version: nativeFloor }], {
             PLATFORM: platform,
             VERSION: version,
             NATIVE_FLOOR: nativeFloor,
@@ -303,7 +304,7 @@ it('allows reuse only of a verified native .0 record from the exact source', () 
     const native = {
         ...goodBundle,
         name: '1.7.0',
-        minUpdateVersion: '1.7.0',
+        min_update_version: '1.7.0',
         comment: '[ota-floors: android=1.7.0 ios=1.7.0]',
     }
     const overrides = { VERSION: '1.7.0', FLOOR_ANDROID: '1.7.0', FLOOR_IOS: '1.7.0', NATIVE_FLOOR: '1.7.0' }

--- a/scripts/capgo-release-guard.mjs
+++ b/scripts/capgo-release-guard.mjs
@@ -81,7 +81,8 @@ export function verifyBundle(bundle, env) {
     if (typeof bundle.comment !== 'string' || !bundle.comment.trimEnd().endsWith(expected)) {
         throw new Error(`bundle ${version} does not carry the expected candidate floors`)
     }
-    if (bundle.minUpdateVersion !== nativeFloor) throw new Error(`bundle ${version} has the wrong server floor`)
+    // GET /bundle returns the app_versions row without camel-case mapping.
+    if (bundle.min_update_version !== nativeFloor) throw new Error(`bundle ${version} has the wrong server floor`)
     if (bundle.link !== `https://github.com/peanutprotocol/peanut-ui/commit/${sha}`) {
         throw new Error(`bundle ${version} belongs to a different or unverified source commit`)
     }


### PR DESCRIPTION
Run [34558609974](https://github.com/peanutprotocol/peanut-ui/actions/runs/34558609974) uploaded both `1.6.4` platform records, then stopped before promotion because the verifier read `minUpdateVersion`. Capgo's `GET /bundle` returns raw `app_versions` rows with the field `min_update_version`; the Capgo console confirms `1.6.4-ios` has the intended `1.5.0` floor.

Read and require the actual snake-case API field. The regression fixtures now match the real response shape and explicitly reject a camel-case-only record, so the verifier remains fail-closed if the floor is absent or mismatched.

No production channel was changed by the failed run. A fresh retry will reserve `1.6.5` because the unpromoted `1.6.4-ios` and `1.6.4-android` records already exist.

Validation:

- `pnpm exec jest scripts/__tests__/capgo-release-guard.test.js scripts/__tests__/release-version.test.js scripts/__tests__/ota-floor-marker-contract.test.js scripts/__tests__/release-branch-guards.test.js --runInBand` (144 tests)
- `pnpm exec prettier --check scripts/capgo-release-guard.mjs scripts/__tests__/capgo-release-guard.test.js`
- `git diff --check`
