### PR TITLE
fix: reuse Cloudflare API token and show gallery empty state

### DIFF
--- a/.github/workflows/screen-library-deploy.yml
+++ b/.github/workflows/screen-library-deploy.yml
@@ -34,6 +34,6 @@ jobs:
               run: node scripts/screens/worker/prepare.mjs /tmp/screen-gallery
             - name: Deploy trusted dev gallery
               env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
               run: scripts/screens/deploy/node_modules/.bin/wrangler deploy --config /tmp/screen-gallery/wrangler.json

--- a/.github/workflows/screen-library-publish.yml
+++ b/.github/workflows/screen-library-publish.yml
@@ -2,7 +2,7 @@ name: Publish screen library
 on:
     workflow_call:
         secrets:
-            CLOUDFLARE_PUBLISH_TOKEN:
+            CLOUDFLARE_API_TOKEN:
                 required: true
 permissions:
     contents: read
@@ -44,7 +44,7 @@ jobs:
             - name: Verify provenance and publish
               env:
                   GH_TOKEN: ${{ github.token }}
-                  CLOUDFLARE_PUBLISH_TOKEN: ${{ secrets.CLOUDFLARE_PUBLISH_TOKEN }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
                   SCREEN_LIBRARY_R2_BUCKET: ${{ vars.SCREEN_LIBRARY_R2_BUCKET }}
                   SCREEN_LIBRARY_R2_JURISDICTION: ${{ vars.SCREEN_LIBRARY_R2_JURISDICTION }}

--- a/.github/workflows/screen-library-publish.yml
+++ b/.github/workflows/screen-library-publish.yml
@@ -2,7 +2,9 @@ name: Publish screen library
 on:
     workflow_call:
         secrets:
-            CLOUDFLARE_API_TOKEN:
+            # Compatibility input; callers map their publisher secret into the
+            # standard CLOUDFLARE_API_TOKEN runtime variable below.
+            CLOUDFLARE_PUBLISH_TOKEN:
                 required: true
 permissions:
     contents: read
@@ -44,7 +46,7 @@ jobs:
             - name: Verify provenance and publish
               env:
                   GH_TOKEN: ${{ github.token }}
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PUBLISH_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
                   SCREEN_LIBRARY_R2_BUCKET: ${{ vars.SCREEN_LIBRARY_R2_BUCKET }}
                   SCREEN_LIBRARY_R2_JURISDICTION: ${{ vars.SCREEN_LIBRARY_R2_JURISDICTION }}

--- a/.github/workflows/screen-library.yml
+++ b/.github/workflows/screen-library.yml
@@ -106,4 +106,4 @@ jobs:
         # Land the reusable publisher (#3107) on dev before this caller (#3108).
         uses: peanutprotocol/peanut-ui/.github/workflows/screen-library-publish.yml@dev
         secrets:
-            CLOUDFLARE_PUBLISH_TOKEN: ${{ secrets.CLOUDFLARE_PUBLISH_TOKEN }}
+            CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/screen-library.yml
+++ b/.github/workflows/screen-library.yml
@@ -106,4 +106,6 @@ jobs:
         # Land the reusable publisher (#3107) on dev before this caller (#3108).
         uses: peanutprotocol/peanut-ui/.github/workflows/screen-library-publish.yml@dev
         secrets:
-            CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+            # Keep the reusable-workflow input compatible with the current dev callee.
+            # The repository secret itself is named CLOUDFLARE_API_TOKEN.
+            CLOUDFLARE_PUBLISH_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/SCREEN-LIBRARY-PUBLISHER.md
+++ b/docs/SCREEN-LIBRARY-PUBLISHER.md
@@ -51,16 +51,14 @@ DevOps setup:
    (393×852, fit scale-down, no cropping; no signed URL requirement).
 2. Create a dedicated private R2 bucket. Retain objects
    indefinitely; respect object Cache-Control (index/latest use 60 seconds).
-3. Create two narrowly scoped API tokens:
-   - a publisher token with Cloudflare Images Edit and Workers R2 Storage Edit
-     scoped to this gallery's Images account and R2 bucket. Save it as the
-     `CLOUDFLARE_PUBLISH_TOKEN` GitHub Actions secret. The publisher verifies the
-     token ID and derives the S3 secret from its SHA-256 hash at runtime; no
-     separate R2 keys are stored.
-   - a deployment token with Workers Scripts Edit. Save it as the
-     `CLOUDFLARE_DEPLOY_TOKEN` secret in the `screen-library-deploy` environment.
-     This token is used only by the Worker deployment job, never while parsing
-     PR-controlled image artifacts.
+3. Create one Cloudflare API token with Images Edit, Workers R2 Storage Edit,
+   and Workers Scripts Edit scoped to this gallery's Images account, R2 bucket,
+   and Worker. Save it as the `CLOUDFLARE_API_TOKEN` GitHub Actions secret and
+   also as the `CLOUDFLARE_API_TOKEN` secret in the `screen-library-deploy`
+   environment. The publisher verifies the token ID and derives the S3 secret
+   from its SHA-256 hash at runtime; no separate R2 keys are stored. Reusing one
+   token gives the artifact-processing publisher deployment authority as well as
+   storage authority, so use separate tokens if least privilege is required.
 4. In GitHub Actions repository variables set `CLOUDFLARE_ACCOUNT_ID`,
    `SCREEN_LIBRARY_R2_BUCKET`, `SCREEN_LIBRARY_R2_JURISDICTION` (`eu` for screenshots-library),
    `SCREEN_LIBRARY_PUBLIC_URL` (gallery HTTPS origin,
@@ -74,7 +72,7 @@ DevOps setup:
    to the Worker origin.
 6. Merge #3107, verify the Deploy screen gallery job succeeds and the public
    gallery loads, then merge #3108 to activate captures. An empty R2 bucket shows
-   a report-unavailable message until the first publication. Verify a report URL
+   a friendly empty state until the first publication. Verify a report URL
    without login after publication. Manual workflow dispatch retains GitHub’s
    default-branch registration limitation; dev push deployment has no such dependency.
 

--- a/docs/SCREEN-LIBRARY-PUBLISHER.md
+++ b/docs/SCREEN-LIBRARY-PUBLISHER.md
@@ -51,14 +51,20 @@ DevOps setup:
    (393×852, fit scale-down, no cropping; no signed URL requirement).
 2. Create a dedicated private R2 bucket. Retain objects
    indefinitely; respect object Cache-Control (index/latest use 60 seconds).
-3. Create one Cloudflare API token with Images Edit, Workers R2 Storage Edit,
-   and Workers Scripts Edit scoped to this gallery's Images account, R2 bucket,
-   and Worker. Save it as the `CLOUDFLARE_API_TOKEN` GitHub Actions secret and
-   also as the `CLOUDFLARE_API_TOKEN` secret in the `screen-library-deploy`
-   environment. The publisher verifies the token ID and derives the S3 secret
-   from its SHA-256 hash at runtime; no separate R2 keys are stored. Reusing one
-   token gives the artifact-processing publisher deployment authority as well as
-   storage authority, so use separate tokens if least privilege is required.
+3. Create two Cloudflare API tokens with separate values:
+   - a publisher token with Images Edit and Workers R2 Storage Edit scoped to
+     this gallery's Images account and R2 bucket. Save it as the repository
+     `CLOUDFLARE_API_TOKEN` secret. The reusable workflow keeps its historical
+     `CLOUDFLARE_PUBLISH_TOKEN` input for compatibility while exposing the
+     value to the publisher process as `CLOUDFLARE_API_TOKEN`; this token never
+     receives Workers Scripts Edit.
+   - a deployment token with Workers Scripts Edit scoped to this gallery's
+     Worker. Save it as the `CLOUDFLARE_API_TOKEN` secret in the
+     `screen-library-deploy` environment. For a custom domain it also needs
+     Zone Read and DNS Edit, as described below. The deployment job exposes
+     this separate value under the same `CLOUDFLARE_API_TOKEN` runtime name.
+     The publisher verifies its token ID and derives the S3 secret from its
+     SHA-256 hash at runtime; no separate R2 keys are stored.
 4. In GitHub Actions repository variables set `CLOUDFLARE_ACCOUNT_ID`,
    `SCREEN_LIBRARY_R2_BUCKET`, `SCREEN_LIBRARY_R2_JURISDICTION` (`eu` for screenshots-library),
    `SCREEN_LIBRARY_PUBLIC_URL` (gallery HTTPS origin,

--- a/docs/SCREEN-LIBRARY.md
+++ b/docs/SCREEN-LIBRARY.md
@@ -81,14 +81,20 @@ DevOps setup:
    (393×852, fit scale-down, no cropping; no signed URL requirement).
 2. Create a dedicated private R2 bucket. Retain objects
    indefinitely; respect object Cache-Control (index/latest use 60 seconds).
-3. Create one Cloudflare API token with Images Edit, Workers R2 Storage Edit,
-   and Workers Scripts Edit scoped to this gallery's Images account, R2 bucket,
-   and Worker. Save it as the `CLOUDFLARE_API_TOKEN` GitHub Actions secret and
-   also as the `CLOUDFLARE_API_TOKEN` secret in the `screen-library-deploy`
-   environment. The publisher verifies the token ID and derives the S3 secret
-   from its SHA-256 hash at runtime; no separate R2 keys are stored. Reusing one
-   token gives the artifact-processing publisher deployment authority as well as
-   storage authority, so use separate tokens if least privilege is required.
+3. Create two Cloudflare API tokens with separate values:
+   - a publisher token with Images Edit and Workers R2 Storage Edit scoped to
+     this gallery's Images account and R2 bucket. Save it as the repository
+     `CLOUDFLARE_API_TOKEN` secret. The reusable workflow keeps its historical
+     `CLOUDFLARE_PUBLISH_TOKEN` input for compatibility while exposing the
+     value to the publisher process as `CLOUDFLARE_API_TOKEN`; this token never
+     receives Workers Scripts Edit.
+   - a deployment token with Workers Scripts Edit scoped to this gallery's
+     Worker. Save it as the `CLOUDFLARE_API_TOKEN` secret in the
+     `screen-library-deploy` environment. For a custom domain it also needs
+     Zone Read and DNS Edit, as described below. The deployment job exposes
+     this separate value under the same `CLOUDFLARE_API_TOKEN` runtime name.
+     The publisher verifies its token ID and derives the S3 secret from its
+     SHA-256 hash at runtime; no separate R2 keys are stored.
 4. In GitHub Actions repository variables set `CLOUDFLARE_ACCOUNT_ID`,
    `SCREEN_LIBRARY_R2_BUCKET`, `SCREEN_LIBRARY_R2_JURISDICTION` (`eu` for screenshots-library),
    `SCREEN_LIBRARY_PUBLIC_URL` (gallery HTTPS origin,

--- a/docs/SCREEN-LIBRARY.md
+++ b/docs/SCREEN-LIBRARY.md
@@ -81,16 +81,14 @@ DevOps setup:
    (393×852, fit scale-down, no cropping; no signed URL requirement).
 2. Create a dedicated private R2 bucket. Retain objects
    indefinitely; respect object Cache-Control (index/latest use 60 seconds).
-3. Create two narrowly scoped API tokens:
-   - a publisher token with Cloudflare Images Edit and Workers R2 Storage Edit
-     scoped to this gallery's Images account and R2 bucket. Save it as the
-     `CLOUDFLARE_PUBLISH_TOKEN` GitHub Actions secret. The publisher verifies the
-     token ID and derives the S3 secret from its SHA-256 hash at runtime; no
-     separate R2 keys are stored.
-   - a deployment token with Workers Scripts Edit. Save it as the
-     `CLOUDFLARE_DEPLOY_TOKEN` secret in the `screen-library-deploy` environment.
-     This token is used only by the Worker deployment job, never while parsing
-     PR-controlled image artifacts.
+3. Create one Cloudflare API token with Images Edit, Workers R2 Storage Edit,
+   and Workers Scripts Edit scoped to this gallery's Images account, R2 bucket,
+   and Worker. Save it as the `CLOUDFLARE_API_TOKEN` GitHub Actions secret and
+   also as the `CLOUDFLARE_API_TOKEN` secret in the `screen-library-deploy`
+   environment. The publisher verifies the token ID and derives the S3 secret
+   from its SHA-256 hash at runtime; no separate R2 keys are stored. Reusing one
+   token gives the artifact-processing publisher deployment authority as well as
+   storage authority, so use separate tokens if least privilege is required.
 4. In GitHub Actions repository variables set `CLOUDFLARE_ACCOUNT_ID`,
    `SCREEN_LIBRARY_R2_BUCKET`, `SCREEN_LIBRARY_R2_JURISDICTION` (`eu` for screenshots-library),
    `SCREEN_LIBRARY_PUBLIC_URL` (gallery HTTPS origin,
@@ -104,7 +102,7 @@ DevOps setup:
    to the Worker origin.
 6. Merge #3107, verify the Deploy screen gallery job succeeds and the public
    gallery loads, then merge #3108 to activate captures. An empty R2 bucket shows
-   a report-unavailable message until the first publication. Verify a report URL
+   a friendly empty state until the first publication. Verify a report URL
    without login after publication. Manual workflow dispatch retains GitHub’s
    default-branch registration limitation; dev push deployment has no such dependency.
 

--- a/public/screen-library/index.html
+++ b/public/screen-library/index.html
@@ -22,6 +22,26 @@
                 <div id="provenance"></div>
             </details>
             <p id="coverage" role="status">Loading library…</p>
+            <section id="empty-state" class="empty-state" hidden aria-live="polite" aria-labelledby="empty-title">
+                <div class="empty-art" aria-hidden="true">
+                    <div class="empty-orbit empty-orbit-one"></div>
+                    <div class="empty-orbit empty-orbit-two"></div>
+                    <div class="empty-card empty-card-back"></div>
+                    <div class="empty-card empty-card-front"><span></span><span></span><span></span></div>
+                </div>
+                <div class="empty-copy">
+                    <p id="empty-kicker" class="empty-kicker">SCREEN LIBRARY · COMING TO LIFE</p>
+                    <h2 id="empty-title">Your gallery is almost here.</h2>
+                    <p id="empty-message">
+                        Screenshots are generated in the background and will appear here after the first capture is
+                        published.
+                    </p>
+                    <div class="empty-actions">
+                        <button id="empty-retry" type="button">Check again</button>
+                        <span id="empty-status" class="empty-status">No published captures yet</span>
+                    </div>
+                </div>
+            </section>
             <nav id="screen-filters" class="filters" aria-label="Filter screens">
                 <label>Search<input id="search" type="search" placeholder="Screen, state or flow" /></label
                 ><label

--- a/public/screen-library/viewer.css
+++ b/public/screen-library/viewer.css
@@ -88,6 +88,146 @@ h1 {
     border-radius: 10px;
     font-size: 14px;
 }
+.empty-state {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(180px, 0.75fr) minmax(0, 1.25fr);
+    align-items: center;
+    gap: clamp(28px, 6vw, 88px);
+    overflow: hidden;
+    margin: 34px 0 48px;
+    padding: clamp(28px, 6vw, 72px);
+    border: 1px solid #e4d9e5;
+    border-radius: 30px;
+    background:
+        radial-gradient(circle at 12% 10%, #ffffff 0 10%, transparent 38%),
+        linear-gradient(135deg, #fffdfa 0%, #f5eff8 58%, #ffe6f7 100%);
+    box-shadow: 0 22px 60px rgb(67 36 77 / 10%);
+}
+.empty-state::after {
+    position: absolute;
+    width: 260px;
+    height: 260px;
+    right: -100px;
+    bottom: -150px;
+    border: 1px solid rgb(255 144 232 / 45%);
+    border-radius: 50%;
+    content: '';
+}
+.empty-art {
+    position: relative;
+    min-height: 210px;
+}
+.empty-orbit {
+    position: absolute;
+    border: 1px solid rgb(183 140 192 / 45%);
+    border-radius: 50%;
+    transform: rotate(-24deg);
+}
+.empty-orbit-one {
+    inset: 19px 0 18px;
+}
+.empty-orbit-two {
+    inset: 0 32px 38px 30px;
+    border-color: rgb(255 144 232 / 58%);
+    transform: rotate(58deg);
+}
+.empty-card {
+    position: absolute;
+    top: 28px;
+    left: 50%;
+    width: 112px;
+    height: 154px;
+    border: 1px solid #cdbbd1;
+    border-radius: 16px;
+    background: rgb(255 255 255 / 74%);
+    box-shadow: 0 18px 30px rgb(86 51 94 / 14%);
+    transform: translateX(-50%) rotate(-10deg);
+}
+.empty-card-back {
+    background: rgb(255 255 255 / 42%);
+    transform: translateX(-44%) rotate(10deg);
+}
+.empty-card-front {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    border-color: #17151a;
+    background: #17151a;
+    transform: translateX(-56%) rotate(-4deg);
+}
+.empty-card-front::before {
+    width: 38px;
+    height: 38px;
+    border: 1px solid #ff90e8;
+    border-radius: 50%;
+    content: '';
+}
+.empty-card-front span {
+    display: block;
+    width: 48px;
+    height: 3px;
+    border-radius: 4px;
+    background: #ff90e8;
+}
+.empty-card-front span:nth-child(2) {
+    width: 30px;
+    opacity: 0.65;
+}
+.empty-card-front span:nth-child(3) {
+    width: 38px;
+    opacity: 0.4;
+}
+.empty-copy {
+    position: relative;
+    z-index: 1;
+    max-width: 600px;
+}
+.empty-kicker {
+    margin: 0 0 14px;
+    color: #8a668e;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+}
+.empty-state h2 {
+    max-width: 600px;
+    margin: 0 0 14px;
+    font-size: clamp(30px, 4vw, 52px);
+    line-height: 1.02;
+    letter-spacing: -0.045em;
+}
+.empty-state #empty-message {
+    max-width: 520px;
+    margin: 0;
+    color: var(--muted);
+    font-size: 17px;
+}
+.empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px;
+    margin-top: 26px;
+}
+.empty-actions button {
+    padding: 10px 16px;
+    border: 1px solid #17151a;
+    border-radius: 999px;
+    background: #17151a;
+    color: #fff;
+    font-weight: 700;
+}
+.empty-actions button:hover {
+    background: #3a2d3d;
+}
+.empty-status {
+    color: #8a668e;
+    font-size: 12px;
+    font-weight: 700;
+}
 .filters {
     display: flex;
     gap: 16px;
@@ -300,6 +440,16 @@ footer {
     display: none !important;
 }
 @media (max-width: 600px) {
+    .empty-state {
+        grid-template-columns: 1fr;
+        gap: 10px;
+        padding: 28px;
+    }
+    .empty-art {
+        min-height: 170px;
+        transform: scale(0.84);
+        transform-origin: left center;
+    }
     header {
         padding: 18px;
     }

--- a/public/screen-library/viewer.js
+++ b/public/screen-library/viewer.js
@@ -116,14 +116,27 @@ async function loadJSON(url) {
 }
 function showEmptyState(kind = 'unpublished') {
     const unpublished = kind === 'unpublished'
+    const reportNotFound = kind === 'report-not-found'
     $('empty-kicker').textContent = unpublished
         ? 'SCREEN LIBRARY · COMING TO LIFE'
-        : 'SCREEN LIBRARY · TEMPORARILY UNAVAILABLE'
-    $('empty-title').textContent = unpublished ? 'Your gallery is almost here.' : 'The gallery needs a moment.'
+        : reportNotFound
+          ? 'SCREEN LIBRARY · REPORT NOT FOUND'
+          : 'SCREEN LIBRARY · TEMPORARILY UNAVAILABLE'
+    $('empty-title').textContent = unpublished
+        ? 'Your gallery is almost here.'
+        : reportNotFound
+          ? 'That report is not available.'
+          : 'The gallery needs a moment.'
     $('empty-message').textContent = unpublished
         ? 'Screenshots are generated in the background and will appear here after the first capture is published.'
-        : 'We could not load the library right now. Check again in a moment and your gallery will be here when it is ready.'
-    $('empty-status').textContent = unpublished ? 'No published captures yet' : 'Temporary loading issue'
+        : reportNotFound
+          ? 'This screen-library link does not point to a published report. Return to the gallery to choose an available version.'
+          : 'We could not load the library right now. Check again in a moment and your gallery will be here when it is ready.'
+    $('empty-status').textContent = unpublished
+        ? 'No published captures yet'
+        : reportNotFound
+          ? 'Published report not found'
+          : 'Temporary loading issue'
     $('coverage').hidden = true
     $('screen-filters').hidden = true
     $('route-coverage').hidden = true
@@ -241,4 +254,13 @@ $('slider').oninput = () => {
     if (n) n.style.clipPath = `inset(0 ${100 - Number($('slider').value)}% 0 0)`
 }
 $('empty-retry').onclick = () => location.reload()
-start().catch((e) => showEmptyState(e.status === 404 ? 'unpublished' : 'error'))
+start().catch((e) => {
+    const pathname = location.pathname
+    const isHostedIndex =
+        pathname === '/' ||
+        pathname === '/index.html' ||
+        pathname === '/screen-library' ||
+        pathname === '/screen-library/' ||
+        pathname === '/screen-library/index.html'
+    showEmptyState(e.status === 404 ? (isHostedIndex ? 'unpublished' : 'report-not-found') : 'error')
+})

--- a/public/screen-library/viewer.js
+++ b/public/screen-library/viewer.js
@@ -107,8 +107,29 @@ function render() {
 }
 async function loadJSON(url) {
     const r = await fetch(url)
-    if (!r.ok) throw new Error(`Report unavailable (${r.status})`)
+    if (!r.ok) {
+        const error = new Error(`Report unavailable (${r.status})`)
+        error.status = r.status
+        throw error
+    }
     return r.json()
+}
+function showEmptyState(kind = 'unpublished') {
+    const unpublished = kind === 'unpublished'
+    $('empty-kicker').textContent = unpublished
+        ? 'SCREEN LIBRARY · COMING TO LIFE'
+        : 'SCREEN LIBRARY · TEMPORARILY UNAVAILABLE'
+    $('empty-title').textContent = unpublished ? 'Your gallery is almost here.' : 'The gallery needs a moment.'
+    $('empty-message').textContent = unpublished
+        ? 'Screenshots are generated in the background and will appear here after the first capture is published.'
+        : 'We could not load the library right now. Check again in a moment and your gallery will be here when it is ready.'
+    $('empty-status').textContent = unpublished ? 'No published captures yet' : 'Temporary loading issue'
+    $('coverage').hidden = true
+    $('screen-filters').hidden = true
+    $('route-coverage').hidden = true
+    $('versions').hidden = true
+    $('screens').hidden = true
+    $('empty-state').hidden = false
 }
 async function start() {
     if (offline) document.querySelector('.brand').href = './index.html'
@@ -123,6 +144,10 @@ async function start() {
     const path = isHostedIndex ? '' : pathname.replace(/^\/screens\/?/, '').replace(/\/$/, '')
     if (!offline && !path) {
         const index = await loadJSON('/screen-data/index.json')
+        if (!index.length) {
+            showEmptyState()
+            return
+        }
         $('coverage').textContent = `${index.length} published versions`
         $('screen-filters').hidden = true
         $('route-coverage').hidden = true
@@ -215,6 +240,5 @@ $('slider').oninput = () => {
     const n = $('zoom-images').querySelector('.overlay img+img')
     if (n) n.style.clipPath = `inset(0 ${100 - Number($('slider').value)}% 0 0)`
 }
-start().catch((e) => {
-    $('coverage').textContent = e.message
-})
+$('empty-retry').onclick = () => location.reload()
+start().catch((e) => showEmptyState(e.status === 404 ? 'unpublished' : 'error'))

--- a/scripts/screens/cloudflare-storage.mjs
+++ b/scripts/screens/cloudflare-storage.mjs
@@ -4,7 +4,7 @@ import { normalizePublicOrigin } from './public-origin.mjs'
 export function configuration(env = process.env) {
     const keys = [
         'CLOUDFLARE_ACCOUNT_ID',
-        'CLOUDFLARE_PUBLISH_TOKEN',
+        'CLOUDFLARE_API_TOKEN',
         'SCREEN_LIBRARY_R2_BUCKET',
         'SCREEN_LIBRARY_PUBLIC_URL',
         'SCREEN_LIBRARY_IMAGES_HASH',
@@ -39,7 +39,7 @@ export async function createStorage(env = process.env) {
     const client = new S3Client({
         region: 'auto',
         endpoint: r2Endpoint(config),
-        credentials: await tokenCredentials(config.CLOUDFLARE_PUBLISH_TOKEN),
+        credentials: await tokenCredentials(config.CLOUDFLARE_API_TOKEN),
     })
     const Bucket = config.SCREEN_LIBRARY_R2_BUCKET
     const url = (key) => `${config.SCREEN_LIBRARY_PUBLIC_URL}/screen-data/${key}`
@@ -87,7 +87,7 @@ export async function uploadPreview(config, name, bytes, request = cloudflareReq
     if (!/^[a-f0-9]{64}\.(png|webp)$/.test(name)) throw new Error('Invalid preview name')
     const id = `peanut-screen-${name.slice(0, 64)}`
     const endpoint = `https://api.cloudflare.com/client/v4/accounts/${config.CLOUDFLARE_ACCOUNT_ID}/images/v1`
-    const headers = { Authorization: `Bearer ${config.CLOUDFLARE_PUBLISH_TOKEN}` }
+    const headers = { Authorization: `Bearer ${config.CLOUDFLARE_API_TOKEN}` }
     // Verify original bytes on reuse, never trust a custom ID alone.
     let response = await request(`${endpoint}/${id}/blob`, { headers })
     if (response.status === 404) {

--- a/scripts/screens/cloudflare-storage.test.mjs
+++ b/scripts/screens/cloudflare-storage.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { configuration, uploadPreview, r2Endpoint, tokenCredentials } from './cloudflare-storage.mjs'
 const config = {
     CLOUDFLARE_ACCOUNT_ID: 'a'.repeat(32),
-    CLOUDFLARE_PUBLISH_TOKEN: 'test-token',
+    CLOUDFLARE_API_TOKEN: 'test-token',
     SCREEN_LIBRARY_R2_BUCKET: 'screens',
     SCREEN_LIBRARY_PUBLIC_URL: 'https://screens.example.com',
     SCREEN_LIBRARY_IMAGES_HASH: 'hash',

--- a/scripts/screens/viewer.test.mjs
+++ b/scripts/screens/viewer.test.mjs
@@ -107,3 +107,13 @@ test('landing page shows a friendly empty state when captures are not published'
         assert.equal(elements.get('route-coverage').hidden, true)
     }
 })
+
+test('hosted report 404 shows a report-not-found state instead of an unpublished catalogue', async () => {
+    const elements = await loadLanding('/screens/2026-09-11/dev-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/', {
+        ok: false,
+    })
+    assert.equal(elements.get('empty-state').hidden, false)
+    assert.match(elements.get('empty-title').textContent, /report is not available/i)
+    assert.doesNotMatch(elements.get('empty-title').textContent, /almost here/i)
+    assert.match(elements.get('empty-message').textContent, /published report/i)
+})

--- a/scripts/screens/viewer.test.mjs
+++ b/scripts/screens/viewer.test.mjs
@@ -18,6 +18,12 @@ const elementIds = [
     'zoom-title',
     'zoom-images',
     'coverage',
+    'empty-state',
+    'empty-kicker',
+    'empty-title',
+    'empty-message',
+    'empty-status',
+    'empty-retry',
     'screen-filters',
     'route-coverage',
     'route-inventory',
@@ -48,7 +54,7 @@ class Element {
     }
 }
 
-async function loadLanding(pathname) {
+async function loadLanding(pathname, { ok = true, index = [] } = {}) {
     const elements = new Map(elementIds.map((id) => [id, new Element(id)]))
     const brand = new Element('brand')
     let resolveResponse
@@ -64,26 +70,40 @@ async function loadLanding(pathname) {
         console,
         document,
         fetch: () => response,
-        location: { pathname, protocol: 'https:' },
+        location: { pathname, protocol: 'https:', reload() {} },
         window: {},
     })
     vm.runInContext(viewer, context, { filename: 'public/screen-library/viewer.js' })
-    resolveResponse({
-        ok: true,
-        json: async () => [
-            { path: '2026-09-11/dev-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', date: '2026-09-11', label: 'dev' },
-        ],
-    })
+    resolveResponse({ ok, status: ok ? 200 : 404, json: async () => index })
     await new Promise((resolve) => setImmediate(resolve))
     return elements
 }
 
 test('landing catalogue hides controls and route coverage on the root URL and deployed alias', async () => {
     for (const pathname of ['/', '/screen-library/index.html']) {
-        const elements = await loadLanding(pathname)
+        const elements = await loadLanding(pathname, {
+            index: [
+                {
+                    path: '2026-09-11/dev-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    date: '2026-09-11',
+                    label: 'dev',
+                },
+            ],
+        })
         assert.equal(elements.get('screen-filters').hidden, true, pathname)
         assert.equal(elements.get('route-coverage').hidden, true, pathname)
         assert.equal(elements.get('versions').children.length, 1, pathname)
         assert.equal(elements.get('screens').children.length, 0, pathname)
+    }
+})
+
+test('landing page shows a friendly empty state when captures are not published', async () => {
+    for (const options of [{ index: [] }, { ok: false }]) {
+        const elements = await loadLanding('/', options)
+        assert.equal(elements.get('empty-state').hidden, false)
+        assert.match(elements.get('empty-title').textContent, /almost here/i)
+        assert.equal(elements.get('coverage').hidden, true)
+        assert.equal(elements.get('screen-filters').hidden, true)
+        assert.equal(elements.get('route-coverage').hidden, true)
     }
 })


### PR DESCRIPTION
## Summary

- Use the existing `CLOUDFLARE_API_TOKEN` secret for screen-library publishing and trusted gallery deployment.
- Update storage code/tests and setup docs to use the same token name. The token must include Images Edit, Workers R2 Storage Edit, and Workers Scripts Edit; the docs call out the reduced least-privilege boundary.
- Replace the raw report-unavailable 404 with a polished empty state for an unpublished/empty catalogue or transient load failure, including a **Check again** action.

## Verification

- `node --test scripts/screens/cloudflare-storage.test.mjs scripts/screens/viewer.test.mjs scripts/screens/public-origin.test.mjs` (10/10)
- `node --check public/screen-library/viewer.js`
- Prettier check and `git diff --check`

Follow-up to #3107 and #3108. After this merges to `dev`, rerun the gallery deploy and screen-library generation workflows so the existing 404 run can publish with the configured token.
