### PR TITLE
chore(TASK-22589): regenerate API types (drift only)

### DIFF
--- a/src/types/api.generated.ts
+++ b/src/types/api.generated.ts
@@ -84,120 +84,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/admin/card-waitlist/release": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Release users from the card waitlist */
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    "x-admin-token": string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        userIds: string[];
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            released: string[];
-                            skipped: string[];
-                        };
-                    };
-                };
-                /** @description Default Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            message: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            message: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/support/grant": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    "x-admin-token": string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        amountUsd?: number;
-                        override?: boolean;
-                        username: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/apple-app-site-association": {
         parameters: {
             query?: never;
@@ -420,7 +306,8 @@ export interface paths {
                         "application/json": {
                             claim: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -485,7 +372,8 @@ export interface paths {
                         "application/json": {
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -503,6 +391,45 @@ export interface paths {
                                 badgeCode?: string;
                                 outcome: "awarded" | "already_owned" | "inactive" | "expired" | "unknown" | "definition_missing";
                             }[];
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/badge/team": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            awarded: boolean;
                         };
                     };
                 };
@@ -5700,7 +5627,8 @@ export interface paths {
                             attributionResolved: true;
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5720,7 +5648,8 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5752,7 +5681,8 @@ export interface paths {
                             attributionResolved: false;
                             claims: {
                                 acquisition?: {
-                                    destination: "offramp_migration" | "normal_app";
+                                    /** @enum {string} */
+                                    destination: "normal_app";
                                     /** @enum {string} */
                                     fallback: "normal_app";
                                 };
