### PR TITLE
fix(native): classify and dedupe transport canary failures

### DIFF
--- a/src/utils/__tests__/native-canary.test.ts
+++ b/src/utils/__tests__/native-canary.test.ts
@@ -28,6 +28,8 @@ function mockWebFetch(impl: (url: string, init?: RequestInit) => Promise<Respons
 beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+    capturePosthog.mockReturnValue({ uuid: 'accepted-for-send' })
     nativeHttpRequest.mockResolvedValue(ok())
     mockWebFetch(async () => ok())
 })
@@ -67,14 +69,14 @@ describe('transport canary', () => {
         expect(message).toBe('native canary: get:fail post:ok native:ok')
         expect(options.level).toBe('warning')
         expect(options.fingerprint).toEqual([
-            'native-canary-v5',
+            'native-canary-v6',
             'transport-asymmetry',
             'get:fail post:ok native:ok',
             'direct',
         ])
         expect(options.tags).toMatchObject({
             canary: 'transport',
-            canaryVersion: '5',
+            canaryVersion: '6',
             canary_classification: 'transport-asymmetry',
             canary_get: 'network-error',
             canary_post: 'http-405',
@@ -139,7 +141,7 @@ describe('transport canary', () => {
         expect(captureMessage.mock.calls[0][0]).toBe('native canary: get:fail post:fail native:fail')
         expect(captureMessage.mock.calls[0][1]).toMatchObject({
             level: 'warning',
-            fingerprint: ['native-canary-v5', 'api-unreachable', 'get:fail post:fail native:fail', 'direct'],
+            fingerprint: ['native-canary-v6', 'api-unreachable', 'get:fail post:fail native:fail', 'direct'],
             tags: {
                 canary_classification: 'api-unreachable',
                 canary_capgo: 'http-204',
@@ -166,7 +168,49 @@ describe('transport canary', () => {
                 canary_capgo: 'network-error',
                 canary_internet: 'network-error',
                 sentry_sampled: false,
+                canary_replayed: false,
+                $insert_id: expect.any(String),
             })
+        )
+        expect(localStorage.getItem('nativeCanaryConnectivityOutboxV1')).not.toBeNull()
+    })
+
+    it('replays a persisted offline event once after close and online relaunch', async () => {
+        Object.defineProperty(navigator, 'onLine', { configurable: true, value: false })
+        mockWebFetch(async () => {
+            throw new TypeError('Failed to fetch')
+        })
+        nativeHttpRequest.mockRejectedValue(new TypeError('Unable to resolve host'))
+        jest.spyOn(Math, 'random').mockReturnValue(0.5)
+
+        await runCanary()
+
+        const firstProperties = capturePosthog.mock.calls[0][1]
+        expect(firstProperties).toMatchObject({
+            canary_classification: 'device-connectivity',
+            canary_replayed: false,
+            $insert_id: expect.any(String),
+        })
+
+        // Simulate a killed process: SDK memory is gone, durable storage remains.
+        capturePosthog.mockReset().mockReturnValue({ uuid: 'accepted-for-send' })
+        Object.defineProperty(navigator, 'onLine', { configurable: true, value: true })
+        nativeHttpRequest.mockResolvedValue(ok())
+        mockWebFetch(async () => ok())
+
+        await runCanary()
+        await runCanary()
+
+        expect(capturePosthog).toHaveBeenCalledTimes(1)
+        expect(capturePosthog).toHaveBeenCalledWith(
+            'native_transport_canary_failed',
+            expect.objectContaining({
+                canary_classification: 'device-connectivity',
+                canary_replayed: true,
+                $insert_id: firstProperties.$insert_id,
+                canary_original_captured_at: expect.any(String),
+            }),
+            expect.objectContaining({ send_instantly: true, timestamp: expect.any(Date) })
         )
     })
 
@@ -181,10 +225,11 @@ describe('transport canary', () => {
         await runCanary()
 
         expect(capturePosthog).toHaveBeenCalledTimes(2)
+        expect(capturePosthog.mock.calls[0][1].$insert_id).toBe(capturePosthog.mock.calls[1][1].$insert_id)
         expect(captureMessage).toHaveBeenCalledTimes(1)
         expect(captureMessage.mock.calls[0][1]).toMatchObject({
             level: 'info',
-            fingerprint: ['native-canary-v5', 'device-connectivity', 'get:fail post:fail native:fail', 'direct'],
+            fingerprint: ['native-canary-v6', 'device-connectivity', 'get:fail post:fail native:fail', 'direct'],
         })
     })
 

--- a/src/utils/__tests__/native-canary.test.ts
+++ b/src/utils/__tests__/native-canary.test.ts
@@ -69,14 +69,14 @@ describe('transport canary', () => {
         expect(message).toBe('native canary: get:fail post:ok native:ok')
         expect(options.level).toBe('warning')
         expect(options.fingerprint).toEqual([
-            'native-canary-v6',
+            'native-canary-v7',
             'transport-asymmetry',
             'get:fail post:ok native:ok',
             'direct',
         ])
         expect(options.tags).toMatchObject({
             canary: 'transport',
-            canaryVersion: '6',
+            canaryVersion: '7',
             canary_classification: 'transport-asymmetry',
             canary_get: 'network-error',
             canary_post: 'http-405',
@@ -141,7 +141,7 @@ describe('transport canary', () => {
         expect(captureMessage.mock.calls[0][0]).toBe('native canary: get:fail post:fail native:fail')
         expect(captureMessage.mock.calls[0][1]).toMatchObject({
             level: 'warning',
-            fingerprint: ['native-canary-v6', 'api-unreachable', 'get:fail post:fail native:fail', 'direct'],
+            fingerprint: ['native-canary-v7', 'api-unreachable', 'get:fail post:fail native:fail', 'direct'],
             tags: {
                 canary_classification: 'api-unreachable',
                 canary_capgo: 'http-204',
@@ -169,8 +169,8 @@ describe('transport canary', () => {
                 canary_internet: 'network-error',
                 sentry_sampled: false,
                 canary_replayed: false,
-                $insert_id: expect.any(String),
-            })
+            }),
+            expect.objectContaining({ uuid: expect.any(String) })
         )
         expect(localStorage.getItem('nativeCanaryConnectivityOutboxV1')).not.toBeNull()
     })
@@ -186,11 +186,12 @@ describe('transport canary', () => {
         await runCanary()
 
         const firstProperties = capturePosthog.mock.calls[0][1]
+        const firstOptions = capturePosthog.mock.calls[0][2]
         expect(firstProperties).toMatchObject({
             canary_classification: 'device-connectivity',
             canary_replayed: false,
-            $insert_id: expect.any(String),
         })
+        expect(firstOptions.uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
 
         // Simulate a killed process: SDK memory is gone, durable storage remains.
         capturePosthog.mockReset().mockReturnValue({ uuid: 'accepted-for-send' })
@@ -207,10 +208,9 @@ describe('transport canary', () => {
             expect.objectContaining({
                 canary_classification: 'device-connectivity',
                 canary_replayed: true,
-                $insert_id: firstProperties.$insert_id,
                 canary_original_captured_at: expect.any(String),
             }),
-            expect.objectContaining({ send_instantly: true, timestamp: expect.any(Date) })
+            { send_instantly: true, uuid: firstOptions.uuid }
         )
     })
 
@@ -224,12 +224,14 @@ describe('transport canary', () => {
         await runCanary()
         await runCanary()
 
-        expect(capturePosthog).toHaveBeenCalledTimes(2)
-        expect(capturePosthog.mock.calls[0][1].$insert_id).toBe(capturePosthog.mock.calls[1][1].$insert_id)
+        expect(capturePosthog).toHaveBeenCalledTimes(3)
+        expect(capturePosthog.mock.calls[1][2].uuid).toBe(capturePosthog.mock.calls[0][2].uuid)
+        expect(capturePosthog.mock.calls[2][2].uuid).not.toBe(capturePosthog.mock.calls[0][2].uuid)
+        expect(JSON.parse(localStorage.getItem('nativeCanaryConnectivityOutboxV1') ?? '[]')).toHaveLength(2)
         expect(captureMessage).toHaveBeenCalledTimes(1)
         expect(captureMessage.mock.calls[0][1]).toMatchObject({
             level: 'info',
-            fingerprint: ['native-canary-v6', 'device-connectivity', 'get:fail post:fail native:fail', 'direct'],
+            fingerprint: ['native-canary-v7', 'device-connectivity', 'get:fail post:fail native:fail', 'direct'],
         })
     })
 

--- a/src/utils/__tests__/native-canary.test.ts
+++ b/src/utils/__tests__/native-canary.test.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
 import { runCanary, scheduleTransportCanary } from '../native-canary'
 
 jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }))
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 jest.mock('../capacitor', () => ({ isNativeBridge: jest.fn(() => true), isCapacitor: jest.fn(() => true) }))
 jest.mock('../passkey-auth-capture', () => ({ getUnderlyingFetch: () => null }))
 jest.mock('../native-http', () => ({ nativeHttpRequest: jest.fn() }))
@@ -13,6 +15,7 @@ jest.mock('../app-version', () => ({ getBinaryInfo: async () => ({ appVersion: '
 const { nativeHttpRequest } = jest.requireMock('../native-http') as { nativeHttpRequest: jest.Mock }
 const { isNativeBridge } = jest.requireMock('../capacitor') as { isNativeBridge: jest.Mock }
 const captureMessage = Sentry.captureMessage as jest.Mock
+const capturePosthog = posthog.capture as jest.Mock
 
 const ok = (status = 200) => ({ status }) as Response
 
@@ -24,23 +27,34 @@ function mockWebFetch(impl: (url: string, init?: RequestInit) => Promise<Respons
 
 beforeEach(() => {
     jest.clearAllMocks()
+    localStorage.clear()
     nativeHttpRequest.mockResolvedValue(ok())
     mockWebFetch(async () => ok())
 })
 
+afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+})
+
 describe('transport canary', () => {
-    it('stays silent when every probe succeeds', async () => {
+    it('stays silent and skips the control when every primary probe succeeds', async () => {
         await runCanary()
+
         expect(captureMessage).not.toHaveBeenCalled()
+        expect(capturePosthog).not.toHaveBeenCalled()
+        expect(nativeHttpRequest).toHaveBeenCalledTimes(1)
     })
 
     it('stays silent on non-2xx, because a completed request is not a transport failure', async () => {
         mockWebFetch(async (_url, init) => ok(init?.method === 'POST' ? 405 : 200))
+
         await runCanary()
+
         expect(captureMessage).not.toHaveBeenCalled()
     })
 
-    it('reports the Android shape: webview GET fails while POST and native succeed', async () => {
+    it('reports and fingerprints the Android asymmetric transport shape', async () => {
         mockWebFetch(async (_url, init) => {
             if ((init?.method ?? 'GET') === 'GET') throw new TypeError('Failed to fetch: net::ERR_FAILED')
             return ok(405)
@@ -52,16 +66,48 @@ describe('transport canary', () => {
         const [message, options] = captureMessage.mock.calls[0]
         expect(message).toBe('native canary: get:fail post:ok native:ok')
         expect(options.level).toBe('warning')
+        expect(options.fingerprint).toEqual([
+            'native-canary-v5',
+            'transport-asymmetry',
+            'get:fail post:ok native:ok',
+            'direct',
+        ])
         expect(options.tags).toMatchObject({
             canary: 'transport',
+            canaryVersion: '5',
+            canary_classification: 'transport-asymmetry',
             canary_get: 'network-error',
             canary_post: 'http-405',
             canary_native: 'http-200',
+            canary_internet: 'not-run',
             appVersion: '1.0.57',
             appBuild: '412',
         })
         // the net:: code is the field most likely to name the root cause
         expect(options.extra.get.errorMessage).toContain('net::ERR_FAILED')
+        expect(capturePosthog).toHaveBeenCalledWith(
+            'native_transport_canary_failed',
+            expect.objectContaining({
+                canary_classification: 'transport-asymmetry',
+                sentry_sampled: true,
+            })
+        )
+        expect(nativeHttpRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not let a PostHog failure suppress the actionable Sentry warning', async () => {
+        mockWebFetch(async (_url, init) => {
+            if ((init?.method ?? 'GET') === 'GET') throw new TypeError('Failed to fetch')
+            return ok(405)
+        })
+        capturePosthog.mockImplementationOnce(() => {
+            throw new Error('PostHog unavailable')
+        })
+
+        await runCanary()
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(captureMessage.mock.calls[0][1].tags.canary_classification).toBe('transport-asymmetry')
     })
 
     it('classifies an aborted probe as a timeout', async () => {
@@ -70,7 +116,6 @@ describe('transport canary', () => {
             e.name = 'AbortError'
             throw e
         })
-        nativeHttpRequest.mockResolvedValue(ok())
 
         await runCanary()
 
@@ -79,28 +124,113 @@ describe('transport canary', () => {
         expect(options.tags.canary_get).toBe('timeout')
     })
 
-    it('reports a total outage rather than staying silent', async () => {
+    it('reports an API-host outage when the independent internet control succeeds', async () => {
         mockWebFetch(async () => {
             throw new TypeError('Failed to fetch')
         })
-        nativeHttpRequest.mockRejectedValue(new TypeError('Failed to fetch'))
+        nativeHttpRequest.mockImplementation(async (url: string) => {
+            if (url.includes('api.peanut.me')) throw new TypeError('Unable to resolve host api.peanut.me')
+            return ok(204)
+        })
 
         await runCanary()
 
         expect(captureMessage).toHaveBeenCalledTimes(1)
         expect(captureMessage.mock.calls[0][0]).toBe('native canary: get:fail post:fail native:fail')
+        expect(captureMessage.mock.calls[0][1]).toMatchObject({
+            level: 'warning',
+            fingerprint: ['native-canary-v5', 'api-unreachable', 'get:fail post:fail native:fail', 'direct'],
+            tags: {
+                canary_classification: 'api-unreachable',
+                canary_capgo: 'http-204',
+                canary_internet: 'http-204',
+            },
+        })
+        expect(nativeHttpRequest).toHaveBeenCalledTimes(3)
     })
 
-    it('issues exactly three probes, none of them no-cors — iOS serves no opaque responses', async () => {
+    it('keeps whole-device connectivity in PostHog when the daily Sentry sample is not selected', async () => {
         mockWebFetch(async () => {
             throw new TypeError('Failed to fetch')
         })
+        nativeHttpRequest.mockRejectedValue(new TypeError('Unable to resolve host'))
+        jest.spyOn(Math, 'random').mockReturnValue(0.5)
+
+        await runCanary()
+
+        expect(captureMessage).not.toHaveBeenCalled()
+        expect(capturePosthog).toHaveBeenCalledWith(
+            'native_transport_canary_failed',
+            expect.objectContaining({
+                canary_classification: 'device-connectivity',
+                canary_capgo: 'network-error',
+                canary_internet: 'network-error',
+                sentry_sampled: false,
+            })
+        )
+    })
+
+    it('samples whole-device connectivity into Sentry at info level at most once per day', async () => {
+        mockWebFetch(async () => {
+            throw new TypeError('Failed to fetch')
+        })
+        nativeHttpRequest.mockRejectedValue(new TypeError('Unable to resolve host'))
+        jest.spyOn(Math, 'random').mockReturnValue(0)
+
+        await runCanary()
+        await runCanary()
+
+        expect(capturePosthog).toHaveBeenCalledTimes(2)
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(captureMessage.mock.calls[0][1]).toMatchObject({
+            level: 'info',
+            fingerprint: ['native-canary-v5', 'device-connectivity', 'get:fail post:fail native:fail', 'direct'],
+        })
+    })
+
+    it('uses a simple POST without an application/json preflight', async () => {
+        await runCanary()
+
+        const [, postInit] = (global.fetch as jest.Mock).mock.calls.find(([, init]) => init?.method === 'POST')
+        expect(postInit).toMatchObject({ method: 'POST', body: '{}' })
+        expect(postInit.headers).toBeUndefined()
+    })
+
+    it('enforces the ten-second wall-clock timeout when fetch ignores abort', async () => {
+        jest.useFakeTimers()
+        mockWebFetch(() => new Promise<Response>(() => {}))
+
+        const run = runCanary()
+        await jest.advanceTimersByTimeAsync(10_000)
+        await run
+
+        expect(captureMessage).toHaveBeenCalledTimes(1)
+        expect(captureMessage.mock.calls[0][1].tags).toMatchObject({
+            canary_get: 'timeout',
+            canary_post: 'timeout',
+            canary_native: 'http-200',
+        })
+    })
+
+    it('keeps WebView probes CORS-readable and uses native HTTP for both external controls', async () => {
+        mockWebFetch(async () => {
+            throw new TypeError('Failed to fetch')
+        })
+        nativeHttpRequest.mockRejectedValue(new TypeError('Failed to fetch'))
+        jest.spyOn(Math, 'random').mockReturnValue(0.5)
+
         await runCanary()
 
         const modes = (global.fetch as jest.Mock).mock.calls.map(([, init]) => init?.mode)
         expect(modes).toHaveLength(2)
         expect(modes.every((m) => m === undefined)).toBe(true)
-        expect(nativeHttpRequest).toHaveBeenCalledTimes(1)
+        expect(nativeHttpRequest).toHaveBeenCalledTimes(3)
+        expect(nativeHttpRequest).toHaveBeenCalledWith('https://plugin.capgo.app/', { method: 'GET' }, 10_000)
+        expect(nativeHttpRequest).toHaveBeenCalledWith(
+            'https://www.gstatic.com/generate_204',
+            { method: 'GET' },
+            10_000
+        )
     })
 
     /*
@@ -117,6 +247,5 @@ describe('transport canary', () => {
 
         expect(global.fetch).not.toHaveBeenCalled()
         expect(nativeHttpRequest).not.toHaveBeenCalled()
-        jest.useRealTimers()
     })
 })

--- a/src/utils/native-canary.ts
+++ b/src/utils/native-canary.ts
@@ -191,18 +191,20 @@ function freshConnectivityEvents(events: PendingCanaryEvent[], now: Date = new D
 }
 
 function eventId(): string {
-    return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+
+    const bytes = new Uint8Array(16)
+    if (globalThis.crypto?.getRandomValues) globalThis.crypto.getRandomValues(bytes)
+    else for (let index = 0; index < bytes.length; index += 1) bytes[index] = Math.floor(Math.random() * 256)
+    bytes[6] = (bytes[6] & 0x0f) | 0x40
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
 }
 
 function persistConnectivityEvent(properties: CanaryEventProperties, now: Date = new Date()): PendingCanaryEvent {
     const day = utcDay(now)
     const events = freshConnectivityEvents(readConnectivityOutbox(), now)
-    const existing = events.find((event) => event.day === day)
-    if (existing) {
-        writeConnectivityOutbox(events)
-        return existing
-    }
-
     const pending = { id: eventId(), day, capturedAt: now.toISOString(), properties }
     writeConnectivityOutbox([...events, pending])
     return pending
@@ -213,16 +215,15 @@ function capturePostHog(properties: CanaryEventProperties, pending?: PendingCana
 
     const durableProperties = {
         ...pending.properties,
-        $insert_id: pending.id,
         canary_replayed: replayed,
         canary_original_captured_at: pending.capturedAt,
     }
     return replayed
         ? posthog.capture(CANARY_EVENT_NAME, durableProperties, {
               send_instantly: true,
-              timestamp: new Date(pending.capturedAt),
+              uuid: pending.id,
           })
-        : posthog.capture(CANARY_EVENT_NAME, durableProperties)
+        : posthog.capture(CANARY_EVENT_NAME, durableProperties, { uuid: pending.id })
 }
 
 function flushConnectivityOutbox(): void {
@@ -234,7 +235,7 @@ function flushConnectivityOutbox(): void {
     for (const event of events) {
         if (event.lastReplayDay === day) continue
         try {
-            // A stable $insert_id makes retries idempotent at ingestion. Keep the
+            // A stable SDK event UUID makes retries idempotent at ingestion. Keep the
             // compact event for the retention window because capture() confirms
             // SDK acceptance, not network delivery; retry it at most once/day.
             if (capturePostHog(event.properties, event, true)) event.lastReplayDay = day
@@ -297,7 +298,7 @@ export async function runCanary(): Promise<void> {
     const sentrySampled = classification !== 'device-connectivity' || shouldSampleConnectivityToSentry()
 
     const eventProperties: CanaryEventProperties = {
-        canary_version: '6',
+        canary_version: '7',
         canary_signature: signature,
         canary_classification: classification,
         canary_get: outcomes.get,
@@ -319,9 +320,7 @@ export async function runCanary(): Promise<void> {
 
     try {
         const pending = classification === 'device-connectivity' ? persistConnectivityEvent(eventProperties) : undefined
-        // flushConnectivityOutbox already replayed this device-day on this
-        // launch. Do not enqueue the same stable $insert_id a second time.
-        if (!pending || pending.lastReplayDay !== utcDay()) capturePostHog(eventProperties, pending)
+        capturePostHog(eventProperties, pending)
     } catch {
         // Diagnostics must never affect app startup or the Sentry signal.
     }
@@ -330,10 +329,10 @@ export async function runCanary(): Promise<void> {
 
     Sentry.captureMessage(`native canary: ${signature}`, {
         level: classification === 'device-connectivity' ? 'info' : 'warning',
-        fingerprint: ['native-canary-v6', classification, signature, webviewTransport],
+        fingerprint: ['native-canary-v7', classification, signature, webviewTransport],
         tags: {
             canary: 'transport',
-            canaryVersion: '6',
+            canaryVersion: '7',
             canary_signature: signature,
             canary_classification: classification,
             canary_get: outcomes.get,

--- a/src/utils/native-canary.ts
+++ b/src/utils/native-canary.ts
@@ -13,10 +13,13 @@
  *
  * - ONE event per launch, and only when something actually failed. A clean
  *   launch reports nothing at all, so the steady-state cost is zero.
- * - Three probes, not five. `get-users-me` added an auth variable to a
+ * - Three primary probes, not five. `get-users-me` added an auth variable to a
  *   reachability question, and `get-healthz-nocors` is unusable — see below.
- * - `level:warning`, so this can never rejoin the `level:info` flood that
- *   made the original a deletion target.
+ * - Native Capgo and public-internet control probes run only after all three
+ *   primary probes fail. They separate an API-host incident from ordinary
+ *   device connectivity without adding round trips to healthy launches.
+ * - Asymmetric/API-host failures stay `warning`; whole-device connectivity is
+ *   measured in PostHog and sampled into Sentry at `info` level.
  *
  * NO `no-cors` PROBE, which is what makes this safe to run on iOS. WKWebView
  * serves no opaque responses at all: the retired canary measured that probe
@@ -33,18 +36,27 @@
  * so per-build rates (the split that surfaced 3% on `8016c68` vs 21% on
  * `d4bd3ab`) can be reproduced by splitting on those.
  *
- * Query: message starts `native canary:` — the message carries the outcome
- * signature so each distinct failure shape is its own Sentry issue.
+ * Query: message starts `native canary:`. An explicit fingerprint includes the
+ * signature because the browser SDK attaches a synthetic stack to messages;
+ * without it, Sentry groups every shape at this file's captureMessage callsite.
  */
 
 import * as Sentry from '@sentry/nextjs'
+import posthog from 'posthog-js'
 import { PEANUT_API_URL } from '@/constants/general.consts'
 import { isNativeBridge } from './capacitor'
 import { getBinaryInfo } from './app-version'
 import { getUnderlyingFetch } from './passkey-auth-capture'
 import { nativeHttpRequest } from './native-http'
+import { readStoredValue, writeStoredValue } from './safe-storage'
 
 const CANARY_TIMEOUT_MS = 10_000
+const CAPGO_CONTROL_URL = 'https://plugin.capgo.app/'
+const INTERNET_CONTROL_URL = 'https://www.gstatic.com/generate_204'
+const CONNECTIVITY_SENTRY_SAMPLE_RATE = 0.1
+const CONNECTIVITY_SENTRY_DAY_KEY = 'nativeCanaryConnectivitySentryDay'
+
+type CanaryClassification = 'transport-asymmetry' | 'api-unreachable' | 'device-connectivity'
 
 let scheduled = false
 
@@ -71,12 +83,27 @@ function toProbeError(error: unknown, startedAt: number): ProbeResult {
     }
 }
 
+function timeoutError(): Error {
+    return Object.assign(new Error('canary probe timed out'), { name: 'AbortError' })
+}
+
 async function probe(path: string, init: RequestInit): Promise<ProbeResult> {
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), CANARY_TIMEOUT_MS)
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
     const startedAt = Date.now()
     try {
-        const response = await fetch(`${PEANUT_API_URL}${path}`, { ...init, signal: controller.signal })
+        // Capacitor's fetch patch does not consistently honour AbortController.
+        // Race the await as well, so the advertised ten-second budget remains a
+        // wall-clock bound even when the request continues in native code.
+        const response = await Promise.race([
+            fetch(`${PEANUT_API_URL}${path}`, { ...init, signal: controller.signal }),
+            new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => {
+                    controller.abort()
+                    reject(timeoutError())
+                }, CANARY_TIMEOUT_MS)
+            }),
+        ])
         // any HTTP status counts as success: 404/405 still proves the request
         // completed end to end, which is the only thing being measured
         return { outcome: `http-${response.status}`, durationMs: Date.now() - startedAt }
@@ -87,14 +114,23 @@ async function probe(path: string, init: RequestInit): Promise<ProbeResult> {
     }
 }
 
-async function nativeProbe(path: string): Promise<ProbeResult> {
+async function nativeProbe(url: string): Promise<ProbeResult> {
     const startedAt = Date.now()
     try {
-        const response = await nativeHttpRequest(`${PEANUT_API_URL}${path}`, { method: 'GET' }, CANARY_TIMEOUT_MS)
+        const response = await nativeHttpRequest(url, { method: 'GET' }, CANARY_TIMEOUT_MS)
         return { outcome: `http-${response.status}`, durationMs: Date.now() - startedAt }
     } catch (error) {
         return toProbeError(error, startedAt)
     }
+}
+
+function shouldSampleConnectivityToSentry(): boolean {
+    const day = new Date().toISOString().slice(0, 10)
+    if (readStoredValue(CONNECTIVITY_SENTRY_DAY_KEY) === day) return false
+    // Persist the daily decision, including a decision not to sample. Otherwise
+    // repeated launches would turn 10% sampling into near-certain reporting.
+    writeStoredValue(CONNECTIVITY_SENTRY_DAY_KEY, day)
+    return Math.random() < CONNECTIVITY_SENTRY_SAMPLE_RATE
 }
 
 export async function runCanary(): Promise<void> {
@@ -103,10 +139,16 @@ export async function runCanary(): Promise<void> {
         {
             name: 'post',
             transport: 'webview',
-            run: () =>
-                probe('/healthz', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' }),
+            // A string body defaults to the CORS-safelisted text/plain content
+            // type. Setting application/json would add an OPTIONS preflight and
+            // make this compare GET with "preflight + POST", a different test.
+            run: () => probe('/healthz', { method: 'POST', body: '{}' }),
         },
-        { name: 'native', transport: 'cap-native-http', run: () => nativeProbe('/healthz') },
+        {
+            name: 'native',
+            transport: 'cap-native-http',
+            run: () => nativeProbe(`${PEANUT_API_URL}/healthz`),
+        },
     ]
 
     // Parallel so a dead network costs one CANARY_TIMEOUT_MS, not three.
@@ -115,37 +157,87 @@ export async function runCanary(): Promise<void> {
 
     const outcomes = Object.fromEntries(probes.map(({ name }, i) => [name, results[i].outcome]))
     const signature = probes.map(({ name }, i) => `${name}:${isFailure(results[i]) ? 'fail' : 'ok'}`).join(' ')
+    const allPrimaryFailed = results.every(isFailure)
+    // Native HTTP avoids WebView CORS/no-cors differences, including iOS's lack
+    // of opaque responses. Two independent hosts avoid classifying one blocked
+    // control provider as a dead device. Only pay for them after every API
+    // transport failed.
+    const [capgo, internet] = allPrimaryFailed
+        ? await Promise.all([nativeProbe(CAPGO_CONTROL_URL), nativeProbe(INTERNET_CONTROL_URL)])
+        : [null, null]
+    const classification: CanaryClassification = allPrimaryFailed
+        ? (capgo && !isFailure(capgo)) || (internet && !isFailure(internet))
+            ? 'api-unreachable'
+            : 'device-connectivity'
+        : 'transport-asymmetry'
 
     // CapacitorWebFetch is assigned unconditionally by the native bridge; only
     // an actual patch of window.fetch means the CapacitorHttp proxy is active.
     const capWebFetch = (window as unknown as { CapacitorWebFetch?: typeof fetch }).CapacitorWebFetch
     const baseFetch = getUnderlyingFetch() ?? window.fetch
+    const webviewTransport = !!capWebFetch && baseFetch !== capWebFetch ? 'cap-http-proxy' : 'direct'
     const { appVersion, appBuild } = (await getBinaryInfo()) ?? { appVersion: 'unknown', appBuild: 'unknown' }
+    const sentrySampled = classification !== 'device-connectivity' || shouldSampleConnectivityToSentry()
 
-    Sentry.captureMessage(`native canary: ${signature}`, {
-        level: 'warning',
-        tags: {
-            canary: 'transport',
-            canaryVersion: '4',
+    try {
+        posthog.capture('native_transport_canary_failed', {
+            canary_version: '5',
             canary_signature: signature,
+            canary_classification: classification,
             canary_get: outcomes.get,
             canary_post: outcomes.post,
             canary_native: outcomes.native,
-            webviewTransport: !!capWebFetch && baseFetch !== capWebFetch ? 'cap-http-proxy' : 'direct',
+            canary_capgo: capgo?.outcome,
+            canary_internet: internet?.outcome,
+            canary_get_ms: results[0].durationMs,
+            canary_post_ms: results[1].durationMs,
+            canary_native_ms: results[2].durationMs,
+            canary_capgo_ms: capgo?.durationMs,
+            canary_internet_ms: internet?.durationMs,
+            webview_transport: webviewTransport,
+            app_version: appVersion,
+            app_build: appBuild,
+            online: navigator.onLine,
+            sentry_sampled: sentrySampled,
+        })
+    } catch {
+        // Diagnostics must never affect app startup or the Sentry signal.
+    }
+
+    if (!sentrySampled) return
+
+    Sentry.captureMessage(`native canary: ${signature}`, {
+        level: classification === 'device-connectivity' ? 'info' : 'warning',
+        fingerprint: ['native-canary-v5', classification, signature, webviewTransport],
+        tags: {
+            canary: 'transport',
+            canaryVersion: '5',
+            canary_signature: signature,
+            canary_classification: classification,
+            canary_get: outcomes.get,
+            canary_post: outcomes.post,
+            canary_native: outcomes.native,
+            canary_capgo: capgo?.outcome ?? 'not-run',
+            canary_internet: internet?.outcome ?? 'not-run',
+            webviewTransport,
             appVersion,
             appBuild,
             online: String(navigator.onLine),
         },
-        extra: Object.fromEntries(
-            probes.map(({ name }, i) => [
-                name,
-                {
-                    durationMs: results[i].durationMs,
-                    errorName: results[i].errorName,
-                    errorMessage: results[i].errorMessage,
-                },
-            ])
-        ),
+        extra: {
+            ...Object.fromEntries(
+                probes.map(({ name }, i) => [
+                    name,
+                    {
+                        durationMs: results[i].durationMs,
+                        errorName: results[i].errorName,
+                        errorMessage: results[i].errorMessage,
+                    },
+                ])
+            ),
+            ...(capgo ? { capgo } : {}),
+            ...(internet ? { internet } : {}),
+        },
     })
 }
 

--- a/src/utils/native-canary.ts
+++ b/src/utils/native-canary.ts
@@ -48,13 +48,16 @@ import { isNativeBridge } from './capacitor'
 import { getBinaryInfo } from './app-version'
 import { getUnderlyingFetch } from './passkey-auth-capture'
 import { nativeHttpRequest } from './native-http'
-import { readStoredValue, writeStoredValue } from './safe-storage'
+import { readStoredValue, removeStoredValue, writeStoredValue } from './safe-storage'
 
 const CANARY_TIMEOUT_MS = 10_000
 const CAPGO_CONTROL_URL = 'https://plugin.capgo.app/'
 const INTERNET_CONTROL_URL = 'https://www.gstatic.com/generate_204'
 const CONNECTIVITY_SENTRY_SAMPLE_RATE = 0.1
 const CONNECTIVITY_SENTRY_DAY_KEY = 'nativeCanaryConnectivitySentryDay'
+const CONNECTIVITY_OUTBOX_KEY = 'nativeCanaryConnectivityOutboxV1'
+const CONNECTIVITY_OUTBOX_RETENTION_DAYS = 7
+const CANARY_EVENT_NAME = 'native_transport_canary_failed'
 
 type CanaryClassification = 'transport-asymmetry' | 'api-unreachable' | 'device-connectivity'
 
@@ -65,6 +68,16 @@ interface ProbeResult {
     durationMs: number
     errorName?: string
     errorMessage?: string
+}
+
+type CanaryEventProperties = Record<string, string | number | boolean | undefined>
+
+interface PendingCanaryEvent {
+    id: string
+    day: string
+    capturedAt: string
+    lastReplayDay?: string
+    properties: CanaryEventProperties
 }
 
 function isFailure(result: ProbeResult): boolean {
@@ -133,7 +146,111 @@ function shouldSampleConnectivityToSentry(): boolean {
     return Math.random() < CONNECTIVITY_SENTRY_SAMPLE_RATE
 }
 
+function utcDay(date: Date = new Date()): string {
+    return date.toISOString().slice(0, 10)
+}
+
+function isPendingCanaryEvent(value: unknown): value is PendingCanaryEvent {
+    if (!value || typeof value !== 'object') return false
+    const event = value as Partial<PendingCanaryEvent>
+    return (
+        typeof event.id === 'string' &&
+        typeof event.day === 'string' &&
+        typeof event.capturedAt === 'string' &&
+        !!event.properties &&
+        typeof event.properties === 'object'
+    )
+}
+
+function readConnectivityOutbox(): PendingCanaryEvent[] {
+    const stored = readStoredValue(CONNECTIVITY_OUTBOX_KEY)
+    if (!stored) return []
+    try {
+        const parsed: unknown = JSON.parse(stored)
+        return Array.isArray(parsed) ? parsed.filter(isPendingCanaryEvent) : []
+    } catch {
+        return []
+    }
+}
+
+function writeConnectivityOutbox(events: PendingCanaryEvent[]): void {
+    if (events.length === 0) {
+        removeStoredValue(CONNECTIVITY_OUTBOX_KEY)
+        return
+    }
+    writeStoredValue(CONNECTIVITY_OUTBOX_KEY, JSON.stringify(events))
+}
+
+function freshConnectivityEvents(events: PendingCanaryEvent[], now: Date = new Date()): PendingCanaryEvent[] {
+    const oldest = new Date(now)
+    oldest.setUTCDate(oldest.getUTCDate() - CONNECTIVITY_OUTBOX_RETENTION_DAYS)
+    return events.filter(({ capturedAt }) => {
+        const timestamp = Date.parse(capturedAt)
+        return Number.isFinite(timestamp) && timestamp >= oldest.getTime()
+    })
+}
+
+function eventId(): string {
+    return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function persistConnectivityEvent(properties: CanaryEventProperties, now: Date = new Date()): PendingCanaryEvent {
+    const day = utcDay(now)
+    const events = freshConnectivityEvents(readConnectivityOutbox(), now)
+    const existing = events.find((event) => event.day === day)
+    if (existing) {
+        writeConnectivityOutbox(events)
+        return existing
+    }
+
+    const pending = { id: eventId(), day, capturedAt: now.toISOString(), properties }
+    writeConnectivityOutbox([...events, pending])
+    return pending
+}
+
+function capturePostHog(properties: CanaryEventProperties, pending?: PendingCanaryEvent, replayed = false) {
+    if (!pending) return posthog.capture(CANARY_EVENT_NAME, properties)
+
+    const durableProperties = {
+        ...pending.properties,
+        $insert_id: pending.id,
+        canary_replayed: replayed,
+        canary_original_captured_at: pending.capturedAt,
+    }
+    return replayed
+        ? posthog.capture(CANARY_EVENT_NAME, durableProperties, {
+              send_instantly: true,
+              timestamp: new Date(pending.capturedAt),
+          })
+        : posthog.capture(CANARY_EVENT_NAME, durableProperties)
+}
+
+function flushConnectivityOutbox(): void {
+    if (!navigator.onLine) return
+
+    const now = new Date()
+    const day = utcDay(now)
+    const events = freshConnectivityEvents(readConnectivityOutbox(), now)
+    for (const event of events) {
+        if (event.lastReplayDay === day) continue
+        try {
+            // A stable $insert_id makes retries idempotent at ingestion. Keep the
+            // compact event for the retention window because capture() confirms
+            // SDK acceptance, not network delivery; retry it at most once/day.
+            if (capturePostHog(event.properties, event, true)) event.lastReplayDay = day
+        } catch {
+            // Leave it pending for the next online launch.
+        }
+    }
+    writeConnectivityOutbox(events)
+}
+
 export async function runCanary(): Promise<void> {
+    // PostHog's retry queue is memory-only. Replay any durable connectivity
+    // signal before the healthy fast path returns, so offline -> kill -> online
+    // relaunch still produces an analytics event.
+    flushConnectivityOutbox()
+
     const probes = [
         { name: 'get', transport: 'webview', run: () => probe('/healthz', { method: 'GET' }) },
         {
@@ -179,27 +296,32 @@ export async function runCanary(): Promise<void> {
     const { appVersion, appBuild } = (await getBinaryInfo()) ?? { appVersion: 'unknown', appBuild: 'unknown' }
     const sentrySampled = classification !== 'device-connectivity' || shouldSampleConnectivityToSentry()
 
+    const eventProperties: CanaryEventProperties = {
+        canary_version: '6',
+        canary_signature: signature,
+        canary_classification: classification,
+        canary_get: outcomes.get,
+        canary_post: outcomes.post,
+        canary_native: outcomes.native,
+        canary_capgo: capgo?.outcome,
+        canary_internet: internet?.outcome,
+        canary_get_ms: results[0].durationMs,
+        canary_post_ms: results[1].durationMs,
+        canary_native_ms: results[2].durationMs,
+        canary_capgo_ms: capgo?.durationMs,
+        canary_internet_ms: internet?.durationMs,
+        webview_transport: webviewTransport,
+        app_version: appVersion,
+        app_build: appBuild,
+        online: navigator.onLine,
+        sentry_sampled: sentrySampled,
+    }
+
     try {
-        posthog.capture('native_transport_canary_failed', {
-            canary_version: '5',
-            canary_signature: signature,
-            canary_classification: classification,
-            canary_get: outcomes.get,
-            canary_post: outcomes.post,
-            canary_native: outcomes.native,
-            canary_capgo: capgo?.outcome,
-            canary_internet: internet?.outcome,
-            canary_get_ms: results[0].durationMs,
-            canary_post_ms: results[1].durationMs,
-            canary_native_ms: results[2].durationMs,
-            canary_capgo_ms: capgo?.durationMs,
-            canary_internet_ms: internet?.durationMs,
-            webview_transport: webviewTransport,
-            app_version: appVersion,
-            app_build: appBuild,
-            online: navigator.onLine,
-            sentry_sampled: sentrySampled,
-        })
+        const pending = classification === 'device-connectivity' ? persistConnectivityEvent(eventProperties) : undefined
+        // flushConnectivityOutbox already replayed this device-day on this
+        // launch. Do not enqueue the same stable $insert_id a second time.
+        if (!pending || pending.lastReplayDay !== utcDay()) capturePostHog(eventProperties, pending)
     } catch {
         // Diagnostics must never affect app startup or the Sentry signal.
     }
@@ -208,10 +330,10 @@ export async function runCanary(): Promise<void> {
 
     Sentry.captureMessage(`native canary: ${signature}`, {
         level: classification === 'device-connectivity' ? 'info' : 'warning',
-        fingerprint: ['native-canary-v5', classification, signature, webviewTransport],
+        fingerprint: ['native-canary-v6', classification, signature, webviewTransport],
         tags: {
             canary: 'transport',
-            canaryVersion: '5',
+            canaryVersion: '6',
             canary_signature: signature,
             canary_classification: classification,
             canary_get: outcomes.get,


### PR DESCRIPTION
## Summary

- give every canary classification/signature/transport an explicit Sentry fingerprint so different failure shapes no longer collapse into one issue
- classify total API failures with native Capgo and public-internet controls; keep API/transport incidents as warnings while routing device-connectivity volume through PostHog and a 10% once-per-device/day Sentry info sample
- make the POST probe CORS-simple and enforce the documented 10-second wall-clock bound even when Capacitor's fetch patch ignores abort

## Verification

- `pnpm exec jest src/utils/__tests__/native-canary.test.ts src/utils/__tests__/safe-storage.test.ts src/utils/__tests__/sentry-init.test.ts --runInBand` (23 tests passed)
- `pnpm exec jest src/utils/__tests__/no-direct-peanut-api-fetch.test.ts sentry.utils.test.ts --runInBand` (119 tests passed)
- `pnpm exec eslint src/utils/native-canary.ts src/utils/__tests__/native-canary.test.ts`
- `pnpm exec prettier --check src/utils/native-canary.ts src/utils/__tests__/native-canary.test.ts`
- `git diff --check`
- `pnpm typecheck` reaches only the existing `instrumentation-client.ts:107` `maskAttributeFn` diagnostics; that file is unchanged from `origin/dev`

Sentry context: https://peanut-c34d84c05.sentry.io/issues/7725035800/
