### PR TITLE
Keep web signup enabled on PR previews

### DIFF
--- a/src/hooks/useMigrationFlag.ts
+++ b/src/hooks/useMigrationFlag.ts
@@ -5,8 +5,9 @@ import { isPwaSunsetOn } from '@/utils/migration.utils'
 
 /**
  * Read the migration flag after hydration and subscribe to PostHog updates.
- * No automatic staging bypass: QA must exercise both flag states.
- * For local or preview QA, set localStorage['pwa-sunset'] = 'true' and reload.
+ * PR previews bypass the flag so reviewers can exercise web signup. Staging
+ * keeps both flag states available to QA. For local or staging QA, set
+ * localStorage['pwa-sunset'] = 'true' and reload.
  */
 export function useMigrationFlag(): boolean {
     useFeatureFlags()

--- a/src/utils/__tests__/migration.utils.test.ts
+++ b/src/utils/__tests__/migration.utils.test.ts
@@ -69,6 +69,8 @@ beforeEach(() => {
     localStorage.clear()
     mockFlagEnabled = false
     mockIsCapacitor = false
+    delete process.env.NEXT_PUBLIC_VERCEL_ENV
+    delete process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
 })
 
 describe('isPwaSunsetOn', () => {
@@ -78,6 +80,29 @@ describe('isPwaSunsetOn', () => {
 
     it('follows the posthog flag', () => {
         mockFlagEnabled = true
+        expect(isPwaSunsetOn()).toBe(true)
+    })
+
+    it('keeps web signup enabled on ad-hoc Vercel PR previews', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF = 'feat/review-this-change'
+        mockFlagEnabled = true
+
+        expect(isPwaSunsetOn()).toBe(false)
+    })
+
+    it('still follows the migration flag on the dev branch staging deployment', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF = 'dev'
+        mockFlagEnabled = true
+
+        expect(isPwaSunsetOn()).toBe(true)
+    })
+
+    it('does not mistake local preview-mode fixture builds for Vercel PR previews', () => {
+        process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview'
+        mockFlagEnabled = true
+
         expect(isPwaSunsetOn()).toBe(true)
     })
 
@@ -102,7 +127,6 @@ describe('isPwaSunsetOn', () => {
         try {
             jest.isolateModules(() => {
                 // IS_PROD_DOMAIN is computed at module load, so re-require it
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
                 const fresh = require('@/utils/migration.utils') as typeof import('@/utils/migration.utils')
                 expect(fresh.isPwaSunsetOn()).toBe(expected)
             })

--- a/src/utils/migration.utils.ts
+++ b/src/utils/migration.utils.ts
@@ -20,11 +20,29 @@ import {
 const IS_PROD_DOMAIN = BASE_URL === 'https://peanut.me'
 
 /**
- * Read the flag from PostHog. Local, CI and preview builds also accept
+ * PR previews are temporary review environments, so they must retain the web
+ * signup flow even when the production PWA sunset flag is enabled. The dev
+ * branch is excluded because its preview deployment backs staging, where QA
+ * still needs to exercise the production migration state.
+ *
+ * Require a git ref as well as VERCEL_ENV: local visual builds set only
+ * NEXT_PUBLIC_VERCEL_ENV=preview to enable fixtures and must keep the explicit
+ * localStorage sunset override working.
+ */
+function isVercelPrPreview(): boolean {
+    const gitRef = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF
+    return process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' && Boolean(gitRef) && gitRef !== 'dev'
+}
+
+/**
+ * Read the flag from PostHog. Local, CI and staging builds also accept
  * localStorage['pwa-sunset'] = 'true' because PostHog may be unavailable there.
- * Production builds for peanut.me ignore the override.
+ * Production builds for peanut.me ignore the override. Ad-hoc PR previews
+ * always keep the web signup flow available for product review.
  */
 export function isPwaSunsetOn(): boolean {
+    if (isVercelPrPreview()) return false
+
     if (
         (IS_DEV || !IS_PROD_DOMAIN) &&
         typeof localStorage !== 'undefined' &&


### PR DESCRIPTION
## Summary

- bypass the production PWA sunset flag on ad-hoc Vercel PR previews
- keep staging (`dev`) on the normal migration-flag path for QA
- preserve local preview fixture builds and their explicit sunset override

## Validation

- `pnpm jest src/utils/__tests__/migration.utils.test.ts --runInBand` (33 passed)
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- preview-configured `pnpm build`

## Expected behavior

Vercel PR deployment URLs show the existing **Sign up** CTA and allow the PWA signup flow. Production and staging migration behavior remains unchanged.
