### PR TITLE
fix(avatar): localize badge artwork names

### DIFF
--- a/src/components/Avatar/AvatarPicker.tsx
+++ b/src/components/Avatar/AvatarPicker.tsx
@@ -123,7 +123,10 @@ export function AvatarPicker({ open, onOpenChange }: AvatarPickerProps) {
     const describe = (key: string | null): { name: string; line: string } => {
         if (!key) return { name: t('initialName', { letter: first.toUpperCase() }), line: t('initialLine') }
         const [kind, code, slug] = key.split('.')
-        if (kind === 'badge') return { name: capitalise(slug), line: badgeName[code] ?? code }
+        if (kind === 'badge') {
+            const nameKey = `badge.${code}.${slug}` as Parameters<typeof t>[0]
+            return { name: t.has(nameKey) ? t(nameKey) : capitalise(slug), line: badgeName[code] ?? code }
+        }
         const nameKey = `cast.${code}.name` as Parameters<typeof t>[0]
         const lineKey = `cast.${code}.line` as Parameters<typeof t>[0]
         return { name: t.has(nameKey) ? t(nameKey) : capitalise(code), line: t.has(lineKey) ? t(lineKey) : '' }

--- a/src/components/Avatar/__tests__/AvatarPicker.test.tsx
+++ b/src/components/Avatar/__tests__/AvatarPicker.test.tsx
@@ -181,17 +181,38 @@ describe('AvatarPicker', () => {
     })
 
     it.each([
-        { locale: 'es-419', messages: es419, expectedName: 'Cazador de bugs' },
-        { locale: 'pt-BR', messages: ptBR, expectedName: 'Caçador de bugs' },
-    ] as const)('localizes the earned badge name in $locale', ({ locale, messages, expectedName }) => {
+        { locale: 'es-419', messages: es419, artName: 'Escarabajo de bugs', expectedName: 'Cazador de bugs' },
+        { locale: 'pt-BR', messages: ptBR, artName: 'Besouro dos bugs', expectedName: 'Caçador de bugs' },
+    ] as const)('localizes the earned badge name and art in $locale', ({ locale, messages, artName, expectedName }) => {
         renderWithIntl(
             <NextIntlClientProvider locale={locale} messages={messages} timeZone="UTC">
                 <AvatarPicker open onOpenChange={jest.fn()} />
             </NextIntlClientProvider>
         )
 
-        expect(tile(/Beetle/)).toHaveTextContent(expectedName)
-        expect(tile(/Beetle/)).not.toHaveTextContent('Bug Whisperer')
+        expect(tile(new RegExp(artName))).toHaveTextContent(expectedName)
+        expect(tile(new RegExp(artName))).not.toHaveTextContent('Bug Whisperer')
+    })
+
+    it('gives simultaneously visible wink artworks distinct Spanish names', () => {
+        mockBadgeParam = 'BETA_TESTER'
+        mockUser.user.avatarKey = 'badge.CARD_FIRST_SWIPE.wink'
+        mockUser.user.badges = [
+            { code: 'BETA_TESTER', name: 'Beta Tester' },
+            { code: 'CARD_FIRST_SWIPE', name: 'First Swipe' },
+        ]
+        ;(Math.random as jest.Mock).mockReturnValue(0.99)
+
+        renderWithIntl(
+            <NextIntlClientProvider locale="es-419" messages={es419} timeZone="UTC">
+                <AvatarPicker open onOpenChange={jest.fn()} />
+            </NextIntlClientProvider>
+        )
+
+        const visibleWinks = tiles().filter((el) => el.textContent?.includes('Guiño'))
+        expect(visibleWinks).toHaveLength(2)
+        expect(visibleWinks.some((el) => el.textContent?.includes('Guiño beta'))).toBe(true)
+        expect(visibleWinks.some((el) => el.textContent?.includes('Guiño del primer swipe'))).toBe(true)
     })
 
     it('deals an earned avatar, tagged, to a user who holds a badge — and none to one who does not', () => {

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3767,6 +3767,88 @@
         "rollDie": "Roll the die",
         "initialName": "Just {letter}",
         "initialLine": "Your initial",
+        "badge": {
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "crystal": "Arbiverse Crystal",
+                "hex": "Arbiverse Hex",
+                "cheer": "Arbiverse Cheer"
+            },
+            "BETA_TESTER": {
+                "flask": "Beta Flask",
+                "bubble": "Beta Bubble",
+                "wink": "Beta Wink"
+            },
+            "BUG_WHISPERER": {
+                "beetle": "Bug Beetle",
+                "shell": "Bug Shell",
+                "peek": "Bug Peek"
+            },
+            "CARD_ALPHA": {
+                "card": "Alpha Card",
+                "swipe": "Alpha Swipe",
+                "tape": "Alpha Tape"
+            },
+            "CARD_FIRST_SWIPE": {
+                "card": "First Swipe Card",
+                "chip": "First Swipe Chip",
+                "wink": "First Swipe Wink"
+            },
+            "CARD_SPENT_1K": {
+                "stack": "Spender Stack",
+                "note": "Spender Note",
+                "cheer": "Spender Cheer"
+            },
+            "DEVCONNECT_BA_2025": {
+                "sun": "Devconnect Sun",
+                "rise": "Devconnect Sunrise",
+                "wink": "Devconnect Wink"
+            },
+            "ETHFLORIPA_HUB": {
+                "eth": "EthFloripa ETH",
+                "island": "EthFloripa Island",
+                "palm": "EthFloripa Palm"
+            },
+            "EVENT_ALUMNI": {
+                "cap": "Alumni Cap",
+                "board": "Alumni Board",
+                "wink": "Alumni Wink"
+            },
+            "IRL_NOMADS": {
+                "pack": "Nomad Pack",
+                "roll": "Nomad Roll",
+                "pocket": "Nomad Pocket"
+            },
+            "NAIJA": {
+                "flag": "Naija Flag",
+                "wave": "Naija Wave",
+                "wink": "Naija Wink"
+            },
+            "NITA": {
+                "letter": "NITA Letter",
+                "sparkle": "NITA Sparkle",
+                "wink": "NITA Wink"
+            },
+            "OFFRAMP_USER": {
+                "bolt": "Offramp Bolt",
+                "spark": "Offramp Spark",
+                "wink": "Offramp Wink"
+            },
+            "OG_2025_10_12": {
+                "coin": "OG Coin",
+                "link": "OG Link",
+                "shades": "OG Shades"
+            },
+            "SHHHHH": {
+                "lips": "Secret Lips",
+                "shush": "Secret Shush",
+                "wink": "Secret Wink"
+            },
+            "WAITLIST_SKIP": {
+                "key": "Waitlist Key",
+                "keyhole": "Waitlist Keyhole",
+                "wink": "Waitlist Wink"
+            }
+        },
         "cast": {
             "apple": {
                 "name": "Jackpot Cherry",

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3767,6 +3767,88 @@
         "rollDie": "Tirar el dado",
         "initialName": "Solo {letter}",
         "initialLine": "Tu inicial",
+        "badge": {
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "crystal": "Cristal de Arbiverse",
+                "hex": "Hexágono de Arbiverse",
+                "cheer": "Celebración de Arbiverse"
+            },
+            "BETA_TESTER": {
+                "flask": "Matraz de beta",
+                "bubble": "Burbuja de beta",
+                "wink": "Guiño beta"
+            },
+            "BUG_WHISPERER": {
+                "beetle": "Escarabajo de bugs",
+                "shell": "Concha de bugs",
+                "peek": "Mirada de bugs"
+            },
+            "CARD_ALPHA": {
+                "card": "Carta alfa",
+                "swipe": "Deslizada alfa",
+                "tape": "Cinta alfa"
+            },
+            "CARD_FIRST_SWIPE": {
+                "card": "Carta del primer swipe",
+                "chip": "Chip del primer swipe",
+                "wink": "Guiño del primer swipe"
+            },
+            "CARD_SPENT_1K": {
+                "stack": "Pila del gastador",
+                "note": "Nota del gastador",
+                "cheer": "Celebración del gastador"
+            },
+            "DEVCONNECT_BA_2025": {
+                "sun": "Sol de Devconnect",
+                "rise": "Amanecer de Devconnect",
+                "wink": "Guiño de Devconnect"
+            },
+            "ETHFLORIPA_HUB": {
+                "eth": "ETH de EthFloripa",
+                "island": "Isla de EthFloripa",
+                "palm": "Palmera de EthFloripa"
+            },
+            "EVENT_ALUMNI": {
+                "cap": "Gorra de alumni",
+                "board": "Pizarra de alumni",
+                "wink": "Guiño de alumni"
+            },
+            "IRL_NOMADS": {
+                "pack": "Mochila nómada",
+                "roll": "Rollo nómada",
+                "pocket": "Bolsillo nómada"
+            },
+            "NAIJA": {
+                "flag": "Bandera de Naija",
+                "wave": "Ola de Naija",
+                "wink": "Guiño de Naija"
+            },
+            "NITA": {
+                "letter": "Carta de NITA",
+                "sparkle": "Destello de NITA",
+                "wink": "Guiño de NITA"
+            },
+            "OFFRAMP_USER": {
+                "bolt": "Rayo de offramp",
+                "spark": "Destello de offramp",
+                "wink": "Guiño de offramp"
+            },
+            "OG_2025_10_12": {
+                "coin": "Moneda OG",
+                "link": "Enlace OG",
+                "shades": "Gafas OG"
+            },
+            "SHHHHH": {
+                "lips": "Labios secretos",
+                "shush": "Shhh secreto",
+                "wink": "Guiño secreto"
+            },
+            "WAITLIST_SKIP": {
+                "key": "Llave de la lista",
+                "keyhole": "Cerradura de la lista",
+                "wink": "Guiño de la lista"
+            }
+        },
         "cast": {
             "apple": {
                 "name": "Cereza ganadora",

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1664,6 +1664,35 @@
         }
     },
     "avatar": {
+        "badge": {
+            "BETA_TESTER": {
+                "wink": "Guiño beta"
+            },
+            "CARD_FIRST_SWIPE": {
+                "wink": "Guiño del primer swipe"
+            },
+            "DEVCONNECT_BA_2025": {
+                "wink": "Guiño de Devconnect"
+            },
+            "EVENT_ALUMNI": {
+                "wink": "Guiño de alumni"
+            },
+            "NAIJA": {
+                "wink": "Guiño de Naija"
+            },
+            "NITA": {
+                "wink": "Guiño de NITA"
+            },
+            "OFFRAMP_USER": {
+                "wink": "Guiño de offramp"
+            },
+            "SHHHHH": {
+                "wink": "Guiño secreto"
+            },
+            "WAITLIST_SKIP": {
+                "wink": "Guiño de la lista"
+            }
+        },
         "cast": {
             "cactus": {
                 "name": "Ají valiente"

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1664,35 +1664,6 @@
         }
     },
     "avatar": {
-        "badge": {
-            "BETA_TESTER": {
-                "wink": "Guiño beta"
-            },
-            "CARD_FIRST_SWIPE": {
-                "wink": "Guiño del primer swipe"
-            },
-            "DEVCONNECT_BA_2025": {
-                "wink": "Guiño de Devconnect"
-            },
-            "EVENT_ALUMNI": {
-                "wink": "Guiño de alumni"
-            },
-            "NAIJA": {
-                "wink": "Guiño de Naija"
-            },
-            "NITA": {
-                "wink": "Guiño de NITA"
-            },
-            "OFFRAMP_USER": {
-                "wink": "Guiño de offramp"
-            },
-            "SHHHHH": {
-                "wink": "Guiño secreto"
-            },
-            "WAITLIST_SKIP": {
-                "wink": "Guiño de la lista"
-            }
-        },
         "cast": {
             "cactus": {
                 "name": "Ají valiente"

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3767,6 +3767,88 @@
         "rollDie": "Jogar o dado",
         "initialName": "Só {letter}",
         "initialLine": "Sua inicial",
+        "badge": {
+            "ARBIVERSE_DEVCONNECT_BA_2025": {
+                "crystal": "Cristal da Arbiverse",
+                "hex": "Hexágono da Arbiverse",
+                "cheer": "Comemoração da Arbiverse"
+            },
+            "BETA_TESTER": {
+                "flask": "Frasco da beta",
+                "bubble": "Bolha da beta",
+                "wink": "Piscadinha da beta"
+            },
+            "BUG_WHISPERER": {
+                "beetle": "Besouro dos bugs",
+                "shell": "Concha dos bugs",
+                "peek": "Olhar dos bugs"
+            },
+            "CARD_ALPHA": {
+                "card": "Cartão alfa",
+                "swipe": "Deslize alfa",
+                "tape": "Fita alfa"
+            },
+            "CARD_FIRST_SWIPE": {
+                "card": "Cartão do primeiro swipe",
+                "chip": "Chip do primeiro swipe",
+                "wink": "Piscadinha do primeiro swipe"
+            },
+            "CARD_SPENT_1K": {
+                "stack": "Pilha do gastador",
+                "note": "Nota do gastador",
+                "cheer": "Comemoração do gastador"
+            },
+            "DEVCONNECT_BA_2025": {
+                "sun": "Sol da Devconnect",
+                "rise": "Amanhecer da Devconnect",
+                "wink": "Piscadinha da Devconnect"
+            },
+            "ETHFLORIPA_HUB": {
+                "eth": "ETH da EthFloripa",
+                "island": "Ilha da EthFloripa",
+                "palm": "Palmeira da EthFloripa"
+            },
+            "EVENT_ALUMNI": {
+                "cap": "Boné dos alumni",
+                "board": "Placar dos alumni",
+                "wink": "Piscadinha dos alumni"
+            },
+            "IRL_NOMADS": {
+                "pack": "Mochila nômade",
+                "roll": "Rolo nômade",
+                "pocket": "Bolso nômade"
+            },
+            "NAIJA": {
+                "flag": "Bandeira da Naija",
+                "wave": "Onda da Naija",
+                "wink": "Piscadinha da Naija"
+            },
+            "NITA": {
+                "letter": "Carta da NITA",
+                "sparkle": "Brilho da NITA",
+                "wink": "Piscadinha da NITA"
+            },
+            "OFFRAMP_USER": {
+                "bolt": "Raio da offramp",
+                "spark": "Faísca da offramp",
+                "wink": "Piscadinha da offramp"
+            },
+            "OG_2025_10_12": {
+                "coin": "Moeda OG",
+                "link": "Link OG",
+                "shades": "Óculos OG"
+            },
+            "SHHHHH": {
+                "lips": "Lábios secretos",
+                "shush": "Shhh secreto",
+                "wink": "Piscadinha secreta"
+            },
+            "WAITLIST_SKIP": {
+                "key": "Chave da fila",
+                "keyhole": "Fechadura da fila",
+                "wink": "Piscadinha da fila"
+            }
+        },
         "cast": {
             "apple": {
                 "name": "Cereja premiada",


### PR DESCRIPTION
## Summary
- localize badge artwork labels by badge code and art slug in English, Spanish, Argentine Spanish overlay, and Brazilian Portuguese
- keep the badge name on the second line and fall back to the slug for unknown future keys
- cover Spanish labels for key/lips-style art and two simultaneously visible wink artworks

## Validation
- pnpm exec jest src/components/Avatar/__tests__/AvatarPicker.test.tsx --runInBand
- pnpm exec jest src/i18n/app/__tests__/messages.test.ts src/i18n/app/__tests__/useAppTranslations.test.tsx --runInBand
- Prettier and ESLint pass for changed files
- Full tsc --noEmit remains blocked by unrelated baseline missing-assets and existing SDK typing errors

Notion task: TASK-22606
PR URL: https://github.com/peanutprotocol/peanut-ui/pull/3142
Head SHA: e795e9586174c7b18750b1d8c2be54a44a263efd
codex-automation: peanut-notion-issue-intake-and-pr-creation
Notion page ID: 3d983811-7579-81d3-b9fb-fbf9e26f15f1