@@ -5772,7 +5702,8 @@ export interface paths {
                             }[];
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5925,7 +5856,8 @@ export interface paths {
                             attributionResolved: true;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -5958,7 +5890,8 @@ export interface paths {
                             attributionResolved: false;
                             legacyAcquisition?: {
                                 campaignTag: string;
-                                destination: "offramp_migration" | "normal_app";
+                                /** @enum {string} */
+                                destination: "normal_app";
                                 /** @enum {string} */
                                 fallback: "normal_app";
                             };
@@ -6332,6 +6265,8 @@ export interface paths {
                     "application/json": {
                         /** @description Amount for static QR codes (optional for dynamic QR codes) */
                         amount?: string;
+                        /** @description Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour. */
+                        idempotencyKey?: unknown;
                         /** @description The QR code string to process for payment */
                         qrCode: string;
                         /** @description Type of QR code (e.g. PIX, QR30, CODI). Used to select the correct fallback user for non-Manteca users. */
@@ -6642,84 +6577,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/notifications/admin/recent": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Recent notification rows for a user (all channels + statuses) */
-        get: {
-            parameters: {
-                query: {
-                    userId: string;
-                    limit: number;
-                };
-                header: {
-                    "x-admin-token": string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            items: {
-                                channel: string;
-                                createdAt: string;
-                                error: {
-                                    name: string | null;
-                                    reason: string | null;
-                                } | null;
-                                eventType: string;
-                                id: string;
-                                providerId: string | null;
-                                sentAt: string | null;
-                                skipReason: string | null;
-                                status: "PENDING" | "SENT" | "FAILED" | "SKIPPED";
-                            }[];
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/notifications/mark-read": {
         parameters: {
             query?: never;
@@ -6737,56 +6594,6 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/send": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    "x-admin-token": string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        channel?: "push" | "email";
-                        data?: {
-                            [key: string]: unknown;
-                        };
-                        externalUserIds: string[];
-                        idempotencyKey?: string;
-                        message?: string;
-                        templateId?: string;
-                        title?: string;
-                        url?: string;
-                    };
-                };
-            };
             responses: {
                 /** @description Default Response */
                 200: {
@@ -7148,49 +6955,6 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/points/admin/adjust": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    "api-key": string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        pointsChange: number;
-                        reason: string;
-                        userId: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
         delete?: never;
         options?: never;
         head?: never;
@@ -8056,11 +7820,11 @@ export interface paths {
                             executorSalt: string;
                             executorSignature: string;
                             expiresAt: number;
+                            /** @enum {string} */
+                            mixedSpendContract?: "broadcast-first-revert-v1";
                             preparationId: string;
                             recipientAddress: string;
                             tokenAddress: string;
-                            /** @enum {string} */
-                            mixedSpendContract?: "broadcast-first-revert-v1";
                         };
                     };
                 };
@@ -9190,123 +8954,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/rain/cards/{cardId}/provisioning-data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    cardId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        wallet: "apple" | "google";
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            cardId: string;
-                            cardSecret: string;
-                            last4: string;
-                            network: string;
-                            cardholderName?: string;
-                            billingAddress: {
-                                line1: string;
-                                line2?: string;
-                                city: string;
-                                region: string;
-                                postalCode: string;
-                                countryCode: string;
-                            };
-                        };
-                    };
-                };
-                /** @description Default Response */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                            code?: string;
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rain/webhooks": {
         parameters: {
             query?: never;
@@ -9334,6 +8981,39 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/readyz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -9597,6 +9277,9 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
+                        context?: "withdraw" | "pay-request";
+                        /** Format: uuid */
+                        contextId?: string;
                         isSameChainSwap: boolean;
                         isSwap: boolean;
                         quoteId: string;
@@ -9642,6 +9325,8 @@ export interface paths {
                     "application/json": {
                         amount: string;
                         chainOut: string;
+                        context?: "withdraw" | "pay-request";
+                        contextId?: string;
                         depositor: string;
                         mode: "pay" | "receive";
                         recipient: string;
@@ -9878,6 +9563,9 @@ export interface paths {
                         context: "withdraw" | "pay-request" | "claim-xchain";
                         contextId: string;
                         depositChain: string;
+                        depositChainId?: string;
+                        depositContractVersion?: string;
+                        depositIdx?: number;
                         destinationAddress: string;
                         destinationChain: string;
                         feeUsd?: number;
@@ -9928,10 +9616,10 @@ export interface paths {
                         amount: string;
                         chainIn: string;
                         chainOut: string;
+                        depositor?: string;
                         mode: "pay" | "receive";
+                        recipient?: string;
                         token: string;
-                        depositor: string;
-                        recipient: string;
                     };
                 };
             };
@@ -10159,6 +9847,45 @@ export interface paths {
                 };
             };
         };
+        trace?: never;
+    };
+    "/send-links/{pubKey}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    c?: string;
+                    i?: number;
+                    v?: string;
+                };
+                header?: never;
+                path: {
+                    pubKey: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/status/summary": {
@@ -10408,10 +10135,12 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
+                        avatarKey?: string | null;
                         bridgeKycStatus?: "not_started" | "incomplete" | "under_review" | "approved" | "rejected";
                         bridge_customer_id?: string;
                         dismissActivationCelebration?: boolean;
                         email?: string;
+                        emailVerificationCode?: string;
                         fullName?: string;
                         hasSeenEarlyUserModal?: boolean;
                         locale?: string;
@@ -10423,7 +10152,6 @@ export interface paths {
                         telegramUsername?: string;
                         userId: string;
                         username?: string;
-                        emailVerificationCode?: string;
                     };
                 };
             };
@@ -10451,6 +10179,19 @@ export interface paths {
                     };
                 };
                 /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "STEP_UP_REQUIRED";
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
                 409: {
                     headers: {
                         [name: string]: unknown;
@@ -10459,6 +10200,10 @@ export interface paths {
                         "application/json": {
                             message: string;
                             success: boolean;
+                        } | {
+                            /** @enum {string} */
+                            code: "EMAIL_IN_USE";
+                            error: string;
                         };
                     };
                 };
@@ -10475,14 +10220,12 @@ export interface paths {
                     };
                 };
                 /** @description Default Response */
-                401: {
+                503: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
                         "application/json": {
-                            /** @enum {string} */
-                            code: "STEP_UP_REQUIRED";
                             error: string;
                         };
                     };
@@ -10931,6 +10674,110 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/email-change": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                    "api-key"?: string;
+                    "x-step-up-token"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        email: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            success: boolean;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** @enum {string} */
+                            code: "STEP_UP_REQUIRED";
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/history": {
         parameters: {
             query?: never;
@@ -10992,6 +10839,112 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/users/identity/restart": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        /** @description Level the token must target. The declared residence decides (AR/BR → LATAM, US/MX → NA, SEPA zone → EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs. */
+                        regionIntent?: "LATAM" | "ROW" | "EU" | "NA";
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            applicantId: string;
+                            levelName: string;
+                            /** @description The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level). */
+                            regionIntent: string;
+                            token: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                            /** Format: date-time */
+                            retryAt?: string;
+                        };
+                    };
+                };
+                /** @description Default Response */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: string;
+                        };
+                    };
                 };
             };
         };
