### PR TITLE
Fix five-tap OTA channel switch

### DIFF
--- a/docs/NATIVE-RELEASE.md
+++ b/docs/NATIVE-RELEASE.md
@@ -706,18 +706,16 @@ from the dashboard instead.
 
 Three prerequisites, all one-time:
 
-- The account must be in the **`beta-ota-channel`** PostHog cohort, which is what keeps
-  the switch off customer devices. Read what it is, though: a client-side flag that
-  decides whether a React component renders. `setChannel` talks to Capgo directly with
-  the app key shipped in every binary, and non-prod builds skip the flag entirely, so
-  anyone running a modified client can self-assign regardless. It stops people who did
-  not mean to be on beta, not people who do. Move the join behind the backend (verify
-  the account server-side, assign the device through Capgo's API) if that ever needs to
-  be a real boundary.
+- The five-tap gesture records `PEANUT_TEAM` for support/diagnostics, but the badge is
+  not an access boundary and must not disable the switch while a profile refresh is
+  slow or unavailable. `setChannel` talks to Capgo directly with the app key shipped in
+  every binary, so Capgo's self-assignment setting is the boundary that actually opens
+  the channel. Move the join behind the backend (verify the account server-side, assign
+  the device through Capgo's API) if that ever needs to be a real boundary.
 - `staging` must have **"Allow devices to self dissociate/associate"** enabled, or
   `setChannel()` is refused and the app says so. Changing it needs a Super Admin — and
   it is the decision that actually opens the channel: from that point any install that
-  can call the plugin can join, whatever the cohort says.
+  can call the plugin can join, after the five-tap switch is revealed.
 - The tester's binary must not outrank the bundle: `disable_auto_update_under_native`
   makes a device on versionName 1.1.x refuse anything sorting below it. Staging's
   commit-count band sits far above production's, so this only bites right after a native

--- a/src/components/Profile/components/BetaUpdatesCard.tsx
+++ b/src/components/Profile/components/BetaUpdatesCard.tsx
@@ -4,9 +4,7 @@ import Card from '@/components/Global/Card'
 import { Toggle } from '@/components/0_Bruddle/Toggle'
 import { LinkButton } from '@/components/0_Bruddle/LinkButton'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { useAuth } from '@/context/authContext'
 import { useOtaChannel } from '@/hooks/useOtaChannel'
-import { PEANUT_TEAM_BADGE } from '@/constants/badges.consts'
 import { BETA_OTA_CHANNEL } from '@/utils/capgo-updater'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
 import { useTranslations } from 'next-intl'
@@ -16,13 +14,13 @@ import { useTranslations } from 'next-intl'
  * points the device at the `staging` Capgo channel, which every merge to `dev`
  * publishes to; leaving drops it back to the store bundle.
  *
- * Joining requires the PEANUT_TEAM badge, which the About screen awards on the
- * fifth tap. The badge is a record of who opted in, NOT an access boundary —
- * anyone who performs the gesture can award it to themselves, and deleting the
- * row only holds until they tap again. Capgo's channel self-assignment setting
- * is the real boundary.
+ * The About screen records the fifth tap as PEANUT_TEAM, but that badge is not
+ * an access boundary: anyone who performs the gesture can award it to
+ * themselves. The gesture controls discoverability and Capgo's channel
+ * self-assignment setting is the real boundary, so a delayed or failed profile
+ * refresh must never leave the switch visible but inert.
  *
- * The badge gates the JOIN, never the card. An earlier version gated the whole
+ * The card renders on every native build. An earlier version gated the whole
  * reveal on a PostHog cohort, so the flag never being created hid the switch
  * from everyone and looked exactly like exclusion — invisible for months.
  *
@@ -40,21 +38,12 @@ export function useBetaUpdatesAccess(): { supported: boolean } {
     return { supported }
 }
 
-/** Without the badge, only a device already on beta may work the switch — off. */
-function useCanJoinBeta(): boolean {
-    const { user } = useAuth()
-    return !!user?.user.badges?.some((badge) => badge.code === PEANUT_TEAM_BADGE)
-}
-
 export const BetaUpdatesCard = () => {
     const t = useTranslations('profile.about.beta')
     const toast = useToast()
     const { supported, status, isBeta, busy, setBeta } = useOtaChannel()
-    const canJoin = useCanJoinBeta()
 
     if (!supported) return null
-
-    const blockedFromJoining = !canJoin && !isBeta
 
     const copyDeviceId = async (deviceId: string) => {
         if (await copyTextToClipboard(deviceId)) toast.info(t('deviceCopied'))
@@ -111,15 +100,8 @@ export const BetaUpdatesCard = () => {
                         {t('description', { channel: BETA_OTA_CHANNEL })}
                     </p>
                 </div>
-                <Toggle
-                    checked={isBeta}
-                    disabled={busy || blockedFromJoining}
-                    onChange={onToggle}
-                    aria-label={t('heading')}
-                />
+                <Toggle checked={isBeta} disabled={busy} onChange={onToggle} aria-label={t('heading')} />
             </div>
-
-            {blockedFromJoining && <p className="text-body-xs text-foreground-secondary">{t('notEligible')}</p>}
 
             <dl className="space-y-1 text-body-xs text-foreground-secondary">
                 <div className="flex justify-between gap-4">

--- a/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
+++ b/src/components/Profile/components/__tests__/BetaUpdatesCard.test.tsx
@@ -1,8 +1,8 @@
 /**
- * The card is native-only. The tap gesture controls discoverability; the
- * PEANUT_TEAM badge is what decides who may JOIN. It must never decide who may
- * leave, and it must never hide the card — a blocked device has to be able to
- * read why. Beyond that, every join outcome has to read honestly: a tester told
+ * The card is native-only. The tap gesture controls discoverability; Capgo's
+ * channel self-assignment is what decides who may JOIN. The PEANUT_TEAM record
+ * must never make the visible switch inert, and it must never decide who may
+ * leave. Beyond that, every join outcome has to read honestly: a tester told
  * to restart when nothing was downloaded goes looking for a build that isn't
  * there.
  */
@@ -20,9 +20,6 @@ jest.mock('@/components/0_Bruddle/Toast', () => ({ useToast: () => toast }))
 const channel = { current: {} as UseOtaChannel }
 jest.mock('@/hooks/useOtaChannel', () => ({ useOtaChannel: () => channel.current }))
 
-let badges: { code: string }[] = [{ code: 'PEANUT_TEAM' }]
-jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: { user: { badges } } }) }))
-
 const setup = (overrides: Partial<UseOtaChannel> = {}) => {
     channel.current = {
         supported: true,
@@ -39,7 +36,6 @@ const switching = (result: OtaChannelSwitchResult) => ({ setBeta: jest.fn().mock
 
 beforeEach(() => {
     jest.clearAllMocks()
-    badges = [{ code: 'PEANUT_TEAM' }]
 })
 
 it('renders nothing off native, where there is no OTA layer at all', () => {
@@ -47,24 +43,18 @@ it('renders nothing off native, where there is no OTA layer at all', () => {
     expect(screen.queryByRole('switch')).not.toBeInTheDocument()
 })
 
-describe('badge gating', () => {
-    it('will not let an account without the badge join', () => {
-        badges = []
+describe('channel switching access', () => {
+    it('keeps the join control enabled when the profile refresh has no badge', async () => {
         setup()
-        expect(screen.getByRole('switch')).toBeDisabled()
+        const toggle = screen.getByRole('switch')
+        expect(toggle).toBeEnabled()
+        fireEvent.click(toggle)
+        await waitFor(() => expect(channel.current.setBeta).toHaveBeenCalledWith(true))
     })
 
-    // A missing badge must never look like silence: that is how the previous
-    // PostHog gate hid the switch from its own testers for months.
-    it('tells a blocked account why, and what to ask for', () => {
-        badges = []
-        setup()
-        expect(screen.getByText(/not enabled for this account/i)).toBeInTheDocument()
-    })
-
-    // Revoking the badge mid-beta must not strand a device on beta code.
-    it('still lets a device already on beta leave once the badge is revoked', async () => {
-        badges = []
+    // The off switch is the only way back to the store bundle, so a device
+    // already on beta must remain able to leave after any profile change.
+    it('still lets a device already on beta leave', async () => {
         setup({
             isBeta: true,
             status: { channel: 'staging', bundleVersion: '1.1.10846', deviceId: 'abc-123', onBuiltinBundle: false },
@@ -73,12 +63,6 @@ describe('badge gating', () => {
         expect(toggle).toBeEnabled()
         fireEvent.click(toggle)
         await waitFor(() => expect(channel.current.setBeta).toHaveBeenCalledWith(false))
-    })
-
-    it('says nothing about eligibility to an account holding the badge', () => {
-        setup()
-        expect(screen.queryByText(/not enabled for this account/i)).not.toBeInTheDocument()
-        expect(screen.getByRole('switch')).toBeEnabled()
     })
 })
 

--- a/src/components/Profile/views/About.view.tsx
+++ b/src/components/Profile/views/About.view.tsx
@@ -44,20 +44,20 @@ export const AboutView = ({ appVersion }: { appVersion: string }) => {
     }, [betaRevealed])
 
     /**
-     * The tap is what earns PEANUT_TEAM, and the badge is what the switch reads
-     * as permission to join. Claim and refetch BEFORE revealing: the card asks
-     * the user object for the badge, so revealing first would show a disabled
-     * toggle and an "ask for access" line for a round trip, on the very gesture
-     * that just granted it.
-     *
-     * The toast fires first so the gesture is acknowledged immediately, and a
-     * failed claim still reveals the card — the off switch has to stay
-     * reachable for a device already on beta, whatever the network did.
+     * The tap records PEANUT_TEAM for support/diagnostics, but the badge is not
+     * the channel access boundary. Reveal the card immediately so a slow or
+     * unavailable profile request cannot produce a visible-but-dead switch;
+     * Capgo decides whether the device may actually join staging.
      */
-    const revealBetaCard = async () => {
+    const revealBetaCard = () => {
         toast.info(t('beta.revealed'))
-        if (await claimPeanutTeamBadge()) await fetchUser()
         setBetaRevealed(true)
+        void claimPeanutTeamBadge().then((claimed) => {
+            if (claimed)
+                void Promise.resolve()
+                    .then(() => fetchUser())
+                    .catch(() => undefined)
+        })
     }
 
     // The fifth tap always answers: the card renders nothing on the web, and a

--- a/src/components/Profile/views/__tests__/About.view.test.tsx
+++ b/src/components/Profile/views/__tests__/About.view.test.tsx
@@ -77,16 +77,29 @@ describe('AboutView', () => {
         expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
     })
 
-    // The card reads the badge off the user object, so revealing before the
-    // claim lands would show a disabled toggle and an "ask for access" line on
-    // the very gesture that just granted it.
-    it('earns the team badge and refetches the user before revealing the card', async () => {
+    // The badge is a support/diagnostic record. The card must be usable while
+    // the record and the best-effort profile refresh complete.
+    it('records the team badge and refreshes the user after revealing the card', async () => {
         render(<AboutView appVersion="1.2.3" />)
         tapVersion(5)
 
         await waitFor(() => expect(claimPeanutTeamBadge).toHaveBeenCalledTimes(1))
         await waitFor(() => expect(fetchUser).toHaveBeenCalledTimes(1))
         expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
+    })
+
+    it('reveals the usable switch before a slow badge write completes', async () => {
+        let releaseClaim!: (claimed: boolean) => void
+        claimPeanutTeamBadge.mockReturnValueOnce(new Promise<boolean>((resolve) => (releaseClaim = resolve)))
+
+        render(<AboutView appVersion="1.2.3" />)
+        tapVersion(5)
+
+        expect(await screen.findByTestId('beta-updates-card')).toBeInTheDocument()
+        expect(fetchUser).not.toHaveBeenCalled()
+
+        releaseClaim(true)
+        await waitFor(() => expect(fetchUser).toHaveBeenCalledTimes(1))
     })
 
     // Offline, the switch still has to appear: a device already on beta needs

--- a/src/constants/badges.consts.ts
+++ b/src/constants/badges.consts.ts
@@ -1,10 +1,9 @@
 /**
  * The badge that records a device's owner as having found the five-tap beta
- * switch on the About screen. The OTA card reads it back as permission to join
- * the `staging` channel — a record of who opted in, NOT an access boundary:
- * anyone who performs the gesture awards it to themselves, and deleting the
- * row only holds until they tap again. Capgo's channel self-assignment setting
- * is the real boundary.
+ * switch on the About screen. It records the opt-in gesture, but is NOT an
+ * access boundary: anyone who performs the gesture awards it to themselves,
+ * and deleting the row only holds until they tap again. Capgo's channel
+ * self-assignment setting is the real boundary.
  *
  * It is never rendered. It says "team" and is handed out on a gesture, so
  * showing it beside earned badges would let any customer wear Peanut staff

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -572,7 +572,7 @@
             "beta": {
                 "heading": "Beta updates",
                 "description": "Receive builds from the {channel} channel before they ship to everyone. Internal testing only.",
-                "channelLabel": "Update channel",
+                "channelLabel": "Current update channel",
                 "defaultChannel": "Default",
                 "bundleLabel": "Running bundle",
                 "deviceLabel": "Device ID",
@@ -586,7 +586,6 @@
                 "leftOverride": "This device was put on beta from the Capgo dashboard, so the app cannot take it off. Ask an admin to remove the device's channel override.",
                 "leftUnconfirmed": "Could not reach Capgo to confirm the switch, so this device is still on the beta build. Try again when you are back online.",
                 "closed": "The {channel} channel does not accept testers yet. Ask an admin to allow self-assignment in Capgo.",
-                "notEligible": "Beta updates are not enabled for this account yet. Tap the version number five times again to retry.",
                 "failed": "Could not change the update channel.",
                 "revealed": "Beta updates switch revealed below.",
                 "appOnly": "Beta updates are only available in the Peanut app."

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -572,7 +572,7 @@
             "beta": {
                 "heading": "Actualizaciones beta",
                 "description": "Recibí compilaciones del canal {channel} antes de que lleguen a todos. Solo para pruebas internas.",
-                "channelLabel": "Canal de actualizaciones",
+                "channelLabel": "Canal de actualizaciones actual",
                 "defaultChannel": "Predeterminado",
                 "bundleLabel": "Paquete en uso",
                 "deviceLabel": "ID del dispositivo",
@@ -586,7 +586,6 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
-                "notEligible": "Las actualizaciones beta todavía no están habilitadas para esta cuenta. Toca cinco veces el número de versión para reintentar.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -337,7 +337,7 @@
             "beta": {
                 "heading": "Actualizaciones beta",
                 "description": "Recibí compilaciones del canal {channel} antes de que lleguen a todos. Solo para pruebas internas.",
-                "channelLabel": "Canal de actualizaciones",
+                "channelLabel": "Canal de actualizaciones actual",
                 "defaultChannel": "Predeterminado",
                 "bundleLabel": "Paquete en uso",
                 "deviceLabel": "ID del dispositivo",
@@ -351,7 +351,6 @@
                 "leftOverride": "Este dispositivo fue puesto en beta desde el panel de Capgo, así que la app no puede sacarlo. Pedile a un administrador que quite la asignación de canal del dispositivo.",
                 "leftUnconfirmed": "No se pudo contactar a Capgo para confirmar el cambio, así que este dispositivo sigue en la compilación beta. Probá de nuevo cuando tengas conexión.",
                 "closed": "El canal {channel} todavía no acepta testers. Pedile a un administrador que habilite la autoasignación en Capgo.",
-                "notEligible": "Las actualizaciones beta todavía no están habilitadas para esta cuenta. Tocá cinco veces el número de versión para reintentar.",
                 "failed": "No se pudo cambiar el canal de actualizaciones.",
                 "revealed": "El interruptor de actualizaciones beta ya está visible abajo.",
                 "appOnly": "Las actualizaciones beta solo están disponibles en la app de Peanut."

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -572,7 +572,7 @@
             "beta": {
                 "heading": "Atualizações beta",
                 "description": "Receba versões do canal {channel} antes de chegarem a todos. Apenas para testes internos.",
-                "channelLabel": "Canal de atualizações",
+                "channelLabel": "Canal de atualizações atual",
                 "defaultChannel": "Padrão",
                 "bundleLabel": "Pacote em uso",
                 "deviceLabel": "ID do dispositivo",
@@ -586,7 +586,6 @@
                 "leftOverride": "Este aparelho foi colocado em beta pelo painel do Capgo, então o app não consegue tirá-lo. Peça a um administrador para remover a atribuição de canal do aparelho.",
                 "leftUnconfirmed": "Não foi possível falar com o Capgo para confirmar a mudança, então este aparelho continua na versão beta. Tente de novo quando estiver online.",
                 "closed": "O canal {channel} ainda não aceita testadores. Peça a um administrador para permitir a autoatribuição no Capgo.",
-                "notEligible": "As atualizações beta ainda não estão habilitadas para esta conta. Toque cinco vezes no número da versão para tentar de novo.",
                 "failed": "Não foi possível alterar o canal de atualizações.",
                 "revealed": "O interruptor de atualizações beta está visível abaixo.",
                 "appOnly": "As atualizações beta só estão disponíveis no app do Peanut."

--- a/src/services/peanut-team-badge.ts
+++ b/src/services/peanut-team-badge.ts
@@ -3,8 +3,8 @@ import { serverFetch } from '@/utils/api-fetch'
 /**
  * Records the tap. Idempotent server-side, and deliberately quiet: a failure
  * here costs the tester nothing they can act on, and the switch reveals itself
- * either way — the join is what needs the badge, and that is checked against
- * the freshly refetched user.
+ * either way — the OTA card remains usable while the record or profile refresh
+ * is unavailable; Capgo remains the channel access boundary.
  */
 export async function claimPeanutTeamBadge(): Promise<boolean> {
     try {


### PR DESCRIPTION
## What changed
- Reveal the native beta OTA card immediately after five taps, without waiting on the badge write or profile refresh.
- Keep the toggle enabled based on the Capgo operation state; the PEANUT_TEAM badge is retained for support/diagnostics and is not an access gate.
- Clarify that the displayed value is the current effective channel, with localized copy in all supported app locales.
- Update the native-release testing notes to match the Capgo self-assignment boundary.

## Validation
- Focused OTA/About tests: 4 suites, 82 tests passed.
- Message catalogs: 2 suites, 47 tests passed.
- Scoped ESLint and Prettier passed.
- Repository-wide TypeScript check remains blocked by pre-existing missing generated/static assets and an unrelated PostHog SessionRecordingOptions typing error.