### PR TITLE
fix(kyc): keep accepted verification tied to bank deposit readiness

### DIFF
--- a/src/app/actions/sumsub.ts
+++ b/src/app/actions/sumsub.ts
@@ -1,4 +1,8 @@
-import { type InitiateSumsubKycResponse, type KYCRegionIntent } from './types/sumsub.types'
+import {
+    type InitiateSumsubKycResponse,
+    type KYCRegionIntent,
+    type VerificationActionSession,
+} from './types/sumsub.types'
 import { serverFetch } from '@/utils/api-fetch'
 
 /**
@@ -76,12 +80,14 @@ export const initiateSumsubKyc = async (params?: {
     levelName?: string
     crossRegion?: boolean
     targetCountry?: string
+    correctSession?: boolean
 }): Promise<{ data?: InitiateSumsubKycResponse; error?: string; code?: SumsubActionErrorCode }> => {
     const body: Record<string, string | boolean | undefined> = {
         regionIntent: params?.regionIntent,
         levelName: params?.levelName,
         crossRegion: params?.crossRegion,
         targetCountry: params?.targetCountry,
+        correctSession: params?.correctSession,
     }
 
     try {
@@ -93,7 +99,10 @@ export const initiateSumsubKyc = async (params?: {
         const responseJson = await response.json()
 
         if (!response.ok) {
-            return backendOrFallback(responseJson, 'Failed to initiate identity verification', 'initiate_failed')
+            return {
+                ...backendOrFallback(responseJson, 'Failed to initiate identity verification', 'initiate_failed'),
+                ...(responseJson.session ? { data: responseJson as InitiateSumsubKycResponse } : {}),
+            }
         }
 
         return {
@@ -102,6 +111,8 @@ export const initiateSumsubKyc = async (params?: {
                 applicantId: responseJson.applicantId,
                 status: responseJson.status,
                 actionType: responseJson.actionType,
+                session: responseJson.session,
+                workflow: responseJson.workflow,
             },
         }
     } catch (e: unknown) {
@@ -293,4 +304,25 @@ export const startKycAction = async (
     } catch (e: unknown) {
         return caughtError(e)
     }
+}
+
+export async function refreshVerificationSession(
+    session: Pick<VerificationActionSession, 'id' | 'generation'>
+): Promise<string> {
+    const response = await serverFetch('/users/identity/session-token', {
+        method: 'POST',
+        body: JSON.stringify({ sessionId: session.id, generation: session.generation }),
+    })
+    const data = await response.json()
+    if (!response.ok || !data.token) throw new Error('Verification session changed. Please reopen verification.')
+    return data.token
+}
+
+export async function getVerificationSession(id: string): Promise<VerificationActionSession | null> {
+    const response = await serverFetch(`/users/identity/sessions/${encodeURIComponent(id)}`, {
+        method: 'GET',
+        cache: 'no-store',
+    })
+    if (!response.ok) return null
+    return (await response.json()).session ?? null
 }

--- a/src/app/actions/types/sumsub.types.ts
+++ b/src/app/actions/types/sumsub.types.ts
@@ -11,6 +11,8 @@ export interface InitiateSumsubKycResponse {
     token: string | null // null when user is already APPROVED or bridge-direct
     applicantId: string | null
     status: SumsubKycStatus
+    session?: VerificationActionSession
+    workflow?: { regionIntent?: KYCRegionIntent; isMultiLevel: boolean }
     actionType?: KycActionType // present for cross-region responses
 }
 
@@ -36,3 +38,20 @@ export type SumsubKycStatus =
  * pattern keep sending it. Remove once every call site sends one of the four.
  */
 export type KYCRegionIntent = 'LATAM' | 'ROW' | 'EU' | 'NA' | 'STANDARD'
+
+export interface VerificationActionSession {
+    id: string
+    generation: number
+    state:
+        | 'COLLECTING'
+        | 'REVIEW_PENDING'
+        | 'SUBMISSION_PENDING'
+        | 'CORRECTION_REQUIRED'
+        | 'PROVIDER_PENDING'
+        | 'READY'
+        | 'BLOCKED'
+    reasonCode: string | null
+    targetCountry: string
+    externalActionId: string
+    isMultiLevel: boolean
+}

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -1,3 +1,5 @@
+import ActionModal from '@/components/Global/ActionModal'
+import { useTranslations } from 'next-intl'
 import { KycRestartCooldownModal } from './KycRestartCooldownModal'
 import { SumsubKycWrapper } from '@/components/Kyc/SumsubKycWrapper'
 import { KycVerificationInProgressModal } from '@/components/Kyc/KycVerificationInProgressModal'
