### PR TITLE
fix: allow residence declarations without a cooldown

### DIFF
--- a/src/components/Profile/views/ResidenceChangeDrawer.tsx
+++ b/src/components/Profile/views/ResidenceChangeDrawer.tsx
@@ -24,8 +24,6 @@ interface ResidenceChangeDrawerProps {
     declaredSecond?: string | null
     /** KYC-verified residence, when one exists */
     verified: string | null
-    /** when the escalating change cooldown lifts (ISO); null = change allowed now */
-    nextChangeAllowedAt?: string | null
     /** refetch the user so the new declared residence lands everywhere */
     onSaved: () => Promise<unknown> | void
     /** start identity re-verification at the current level (existing restart primitive) */
@@ -49,7 +47,6 @@ const ResidenceChangeDrawer = ({
     declared,
     declaredSecond,
     verified,
-    nextChangeAllowedAt,
     onSaved,
     onReverify,
 }: ResidenceChangeDrawerProps) => {
@@ -74,21 +71,6 @@ const ResidenceChangeDrawer = ({
 
     const selectedRestrictions = deriveResidenceRestrictionsFrom(restrictionSets, selected || null)
     const differsFromVerified = !!verified && !!selected && selected !== verified
-
-    // Escalating change cooldown (server-enforced; this is the honest preface).
-    // Gate only ACTUAL changes: re-saving the current country stays allowed.
-    const cooldownUntilMs = nextChangeAllowedAt ? Date.parse(nextChangeAllowedAt) : NaN
-    const cooldownActive = Number.isFinite(cooldownUntilMs) && cooldownUntilMs > Date.now()
-    const isActualChange = !!selected && !!declared && selected !== declared
-    const changeBlocked = cooldownActive && isActualChange
-    const cooldownDate = cooldownActive
-        ? new Date(cooldownUntilMs).toLocaleString(locale, {
-              month: 'short',
-              day: 'numeric',
-              hour: 'numeric',
-              minute: '2-digit',
-          })
-        : null
 
     const save = async (reverifyAfter: boolean) => {
         if (!userId || !selected || isSaving) return false
@@ -163,11 +145,6 @@ const ResidenceChangeDrawer = ({
                             value={selected || undefined}
                             onValueChange={setSelected}
                         />
-                        {cooldownActive && cooldownDate && (
-                            <p className="text-body-xs text-foreground-secondary">
-                                {t('cooldownNote', { until: cooldownDate })}
-                            </p>
-                        )}
                         {differsFromVerified && (
                             <p className="text-body-xs text-foreground-secondary">{t('verifiedMismatchNote')}</p>
                         )}
@@ -185,7 +162,7 @@ const ResidenceChangeDrawer = ({
                             variant="purple"
                             shadowSize="4"
                             className="mt-1 w-full justify-center"
-                            disabled={isSaving || !selected || !userId || changeBlocked}
+                            disabled={isSaving || !selected || !userId}
                             onClick={() => void save(false)}
                         >
                             {isSaving ? tCommon('loading') : t('save')}
@@ -194,7 +171,7 @@ const ResidenceChangeDrawer = ({
                             <Button
                                 variant="stroke"
                                 className="w-full justify-center"
-                                disabled={isSaving || changeBlocked}
+                                disabled={isSaving}
                                 onClick={() => void save(true)}
                             >
                                 {t('saveAndReverify')}

--- a/src/components/Profile/views/UnlockPayments.view.tsx
+++ b/src/components/Profile/views/UnlockPayments.view.tsx
@@ -468,7 +468,6 @@ const UnlockPayments = () => {
                 declared={residence?.declared ?? null}
                 declaredSecond={declaredSecondIso2}
                 verified={residence?.verified ?? null}
-                nextChangeAllowedAt={residence?.nextChangeAllowedAt ?? null}
                 onSaved={async () => {
                     // A residence change shifts everything derived from it:
                     // card eligibility (server recomputes from the declared

--- a/src/components/Profile/views/__tests__/ResidenceChangeDrawer.test.tsx
+++ b/src/components/Profile/views/__tests__/ResidenceChangeDrawer.test.tsx
@@ -46,17 +46,20 @@ describe('ResidenceChangeDrawer', () => {
         expect(onReverify).not.toHaveBeenCalled()
     })
 
-    it('the change cooldown shows its date and blocks changing to another country, not re-saving', () => {
-        const future = new Date(Date.now() + 60 * 60 * 1000).toISOString()
-        render({ declared: 'BR', verified: 'BR', nextChangeAllowedAt: future })
-        // The note is visible before any pick, so nobody discovers the wait late.
-        expect(screen.getByText(/You can change it again after/)).toBeInTheDocument()
-        // Re-saving the current country stays allowed.
+    it('changing the dropdown only updates the selection; Save persists without starting verification', async () => {
+        const { onClose, onReverify } = render({ declared: 'BR', verified: 'BR' })
+        for (const country of ['France', 'Germany']) {
+            fireEvent.click(screen.getByRole('combobox'))
+            fireEvent.click(screen.getByText(country))
+        }
+        expect(mockedUpdate).not.toHaveBeenCalled()
+        expect(onReverify).not.toHaveBeenCalled()
+        expect(screen.queryByText(/You can change it again after/)).not.toBeInTheDocument()
         expect(screen.getByText('Save').closest('button')).not.toBeDisabled()
-        // Picking a different country under cooldown disables saving.
-        fireEvent.click(screen.getByRole('combobox'))
-        fireEvent.click(screen.getByText('France'))
-        expect(screen.getByText('Save').closest('button')).toBeDisabled()
+        fireEvent.click(screen.getByText('Save'))
+        await waitFor(() => expect(onClose).toHaveBeenCalled())
+        expect(mockedUpdate).toHaveBeenCalledWith({ userId: 'u1', residenceCountry: 'DE' })
+        expect(onReverify).not.toHaveBeenCalled()
     })
 
     it('offers re-verification only when the pick differs from the verified residence', () => {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -412,8 +412,7 @@
                 "cardRestrictionNote": "Heads up: the card isn't available for residents of this country.",
                 "bankingRestrictionNote": "Heads up: bank transfers aren't available for residents of this country.",
                 "save": "Save",
-                "saveAndReverify": "Submit documents",
-                "cooldownNote": "You changed your residence recently. You can change it again after {until}."
+                "saveAndReverify": "Submit documents"
             },
             "degraded": {
                 "title": "Verification is temporarily down",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -412,8 +412,7 @@
                 "cardRestrictionNote": "Atención: la tarjeta no está disponible para residentes de este país.",
                 "bankingRestrictionNote": "Atención: las transferencias bancarias no están disponibles para residentes de este país.",
                 "save": "Guardar",
-                "saveAndReverify": "Enviar documentos",
-                "cooldownNote": "Cambiaste tu residencia hace poco. Puedes cambiarla de nuevo después del {until}."
+                "saveAndReverify": "Enviar documentos"
             },
             "degraded": {
                 "title": "La verificación está temporalmente caída",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -223,8 +223,7 @@
                 "cardRestrictionNote": "Atención: la tarjeta no está disponible para residentes de este país.",
                 "bankingRestrictionNote": "Atención: las transferencias bancarias no están disponibles para residentes de este país.",
                 "save": "Guardar",
-                "saveAndReverify": "Enviar documentos",
-                "cooldownNote": "Cambiaste tu residencia hace poco. Podés cambiarla de nuevo después del {until}."
+                "saveAndReverify": "Enviar documentos"
             },
             "degraded": {
                 "title": "La verificación está temporalmente caída",

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -412,8 +412,7 @@
                 "cardRestrictionNote": "Atenção: o cartão não está disponível para residentes deste país.",
                 "bankingRestrictionNote": "Atenção: transferências bancárias não estão disponíveis para residentes deste país.",
                 "save": "Salvar",
-                "saveAndReverify": "Enviar documentos",
-                "cooldownNote": "Você mudou sua residência há pouco tempo. Pode mudá-la de novo depois de {until}."
+                "saveAndReverify": "Enviar documentos"
             },
             "degraded": {
                 "title": "A verificação está temporariamente fora do ar",

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -305,8 +305,8 @@ export interface IUserProfile {
     residenceRestrictions?: { banking: boolean; card: boolean }
     // Residence, both flavors: declared at signup (advisory) and verified by
     // KYC (Sumsub address — the compliance source of truth). ISO-2 or null.
-    // nextChangeAllowedAt: when the escalating change cooldown lifts (ISO);
-    // null or absent = a change is allowed right now.
+    // nextChangeAllowedAt: legacy field, ignored for self-declaration.
+    // Cooldowns belong to provider verification, not this country selection.
     // declaredSecond: the optional second jurisdiction from the signup step,
     // served by /users/me since 2026-08-26. Optional here only for the window
     // before that BE lands in production; callers fall back to the device

--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -10460,21 +10460,6 @@ export interface paths {
                         };
                     };
                 };
-                /** @description The declared residence changed too recently. Only the residence keys were refused — every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`. */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {string} */
-                            code: "RESIDENCE_CHANGE_COOLDOWN";
-                            error: string;
-                            /** Format: date-time */
-                            retryAt: string;
-                        };
-                    };
-                };
                 /** @description Default Response */
                 500: {
                     headers: {

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -16787,37 +16787,6 @@
                         },
                         "description": "Default Response"
                     },
-                    "429": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`.",
-                                    "properties": {
-                                        "code": {
-                                            "enum": [
-                                                "RESIDENCE_CHANGE_COOLDOWN"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "retryAt": {
-                                            "format": "date-time",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error",
-                                        "code",
-                                        "retryAt"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "The declared residence changed too recently. Only the residence keys were refused \u2014 every other field in the request was applied. Retry the residence change at `retryAt`; `/users/me` reports the same instant as `residence.nextChangeAllowedAt`."
-                    },
                     "500": {
                         "content": {
                             "application/json": {


### PR DESCRIPTION
The residence drawer showed a cooldown after a self-declaration, even though no external verification was required to save it. Removes the declaration cooldown notice and button gating. Changing the dropdown only changes the selection; Save persists the declaration, and Submit documents explicitly starts the existing KYC flow, where provider cooldowns still apply.

Removes obsolete copy from en, es-419, es-AR, and pt-BR and updates the OpenAPI snapshot/generated types to remove the declaration-specific 429 response. The legacy response field is ignored by the UI.

Validation: 12 drawer tests and 16 parent-screen tests passed, including selection without a request, Save without KYC, and the existing provider cooldown display. Formatting passed; scoped lint has no errors and two pre-existing hook dependency warnings in UnlockPayments. Full local typecheck is blocked by SDK typing and missing generated asset declarations outside this change. Draft pending clean-install CI.

Rollout: deploy the companion API first to remove backend enforcement. No merge or deployment performed.

Companion API: https://github.com/peanutprotocol/peanut-api-ts/pull/1589