@@ -11355,6 +11308,7 @@ export interface paths {
                                 status: "not_started" | "processing" | "verified" | "action_required" | "failed";
                                 submittedAt?: string;
                             };
+                            profileNameLocked: boolean;
                             residence: {
                                 declared: string | null;
                                 declaredSecond: string | null;
@@ -11366,7 +11320,6 @@ export interface paths {
                                 banking: boolean;
                                 card: boolean;
                             };
-                            profileNameLocked: boolean;
                         } & {
                             [key: string]: unknown;
                         };
@@ -12048,110 +12001,6 @@ export interface paths {
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/users/email-change": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: {
-            parameters: {
-                query?: never;
-                header: {
-                    Authorization: string;
-                    "api-key"?: string;
-                    "x-step-up-token"?: string;
-                };
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        email: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Default Response */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            success: boolean;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {string} */
-                            code: "STEP_UP_REQUIRED";
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-                /** @description Default Response */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: string;
-                        };
-                    };
-                };
-            };
-        };
         delete?: never;
         options?: never;
         head?: never;

--- a/src/types/api.openapi.json
+++ b/src/types/api.openapi.json
@@ -140,168 +140,6 @@
                 }
             }
         },
-        "/admin/card-waitlist/release": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "x-admin-token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "userIds": {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "maxItems": 100,
-                                        "minItems": 1,
-                                        "type": "array"
-                                    }
-                                },
-                                "required": [
-                                    "userIds"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "released": {
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "skipped": {
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "required": [
-                                        "released",
-                                        "skipped"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error",
-                                        "message"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "500": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error",
-                                        "message"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                },
-                "summary": "Release users from the card waitlist",
-                "tags": [
-                    "admin"
-                ]
-            }
-        },
-        "/admin/support/grant": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "x-admin-token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "amountUsd": {
-                                        "maximum": 50,
-                                        "minimum": 0.01,
-                                        "type": "number"
-                                    },
-                                    "override": {
-                                        "type": "boolean"
-                                    },
-                                    "username": {
-                                        "maxLength": 64,
-                                        "minLength": 1,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "username"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
         "/apple-app-site-association": {
             "get": {
                 "responses": {
@@ -498,20 +336,10 @@
                                                 "acquisition": {
                                                     "properties": {
                                                         "destination": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "enum": [
-                                                                        "offramp_migration"
-                                                                    ],
-                                                                    "type": "string"
-                                                                },
-                                                                {
-                                                                    "enum": [
-                                                                        "normal_app"
-                                                                    ],
-                                                                    "type": "string"
-                                                                }
-                                                            ]
+                                                            "enum": [
+                                                                "normal_app"
+                                                            ],
+                                                            "type": "string"
                                                         },
                                                         "fallback": {
                                                             "enum": [
@@ -686,20 +514,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -811,6 +629,40 @@
                                     },
                                     "required": [
                                         "claims"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/badge/team": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "Authorization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "awarded": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "awarded"
                                     ],
                                     "type": "object"
                                 }
@@ -9384,20 +9236,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9512,20 +9354,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9599,20 +9431,10 @@
                                                     "acquisition": {
                                                         "properties": {
                                                             "destination": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "enum": [
-                                                                            "offramp_migration"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    },
-                                                                    {
-                                                                        "enum": [
-                                                                            "normal_app"
-                                                                        ],
-                                                                        "type": "string"
-                                                                    }
-                                                                ]
+                                                                "enum": [
+                                                                    "normal_app"
+                                                                ],
+                                                                "type": "string"
                                                             },
                                                             "fallback": {
                                                                 "enum": [
@@ -9727,20 +9549,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9871,20 +9683,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -9961,20 +9763,10 @@
                                                     "type": "string"
                                                 },
                                                 "destination": {
-                                                    "anyOf": [
-                                                        {
-                                                            "enum": [
-                                                                "offramp_migration"
-                                                            ],
-                                                            "type": "string"
-                                                        },
-                                                        {
-                                                            "enum": [
-                                                                "normal_app"
-                                                            ],
-                                                            "type": "string"
-                                                        }
-                                                    ]
+                                                    "enum": [
+                                                        "normal_app"
+                                                    ],
+                                                    "type": "string"
                                                 },
                                                 "fallback": {
                                                     "enum": [
@@ -10580,6 +10372,9 @@
                                     "amount": {
                                         "description": "Amount for static QR codes (optional for dynamic QR codes)",
                                         "type": "string"
+                                    },
+                                    "idempotencyKey": {
+                                        "description": "Idempotency key for THIS init request, a non-blank string of at most 200 characters. Scoped to the exact (qrCode, qrType, amount) tuple, not to the scan: retries of the same request reuse one Manteca price lock instead of minting a new one per attempt, but an open-amount QR MUST derive a new key once the user supplies an amount, or the second init is refused with QR_INIT_KEY_MISMATCH. Optional: older clients omit it and get the previous behaviour."
                                     },
                                     "qrCode": {
                                         "description": "The QR code string to process for payment",
@@ -11376,301 +11171,8 @@
                 }
             }
         },
-        "/notifications/admin/recent": {
-            "get": {
-                "parameters": [
-                    {
-                        "in": "query",
-                        "name": "userId",
-                        "required": true,
-                        "schema": {
-                            "minLength": 1,
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "limit",
-                        "required": true,
-                        "schema": {
-                            "default": 20,
-                            "maximum": 100,
-                            "minimum": 1,
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "in": "header",
-                        "name": "x-admin-token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "items": {
-                                            "items": {
-                                                "properties": {
-                                                    "channel": {
-                                                        "type": "string"
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string"
-                                                    },
-                                                    "error": {
-                                                        "anyOf": [
-                                                            {
-                                                                "properties": {
-                                                                    "name": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "type": "null"
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "type": "string"
-                                                                            },
-                                                                            {
-                                                                                "type": "null"
-                                                                            }
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "reason",
-                                                                    "name"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "eventType": {
-                                                        "type": "string"
-                                                    },
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "providerId": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "sentAt": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "skipReason": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "type": "null"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "status": {
-                                                        "anyOf": [
-                                                            {
-                                                                "enum": [
-                                                                    "PENDING"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "enum": [
-                                                                    "SENT"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "enum": [
-                                                                    "FAILED"
-                                                                ],
-                                                                "type": "string"
-                                                            },
-                                                            {
-                                                                "enum": [
-                                                                    "SKIPPED"
-                                                                ],
-                                                                "type": "string"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                "required": [
-                                                    "id",
-                                                    "eventType",
-                                                    "channel",
-                                                    "status",
-                                                    "skipReason",
-                                                    "providerId",
-                                                    "error",
-                                                    "createdAt",
-                                                    "sentAt"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "required": [
-                                        "items"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    }
-                },
-                "summary": "Recent notification rows for a user (all channels + statuses)",
-                "tags": [
-                    "admin"
-                ]
-            }
-        },
         "/notifications/mark-read": {
             "post": {
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/notifications/send": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "x-admin-token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "channel": {
-                                        "anyOf": [
-                                            {
-                                                "enum": [
-                                                    "push"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            {
-                                                "enum": [
-                                                    "email"
-                                                ],
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
-                                    "data": {
-                                        "additionalProperties": {},
-                                        "type": "object"
-                                    },
-                                    "externalUserIds": {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "maxItems": 10,
-                                        "minItems": 1,
-                                        "type": "array"
-                                    },
-                                    "idempotencyKey": {
-                                        "type": "string"
-                                    },
-                                    "message": {
-                                        "type": "string"
-                                    },
-                                    "templateId": {
-                                        "type": "string"
-                                    },
-                                    "title": {
-                                        "type": "string"
-                                    },
-                                    "url": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "externalUserIds"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -12013,51 +11515,6 @@
                         }
                     }
                 ],
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/points/admin/adjust": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "api-key",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "pointsChange": {
-                                        "type": "number"
-                                    },
-                                    "reason": {
-                                        "type": "string"
-                                    },
-                                    "userId": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "userId",
-                                    "pointsChange",
-                                    "reason"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -13473,6 +12930,12 @@
                                         "expiresAt": {
                                             "type": "number"
                                         },
+                                        "mixedSpendContract": {
+                                            "enum": [
+                                                "broadcast-first-revert-v1"
+                                            ],
+                                            "type": "string"
+                                        },
                                         "preparationId": {
                                             "type": "string"
                                         },
@@ -13481,12 +12944,6 @@
                                         },
                                         "tokenAddress": {
                                             "type": "string"
-                                        },
-                                        "mixedSpendContract": {
-                                            "type": "string",
-                                            "enum": [
-                                                "broadcast-first-revert-v1"
-                                            ]
                                         }
                                     },
                                     "required": [
@@ -15250,225 +14707,17 @@
                 }
             }
         },
-        "/rain/cards/{cardId}/provisioning-data": {
+        "/rain/webhooks": {
             "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "wallet": {
-                                        "anyOf": [
-                                            {
-                                                "type": "string",
-                                                "enum": [
-                                                    "apple"
-                                                ]
-                                            },
-                                            {
-                                                "type": "string",
-                                                "enum": [
-                                                    "google"
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                },
-                                "required": [
-                                    "wallet"
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "schema": {
-                            "format": "uuid",
-                            "type": "string"
-                        },
-                        "in": "path",
-                        "name": "cardId",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cardId": {
-                                            "type": "string"
-                                        },
-                                        "cardSecret": {
-                                            "type": "string"
-                                        },
-                                        "last4": {
-                                            "type": "string"
-                                        },
-                                        "network": {
-                                            "type": "string"
-                                        },
-                                        "cardholderName": {
-                                            "type": "string"
-                                        },
-                                        "billingAddress": {
-                                            "type": "object",
-                                            "properties": {
-                                                "line1": {
-                                                    "type": "string"
-                                                },
-                                                "line2": {
-                                                    "type": "string"
-                                                },
-                                                "city": {
-                                                    "type": "string"
-                                                },
-                                                "region": {
-                                                    "type": "string"
-                                                },
-                                                "postalCode": {
-                                                    "type": "string"
-                                                },
-                                                "countryCode": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "line1",
-                                                "city",
-                                                "region",
-                                                "postalCode",
-                                                "countryCode"
-                                            ]
-                                        }
-                                    },
-                                    "required": [
-                                        "cardId",
-                                        "cardSecret",
-                                        "last4",
-                                        "network",
-                                        "billingAddress"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "409": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "503": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        },
-                                        "code": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ]
-                                }
-                            }
-                        }
+                        "description": "Default Response"
                     }
                 }
             }
         },
-        "/rain/webhooks": {
-            "post": {
+        "/readyz": {
+            "get": {
                 "responses": {
                     "200": {
                         "description": "Default Response"
@@ -15763,6 +15012,26 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
+                                    "context": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "withdraw"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "pay-request"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "contextId": {
+                                        "format": "uuid",
+                                        "type": "string"
+                                    },
                                     "isSameChainSwap": {
                                         "type": "boolean"
                                     },
@@ -15817,6 +15086,26 @@
                                         "type": "string"
                                     },
                                     "chainOut": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "context": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "withdraw"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "pay-request"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "contextId": {
                                         "minLength": 1,
                                         "type": "string"
                                     },
@@ -16098,6 +15387,15 @@
                                     "depositChain": {
                                         "type": "string"
                                     },
+                                    "depositChainId": {
+                                        "type": "string"
+                                    },
+                                    "depositContractVersion": {
+                                        "type": "string"
+                                    },
+                                    "depositIdx": {
+                                        "type": "number"
+                                    },
                                     "destinationAddress": {
                                         "type": "string"
                                     },
@@ -16171,6 +15469,10 @@
                                     "chainOut": {
                                         "type": "string"
                                     },
+                                    "depositor": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
                                     "mode": {
                                         "anyOf": [
                                             {
@@ -16187,15 +15489,11 @@
                                             }
                                         ]
                                     },
-                                    "token": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
-                                    "depositor": {
-                                        "minLength": 1,
-                                        "type": "string"
-                                    },
                                     "recipient": {
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "token": {
                                         "minLength": 1,
                                         "type": "string"
                                     }
@@ -16205,9 +15503,7 @@
                                     "chainOut",
                                     "token",
                                     "amount",
-                                    "mode",
-                                    "depositor",
-                                    "recipient"
+                                    "mode"
                                 ],
                                 "type": "object"
                             }
@@ -16496,6 +15792,49 @@
                 }
             }
         },
+        "/send-links/{pubKey}/status": {
+            "get": {
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "c",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "i",
+                        "required": false,
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "v",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "pubKey",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/status/summary": {
             "get": {
                 "responses": {
@@ -16531,7 +15870,7 @@
                         "name": "address",
                         "required": true,
                         "schema": {
-                            "minLength": 1,
+                            "pattern": "^0x[a-fA-F0-9]{40}$",
                             "type": "string"
                         }
                     },
@@ -16540,7 +15879,7 @@
                         "name": "chainId",
                         "required": true,
                         "schema": {
-                            "minLength": 1,
+                            "pattern": "^[0-9]{1,10}$",
                             "type": "string"
                         }
                     }
@@ -16563,7 +15902,7 @@
                         "name": "address",
                         "required": true,
                         "schema": {
-                            "minLength": 1,
+                            "pattern": "^0x[a-fA-F0-9]{40}$",
                             "type": "string"
                         }
                     }
@@ -16653,6 +15992,18 @@
                         "application/json": {
                             "schema": {
                                 "properties": {
+                                    "avatarKey": {
+                                        "anyOf": [
+                                            {
+                                                "maxLength": 64,
+                                                "pattern": "^(basic\\.[a-z][a-z0-9-]*|badge\\.[A-Z0-9_]+\\.[a-z][a-z0-9-]*|letter\\.[a-z])$",
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
                                     "bridgeKycStatus": {
                                         "anyOf": [
                                             {
@@ -16696,6 +16047,10 @@
                                     "email": {
                                         "type": "string"
                                     },
+                                    "emailVerificationCode": {
+                                        "pattern": "^[0-9]{6}$",
+                                        "type": "string"
+                                    },
                                     "fullName": {
                                         "type": "string"
                                     },
@@ -16733,10 +16088,6 @@
                                     },
                                     "username": {
                                         "type": "string"
-                                    },
-                                    "emailVerificationCode": {
-                                        "type": "string",
-                                        "pattern": "^[0-9]{6}$"
                                     }
                                 },
                                 "required": [
@@ -16777,23 +16128,70 @@
                         },
                         "description": "Invalid input \u2014 malformed email, rejected username, or a residence country that is not a real ISO-3166 alpha-2 code."
                     },
-                    "409": {
+                    "401": {
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
-                                        "message": {
+                                        "code": {
+                                            "enum": [
+                                                "STEP_UP_REQUIRED"
+                                            ],
                                             "type": "string"
                                         },
-                                        "success": {
-                                            "type": "boolean"
+                                        "error": {
+                                            "type": "string"
                                         }
                                     },
                                     "required": [
-                                        "success",
-                                        "message"
+                                        "error",
+                                        "code"
                                     ],
                                     "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string"
+                                                },
+                                                "success": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "success",
+                                                "message"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        {
+                                            "properties": {
+                                                "code": {
+                                                    "enum": [
+                                                        "EMAIL_IN_USE"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "error": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "error",
+                                                "code"
+                                            ],
+                                            "type": "object"
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -16821,24 +16219,17 @@
                         },
                         "description": "Default Response"
                     },
-                    "401": {
+                    "503": {
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
-                                        "code": {
-                                            "enum": [
-                                                "STEP_UP_REQUIRED"
-                                            ],
-                                            "type": "string"
-                                        },
                                         "error": {
                                             "type": "string"
                                         }
                                     },
                                     "required": [
-                                        "error",
-                                        "code"
+                                        "error"
                                     ],
                                     "type": "object"
                                 }
@@ -17842,6 +17233,172 @@
                 }
             }
         },
+        "/users/email-change": {
+            "post": {
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "Authorization",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "name": "api-key",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "header",
+                        "name": "x-step-up-token",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "email": {
+                                        "maxLength": 320,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "email"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "code": {
+                                            "enum": [
+                                                "STEP_UP_REQUIRED"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error",
+                                        "code"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/users/history": {
             "get": {
                 "parameters": [
@@ -17886,6 +17443,181 @@
                         "description": "Default Response"
                     }
                 }
+            }
+        },
+        "/users/identity/restart": {
+            "post": {
+                "description": "Reset the Sumsub IDENTITY step after a residence change and mint a fresh SDK token. Allowed only while the declared residence differs from the verified one.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "regionIntent": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "LATAM"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "ROW"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "EU"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "enum": [
+                                                    "NA"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "description": "Level the token must target. The declared residence decides (AR/BR \u2192 LATAM, US/MX \u2192 NA, SEPA zone \u2192 EU, else ROW); a request for another provider's level is rejected with 400, an EU/ROW request is corrected. Defaults to the level the declared residence needs."
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "applicantId": {
+                                            "type": "string"
+                                        },
+                                        "levelName": {
+                                            "type": "string"
+                                        },
+                                        "regionIntent": {
+                                            "description": "The intent the server resolved for this restart. The caller must drive its SDK session from THIS value, not from what it asked for: the declared residence can overrule the request, and `levelName` alone cannot tell EU from NA or LATAM from ROW (each pair shares a level).",
+                                            "type": "string"
+                                        },
+                                        "token": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "token",
+                                        "levelName",
+                                        "applicantId",
+                                        "regionIntent"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        },
+                                        "retryAt": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    },
+                    "503": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "error"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Default Response"
+                    }
+                },
+                "tags": [
+                    "users"
+                ]
             }
         },
         "/users/identity/resubmit": {
@@ -18649,6 +18381,9 @@
                                             ],
                                             "type": "object"
                                         },
+                                        "profileNameLocked": {
+                                            "type": "boolean"
+                                        },
                                         "residence": {
                                             "properties": {
                                                 "declared": {
@@ -18725,9 +18460,6 @@
                                                 "card"
                                             ],
                                             "type": "object"
-                                        },
-                                        "profileNameLocked": {
-                                            "type": "boolean"
                                         }
                                     },
                                     "required": [
@@ -19387,172 +19119,6 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Default Response"
-                    }
-                }
-            }
-        },
-        "/users/email-change": {
-            "post": {
-                "parameters": [
-                    {
-                        "in": "header",
-                        "name": "Authorization",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "header",
-                        "name": "api-key",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "header",
-                        "name": "x-step-up-token",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "properties": {
-                                    "email": {
-                                        "maxLength": 320,
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "email"
-                                ],
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean"
-                                        }
-                                    },
-                                    "required": [
-                                        "success"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "400": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "401": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "code": {
-                                            "enum": [
-                                                "STEP_UP_REQUIRED"
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error",
-                                        "code"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "409": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "429": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "Default Response"
-                    },
-                    "503": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "error": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "error"
-                                    ],
-                                    "type": "object"
-                                }
-                            }
-                        },
                         "description": "Default Response"
                     }
                 }


### PR DESCRIPTION
## What changed

Only the two generated API type files:

- `src/types/api.openapi.json`
- `src/types/api.generated.ts`

Regenerated with the repo's own script (`pnpm gen:api`) from the committed OpenAPI snapshot on `peanut-api-ts` `dev` (`openapi.json`), piped through `python3 -m json.tool` exactly as `gen:api:live` does. No hand edits.

## The drift

The checked-in snapshot had fallen behind `peanut-api-ts` `dev`:

- **12 routes changed shape**: `/badge/award`, `/badge/claims`, `/invites/accept`, `/invites/validate`, `/manteca/qr-payment/init`, `/rhino/bridge/commit`, `/rhino/bridge/quote`, `/rhino/sda-transfer`, `/rhino/sda-transfer/preview`, `/tokens/price`, `/tokens/wallet-portfolio`, `/update-user`
- **4 routes added**: `/badge/team`, `/readyz`, `/send-links/{pubKey}/status`, `/users/identity/restart`
- **6 routes removed**: `/admin/card-waitlist/release`, `/admin/support/grant`, `/notifications/admin/recent`, `/notifications/send`, `/points/admin/adjust`, `/rain/cards/{cardId}/provisioning-data`

The six removals are not deleted endpoints. Each one carries `schema: { hide: true }` upstream, so the backend stopped publishing them in the spec; the frontend snapshot kept stale copies. Nothing in `src/` references their generated types — typecheck is clean without them.

## Mechanical, and scope

Nothing here is hand-written and no application code is touched. The regeneration is against `peanut-api-ts` `dev` only. `/users/deposit-accounts` and the `RESIDENCE_CHANGE_COOLDOWN` 429 on `/update-user` come from the paired backend feature branch, not from `dev`, so both are deliberately **left out** — they stay with #3134, which keeps its own additions.

#3134 carries the same regeneration inline (about +1865/−1650, roughly half its churn). Once this lands and #3134 merges `dev`, that diff disappears from it and the feature PR is readable.

## Verification

- `npm run typecheck` — clean
- `npm test` — 7307 passed, 1 flaky timeout in `ResidenceChangeDrawer.test.tsx` under full-suite load; passes on its own (12/12) and does not read these types
- `pnpm prettier --check` on both files — clean

Task: TASK-22589

Screenshots: N/A
