### PR TITLE
fix(passkey): dedupe concurrent ceremony exception telemetry

### DIFF
--- a/src/utils/__tests__/passkeyCeremony.utils.test.ts
+++ b/src/utils/__tests__/passkeyCeremony.utils.test.ts
@@ -3,6 +3,7 @@ import {
     CeremonyTimeoutError,
     PasskeyShimFailedError,
     PasskeyShimNotReadyError,
+    captureCeremonyGuardError,
     currentCeremonyId,
     guardPasskeyCeremony,
     isCeremonyGuardError,
@@ -17,12 +18,15 @@ import {
 import { clearCachedStepUpToken, getCachedStepUpToken } from '@/services/step-up-cache'
 import { isCapacitor } from '@/utils/capacitor'
 import { setAuthToken } from '@/utils/auth-token'
+import { addBreadcrumb, captureException } from '@/utils/sentry-lazy'
 
 jest.mock('@/utils/capacitor', () => ({ isCapacitor: jest.fn(() => false) }))
 jest.mock('@/utils/auth-token', () => ({ setAuthToken: jest.fn() }))
-jest.mock('@/utils/sentry-lazy', () => ({ captureException: jest.fn() }))
+jest.mock('@/utils/sentry-lazy', () => ({ captureException: jest.fn(), addBreadcrumb: jest.fn() }))
 const mockIsCapacitor = isCapacitor as jest.Mock
 const mockSetAuthToken = setAuthToken as jest.Mock
+const mockCaptureException = captureException as jest.Mock
+const mockAddBreadcrumb = addBreadcrumb as jest.Mock
 
 const SHIM_INSTALLED = '__capgoPasskeyShimInstalled'
 const SHIM_FAILED = '__capgoPasskeyShimFailed'
@@ -37,6 +41,8 @@ afterEach(() => {
     mockIsCapacitor.mockReset()
     mockIsCapacitor.mockReturnValue(false)
     mockSetAuthToken.mockReset()
+    mockCaptureException.mockReset()
+    mockAddBreadcrumb.mockReset()
     jest.useRealTimers()
 })
 
@@ -210,6 +216,41 @@ describe('guardPasskeyCeremony', () => {
         expect(isCeremonyStillActive(idA)).toBe(true)
         resolveA('done')
         await pendingA
+    })
+
+    it('reports only the first conflict while one ceremony owns the window', async () => {
+        let resolveA!: (v: string) => void
+        const pendingA = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveA = resolve
+                })
+        )
+        await Promise.resolve()
+        expect(currentCeremonyId()).not.toBeNull()
+
+        captureCeremonyGuardError(new CeremonyConflictError(), 'register')
+        captureCeremonyGuardError(new CeremonyConflictError(), 'register')
+        captureCeremonyGuardError(new CeremonyConflictError(), 'register')
+
+        expect(mockCaptureException).toHaveBeenCalledTimes(1)
+        expect(mockAddBreadcrumb).toHaveBeenCalledTimes(2)
+
+        resolveA('done')
+        await pendingA
+
+        let resolveB!: (v: string) => void
+        const pendingB = guardPasskeyCeremony(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolveB = resolve
+                })
+        )
+        await Promise.resolve()
+        captureCeremonyGuardError(new CeremonyConflictError(), 'register')
+        expect(mockCaptureException).toHaveBeenCalledTimes(2)
+        resolveB('done')
+        await pendingB
     })
 
     it('persists a stashed verify token only when the ceremony resolves', async () => {

--- a/src/utils/passkeyCeremony.utils.ts
+++ b/src/utils/passkeyCeremony.utils.ts
@@ -1,4 +1,4 @@
-import { captureException } from '@/utils/sentry-lazy'
+import { addBreadcrumb, captureException } from '@/utils/sentry-lazy'
 import { isCapacitor } from '@/utils/capacitor'
 import { setAuthToken } from '@/utils/auth-token'
 import { setCachedStepUpToken } from '@/services/step-up-cache'
@@ -71,16 +71,40 @@ const GUARD_ERROR_TAG: Record<string, string> = {
     CeremonyConflictError: 'ceremony_conflict',
 }
 
+// A second tap while a ceremony owns the window is a rejected interaction, not
+// a second passkey failure. Keep the first conflict useful for diagnostics but
+// do not let a rapid burst of losing taps multiply the exception count. The
+// entry is removed when its owning ceremony ends, so a later real conflict is
+// still reportable.
+const reportedConflictCeremonies = new Set<number>()
+
 /**
- * One Sentry capture for guard errors from both the login and register catch
- * paths — the tag is derived from the error class, so a new guard error can't
- * silently collapse into the wrong bucket in one copy of a hand-rolled ternary.
+ * Capture guard errors from both the login and register catch paths — the tag
+ * is derived from the error class, so a new guard error cannot silently
+ * collapse into the wrong bucket in one copy of a hand-rolled ternary.
+ * Conflicts are limited to one exception per active ceremony above; later
+ * losing taps remain breadcrumbs rather than new exception events.
  */
 export const captureCeremonyGuardError = (
     err: Error,
     flow: 'login' | 'register',
     extra?: Record<string, unknown>
 ): void => {
+    if (err.name === 'CeremonyConflictError') {
+        const ceremonyId = currentCeremonyId()
+        if (ceremonyId !== null) {
+            if (reportedConflictCeremonies.has(ceremonyId)) {
+                addBreadcrumb({
+                    category: 'webauthn.ceremony',
+                    level: 'info',
+                    message: `suppressed duplicate ${flow} ceremony conflict`,
+                    data: { ceremonyId },
+                })
+                return
+            }
+            reportedConflictCeremonies.add(ceremonyId)
+        }
+    }
     captureException(err, {
         tags: { error_type: `${flow}_${GUARD_ERROR_TAG[err.name] ?? 'ceremony_guard'}` },
         extra: { shimInstalled: isPasskeyShimInstalled(), isCapacitor: isCapacitor(), ...extra },
@@ -200,6 +224,7 @@ export const guardPasskeyCeremony = async <T>(startCeremony: () => Promise<T>): 
         return result
     } finally {
         if (activeCeremonyId === ceremonyId) activeCeremonyId = null
+        reportedConflictCeremonies.delete(ceremonyId)
         stashedVerifyToken = null
         stashedStepUp = null
     }


### PR DESCRIPTION
## Summary

- keep the first `CeremonyConflictError` for an active passkey ceremony as the diagnostic Sentry exception
- turn later losing taps in that same ceremony into breadcrumbs instead of duplicate exceptions
- reset the dedupe state when the ceremony ends and add regression coverage

## Evidence

PostHog project 138913 showed five `CeremonyConflictError` exceptions for one iOS setup session within 256 ms on 2026-09-10. This was a rapid competing-tap burst, not five independent ceremonies.

## Validation

- [x] 45 focused Jest tests across ceremony, signup, and login failure paths
- [x] targeted ESLint
- [x] Prettier check
- [ ] full TypeScript check: blocked by existing missing generated/asset modules and the unrelated `instrumentation-client` `maskAttributeFn` type mismatch; no errors were reported in the changed files

Notion task: TASK-21644