@@ -17,8 +19,17 @@ interface SumsubKycModalsProps {
  * pair with useMultiPhaseKycFlow hook for the logic.
  */
 export const SumsubKycModals = ({ flow, onCooldownClose }: SumsubKycModalsProps) => {
+    const t = useTranslations('kyc.correction')
     return (
         <>
+            <ActionModal
+                visible={flow.showCorrection}
+                onClose={flow.dismissCorrection}
+                title={t('title')}
+                description={flow.verificationSession?.reasonCode === 'INVALID_TAX_ID' ? t('taxId') : t('details')}
+                tone="warning"
+                ctas={[{ text: t('correct'), variant: 'purple', onClick: flow.correctVerificationData }]}
+            />
             <KycRestartCooldownModal
                 cooldown={flow.errorCooldown}
                 onClose={() => {
@@ -27,6 +38,11 @@ export const SumsubKycModals = ({ flow, onCooldownClose }: SumsubKycModalsProps)
                 }}
             />
             <SumsubKycWrapper
+                sessionKey={
+                    flow.verificationSession
+                        ? `${flow.verificationSession.id}:${flow.verificationSession.generation}`
+                        : undefined
+                }
                 visible={flow.showWrapper}
                 accessToken={flow.accessToken}
                 onClose={flow.handleSdkClose}

--- a/src/components/Kyc/SumsubKycModals.tsx
+++ b/src/components/Kyc/SumsubKycModals.tsx
@@ -23,7 +23,7 @@ export const SumsubKycModals = ({ flow, onCooldownClose }: SumsubKycModalsProps)
     return (
         <>
             <ActionModal
-                visible={flow.showCorrection}
+                visible={flow.showCorrection === true}
                 onClose={flow.dismissCorrection}
                 title={t('title')}
                 description={flow.verificationSession?.reasonCode === 'INVALID_TAX_ID' ? t('taxId') : t('details')}

--- a/src/components/Kyc/SumsubWebSdkModal.tsx
+++ b/src/components/Kyc/SumsubWebSdkModal.tsx
@@ -17,6 +17,7 @@ import type { SumsubSdkProps, SumsubHelpModalVariant } from './sumsubSdk.types'
  */
 export const SumsubWebSdkModal = ({
     visible,
+    sessionKey,
     accessToken,
     onClose,
     onComplete,
@@ -32,6 +33,7 @@ export const SumsubWebSdkModal = ({
 
     const { sdkLoadError, setSdkContainer, hasSubmittedRef } = useSumsubWebSdk({
         visible,
+        sessionKey,
         accessToken,
         onComplete,
         onSubmitted,

--- a/src/components/Kyc/__tests__/useSumsubWebSdk.test.ts
+++ b/src/components/Kyc/__tests__/useSumsubWebSdk.test.ts
@@ -116,3 +116,28 @@ describe('useSumsubWebSdk', () => {
         expect(result.current.sdkLoadError).toBe(false)
     })
 })
+
+describe('SDK credential lifecycle', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        installSdk()
+    })
+    afterEach(() => {
+        delete (window as unknown as { snsWebSdk?: unknown }).snsWebSdk
+    })
+    it('refreshing the token preserves the mounted questionnaire; changing session replaces it', () => {
+        let token = 'first'
+        let sessionKey = 'session:0'
+        const { result, rerender } = renderHookWithIntl(() =>
+            useSumsubWebSdk({ ...baseArgs(), accessToken: token, sessionKey })
+        )
+        act(() => result.current.setSdkContainer(document.createElement('div')))
+        expect(launch).toHaveBeenCalledTimes(1)
+        token = 'refreshed'
+        rerender()
+        expect(launch).toHaveBeenCalledTimes(1)
+        sessionKey = 'session:1'
+        rerender()
+        expect(launch).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/components/Kyc/sumsubSdk.types.ts
+++ b/src/components/Kyc/sumsubSdk.types.ts
@@ -4,6 +4,7 @@
  * interchangeable from a call site's point of view.
  */
 export interface SumsubSdkProps {
+    sessionKey?: string
     visible: boolean
     accessToken: string | null
     onClose: () => void

--- a/src/components/Kyc/useSumsubWebSdk.ts
+++ b/src/components/Kyc/useSumsubWebSdk.ts
@@ -38,6 +38,7 @@ type UseSumsubWebSdkArgs = Omit<SumsubSdkProps, 'onClose'>
  */
 export function useSumsubWebSdk({
     visible,
+    sessionKey,
     accessToken,
     onComplete,
     onSubmitted,
@@ -45,6 +46,9 @@ export function useSumsubWebSdk({
     onRefreshToken,
     isMultiLevel,
 }: UseSumsubWebSdkArgs) {
+    const accessTokenRef = useRef(accessToken)
+    accessTokenRef.current = accessToken
+    const hasAccessToken = !!accessToken
     const [sdkLoaded, setSdkLoaded] = useState(false)
     const [sdkLoadError, setSdkLoadError] = useState(false)
     // Callback ref, NOT useRef: Modal is a headlessui <Transition>, which promotes
@@ -131,7 +135,7 @@ export function useSumsubWebSdk({
 
     // initialize sdk as soon as the modal is visible and all deps are ready
     useEffect(() => {
-        if (!visible || !accessToken || !sdkLoaded || !sdkContainer) return
+        if (!visible || !hasAccessToken || !sdkLoaded || !sdkContainer) return
 
         // clean up previous instance
         if (sdkInstanceRef.current) {
@@ -220,7 +224,7 @@ export function useSumsubWebSdk({
             const handleActionCompleted = handleStatusEvent('onApplicantActionStatusChanged')
 
             const sdk = window.snsWebSdk
-                .init(accessToken, stableOnRefreshToken)
+                .init(accessTokenRef.current!, stableOnRefreshToken)
                 .withConf({ lang: sumsubLocaleRef.current, theme: 'light' })
                 .withOptions({ addViewportTag: false, adaptIframeHeight: true })
                 .on('onApplicantSubmitted', handleSubmitted)
@@ -293,7 +297,8 @@ export function useSumsubWebSdk({
         }
     }, [
         visible,
-        accessToken,
+        hasAccessToken,
+        sessionKey,
         sdkLoaded,
         sdkContainer,
         stableOnComplete,

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -1,8 +1,8 @@
 import { act } from '@testing-library/react'
 import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
 import posthog from 'posthog-js'
-import { useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
-import { initiateSumsubKyc } from '@/app/actions/sumsub'
+import { deriveCapabilityPhaseSignals, useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
+import { getVerificationSession, refreshVerificationSession, initiateSumsubKyc } from '@/app/actions/sumsub'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // Pins the KYC_REJECTED capture + user-store refresh effect: it must be
@@ -19,6 +19,8 @@ jest.mock('@/app/actions/sumsub', () => ({
     // isTerminalActionCode must come from the real module, or the hook's
     // terminal-refusal branch calls undefined and every initiate bails.
     initiateSumsubKyc: jest.fn(),
+    getVerificationSession: jest.fn(),
+    refreshVerificationSession: jest.fn(),
     initiateSelfHealResubmission: jest.fn(),
     restartIdentityVerification: jest.fn(),
     startKycAction: jest.fn(),
@@ -174,5 +176,150 @@ describe('useMultiPhaseKycFlow — KYC_REJECTED capture effect', () => {
             expect(rejectedCaptures()).toHaveLength(1)
             expect(mockFetchUser).toHaveBeenCalledTimes(1)
         })
+    })
+})
+
+describe('deposit session regression contracts', () => {
+    const session = (state: 'COLLECTING' | 'SUBMISSION_PENDING' | 'CORRECTION_REQUIRED' | 'READY', generation = 0) => ({
+        id: 'session-1',
+        generation,
+        state,
+        reasonCode: state === 'CORRECTION_REQUIRED' ? 'INVALID_TAX_ID' : null,
+        targetCountry: 'AR',
+        externalActionId: `manteca-user-${generation}-AR`,
+        isMultiLevel: false,
+    })
+    beforeEach(() => {
+        jest.useFakeTimers()
+        jest.clearAllMocks()
+        mockInitiate.mockReset()
+        ;(getVerificationSession as jest.Mock).mockResolvedValue(session('SUBMISSION_PENDING'))
+        mockFetchUser.mockResolvedValue(null)
+    })
+    afterEach(() => jest.useRealTimers())
+    it('accepted documents wait via read-only progress, ignore base APPROVED and complete only once READY', async () => {
+        mockInitiate.mockResolvedValue({
+            data: {
+                token: null,
+                applicantId: 'app',
+                status: 'IN_REVIEW',
+                actionType: 'manteca',
+                session: session('SUBMISSION_PENDING'),
+            },
+        })
+        const success = jest.fn()
+        const { result } = renderHook(() => useMultiPhaseKycFlow({ onKycSuccess: success }))
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'AR')
+        })
+        await act(async () => {
+            mockWs.handler?.('APPROVED')
+            await jest.advanceTimersByTimeAsync(12000)
+        })
+        expect(success).not.toHaveBeenCalled()
+        expect(result.current.showWrapper).toBe(false)
+        expect(mockInitiate).toHaveBeenCalledTimes(1)
+        expect(getVerificationSession).toHaveBeenCalledWith('session-1')
+        ;(getVerificationSession as jest.Mock).mockResolvedValue(session('READY'))
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(4000)
+        })
+        expect(success).toHaveBeenCalledTimes(1)
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(8000)
+        })
+        expect(success).toHaveBeenCalledTimes(1)
+    })
+    it('correction is explicit and retains the target country', async () => {
+        mockInitiate.mockResolvedValueOnce({
+            error: 'correct data',
+            data: { token: null, applicantId: 'app', status: 'IN_REVIEW', session: session('CORRECTION_REQUIRED') },
+        })
+        const { result } = renderHook(() => useMultiPhaseKycFlow({}))
+        await act(async () => {
+            await result.current.handleInitiateKyc('LATAM', undefined, true, 'AR')
+        })
+        expect(result.current.showCorrection).toBe(true)
+        expect(result.current.showWrapper).toBe(false)
+        mockInitiate.mockResolvedValueOnce({
+            data: {
+                token: 'new-token',
+                applicantId: 'app',
+                status: 'APPROVED',
+                actionType: 'manteca',
+                session: session('COLLECTING', 1),
+            },
+        })
+        await act(async () => {
+            await result.current.correctVerificationData()
+        })
+        expect(mockInitiate).toHaveBeenLastCalledWith(
+            expect.objectContaining({ regionIntent: 'LATAM', targetCountry: 'AR', correctSession: true })
+        )
+        expect(result.current.showWrapper).toBe(true)
+        ;(refreshVerificationSession as jest.Mock).mockResolvedValue('refreshed')
+        await act(async () => {
+            expect(await result.current.refreshToken()).toBe('refreshed')
+        })
+        expect(refreshVerificationSession).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'session-1', generation: 1 })
+        )
+        expect(mockInitiate).toHaveBeenCalledTimes(2)
+    })
+    it('a generic drawer resume uses the server workflow descriptor', async () => {
+        mockInitiate.mockResolvedValue({
+            data: {
+                token: 'workflow-token',
+                applicantId: 'app',
+                status: 'PENDING',
+                workflow: { regionIntent: 'EU', isMultiLevel: true },
+            },
+        })
+        const { result } = renderHook(() => useMultiPhaseKycFlow({}))
+        await act(async () => {
+            await result.current.handleInitiateKyc()
+        })
+        expect(result.current.isMultiLevel).toBe(true)
+        await act(async () => {
+            mockWs.handler?.('ACTION_REQUIRED')
+        })
+        expect(result.current.showWrapper).toBe(true)
+    })
+    it('skipping terms is dismissal, never successful verification', () => {
+        const success = jest.fn()
+        const { result } = renderHook(() => useMultiPhaseKycFlow({ onKycSuccess: success }))
+        act(() => result.current.handleSkipTerms())
+        expect(success).not.toHaveBeenCalled()
+    })
+    it.each(['blocked', 'requires-info', 'unavailable', 'pending'])(
+        'a %s deposit rail cannot be success even when QR is enabled',
+        (status) => {
+            const capabilities = {
+                rails: [
+                    { provider: 'bridge', channel: 'bank', country: 'EU', currency: 'EUR', status },
+                    { provider: 'manteca', channel: 'qr-only', country: 'AR', currency: 'ARS', status: 'enabled' },
+                ],
+                nextActions: [],
+                restrictions: [],
+            }
+            expect(deriveCapabilityPhaseSignals(capabilities as never, 'EU').allSettled).toBe(false)
+        }
+    )
+    it('an enabled account in another country cannot complete an AR deposit flow', () => {
+        const capabilities = {
+            rails: [
+                {
+                    provider: 'manteca',
+                    channel: 'bank',
+                    country: 'BR',
+                    currency: 'BRL',
+                    status: 'enabled',
+                    operations: { deposit: 'enabled' },
+                },
+            ],
+            nextActions: [],
+            restrictions: [],
+        }
+        expect(deriveCapabilityPhaseSignals(capabilities as never, 'LATAM', 'AR').allSettled).toBe(false)
     })
 })

--- a/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
+++ b/src/hooks/__tests__/useMultiPhaseKycFlow.test.ts
@@ -3,6 +3,7 @@ import { renderHookWithIntl as renderHook } from '@/test-utils/intl'
 import posthog from 'posthog-js'
 import { deriveCapabilityPhaseSignals, useMultiPhaseKycFlow } from '@/hooks/useMultiPhaseKycFlow'
 import { getVerificationSession, refreshVerificationSession, initiateSumsubKyc } from '@/app/actions/sumsub'
+import { markSubmitted } from '@/hooks/useSubmissionWindow'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
 
 // Pins the KYC_REJECTED capture + user-store refresh effect: it must be
@@ -224,6 +225,31 @@ describe('deposit session regression contracts', () => {
         await act(async () => {
             await jest.advanceTimersByTimeAsync(4000)
         })
+        // READY is necessary but the downstream capability snapshot must catch up.
+        expect(success).not.toHaveBeenCalled()
+        expect(markSubmitted).toHaveBeenCalled()
+        expect(mockFetchUser).toHaveBeenCalled()
+        const refreshed = {
+            capabilities: {
+                rails: [
+                    {
+                        provider: 'manteca',
+                        channel: 'bank',
+                        country: 'AR',
+                        currency: 'ARS',
+                        status: 'enabled',
+                        operations: { deposit: 'enabled' },
+                    },
+                ],
+                nextActions: [],
+                restrictions: [],
+            },
+        }
+        mockFetchUser.mockResolvedValue(refreshed)
+        await act(async () => {
+            await jest.advanceTimersByTimeAsync(4000)
+        })
+        expect(deriveCapabilityPhaseSignals(refreshed.capabilities as never, 'LATAM', 'AR').allSettled).toBe(true)
         expect(success).toHaveBeenCalledTimes(1)
         await act(async () => {
             await jest.advanceTimersByTimeAsync(8000)
@@ -305,6 +331,28 @@ describe('deposit session regression contracts', () => {
             expect(deriveCapabilityPhaseSignals(capabilities as never, 'EU').allSettled).toBe(false)
         }
     )
+    it.each([
+        ['GB', 'GBP', 'EU'],
+        ['MX', 'MXN', 'NA'],
+    ] as const)('uses the requested %s bank jurisdiction', (country, currency, intent) => {
+        const capabilities = {
+            rails: [{ provider: 'bridge', channel: 'bank', country, currency, status: 'enabled' }],
+            nextActions: [],
+            restrictions: [],
+        }
+        expect(deriveCapabilityPhaseSignals(capabilities as never, intent, country).allSettled).toBe(true)
+        const other = {
+            ...capabilities,
+            rails: [
+                {
+                    ...capabilities.rails[0],
+                    country: intent === 'EU' ? 'EU' : 'US',
+                    currency: intent === 'EU' ? 'EUR' : 'USD',
+                },
+            ],
+        }
+        expect(deriveCapabilityPhaseSignals(other as never, intent, country).allSettled).toBe(false)
+    })
     it('an enabled account in another country cannot complete an AR deposit flow', () => {
         const capabilities = {
             rails: [

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -1,3 +1,4 @@
+import { railJurisdictionForBank } from '@/utils/bridge.utils'
 import { useTranslations } from 'next-intl'
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useAuth } from '@/context/authContext'
@@ -34,6 +35,7 @@ export function deriveCapabilityPhaseSignals(
     targetCountry?: string
 ) {
     const { rails: allRails, nextActions } = capabilities ?? EMPTY_CAPABILITIES
+    const jurisdiction = railJurisdictionForBank(targetCountry)
     const rails = allRails.filter(
         (rail) =>
             rail.channel === 'bank' &&
@@ -42,8 +44,13 @@ export function deriveCapabilityPhaseSignals(
                 : intent === 'EU' || intent === 'NA'
                   ? rail.provider === 'bridge'
                   : true) &&
-            (intent === 'LATAM' && targetCountry ? rail.country === targetCountry : true) &&
-            (intent === 'EU' ? rail.currency === 'EUR' : intent === 'NA' ? rail.currency === 'USD' : true)
+            (jurisdiction
+                ? rail.country === jurisdiction
+                : intent === 'EU'
+                  ? rail.currency === 'EUR'
+                  : intent === 'NA'
+                    ? rail.currency === 'USD'
+                    : true)
     )
     const anyPending = rails.some((rail) => (rail.operations?.deposit ?? rail.status) === 'pending')
     // The accept-tos branch sits above the identity check in deriveGate's
@@ -453,24 +460,54 @@ export const useMultiPhaseKycFlow = ({
     }, [modalPhase, preparingTimedOut, clearPreparingTimer])
 
     const completedSessionRef = useRef<string | null>(null)
+    const sessionId = verificationSession?.id
+    const sessionGeneration = verificationSession?.generation
+    const sessionState = verificationSession?.state
+    const sessionCountry = verificationSession?.targetCountry
     useEffect(() => {
-        if (!verificationSession) return
-        if (verificationSession.state === 'CORRECTION_REQUIRED' || verificationSession.state === 'BLOCKED') {
+        if (!sessionId) return
+        if (sessionState === 'CORRECTION_REQUIRED' || sessionState === 'BLOCKED') {
             setForceShowModal(false)
             clearPreparingTimer()
             return
         }
         if (!isVerificationProgressModalOpen) return
-        if (verificationSession.state === 'READY') {
-            const key = `${verificationSession.id}:${verificationSession.generation}`
-            if (completedSessionRef.current !== key) {
-                completedSessionRef.current = key
-                completeFlow()
+        setModalPhase('preparing')
+        if (sessionState !== 'READY') return
+        const key = `${sessionId}:${sessionGeneration}`
+        if (completedSessionRef.current === key) return
+        let cancelled = false
+        let timer: ReturnType<typeof setTimeout> | undefined
+        const refreshBeforeCompletion = async () => {
+            markSubmitted()
+            try {
+                const refreshed = await fetchUser()
+                if (cancelled) return
+                if (deriveCapabilityPhaseSignals(refreshed?.capabilities, 'LATAM', sessionCountry).allSettled) {
+                    completedSessionRef.current = key
+                    completeFlow()
+                    return
+                }
+            } catch {
+                // Keep the flow pending until the refreshed downstream gate is usable.
             }
-        } else {
-            setModalPhase('preparing')
+            if (!cancelled) timer = setTimeout(refreshBeforeCompletion, 4000)
         }
-    }, [verificationSession, isVerificationProgressModalOpen, completeFlow, clearPreparingTimer])
+        void refreshBeforeCompletion()
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+        }
+    }, [
+        sessionId,
+        sessionGeneration,
+        sessionState,
+        sessionCountry,
+        isVerificationProgressModalOpen,
+        fetchUser,
+        completeFlow,
+        clearPreparingTimer,
+    ])
 
     // phase transitions driven by rail tracking
     useEffect(() => {

--- a/src/hooks/useMultiPhaseKycFlow.ts
+++ b/src/hooks/useMultiPhaseKycFlow.ts
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useAuth } from '@/context/authContext'
 import { useSumsubKycFlow } from '@/hooks/useSumsubKycFlow'
@@ -25,11 +26,26 @@ const EMPTY_CAPABILITIES: UserCapabilities = { rails: [], nextActions: [], restr
  *     action (today, the ONLY ToS-acceptance flow on the platform — sources
  *     from the gate state's `accept-tos` kind, scoped to the bank channel).
  *   - anyPending ← any rail provisioning, no user action needed.
- *   - allSettled ← rails non-empty AND none pending.
+ *   - allSettled ← at least one usable deposit rail for the requested destination.
  */
-function deriveCapabilityPhaseSignals(capabilities: UserCapabilities | undefined) {
-    const { rails, nextActions } = capabilities ?? EMPTY_CAPABILITIES
-    const anyPending = rails.some((rail) => rail.status === 'pending')
+export function deriveCapabilityPhaseSignals(
+    capabilities: UserCapabilities | undefined,
+    intent?: KYCRegionIntent,
+    targetCountry?: string
+) {
+    const { rails: allRails, nextActions } = capabilities ?? EMPTY_CAPABILITIES
+    const rails = allRails.filter(
+        (rail) =>
+            rail.channel === 'bank' &&
+            (intent === 'LATAM'
+                ? rail.provider === 'manteca'
+                : intent === 'EU' || intent === 'NA'
+                  ? rail.provider === 'bridge'
+                  : true) &&
+            (intent === 'LATAM' && targetCountry ? rail.country === targetCountry : true) &&
+            (intent === 'EU' ? rail.currency === 'EUR' : intent === 'NA' ? rail.currency === 'USD' : true)
+    )
+    const anyPending = rails.some((rail) => (rail.operations?.deposit ?? rail.status) === 'pending')
     // The accept-tos branch sits above the identity check in deriveGate's
     // priority order; identityVerified doesn't affect it. Passing `false` here
     // is safe + avoids reading identityVerification.status to find a ToS state.
@@ -39,8 +55,9 @@ function deriveCapabilityPhaseSignals(capabilities: UserCapabilities | undefined
     return {
         needsTos: gate.kind === 'accept-tos',
         anyPending,
+        allBlocked: rails.length > 0 && rails.every((rail) => (rail.operations?.deposit ?? rail.status) === 'blocked'),
         // mirrors old allSettled: empty rails are NOT settled (still provisioning)
-        allSettled: rails.length > 0 && !anyPending,
+        allSettled: rails.some((rail) => (rail.operations?.deposit ?? rail.status) === 'enabled'),
         railCount: rails.length,
     }
 }
@@ -124,6 +141,7 @@ export const useMultiPhaseKycFlow = ({
     regionIntent,
 }: UseMultiPhaseKycFlowOptions) => {
     const { fetchUser, user } = useAuth()
+    const t = useTranslations('kyc')
     const acquisitionSource = user?.invitedBy ? 'referred' : 'organic'
 
     // multi-phase modal state
@@ -141,6 +159,9 @@ export const useMultiPhaseKycFlow = ({
     // completed/abandoned events (LATAM successes fired as kyc_approved with
     // region_intent: None). The last initiated intent wins over the prop.
     const lastIntentRef = useRef<KYCRegionIntent | undefined>(undefined)
+    const [requestedIntent, setRequestedIntent] = useState<KYCRegionIntent | undefined>(regionIntent)
+    const [requestedCountry, setRequestedCountry] = useState<string | undefined>()
+
     // Terminal status already reported for the CURRENT attempt. Cleared on each
     // submission, so a re-opened SDK cannot re-report the same rejection while a
     // genuinely new rejection after a retry still reports (status alone cannot
@@ -166,7 +187,10 @@ export const useMultiPhaseKycFlow = ({
     // The old WebSocket-driven instant rail refresh is replaced by that 4s poll
     // (the old hook already had the same 4s poll as a fallback).
     const { capabilities } = useCapabilities()
-    const { allSettled, needsTos } = useMemo(() => deriveCapabilityPhaseSignals(capabilities), [capabilities])
+    const { allSettled, needsTos, allBlocked } = useMemo(
+        () => deriveCapabilityPhaseSignals(capabilities, requestedIntent, requestedCountry),
+        [capabilities, requestedIntent, requestedCountry]
+    )
     const startTracking = useCallback(() => {}, [])
     const stopTracking = useCallback(() => {}, [])
 
@@ -226,7 +250,11 @@ export const useMultiPhaseKycFlow = ({
         // post-approval branching reads the FRESH capability block from this
         // fetchUser() result (not the reactive useCapabilities() snapshot,
         // which would be stale within this synchronous call).
-        const { needsTos, anyPending, railCount } = deriveCapabilityPhaseSignals(updatedUser?.capabilities)
+        const { needsTos, anyPending, railCount, allSettled } = deriveCapabilityPhaseSignals(
+            updatedUser?.capabilities,
+            lastIntentRef.current ?? regionIntent,
+            requestedCountry
+        )
 
         if (needsTos) {
             setModalPhase('bridge_tos')
@@ -243,9 +271,13 @@ export const useMultiPhaseKycFlow = ({
             return
         }
 
-        // all settled — done
-        completeFlow()
-    }, [fetchUser, startTracking, clearPreparingTimer, completeFlow, onKycApproved])
+        if (allSettled) completeFlow()
+        else {
+            setModalPhase('preparing')
+            setForceShowModal(true)
+            startTracking()
+        }
+    }, [fetchUser, startTracking, clearPreparingTimer, completeFlow, onKycApproved, regionIntent, requestedCountry])
 
     const {
         isLoading,
@@ -268,6 +300,10 @@ export const useMultiPhaseKycFlow = ({
         closeVerificationProgressModal,
         isActionFlow,
         isMultiLevel,
+        verificationSession,
+        showCorrection,
+        correctVerificationData,
+        dismissCorrection,
     } = useSumsubKycFlow({ onKycSuccess: handleSumsubApproved, onManualClose, regionIntent })
 
     // keep ref in sync
@@ -333,10 +369,10 @@ export const useMultiPhaseKycFlow = ({
         originalHandleSdkComplete()
         // for action flows (manteca, self-heal), the base status is already APPROVED
         // and won't transition — directly start the preparing/tracking phase
-        if (isActionFlow) {
+        if (isActionFlow && !verificationSession) {
             handleSumsubApproved()
         }
-    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent])
+    }, [originalHandleSdkComplete, handleSumsubApproved, isActionFlow, regionIntent, verificationSession])
 
     // true only while a PWA-reload resume drives handleInitiateKyc, so the
     // analytics event can distinguish a resume from a genuine new initiation
@@ -357,12 +393,14 @@ export const useMultiPhaseKycFlow = ({
         async (overrideIntent?: KYCRegionIntent, levelName?: string, crossRegion?: boolean, targetCountry?: string) => {
             const intent = overrideIntent ?? regionIntent
             lastIntentRef.current = intent
+            setRequestedIntent(intent)
             lastInitiateArgsRef.current = { intent, levelName, crossRegion, targetCountry }
             posthog.capture(
                 intent === 'LATAM' ? ANALYTICS_EVENTS.MANTECA_KYC_INITIATED : ANALYTICS_EVENTS.KYC_INITIATED,
                 { region_intent: intent, acquisition_source: acquisitionSource, resumed: resumingRef.current }
             )
 
+            setRequestedCountry(targetCountry?.toUpperCase())
             setModalPhase('verifying')
             setForceShowModal(false)
             setPreparingTimedOut(false)
@@ -414,9 +452,37 @@ export const useMultiPhaseKycFlow = ({
         }
     }, [modalPhase, preparingTimedOut, clearPreparingTimer])
 
+    const completedSessionRef = useRef<string | null>(null)
+    useEffect(() => {
+        if (!verificationSession) return
+        if (verificationSession.state === 'CORRECTION_REQUIRED' || verificationSession.state === 'BLOCKED') {
+            setForceShowModal(false)
+            clearPreparingTimer()
+            return
+        }
+        if (!isVerificationProgressModalOpen) return
+        if (verificationSession.state === 'READY') {
+            const key = `${verificationSession.id}:${verificationSession.generation}`
+            if (completedSessionRef.current !== key) {
+                completedSessionRef.current = key
+                completeFlow()
+            }
+        } else {
+            setModalPhase('preparing')
+        }
+    }, [verificationSession, isVerificationProgressModalOpen, completeFlow, clearPreparingTimer])
+
     // phase transitions driven by rail tracking
     useEffect(() => {
+        if (verificationSession) return
         if (modalPhase === 'preparing') {
+            if (allBlocked) {
+                clearPreparingTimer()
+                stopTracking()
+                setForceShowModal(false)
+                closeVerificationProgressModal()
+                return
+            }
             if (needsTos) {
                 setModalPhase('bridge_tos')
                 clearPreparingTimer()
@@ -432,7 +498,16 @@ export const useMultiPhaseKycFlow = ({
                 stopTracking()
             }
         }
-    }, [modalPhase, needsTos, allSettled, clearPreparingTimer, stopTracking])
+    }, [
+        modalPhase,
+        needsTos,
+        allSettled,
+        allBlocked,
+        clearPreparingTimer,
+        stopTracking,
+        verificationSession,
+        closeVerificationProgressModal,
+    ])
 
     // handle "Accept Terms" click in bridge_tos phase
     const handleAcceptTerms = useCallback(async () => {
@@ -486,7 +561,19 @@ export const useMultiPhaseKycFlow = ({
                         }
                         posthog.capture(ANALYTICS_EVENTS.KYC_TOS_ACCEPTED)
                     }
-                    completeFlow()
+                    const refreshed = await fetchUser()
+                    if (
+                        deriveCapabilityPhaseSignals(
+                            refreshed?.capabilities,
+                            lastIntentRef.current ?? regionIntent,
+                            requestedCountry
+                        ).allSettled
+                    )
+                        completeFlow()
+                    else {
+                        setModalPhase('preparing')
+                        setForceShowModal(true)
+                    }
                 } catch {
                     // Don't leave the modal frozen on 'preparing' with no feedback
                     // if the confirm POST / rails poll throws — surface the
@@ -497,13 +584,8 @@ export const useMultiPhaseKycFlow = ({
             }
             // if manual close, stay on bridge_tos phase (user can try again)
         },
-        [fetchUser, completeFlow]
+        [fetchUser, completeFlow, regionIntent, requestedCountry]
     )
-
-    // handle "Skip for now" in bridge_tos phase
-    const handleSkipTerms = useCallback(() => {
-        completeFlow()
-    }, [completeFlow])
 
     // handle modal close (Go to Home, etc.)
     const handleModalClose = useCallback(() => {
@@ -518,6 +600,9 @@ export const useMultiPhaseKycFlow = ({
         stopTracking()
         closeVerificationProgressModal()
     }, [clearPreparingTimer, stopTracking, closeVerificationProgressModal, regionIntent, modalPhase])
+
+    // Deferring terms is a dismissal, never successful deposit readiness.
+    const handleSkipTerms = handleModalClose
 
     // cleanup on unmount
     useEffect(() => {
@@ -536,6 +621,8 @@ export const useMultiPhaseKycFlow = ({
         return 'slow'
     }, [preparingElapsed])
 
+    const depositBlocked = !verificationSession && !showWrapper && allBlocked && modalPhase === 'preparing'
+
     return {
         // initiation
         handleInitiateKyc,
@@ -544,14 +631,18 @@ export const useMultiPhaseKycFlow = ({
         handleStartAction,
         handleFixableRejection,
         isLoading,
-        error,
+        error: error ?? (depositBlocked ? t('railsUnavailableError') : null),
         errorCooldown,
         dismissErrorCooldown,
         // terminal = the user has no action that changes the outcome; consumers
         // must suppress their retry CTA on it (TASK-21882)
-        isTerminalError,
+        isTerminalError: isTerminalError || depositBlocked,
         liveKycStatus,
 
+        verificationSession,
+        showCorrection,
+        correctVerificationData,
+        dismissCorrection,
         // SDK wrapper
         showWrapper,
         accessToken,

--- a/src/hooks/useSumsubKycFlow.ts
+++ b/src/hooks/useSumsubKycFlow.ts
@@ -5,13 +5,19 @@ import { useWebSocket } from '@/hooks/useWebSocket'
 import { useAuth } from '@/context/authContext'
 import {
     initiateSumsubKyc,
+    getVerificationSession,
+    refreshVerificationSession,
     initiateSelfHealResubmission,
     restartIdentityVerification,
     startKycAction,
     isTerminalActionCode,
     type SumsubActionErrorCode,
 } from '@/app/actions/sumsub'
-import { type KYCRegionIntent, type SumsubKycStatus } from '@/app/actions/types/sumsub.types'
+import {
+    type KYCRegionIntent,
+    type SumsubKycStatus,
+    type VerificationActionSession,
+} from '@/app/actions/types/sumsub.types'
 import { isMantecaSupportedCountryCode } from '@/constants/manteca.consts'
 import { isDemoMode } from '@/utils/demo'
 
@@ -107,6 +113,11 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     )
 
     const [accessToken, setAccessToken] = useState<string | null>(null)
+    const [verificationSession, setVerificationSession] = useState<VerificationActionSession | null>(null)
+    const verificationSessionRef = useRef<VerificationActionSession | null>(null)
+    const sessionId = verificationSession?.id
+    const sessionGeneration = verificationSession?.generation
+    const [showCorrection, setShowCorrection] = useState(false)
     const [showWrapper, setShowWrapper] = useState(false)
     const [isLoading, setIsLoading] = useState(false)
     const [error, setErrorState] = useState<string | null>(null)
@@ -121,6 +132,26 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // retriability from the region, which cannot tell the two apart.
     const [isTerminalError, setIsTerminalError] = useState(false)
     const [isVerificationProgressModalOpen, setIsVerificationProgressModalOpen] = useState(false)
+    const acceptSessionView = useCallback(
+        (session: VerificationActionSession) => {
+            verificationSessionRef.current = session
+            setVerificationSession(session)
+            if (session.state === 'CORRECTION_REQUIRED') {
+                setShowWrapper(false)
+                setIsVerificationProgressModalOpen(false)
+                setShowCorrection(true)
+            } else if (session.state === 'BLOCKED') {
+                setShowWrapper(false)
+                setIsVerificationProgressModalOpen(false)
+                setIsTerminalError(true)
+                setError(t('railsUnavailableError'))
+            } else if (session.state === 'READY') {
+                setShowWrapper(false)
+                setIsVerificationProgressModalOpen(true)
+            }
+        },
+        [setError, t]
+    )
     const [liveKycStatus, setLiveKycStatus] = useState<SumsubKycStatus | undefined>(undefined)
     const [rejectLabels, setRejectLabels] = useState<string[] | undefined>(undefined)
     // true when the SDK is showing an applicant action (not a standard level)
@@ -189,6 +220,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         // can never leak a value this guard acts on.
         if (liveKycStatus === 'ACTION_REQUIRED' && showWrapper && isMultiLevel) return
 
+        // A provider action retains base identity approval. Only its own session
+        // can finish this flow, never a stale identity APPROVED websocket event.
+        if (verificationSessionRef.current) return
         const prevStatus = prevStatusRef.current
         prevStatusRef.current = liveKycStatus
 
@@ -257,7 +291,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // it keeps polling for the whole modal-open lifetime so a late/missed
     // websocket event is always eventually recovered.
     useEffect(() => {
-        if (!isVerificationProgressModalOpen) return
+        if (!isVerificationProgressModalOpen || sessionId) return
 
         const startedAt = Date.now()
         let timeoutId: ReturnType<typeof setTimeout>
@@ -294,14 +328,15 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
             cancelled = true
             clearTimeout(timeoutId)
         }
-    }, [isVerificationProgressModalOpen])
+    }, [isVerificationProgressModalOpen, sessionId])
 
     const handleInitiateKyc = useCallback(
         async (
             overrideIntent?: KYCRegionIntent,
             levelName?: string,
             crossRegion?: boolean,
-            rawTargetCountry?: string
+            rawTargetCountry?: string,
+            correctSession = false
         ) => {
             // targetCountry is only ever consumed by the BE as a Manteca geo
             // (pendingMantecaGeo stamp + action externalId suffix). Call sites
@@ -342,7 +377,21 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                     levelName,
                     crossRegion,
                     targetCountry,
+                    correctSession,
                 })
+
+                if (response.data?.session) {
+                    userInitiatedRef.current = false
+                    acceptSessionView(response.data.session)
+                    if (['CORRECTION_REQUIRED', 'BLOCKED'].includes(response.data.session.state)) return false
+                    if (!response.data.token && response.data.session.state !== 'BLOCKED') {
+                        setIsVerificationProgressModalOpen(true)
+                        return false
+                    }
+                } else {
+                    verificationSessionRef.current = null
+                    setVerificationSession(null)
+                }
 
                 // A refusal no retry can change — no resolvable country for this
                 // entry point, or a permanent restriction like Manteca's
@@ -394,7 +443,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 }
 
                 // update effective intent + level for token refresh
-                const effectiveIntent = overrideIntent ?? regionIntent
+                const effectiveIntent = response.data?.workflow?.regionIntent ?? overrideIntent ?? regionIntent
                 if (effectiveIntent) regionIntentRef.current = effectiveIntent
                 levelNameRef.current = levelName
                 targetCountryRef.current = targetCountry
@@ -452,7 +501,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                      */
                     setIsActionFlow(!!actionType && actionType !== 'bridge-uplift')
                     setIsMultiLevel(
-                        (!actionType || actionType === 'bridge-uplift') && isMultiLevelIntent(effectiveIntent)
+                        response.data.session?.isMultiLevel ??
+                            response.data.workflow?.isMultiLevel ??
+                            ((!actionType || actionType === 'bridge-uplift') && isMultiLevelIntent(effectiveIntent))
                     )
                     setShowWrapper(true)
                     return true
@@ -472,8 +523,56 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 initiatingRef.current = false
             }
         },
-        [regionIntent, onKycSuccess, t, actionErrorMessage]
+        [regionIntent, onKycSuccess, t, actionErrorMessage, acceptSessionView, setError]
     )
+
+    const correctVerificationData = useCallback(async () => {
+        const session = verificationSessionRef.current
+        if (!session || session.state !== 'CORRECTION_REQUIRED') return
+        setShowCorrection(false)
+        await handleInitiateKyc('LATAM', undefined, true, session.targetCountry, true)
+    }, [handleInitiateKyc])
+    const dismissCorrection = useCallback(() => setShowCorrection(false), [])
+
+    // Poll progress through a read-only endpoint. Never call initiation to poll
+    // an accepted action: doing so used to mint the same completed questionnaire.
+    useEffect(() => {
+        if (!sessionId || (!showWrapper && !isVerificationProgressModalOpen)) return
+        let cancelled = false
+        let timer: ReturnType<typeof setTimeout>
+        const poll = async () => {
+            try {
+                const session = await getVerificationSession(sessionId)
+                if (
+                    !cancelled &&
+                    session &&
+                    verificationSessionRef.current?.id === session.id &&
+                    verificationSessionRef.current.generation === session.generation
+                )
+                    acceptSessionView(session)
+                else if (
+                    !cancelled &&
+                    session &&
+                    session.id === verificationSessionRef.current?.id &&
+                    session.generation > verificationSessionRef.current.generation
+                ) {
+                    setShowWrapper(false)
+                    acceptSessionView(session)
+                    if (!['CORRECTION_REQUIRED', 'BLOCKED'].includes(session.state))
+                        setIsVerificationProgressModalOpen(true)
+                }
+            } catch {
+                /* Keep waiting on transient reads; never infer completion. */
+            } finally {
+                if (!cancelled) timer = setTimeout(poll, 4000)
+            }
+        }
+        void poll()
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+        }
+    }, [sessionId, sessionGeneration, showWrapper, isVerificationProgressModalOpen, acceptSessionView])
 
     // called when sdk signals applicant submitted
     const handleSdkComplete = useCallback(() => {
@@ -504,6 +603,8 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // routes by how the flow started: start-action key, self-heal provider, or
     // the regular KYC endpoint.
     const refreshToken = useCallback(async (): Promise<string> => {
+        if (verificationSessionRef.current) return refreshVerificationSession(verificationSessionRef.current)
+
         if (actionKeyRef.current) {
             const response = await startKycAction(actionKeyRef.current)
             if (response.error || !response.data?.token) {
@@ -548,7 +649,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     const resetError = useCallback(() => {
         setIsTerminalError(false)
         setError(null)
-    }, [])
+    }, [setError])
 
     // Reset Sumsub IDENTITY step + open the WebSDK with a fresh token. The
     // user lands back on the document-upload screen so they can verify with a
@@ -556,6 +657,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // (Manteca country-ineligibility — uploaded a non-AR/BR document).
     const handleRestartIdentity = useCallback(
         async (overrideIntent?: KYCRegionIntent) => {
+            verificationSessionRef.current = null
+            setVerificationSession(null)
+            setShowCorrection(false)
             setIsLoading(true)
             setError(null)
             setIsTerminalError(false)
@@ -619,7 +723,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setIsLoading(false)
             }
         },
-        [t, actionErrorMessage]
+        [t, actionErrorMessage, setError]
     )
 
     // initiate self-heal document resubmission: calls the resubmit API
@@ -628,6 +732,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // legacy blocking flow.
     const handleSelfHealResubmit = useCallback(
         async (provider: 'BRIDGE' | 'MANTECA', requirementKey?: string) => {
+            verificationSessionRef.current = null
+            setVerificationSession(null)
+            setShowCorrection(false)
             setIsLoading(true)
             setError(null)
             userInitiatedRef.current = true
@@ -664,7 +771,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setIsLoading(false)
             }
         },
-        [t, actionErrorMessage]
+        [t, actionErrorMessage, setError]
     )
 
     // Start a capability nextAction by key (POST /users/kyc/start-action) and
@@ -674,6 +781,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
     // the advisory pre-empt needs to start a future-dated requirement early.
     const handleStartAction = useCallback(
         async (key: string) => {
+            verificationSessionRef.current = null
+            setVerificationSession(null)
+            setShowCorrection(false)
             setIsLoading(true)
             setError(null)
             userInitiatedRef.current = true
@@ -700,7 +810,7 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
                 setIsLoading(false)
             }
         },
-        [t, actionErrorMessage]
+        [t, actionErrorMessage, setError]
     )
 
     // Launch the fix for a `fixable` provider rejection. Manteca RFIs (PEP/FEP,
@@ -743,5 +853,9 @@ export const useSumsubKycFlow = ({ onKycSuccess, onManualClose, regionIntent }: 
         resetError,
         isActionFlow,
         isMultiLevel,
+        verificationSession,
+        showCorrection,
+        correctVerificationData,
+        dismissCorrection,
     }
 }

--- a/src/i18n/app/messages/en.json
+++ b/src/i18n/app/messages/en.json
@@ -3045,6 +3045,12 @@
                 "description": "This verification step is no longer needed. Your current status is on your profile.",
                 "cta": "See my status"
             }
+        },
+        "correction": {
+            "title": "Correct your bank verification details",
+            "taxId": "Your identity is verified, but we could not validate your tax ID for this country. Check and correct it to enable bank transfers.",
+            "details": "Some information needs correcting before bank transfers can be enabled. Your identity verification is saved.",
+            "correct": "Correct details"
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-419.json
+++ b/src/i18n/app/messages/es-419.json
@@ -3045,6 +3045,12 @@
                 "description": "Este paso de verificación ya no es necesario. Tu estado actual está en tu perfil.",
                 "cta": "Ver mi estado"
             }
+        },
+        "correction": {
+            "title": "Corrige los datos de verificación bancaria",
+            "taxId": "Tu identidad está verificada, pero no pudimos validar tu identificación fiscal para este país. Revísala y corrígela para habilitar las transferencias bancarias.",
+            "details": "Hay información que debes corregir para habilitar las transferencias bancarias. Tu verificación de identidad está guardada.",
+            "correct": "Corregir datos"
         }
     },
     "identity": {

--- a/src/i18n/app/messages/es-AR.json
+++ b/src/i18n/app/messages/es-AR.json
@@ -1361,6 +1361,12 @@
             "done": {
                 "title": "Acá ya no queda nada por hacer"
             }
+        },
+        "correction": {
+            "title": "Corregí los datos de verificación bancaria",
+            "taxId": "Tu identidad está verificada, pero no pudimos validar tu identificación fiscal para este país. Revisala y corregila para habilitar las transferencias bancarias.",
+            "details": "Hay información que debés corregir para habilitar las transferencias bancarias. Tu verificación de identidad está guardada.",
+            "correct": "Corregir datos"
         }
     },
     "identity": {

--- a/src/i18n/app/messages/pt-BR.json
+++ b/src/i18n/app/messages/pt-BR.json
@@ -3045,6 +3045,12 @@
                 "description": "Esta etapa de verificação não é mais necessária. Seu status atual está no seu perfil.",
                 "cta": "Ver meu status"
             }
+        },
+        "correction": {
+            "title": "Corrija os dados da verificação bancária",
+            "taxId": "Sua identidade foi verificada, mas não conseguimos validar seu documento fiscal para este país. Confira e corrija os dados para habilitar transferências bancárias.",
+            "details": "Algumas informações precisam ser corrigidas para habilitar transferências bancárias. Sua verificação de identidade está salva.",
+            "correct": "Corrigir dados"
         }
     },
     "identity": {


### PR DESCRIPTION
An accepted verification could reopen the same questionnaire, while base identity approval or an unrelated enabled rail could make the deposit flow report success before bank transfers were usable. This pairs with [API #1594](https://github.com/peanutprotocol/peanut-api-ts/pull/1594) for [TASK-21510](https://app.notion.com/p/3be83811757981a58db4ebb7f48cd404).

- Observe the server's country-specific action session through a read-only progress endpoint. Accepted evidence waits for submission/provider readiness; invalid information opens an explicit correction flow; terminal decisions show support.
- Refresh credentials without remounting the web SDK. Session generations isolate replacement attempts, and server workflow metadata keeps generic multi-level resumes open through the required questionnaire.
- Complete only when the requested bank-deposit operation is usable. QR access, another country's account, rejection, and skipping terms cannot complete the flow.
- Add correction copy in en, es-AR, es-419 and pt-BR, with regression coverage for pending acceptance, stale identity events, session generations, correction, country routing and SDK refresh.

Validation: frozen-lockfile dependencies; 7 relevant UI suites / 113 tests passed, followed by passing focused reruns after the final hook changes; full TypeScript check and changed-file ESLint passed. No production verification was performed.

Rollout: deploy the paired API first, including its migration and audited legacy country-account backfill, then web and native UI releases. See the API recovery runbook for affected-user checks. This PR does not merge, deploy or modify provider configuration.
