### PR TITLE
feat: full i18n overflow sweep — 4 widths × 4 locales × every surface (TASK-22366)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ e2e/__baseline__/
 e2e/__report__/
 e2e/__snapshots__/
 e2e/__shots__/
+e2e/__sweep__/
 e2e/.auth/
 
 # native app signing

--- a/e2e/shots/overflow-sweep.spec.ts
+++ b/e2e/shots/overflow-sweep.spec.ts
@@ -195,13 +195,14 @@ for (const locale of APP_LOCALES_SWEEP) {
             await settle(page)
             const landed = new URL(page.url()).pathname
             if (landed !== route.split('?')[0]) return landed
-            return undefined
-            // scan only after the app renders the catalog (IntlCore stamps lang)
+            // scan only after the app renders the catalog (IntlCore stamps
+            // lang) — without this a cell can scan English fallback and pass
             await expect
                 .poll(() => page.evaluate(() => document.documentElement.lang), {
                     message: 'translated catalog never rendered',
                 })
                 .toBe(locale)
+            return undefined
         }
 
         for (const [name, fixture] of Object.entries(FIXTURES)) {

--- a/e2e/shots/overflow-sweep.spec.ts
+++ b/e2e/shots/overflow-sweep.spec.ts
@@ -227,17 +227,6 @@ for (const locale of APP_LOCALES_SWEEP) {
                     test.skip(true, `redirected to ${bounced}`)
                     return
                 }
-                if (overlay.proof) {
-                    // a renamed query param degrades the cell to a base-page
-                    // scan — prove the overlay actually opened
-                    try {
-                        await page.locator(overlay.proof).first().waitFor({ state: 'visible', timeout: 8_000 })
-                    } catch {
-                        record({ ...cell, status: 'skip', reason: `overlay never opened (${overlay.proof})` }, testInfo)
-                        test.skip(true, 'overlay never opened')
-                        return
-                    }
-                }
                 for (const key of overlay.clickKeys ?? []) {
                     const label = resolveLabel(locale, key)
                     if (!label) {
@@ -251,6 +240,19 @@ for (const locale of APP_LOCALES_SWEEP) {
                     } catch {
                         record({ ...cell, status: 'skip', reason: `could not click “${label}”` }, testInfo)
                         test.skip(true, `could not click ${key}`)
+                        return
+                    }
+                }
+                // AFTER the clicks: a URL param rename degrades the cell to a
+                // base-page scan, and a click whose modal never renders still
+                // "succeeds" — the proof element is what says the overlay is
+                // really on screen
+                if (overlay.proof) {
+                    try {
+                        await page.locator(overlay.proof).first().waitFor({ state: 'visible', timeout: 8_000 })
+                    } catch {
+                        record({ ...cell, status: 'skip', reason: `overlay never opened (${overlay.proof})` }, testInfo)
+                        test.skip(true, 'overlay never opened')
                         return
                     }
                 }

--- a/e2e/shots/overflow-sweep.spec.ts
+++ b/e2e/shots/overflow-sweep.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * Full i18n overflow sweep (TASK-22366 follow-up). Matrix:
+ *  - app fixtures + overlays + setup: 4 locales × 4 widths
+ *  - marketing/landing: every slug × 4 URL locales at 320, template
+ *    representatives at all widths (sweep-targets.ts)
+ *
+ * Every executed cell writes one JSON line into SWEEP_OUT (default
+ * e2e/__sweep__): {id, kind, width, locale, status, overflows|reason}.
+ * A cell whose coverage collapsed (redirect, click miss) records status
+ * "skip" with the reason instead of silently passing — the aggregator
+ * (scripts/overflow-sweep-report.mjs) surfaces both.
+ *
+ * Run through playwright.sweep.config.ts.
+ */
+
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { FIXTURE_STORAGE_KEY, fixtureHref } from '../../src/dev/fixtures/active'
+import { FIXTURES } from '../../src/dev/fixtures/registry'
+import en from '../../src/i18n/app/messages/en.json'
+import es419 from '../../src/i18n/app/messages/es-419.json'
+import esAR from '../../src/i18n/app/messages/es-AR.json'
+import ptBR from '../../src/i18n/app/messages/pt-BR.json'
+import { findOverflows } from './overflow-check'
+import { EXTRA_APP_ROUTES, LANDING_TARGETS, MARKETING_TARGETS, OVERLAY_TARGETS } from './sweep-targets'
+
+const OUT = process.env.SWEEP_OUT ?? 'e2e/__sweep__'
+const FROZEN_NOW = new Date('2026-08-15T12:00:00.000Z')
+const LOADERS = '.animate-spin img[alt="Peanut mascot"], .animate-pulse'
+const FREEZE_CSS = `
+*, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+    caret-color: transparent !important;
+    scroll-behavior: auto !important;
+}
+/* the freeze cancels the fade-in-up-spring reveal, which would leave
+   .animate-on-view wrappers at opacity 0 and hide their text from the
+   scan — force them visible instead */
+.animate-on-view {
+    opacity: 1 !important;
+    transform: none !important;
+}
+`
+// same justification as the per-PR gate
+const EXEMPT: string[] = ['.rfm-marquee-container']
+
+const APP_LOCALES_SWEEP = ['en', 'es-419', 'es-AR', 'pt-BR'] as const
+
+// locale fallback chains mirror src/i18n/app/messages.ts deepMerge order
+const CATALOGS: Record<string, object[]> = {
+    en: [en],
+    'es-419': [es419, en],
+    'es-AR': [esAR, es419, en],
+    'pt-BR': [ptBR, en],
+}
+
+function resolveLabel(locale: string, keyPath: string): string | null {
+    for (const catalog of CATALOGS[locale] ?? []) {
+        let node: unknown = catalog
+        for (const part of keyPath.split('.')) {
+            if (typeof node !== 'object' || node === null) {
+                node = undefined
+                break
+            }
+            node = (node as Record<string, unknown>)[part]
+        }
+        if (typeof node === 'string') return node
+    }
+    return null
+}
+
+type Cell = {
+    id: string
+    kind: 'fixture' | 'overlay' | 'setup' | 'marketing' | 'landing'
+    width: number
+    locale: string
+    status: 'pass' | 'fail' | 'skip'
+    overflows?: unknown[]
+    reason?: string
+}
+
+function record(cell: Cell, testInfo: TestInfo): void {
+    mkdirSync(OUT, { recursive: true })
+    appendFileSync(join(OUT, `${testInfo.project.name}-w${testInfo.workerIndex}.jsonl`), JSON.stringify(cell) + '\n')
+}
+
+function width(testInfo: TestInfo): number {
+    return Number(testInfo.project.name.slice(1))
+}
+
+async function settle(page: Page): Promise<void> {
+    await page.waitForFunction((selector) => {
+        const { innerHeight, innerWidth } = window
+        return Array.from(document.querySelectorAll(selector)).every((el) => {
+            const box = el.getBoundingClientRect()
+            return (
+                box.width === 0 || box.bottom <= 0 || box.top >= innerHeight || box.right <= 0 || box.left >= innerWidth
+            )
+        })
+    }, LOADERS)
+    await page.addStyleTag({ content: FREEZE_CSS })
+    await page.evaluate(() => document.fonts.ready.then(() => undefined))
+    await page.waitForFunction(
+        () => {
+            const seen = window as unknown as { __sweepText?: string }
+            const text = document.body.innerText
+            if (seen.__sweepText === text) return true
+            seen.__sweepText = text
+            return false
+        },
+        null,
+        { polling: 250 }
+    )
+}
+
+async function blockExternal(page: Page): Promise<void> {
+    await page.route('**/*', (route) => {
+        const { hostname } = new URL(route.request().url())
+        return hostname === '127.0.0.1' || hostname === 'localhost' ? route.continue() : route.abort()
+    })
+}
+
+function seenOnceModals(): void {
+    window.sessionStorage.setItem('showNoMoreJailModal', 'true')
+    window.localStorage.setItem('peanut_demo_activation_celebrated_at', '2026-01-01T00:00:00.000Z')
+    window.localStorage.setItem(
+        'demo-user:user-preferences',
+        JSON.stringify({ hasSeenBalanceWarning: { value: true, expiry: 4102444800000 } })
+    )
+    window.sessionStorage.setItem('user_geo_country_code', 'DE')
+    window.sessionStorage.setItem(
+        'user_geo_country_code_timestamp',
+        String(new Date('2026-08-15T11:59:00.000Z').getTime())
+    )
+}
+
+async function scan(page: Page, cell: Omit<Cell, 'status'>, testInfo: TestInfo): Promise<void> {
+    // scrolling can dismiss an open drawer — only walk the page when no
+    // overlay is up (overlay content fits the viewport)
+    const overlayOpen = await page.evaluate(
+        () => document.querySelector('[data-vaul-drawer], [role="dialog"]') !== null
+    )
+    if (!overlayOpen) {
+        await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+        await page.waitForTimeout(250)
+        await page.evaluate(() => window.scrollTo(0, 0))
+    }
+
+    const overflows = await page.evaluate(findOverflows, EXEMPT)
+    if (overflows.length > 0) {
+        await page.evaluate((items) => {
+            for (const item of items) {
+                for (const el of Array.from(document.querySelectorAll('*'))) {
+                    const text = (el as HTMLElement).innerText ?? (el as HTMLInputElement).placeholder ?? ''
+                    if (text.trim().replace(/\s+/g, ' ').startsWith(item.text.slice(0, 40))) {
+                        ;(el as HTMLElement).style.outline = '2px solid red'
+                        break
+                    }
+                }
+            }
+        }, overflows)
+        await testInfo.attach(`${cell.id}-${cell.locale}-overflow`, {
+            body: await page.screenshot({ fullPage: true }),
+            contentType: 'image/png',
+        })
+        record({ ...cell, status: 'fail', overflows }, testInfo)
+    } else {
+        record({ ...cell, status: 'pass' }, testInfo)
+    }
+    const report = overflows.map((o) => `[${o.kind}] ${o.selector} — “${o.text}” (${o.detail})`).join('\n')
+    expect(overflows, `clipped ${cell.locale} copy on ${cell.id} @${cell.width}:\n${report}`).toEqual([])
+}
+
+test.describe.configure({ mode: 'parallel' })
+
+// ---- app screens: fixtures + overlays + setup, per locale describe ----
+
+for (const locale of APP_LOCALES_SWEEP) {
+    test.describe(`app:${locale}`, () => {
+        test.use({ locale })
+
+        /** returns the landed pathname when the route bounced, else undefined */
+        async function openApp(page: Page, route: string, fixture: string): Promise<string | undefined> {
+            await blockExternal(page)
+            await page.clock.setFixedTime(FROZEN_NOW)
+            await page.addInitScript(seenOnceModals)
+            await page.goto(fixtureHref(route, fixture), { waitUntil: 'domcontentloaded' })
+            await expect
+                .poll(() => page.evaluate((key) => window.sessionStorage.getItem(key), FIXTURE_STORAGE_KEY), {
+                    message: 'fixture mode never engaged — preview build?',
+                })
+                .toBe(fixture)
+            await settle(page)
+            const landed = new URL(page.url()).pathname
+            if (landed !== route.split('?')[0]) return landed
+            return undefined
+            // scan only after the app renders the catalog (IntlCore stamps lang)
+            await expect
+                .poll(() => page.evaluate(() => document.documentElement.lang), {
+                    message: 'translated catalog never rendered',
+                })
+                .toBe(locale)
+        }
+
+        for (const [name, fixture] of Object.entries(FIXTURES)) {
+            test(`fixture:${name}:${locale}`, async ({ page }, testInfo) => {
+                const cell = { id: `fixture:${name}`, kind: 'fixture' as const, width: width(testInfo), locale }
+                const bounced = await openApp(page, fixture.route, name)
+                if (bounced) {
+                    record({ ...cell, status: 'skip', reason: `redirected to ${bounced}` }, testInfo)
+                    test.skip(true, `redirected to ${bounced}`)
+                    return
+                }
+                await scan(page, cell, testInfo)
+            })
+        }
+
+        for (const overlay of [...OVERLAY_TARGETS, ...EXTRA_APP_ROUTES]) {
+            test(`overlay:${overlay.id}:${locale}`, async ({ page }, testInfo) => {
+                const cell = { id: `overlay:${overlay.id}`, kind: 'overlay' as const, width: width(testInfo), locale }
+                const bounced = await openApp(page, overlay.route, overlay.fixture ?? 'profile-edit')
+                if (bounced) {
+                    record({ ...cell, status: 'skip', reason: `redirected to ${bounced}` }, testInfo)
+                    test.skip(true, `redirected to ${bounced}`)
+                    return
+                }
+                if (overlay.proof) {
+                    // a renamed query param degrades the cell to a base-page
+                    // scan — prove the overlay actually opened
+                    try {
+                        await page.locator(overlay.proof).first().waitFor({ state: 'visible', timeout: 8_000 })
+                    } catch {
+                        record({ ...cell, status: 'skip', reason: `overlay never opened (${overlay.proof})` }, testInfo)
+                        test.skip(true, 'overlay never opened')
+                        return
+                    }
+                }
+                for (const key of overlay.clickKeys ?? []) {
+                    const label = resolveLabel(locale, key)
+                    if (!label) {
+                        record({ ...cell, status: 'skip', reason: `no catalog value for ${key}` }, testInfo)
+                        test.skip(true, `no catalog value for ${key}`)
+                        return
+                    }
+                    try {
+                        await page.getByText(label, { exact: false }).first().click({ timeout: 8_000 })
+                        await page.waitForTimeout(600)
+                    } catch {
+                        record({ ...cell, status: 'skip', reason: `could not click “${label}”` }, testInfo)
+                        test.skip(true, `could not click ${key}`)
+                        return
+                    }
+                }
+                await scan(page, cell, testInfo)
+            })
+        }
+
+        for (const route of ['/setup', '/setup?step=signup', '/setup?step=login']) {
+            test(`setup:${route}:${locale}`, async ({ page }, testInfo) => {
+                const cdp = await page.context().newCDPSession(page)
+                await cdp.send('WebAuthn.enable')
+                await cdp.send('WebAuthn.addVirtualAuthenticator', {
+                    options: {
+                        protocol: 'ctap2',
+                        transport: 'internal',
+                        hasResidentKey: true,
+                        hasUserVerification: true,
+                        isUserVerified: true,
+                        automaticPresenceSimulation: true,
+                    },
+                })
+                await blockExternal(page)
+                await page.clock.setFixedTime(FROZEN_NOW)
+                await page.goto(route, { waitUntil: 'domcontentloaded' })
+                await settle(page)
+                if (route.includes('step=signup')) {
+                    await expect(page.locator('input:visible').first()).toBeVisible()
+                }
+                await expect
+                    .poll(() => page.evaluate(() => document.documentElement.lang), {
+                        message: 'translated catalog never rendered',
+                    })
+                    .toBe(locale)
+                await scan(page, { id: `setup:${route}`, kind: 'setup', width: width(testInfo), locale }, testInfo)
+            })
+        }
+    })
+}
+
+// ---- marketing: locale in the URL; full slug list at 320, reps everywhere ----
+
+for (const target of MARKETING_TARGETS) {
+    for (const locale of target.locales ?? ['en', 'es-419', 'es-ar', 'pt-br']) {
+        const path = target.path.replace('{locale}', locale)
+        test(`marketing:${path}`, async ({ page }, testInfo) => {
+            test.skip(!target.allWidths && width(testInfo) !== 320, 'full slug list runs at 320 only')
+            const cell = { id: `marketing:${path}`, kind: 'marketing' as const, width: width(testInfo), locale }
+            await blockExternal(page)
+            const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+            await page.waitForTimeout(700)
+            const landed = new URL(page.url()).pathname
+            if (landed !== path.split('?')[0]) {
+                record({ ...cell, status: 'skip', reason: `redirected to ${landed}` }, testInfo)
+                test.skip(true, `redirected to ${landed}`)
+                return
+            }
+            // a notFound() renders at the same pathname — a passing scan of a
+            // 404 or an empty shell would be a vacuous pass
+            const status = response?.status() ?? 0
+            if (status >= 400) {
+                record({ ...cell, status: 'skip', reason: `http ${status}` }, testInfo)
+                test.skip(true, `http ${status}`)
+                return
+            }
+            await settle(page)
+            const textLength = await page.evaluate(() => document.body.innerText.trim().length)
+            if (textLength < 40) {
+                record({ ...cell, status: 'skip', reason: `thin page (${textLength} chars)` }, testInfo)
+                test.skip(true, 'thin page')
+                return
+            }
+            await scan(page, cell, testInfo)
+        })
+    }
+}
+
+for (const { locale, path } of LANDING_TARGETS) {
+    test(`landing:${path}`, async ({ page }, testInfo) => {
+        const cell = { id: `landing:${path}`, kind: 'landing' as const, width: width(testInfo), locale }
+        await blockExternal(page)
+        await page.clock.setFixedTime(FROZEN_NOW)
+        await page.goto(path, { waitUntil: 'domcontentloaded' })
+        await page.waitForTimeout(1500)
+        // lazy sections mount on scroll — walk the page so the scan sees them
+        await page.evaluate(async () => {
+            for (let y = 0; y < document.body.scrollHeight; y += 400) {
+                window.scrollTo(0, y)
+                await new Promise((r) => setTimeout(r, 50))
+            }
+            window.scrollTo(0, 0)
+        })
+        await settle(page)
+        await scan(page, cell, testInfo)
+    })
+}

--- a/e2e/shots/overflow.spec.ts
+++ b/e2e/shots/overflow.spec.ts
@@ -32,6 +32,13 @@ const FREEZE_CSS = `
     caret-color: transparent !important;
     scroll-behavior: auto !important;
 }
+/* the freeze cancels the fade-in-up-spring reveal, which would leave
+   .animate-on-view wrappers at opacity 0 and hide their text from the
+   scan — force them visible instead */
+.animate-on-view {
+    opacity: 1 !important;
+    transform: none !important;
+}
 `
 
 // Known intentional clips — CSS selectors matched against the offending

--- a/e2e/shots/sweep-targets.ts
+++ b/e2e/shots/sweep-targets.ts
@@ -333,9 +333,24 @@ export type OverlayTarget = {
 }
 
 export const OVERLAY_TARGETS: OverlayTarget[] = [
-    { id: 'backup-lose-phone', route: '/profile/backup', clickKeys: ['profile.backup.faq.losePhone'] },
-    { id: 'backup-change-phone', route: '/profile/backup', clickKeys: ['profile.backup.faq.changePhone'] },
-    { id: 'backup-export-keys', route: '/profile/backup', clickKeys: ['profile.backup.faq.exportKeys'] },
+    {
+        id: 'backup-lose-phone',
+        route: '/profile/backup',
+        clickKeys: ['profile.backup.faq.losePhone'],
+        proof: '[data-vaul-drawer], [role="dialog"]',
+    },
+    {
+        id: 'backup-change-phone',
+        route: '/profile/backup',
+        clickKeys: ['profile.backup.faq.changePhone'],
+        proof: '[data-vaul-drawer], [role="dialog"]',
+    },
+    {
+        id: 'backup-export-keys',
+        route: '/profile/backup',
+        clickKeys: ['profile.backup.faq.exportKeys'],
+        proof: '[data-vaul-drawer], [role="dialog"]',
+    },
     { id: 'home-add-drawer', route: '/home?drawer=add', proof: '[data-vaul-drawer], [role="dialog"]' },
     { id: 'home-send-drawer', route: '/home?drawer=send', proof: '[data-vaul-drawer], [role="dialog"]' },
     { id: 'add-money-bank-list', route: '/add-money?method=bank', fixture: 'add-money' },

--- a/e2e/shots/sweep-targets.ts
+++ b/e2e/shots/sweep-targets.ts
@@ -1,0 +1,347 @@
+/**
+ * Target inventory for the full i18n overflow sweep. Enumerated from
+ * src/app/[locale]/(marketing) generateStaticParams + the content tree
+ * (2026-09-11). Every slug runs at 320px in all four URL locales; the
+ * REPRESENTATIVES (one per template + every composition-flagged slug) also
+ * run at 375/393/430. /status is excluded: revalidate=0 live incident feed,
+ * nondeterministic by design.
+ */
+
+export const MARKETING_LOCALES = ['en', 'es-419', 'es-ar', 'pt-br'] as const
+
+const COUNTRIES = [
+    'argentina',
+    'australia',
+    'brazil',
+    'canada',
+    'chile',
+    'colombia',
+    'costa-rica',
+    'france',
+    'germany',
+    'india',
+    'indonesia',
+    'italy',
+    'japan',
+    'kenya',
+    'malaysia',
+    'mexico',
+    'netherlands',
+    'nigeria',
+    'pakistan',
+    'peru',
+    'philippines',
+    'poland',
+    'portugal',
+    'saudi-arabia',
+    'singapore',
+    'south-africa',
+    'spain',
+    'sweden',
+    'tanzania',
+    'thailand',
+    'turkey',
+    'united-arab-emirates',
+    'united-kingdom',
+    'united-states',
+    'vietnam',
+]
+
+const RECEIVE_FROM = [
+    'argentina',
+    'australia',
+    'brazil',
+    'france',
+    'germany',
+    'india',
+    'italy',
+    'kenya',
+    'malaysia',
+    'netherlands',
+    'pakistan',
+    'philippines',
+    'portugal',
+    'saudi-arabia',
+    'singapore',
+    'spain',
+    'united-arab-emirates',
+    'united-kingdom',
+    'united-states',
+]
+
+const SEND_PAIRS = [
+    ['brazil', 'argentina'],
+    ['colombia', 'argentina'],
+    ['france', 'argentina'],
+    ['germany', 'argentina'],
+    ['italy', 'argentina'],
+    ['mexico', 'argentina'],
+    ['spain', 'argentina'],
+    ['united-kingdom', 'argentina'],
+    ['united-states', 'argentina'],
+    ['argentina', 'brazil'],
+    ['colombia', 'brazil'],
+    ['germany', 'brazil'],
+    ['mexico', 'brazil'],
+    ['portugal', 'brazil'],
+    ['united-kingdom', 'brazil'],
+    ['united-states', 'brazil'],
+]
+
+const COMPARE = ['binance-p2p', 'paypal', 'revolut', 'western-union', 'wise']
+const DEPOSIT_FROM = [
+    'belo',
+    'binance',
+    'bitso',
+    'buenbit',
+    'bybit',
+    'coinbase',
+    'crypto-com',
+    'kraken',
+    'kucoin',
+    'lemon',
+    'metamask',
+    'okx',
+    'phantom',
+    'revolut-exchange',
+    'ripio',
+]
+const DEPOSIT_VIA = [
+    'ach',
+    'sepa',
+    'wire',
+    'faster-payments',
+    'spei',
+    'arbitrum',
+    'base',
+    'ethereum',
+    'polygon',
+    'solana',
+    'tron',
+]
+const PAY_WITH = [
+    'bizum',
+    'blik',
+    'cashapp',
+    'codi',
+    'duitnow',
+    'fast-turkey',
+    'fps',
+    'gcash',
+    'interac',
+    'mbway',
+    'mercadopago',
+    'momo',
+    'mpesa',
+    'npp',
+    'paynow',
+    'payshap',
+    'pix',
+    'promptpay',
+    'qris',
+    'raast',
+    'sinpe-movil',
+    'swish',
+    'transfiya',
+    'uaefts',
+    'venmo',
+    'yape',
+    'zengin-net',
+]
+const WITHDRAW = [
+    'ach',
+    'arbitrum',
+    'base',
+    'ethereum',
+    'faster-payments',
+    'polygon',
+    'solana',
+    'spei',
+    'to-bank',
+    'tron',
+]
+const USE_CASES = ['cross-border-travel', 'digital-nomads', 'families', 'remote-workers', 'tourists']
+const HELP = [
+    'account-recovery',
+    'card-collateral',
+    'card-payments',
+    'delete-account',
+    'deposit-bank',
+    'deposit-crypto',
+    'deposit-not-showing',
+    'dollar-rates-argentina',
+    'fees-pricing',
+    'mercadopago-account',
+    'mercadopago-merchants',
+    'mercadopago-qr',
+    'mercadopago-without-dni',
+    'passkeys',
+    'payment-not-received',
+    'peanut-card',
+    'qr-troubleshooting',
+    'recover-wrong-token',
+    'referrals',
+    'refunds',
+    'request-money',
+    'rewards',
+    'rewards-card-payments',
+    'rewards-claiming',
+    'rewards-earning',
+    'rewards-not-showing',
+    'rewards-vs-points',
+    'security-custody',
+    'security-disclosure',
+    'send-euros-argentina',
+    'send-money-link',
+    'supported-geographies',
+    'transaction-limits',
+    'verification',
+    'waitlist-invite-codes',
+    'what-are-digital-dollars',
+    'withdraw-bank',
+    'withdraw-crypto',
+]
+const STORIES = ['arsenii', 'cat', 'kamila', 'lynn', 'mei', 'purple']
+const BLOG = [
+    'earn-with-peanut-3min-setup',
+    'earn-with-peanut-passive-income',
+    'rewards-v2-savings-calculator',
+    'rewards-v2-thank-you',
+    'rewards-v2-the-receipts',
+    'stablecoin-balance-visa-merchants',
+]
+// legal prose is English in every locale (fallback by design), but all four
+// URL locales are prerendered — sweep them all; the chrome around the prose
+// is still localized
+const LEGAL = [
+    'terms',
+    'privacy',
+    'card-esign',
+    'card-privacy',
+    'card-prohibited-activities',
+    'card-terms-international',
+    'card-terms-us',
+]
+
+export type MarketingTarget = {
+    /** path with {locale} placeholder; landing uses fixed per-locale paths */
+    path: string
+    /** run at every width, not just 320 */
+    allWidths?: boolean
+    /** restrict URL locales (legal = en only) */
+    locales?: readonly string[]
+}
+
+// representatives: one per template + every composition-flagged slug
+const REP = new Set([
+    '/{locale}/argentina', // CountryGrid
+    '/{locale}/send-money-to/argentina', // the only <Tabs> user
+    '/{locale}/send-money-from/united-states/to/argentina',
+    '/{locale}/receive-money-from/spain',
+    '/{locale}/compare/peanut-vs-wise', // ExchangeWidget + ArticleLocaleNav
+    '/{locale}/deposit/from-binance',
+    '/{locale}/deposit/via-sepa', // second slug shape of the template
+    '/{locale}/pay-with/mercadopago',
+    '/{locale}/withdraw/to-bank',
+    '/{locale}/use-cases/digital-nomads',
+    '/{locale}/help/fees-pricing', // the ExchangeWidget help article
+    '/{locale}/stories/cat',
+    '/{locale}/blog/rewards-v2-thank-you',
+    '/{locale}/pricing',
+    '/{locale}/supported-networks',
+    '/{locale}/help',
+    '/{locale}/content',
+    '/{locale}/stories',
+])
+
+const paths: string[] = [
+    ...COUNTRIES.map((c) => `/{locale}/${c}`),
+    ...COUNTRIES.map((c) => `/{locale}/send-money-to/${c}`),
+    ...SEND_PAIRS.map(([f, t]) => `/{locale}/send-money-from/${f}/to/${t}`),
+    ...RECEIVE_FROM.map((c) => `/{locale}/receive-money-from/${c}`),
+    ...COMPARE.map((s) => `/{locale}/compare/peanut-vs-${s}`),
+    ...DEPOSIT_FROM.map((s) => `/{locale}/deposit/from-${s}`),
+    ...DEPOSIT_VIA.map((s) => `/{locale}/deposit/via-${s}`),
+    ...PAY_WITH.map((s) => `/{locale}/pay-with/${s}`),
+    ...WITHDRAW.map((s) => `/{locale}/withdraw/${s}`),
+    ...USE_CASES.map((s) => `/{locale}/use-cases/${s}`),
+    ...HELP.map((s) => `/{locale}/help/${s}`),
+    ...STORIES.map((s) => `/{locale}/stories/${s}`),
+    ...BLOG.map((s) => `/{locale}/blog/${s}`),
+    '/{locale}/pricing',
+    '/{locale}/supported-networks',
+    '/{locale}/help',
+    '/{locale}/content',
+    '/{locale}/stories',
+    '/{locale}/press',
+]
+
+export const MARKETING_TARGETS: MarketingTarget[] = [
+    ...paths.map((path) => ({ path, allWidths: REP.has(path) })),
+    ...LEGAL.map((s) => ({ path: `/{locale}/${s}` })),
+]
+
+/**
+ * App routes the fixture registry does not open on its own (registry fixtures
+ * pin states on ~21 routes; these are the remaining prerendered product
+ * surfaces). All run on the default demo fixture — a route that bounces to
+ * /setup or /home records a skip cell, which is a visible coverage gap, not
+ * a silent pass.
+ */
+export const EXTRA_APP_ROUTES: OverlayTarget[] = [
+    { id: 'route-qr-pay', route: '/qr-pay' },
+    { id: 'route-recover-funds', route: '/recover-funds' },
+    { id: 'route-recover-wallet', route: '/recover-wallet' },
+    { id: 'route-card', route: '/card' },
+    { id: 'route-card-limit', route: '/card/limit' },
+    { id: 'route-card-physical', route: '/card/physical' },
+    { id: 'route-card-add-to-wallet', route: '/card/add-to-wallet' },
+    { id: 'route-card-recovery', route: '/card-recovery' },
+    // /points renamed to /rewards — the sweep's redirect skip caught it
+    { id: 'route-rewards', route: '/rewards' },
+    { id: 'route-rewards-invites', route: '/rewards/invites' },
+    { id: 'route-profile-about', route: '/profile/about' },
+    { id: 'route-profile-exchange-rate', route: '/profile/exchange-rate' },
+    { id: 'route-profile-view', route: '/profile/view?username=demo' },
+    // /qr (needs a claim code), /add-money/us/bank and /withdraw/{crypto,manteca}
+    // (need mid-flow state) bounce without deeper harness work — the withdraw
+    // and add-money fixtures cover those screens' entry states
+    { id: 'route-limits-bridge', route: '/limits/bridge' },
+    { id: 'route-kyc-success', route: '/kyc/success' },
+    { id: 'route-shhhhh', route: '/shhhhh' },
+]
+
+/** the four landing pages live outside [locale] */
+export const LANDING_TARGETS: { locale: string; path: string }[] = [
+    { locale: 'en', path: '/' },
+    { locale: 'es-419', path: '/es-419' },
+    { locale: 'es-ar', path: '/es-ar' },
+    { locale: 'pt-br', path: '/pt-br' },
+]
+
+/**
+ * App overlay states beyond the plain fixture routes. `clickKeys` are
+ * catalog key paths resolved to the active locale's label at test time.
+ */
+export type OverlayTarget = {
+    id: string
+    route: string
+    fixture?: string
+    clickKeys?: string[]
+    /** selector that must be visible — proves the overlay actually opened */
+    proof?: string
+}
+
+export const OVERLAY_TARGETS: OverlayTarget[] = [
+    { id: 'backup-lose-phone', route: '/profile/backup', clickKeys: ['profile.backup.faq.losePhone'] },
+    { id: 'backup-change-phone', route: '/profile/backup', clickKeys: ['profile.backup.faq.changePhone'] },
+    { id: 'backup-export-keys', route: '/profile/backup', clickKeys: ['profile.backup.faq.exportKeys'] },
+    { id: 'home-add-drawer', route: '/home?drawer=add', proof: '[data-vaul-drawer], [role="dialog"]' },
+    { id: 'home-send-drawer', route: '/home?drawer=send', proof: '[data-vaul-drawer], [role="dialog"]' },
+    { id: 'add-money-bank-list', route: '/add-money?method=bank', fixture: 'add-money' },
+    { id: 'profile-avatar-picker', route: '/profile?avatarPicker=true', proof: '[data-vaul-drawer], [role="dialog"]' },
+    { id: 'withdraw-all-methods', route: '/withdraw?showAll=true', fixture: 'withdraw' },
+    { id: 'limits-argentina', route: '/limits?region=argentina' },
+    { id: 'limits-brazil', route: '/limits?region=brazil' },
+    { id: 'card-pin-set', route: '/card/pin?mode=set' },
+]

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
         "capgo:upload:dev": "node scripts/native-build.js && pnpm dlx @capgo/cli@8.42.4 bundle upload --channel development --path ./out --version-exists-ok --bundle \"$(node scripts/release-version.mjs staging)\"",
         "capgo:upload:staging": "node scripts/native-build.js && pnpm dlx @capgo/cli@8.42.4 bundle upload --channel staging --path ./out --version-exists-ok --bundle \"$(node scripts/release-version.mjs staging)\"",
         "test:unit:ci": "jest --coverage --reporters=default --reporters=jest-junit",
-        "generate:marketing-messages": "node scripts/generate-marketing-messages.js"
+        "generate:marketing-messages": "node scripts/generate-marketing-messages.js",
+        "test:i18n-overflow:sweep": "NEXT_PUBLIC_VERCEL_ENV=preview pnpm build && pnpm test:i18n-overflow:sweep:run",
+        "test:i18n-overflow:sweep:run": "export SWEEP_OUT=${SWEEP_OUT:-e2e/__sweep__}; rm -rf \"$SWEEP_OUT\"; playwright test --config=playwright.sweep.config.ts; node scripts/overflow-sweep-report.mjs \"$SWEEP_OUT\""
     },
     "dependencies": {
         "@capacitor/android": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "test:unit:ci": "jest --coverage --reporters=default --reporters=jest-junit",
         "generate:marketing-messages": "node scripts/generate-marketing-messages.js",
         "test:i18n-overflow:sweep": "NEXT_PUBLIC_VERCEL_ENV=preview pnpm build && pnpm test:i18n-overflow:sweep:run",
-        "test:i18n-overflow:sweep:run": "export SWEEP_OUT=${SWEEP_OUT:-e2e/__sweep__}; rm -rf \"$SWEEP_OUT\"; playwright test --config=playwright.sweep.config.ts; node scripts/overflow-sweep-report.mjs \"$SWEEP_OUT\""
+        "test:i18n-overflow:sweep:run": "export SWEEP_OUT=${SWEEP_OUT:-e2e/__sweep__}; rm -rf \"$SWEEP_OUT\"; playwright test --config=playwright.sweep.config.ts; PW=$?; node scripts/overflow-sweep-report.mjs \"$SWEEP_OUT\" && [ $PW -eq 0 ]"
     },
     "dependencies": {
         "@capacitor/android": "8.2.0",

--- a/playwright.sweep.config.ts
+++ b/playwright.sweep.config.ts
@@ -1,0 +1,40 @@
+/**
+ * Full i18n overflow sweep (TASK-22366 follow-up): every surface × every
+ * supported locale × the four device widths. This is the on-demand /
+ * nightly matrix — the per-PR gate (playwright.overflow.config.ts) stays
+ * small on purpose. Hugo's framing: window-size simulation + language
+ * simulation, no manual testing.
+ *
+ * Projects are the WIDTHS; the spec varies locale per describe block, so
+ * one project run covers all four locales at that width. Each test writes
+ * one JSON line into SWEEP_OUT; scripts/overflow-sweep-report.mjs folds
+ * them into sweep-report.json.
+ *
+ *   npm run test:i18n-overflow:sweep         # build, run matrix, report
+ *   npm run test:i18n-overflow:sweep:run     # no rebuild
+ */
+
+import { defineConfig } from '@playwright/test'
+import base from './playwright.shots.config'
+
+const WIDTHS = [
+    { width: 320, height: 568 },
+    { width: 375, height: 667 },
+    { width: 393, height: 852 },
+    { width: 430, height: 932 },
+]
+
+export default defineConfig({
+    ...base,
+    // ~2k page loads: give it more headroom than the gate but stay honest
+    // about failure — no retries, a flaky page is a finding.
+    timeout: 90_000,
+    projects: WIDTHS.map(({ width, height }) => ({
+        name: `w${width}`,
+        testMatch: /overflow-sweep\.spec\.ts/,
+        use: {
+            ...base.use,
+            viewport: { width, height },
+        },
+    })),
+})

--- a/scripts/overflow-sweep-report.mjs
+++ b/scripts/overflow-sweep-report.mjs
@@ -1,0 +1,39 @@
+// folds the per-test JSON lines the sweep writes into one report:
+//   node scripts/overflow-sweep-report.mjs [e2e/__sweep__] > summary
+// writes e2e/__sweep__/sweep-report.json and prints a human summary.
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const dir = process.argv[2] ?? 'e2e/__sweep__'
+const cells = []
+for (const f of readdirSync(dir).filter((f) => f.endsWith('.jsonl'))) {
+    for (const line of readFileSync(join(dir, f), 'utf8').split('\n')) {
+        if (line.trim()) cells.push(JSON.parse(line))
+    }
+}
+
+cells.sort((a, b) => (a.id + a.width + a.locale).localeCompare(b.id + b.width + b.locale))
+const fails = cells.filter((c) => c.status === 'fail')
+const skips = cells.filter((c) => c.status === 'skip')
+const passes = cells.filter((c) => c.status === 'pass')
+
+const byKind = {}
+for (const c of cells) byKind[c.kind] = (byKind[c.kind] ?? 0) + 1
+
+const report = {
+    generated: new Date().toISOString(),
+    totals: { cells: cells.length, pass: passes.length, fail: fails.length, skip: skips.length, byKind },
+    fails,
+    skips,
+    cells,
+}
+writeFileSync(join(dir, 'sweep-report.json'), JSON.stringify(report, null, 2))
+
+console.log(`sweep: ${cells.length} cells — ${passes.length} pass, ${fails.length} fail, ${skips.length} skip`)
+console.log('by kind:', JSON.stringify(byKind))
+for (const f of fails) {
+    console.log(`FAIL ${f.id} @${f.width} ${f.locale}`)
+    for (const o of f.overflows ?? []) console.log(`   [${o.kind}] ${o.selector} — "${o.text}" (${o.detail})`)
+}
+for (const s of skips) console.log(`SKIP ${s.id} @${s.width} ${s.locale} — ${s.reason}`)
+if (fails.length > 0) process.exitCode = 1

--- a/src/app/shhhhh/ShhhhhLandingPage.tsx
+++ b/src/app/shhhhh/ShhhhhLandingPage.tsx
@@ -300,7 +300,7 @@ export default function ShhhhhLandingPage() {
                 />
                 <div className="relative z-20 mx-auto grid max-w-6xl grid-cols-1 items-center gap-12 md:grid-cols-[1.1fr_0.9fr]">
                     <div className="min-w-0 text-center md:text-left">
-                        <h1 className="font-roboto-flex-extrabold text-headingMedium font-extraBlack md:text-headingLarge lg:text-[12rem]">
+                        <h1 className="font-roboto-flex-extrabold text-heading font-extraBlack md:text-headingLarge lg:text-[12rem]">
                             {t('hero.wordmark')}
                         </h1>
                         <p className="font-roboto-flex-extrabold mt-6 max-w-xl text-2xl font-extraBlack uppercase md:text-3xl">
@@ -385,7 +385,7 @@ export default function ShhhhhLandingPage() {
             {/* §2 — What it does (yellow) */}
             <section className="relative overflow-hidden bg-secondary-1 px-4 py-24 text-center text-n-1 md:py-32">
                 <div className="mx-auto max-w-5xl">
-                    <h2 className="font-roboto-flex-extrabold mx-auto max-w-3xl text-heading font-extraBlack uppercase md:text-headingMedium">
+                    <h2 className="font-roboto-flex-extrabold mx-auto max-w-3xl text-headingSmall font-extraBlack break-words hyphens-auto uppercase md:text-headingMedium">
                         {t('whatItDoes.titleLine1')}
                         <br />
                         {t('whatItDoes.titleLine2')}
@@ -416,7 +416,7 @@ export default function ShhhhhLandingPage() {
             {/* §3 — Who it's for (PINK) */}
             <section className="relative overflow-hidden bg-primary-1 px-4 py-24 text-n-1 md:py-32">
                 <div className="mx-auto max-w-3xl">
-                    <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack uppercase md:text-headingMedium">
+                    <h2 className="font-roboto-flex-extrabold text-headingSmall font-extraBlack break-words hyphens-auto uppercase md:text-headingMedium">
                         {t('whoItsFor.title')}
                     </h2>
                     <p className="font-roboto-flex mt-10 text-xl leading-relaxed md:text-2xl">{t('whoItsFor.body')}</p>
@@ -431,7 +431,7 @@ export default function ShhhhhLandingPage() {
                 style={{ backgroundColor: '#90A8ED' }}
             >
                 <div className="mx-auto max-w-5xl">
-                    <h2 className="font-roboto-flex-extrabold text-center text-heading font-extraBlack uppercase md:text-headingMedium">
+                    <h2 className="font-roboto-flex-extrabold text-center text-headingSmall font-extraBlack break-words hyphens-auto uppercase md:text-headingMedium">
                         {t('howToGetIn.title')}
                     </h2>
                     <p className="font-roboto-flex mt-3 text-center text-xl font-bold md:text-2xl">
@@ -513,7 +513,7 @@ export default function ShhhhhLandingPage() {
             {/* §5 — Probably not for you (BLACK) */}
             <section className="relative overflow-hidden bg-n-1 px-4 py-24 text-white md:py-32">
                 <div className="mx-auto max-w-3xl">
-                    <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack uppercase md:text-headingMedium">
+                    <h2 className="font-roboto-flex-extrabold text-headingSmall font-extraBlack break-words hyphens-auto uppercase md:text-headingMedium">
                         {t('notForYou.title')}
                     </h2>
                     <p className="font-roboto-flex mt-8 text-xl leading-relaxed opacity-90 md:text-2xl">
@@ -533,7 +533,7 @@ export default function ShhhhhLandingPage() {
                 style={{ backgroundColor: '#F9F4F0' }}
             >
                 <div className="mx-auto max-w-3xl">
-                    <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack uppercase md:text-headingMedium">
+                    <h2 className="font-roboto-flex-extrabold text-headingSmall font-extraBlack break-words hyphens-auto uppercase md:text-headingMedium">
                         {t('faq.title')}
                     </h2>
                     <div className="mt-10 border-y-2 border-n-1">
@@ -577,7 +577,7 @@ export default function ShhhhhLandingPage() {
                     className="pointer-events-none absolute right-[10%] bottom-[20%] w-8 md:right-[18%] md:bottom-[24%] md:w-12"
                 />
                 <div className="relative z-10 mx-auto max-w-3xl">
-                    <h2 className="font-roboto-flex-extrabold text-heading font-extraBlack md:text-headingMedium lg:text-headingLarge">
+                    <h2 className="font-roboto-flex-extrabold text-headingSmall font-extraBlack break-words hyphens-auto md:text-headingMedium lg:text-headingLarge">
                         {t('ready.title')}
                     </h2>
                     <p className="font-roboto-flex-extrabold mt-6 text-2xl font-extraBlack uppercase md:text-3xl">

--- a/src/components/Marketing/MarketingHero.tsx
+++ b/src/components/Marketing/MarketingHero.tsx
@@ -50,7 +50,9 @@ export function MarketingHero({
                         />
                     )}
                     <h1>
-                        <Title text={title} className="text-7xl md:text-9xl" />
+                        {/* 5xl on mobile: the knerd display face clips at 320px
+                            with text-7xl (TASK-22366 sweep) */}
+                        <Title text={title} className="text-5xl md:text-9xl" />
                     </h1>
                     <p className="mt-6 text-3xl font-bold text-black md:text-5xl">{subtitle}</p>
                     {ctaText && (

--- a/src/components/Marketing/mdx/Hero.tsx
+++ b/src/components/Marketing/mdx/Hero.tsx
@@ -28,7 +28,10 @@ export function Hero({ title, subtitle, cta, ctaHref }: HeroProps) {
             <section className="relative overflow-hidden bg-primary-1 px-4 py-16 text-center md:px-8 md:py-24">
                 <CloudsCss clouds={marketingClouds} />
                 <div className="relative z-10 mx-auto max-w-4xl">
-                    <h1 className="font-roboto-flex-extrabold text-[2.5rem] leading-[0.95] font-extraBlack text-black uppercase md:text-[4.5rem]">
+                    {/* break-words + hyphens: one long word ("COMMUNICATIONS",
+                        "INSTANTANEAMENTE") must wrap, not clip, at 320px
+                        (TASK-22366 sweep) */}
+                    <h1 className="font-roboto-flex-extrabold text-[2.5rem] leading-[0.95] font-extraBlack break-words hyphens-auto text-black uppercase md:text-[4.5rem]">
                         {title}
                     </h1>
                     {subtitle && (

--- a/src/components/Setup/components/SetupWrapper.tsx
+++ b/src/components/Setup/components/SetupWrapper.tsx
@@ -338,7 +338,7 @@ export const SetupWrapper = memo(function SetupWrapper({
     const headingDescription = shouldShowBraveInstalledHeaderOnly ? t('description') : description
 
     return (
-        <div className="flex min-h-[calc(100dvh_-_var(--safe-top)_-_var(--safe-bottom))] flex-col overflow-hidden">
+        <div className="flex min-h-[calc(100dvh_-_var(--safe-top)_-_var(--safe-bottom))] flex-col overflow-x-hidden overflow-y-auto">
             {/* navigation buttons */}
             <Navigation
                 showBackButton={showBackButton}
@@ -369,7 +369,10 @@ export const SetupWrapper = memo(function SetupWrapper({
                     animate={animatePanelIn ? { y: 0 } : undefined}
                     transition={{ type: 'spring', stiffness: 260, damping: 30 }}
                     className={twMerge(
-                        'flex flex-col justify-between overflow-hidden bg-white px-6 pt-6 pb-8 md:space-y-4 md:h-dvh md:justify-center',
+                        // y-auto, not hidden: es/pt copy wraps one line longer and the
+                        // bottom of the card (recover-account link) clipped at exact
+                        // viewport height (TASK-22366 sweep) — scroll instead of clip
+                        'flex flex-col justify-between overflow-x-hidden overflow-y-auto bg-white px-6 pt-6 pb-8 md:space-y-4 md:h-dvh md:justify-center',
                         // signup: panel hugs its content so the hero absorbs the slack
                         // (paired with the grow classes in IMAGE_CONTAINER_CLASSES)
                         layoutType === 'signup' ? 'grow-0 md:grow' : 'flex-grow',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -103,7 +103,7 @@
     "content": "Content",
     "contentHubTitle": "Explore Peanut",
     "contentHubSubtitle": "Articles, stories, guides, and comparisons.",
-    "contentSearchPlaceholder": "Search articles, stories, guides...",
+    "contentSearchPlaceholder": "Search articles",
     "filterAll": "All",
     "filterBlog": "Blog",
     "filterStories": "Stories",

--- a/src/i18n/es-419.json
+++ b/src/i18n/es-419.json
@@ -103,7 +103,7 @@
     "content": "Contenido",
     "contentHubTitle": "Explora Peanut",
     "contentHubSubtitle": "Artículos, historias, guías y comparaciones.",
-    "contentSearchPlaceholder": "Buscar artículos, historias, guías...",
+    "contentSearchPlaceholder": "Buscar artículos",
     "filterAll": "Todos",
     "filterBlog": "Blog",
     "filterStories": "Historias",

--- a/src/i18n/es-ar.json
+++ b/src/i18n/es-ar.json
@@ -103,7 +103,7 @@
     "content": "Contenido",
     "contentHubTitle": "Explorá Peanut",
     "contentHubSubtitle": "Artículos, historias, guías y comparaciones.",
-    "contentSearchPlaceholder": "Buscá artículos, historias, guías...",
+    "contentSearchPlaceholder": "Buscar artículos",
     "filterAll": "Todos",
     "filterBlog": "Blog",
     "filterStories": "Historias",

--- a/src/i18n/es-ar.json
+++ b/src/i18n/es-ar.json
@@ -103,7 +103,7 @@
     "content": "Contenido",
     "contentHubTitle": "Explorá Peanut",
     "contentHubSubtitle": "Artículos, historias, guías y comparaciones.",
-    "contentSearchPlaceholder": "Buscar artículos",
+    "contentSearchPlaceholder": "Buscá artículos",
     "filterAll": "Todos",
     "filterBlog": "Blog",
     "filterStories": "Historias",

--- a/src/i18n/pt-br.json
+++ b/src/i18n/pt-br.json
@@ -103,7 +103,7 @@
     "content": "Conteúdo",
     "contentHubTitle": "Explore o Peanut",
     "contentHubSubtitle": "Artigos, histórias, guias e comparações.",
-    "contentSearchPlaceholder": "Buscar artigos, histórias, guias...",
+    "contentSearchPlaceholder": "Buscar artigos",
     "filterAll": "Todos",
     "filterBlog": "Blog",
     "filterStories": "Histórias",


### PR DESCRIPTION
## Summary

The durable follow-up to #3076, per Hugo's "window-size simulation + language simulation, not manual testing": a full-matrix i18n overflow sweep plus the fix pass for everything it caught.

**The sweep** (`npm run test:i18n-overflow:sweep`): renders **every app fixture, overlay and setup screen in en/es-419/es-AR/pt-BR at 320/375/393/430px**, and **every marketing route (240 slugs across all templates) in all four URL locales** at 320px with template representatives at all widths — **2252 cells**. Each cell writes a JSON line; `scripts/overflow-sweep-report.mjs` folds them into `e2e/__sweep__/sweep-report.json`. Coverage collapses (redirects, 404s, overlays that never opened, thin pages) record **visible skips**, never silent passes.

**Fix pass** — what the sweep found and this PR fixes:
- mdx `Hero` h1 clipped single long words ("COMMUNICATIONS", "INSTANTANEAMENTE") on **129 marketing pages** → `break-words hyphens-auto`
- press/careers `MarketingHero` knerd title clipped at 320 → `text-5xl` mobile
- content-hub search placeholder 17px over → 2-word role label (forms copy rule), all locales
- `/shhhhh` headings at 60–80px display sizes clipped in every locale → one token step down + hyphenation
- setup flow clipped the login card's bottom link in es/pt at exact viewport height → wrapper scrolls instead of clipping
- `/points` → `/rewards` rename caught via redirect skip; targets updated

**Verification you can rerun:**
1. Final run: `2252 cells — 2249 pass, 0 fail, 3 skip` (the 3 = `blog/stablecoin-balance-visa-merchants` 404s in non-en: the post has English content only — content follow-up, not code).
2. **Seeded-failure proof**: planting one over-long es-419 placeholder made exactly that cell fail, quoting the planted string ("text needs 447px, input fits 151px"). Detector self-tests (`overflow-detector.spec.ts`) also pin every catch/ignore shape.
3. An adversarial review pass verified the cell-count math exactly (no crashed-and-dropped cells) and drove the vacuous-pass hardening above.

**Named follow-ups (not in this PR):**
- `sweep-targets.ts` is a hand-enumerated snapshot of the route tree (2026-09-11). New slugs added later are silently un-swept — follow-up: derive the list from `generateStaticParams`, or a count-drift check that fails when the route tree and target list diverge.
- Nightly scheduling for the sweep (~25 min): belongs in GitHub Actions cron (subject is the repo) — separate scheduling decision.
- `blog/stablecoin-balance-visa-merchants` has English content only (404s on es/pt URLs) — content follow-up.

## Task

TASK-22366

## Risks / breaking changes

- Product CSS changes are wrap/scroll/size-step-down only; no logic. The setup-wrapper overflow change (`hidden` → `y-auto`) affects all setup screens — behavior identical when content fits, scrolls instead of clips when it doesn't (94 setup unit tests green).
- The sweep is **on-demand, not per-PR CI** (~25 min). The per-PR gate from #3076 stays the fast guard. Candidate for a nightly later — separate scheduling decision.
- Stacked on #3076 (`feat/TASK-22366-i18n-overflow-guard`) — merge that first; this PR's base is set accordingly.

## QA

- `npm run test:i18n-overflow:sweep` on this branch reproduces the report on any machine.
- typecheck green; setup (94), i18n (242), Marketing (23), LandingPage (19) suites green.
