### PR TITLE
Filter expected user outcomes from Sentry

### DIFF
--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -227,6 +227,54 @@ describe('shouldIgnoreError — critical-flow captures', () => {
     it('still ignores user cancellations, tagged or not', () => {
         expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'User rejected the request', tags }))).toBe(true)
     })
+
+    it.each([
+        ['Error', 'Permission dismissed'],
+        ['Error', 'Authentication was not completed'],
+        ['Error', 'Login not verified'],
+        ['CardAuthenticationRequiredError', 'Authentication required'],
+        ['RainCooldownError', 'A previous withdrawal is still active'],
+        ['ApiError', 'You reached the limit of 10 cross-chain withdrawals per hour.'],
+        ['ApiError', 'Company has exceeded their debt limit'],
+    ])('still ignores expected behavior in a critical flow: %s / %s', (type, value) => {
+        expect(shouldIgnoreError(eventWith({ type, value, tags }))).toBe(true)
+    })
+
+    it('does not suppress a generic authentication failure', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Authentication required', tags }))).toBe(false)
+    })
+
+    it('does not suppress technical errors containing expected-outcome prose', () => {
+        expect(
+            shouldIgnoreError(
+                eventWith({ type: 'Error', value: 'Login not verified because the auth API returned 500', tags })
+            )
+        ).toBe(false)
+    })
+})
+
+describe('shouldIgnoreError — expected product and SDK outcomes', () => {
+    it.each([
+        'Permission dismissed',
+        'Permission blocked',
+        'Authentication was not completed',
+        'Login not verified',
+        'You reached the limit of 20 cross-chain withdrawals per day.',
+        'You reached the limit of 30 cross-chain withdrawals per 30 days.',
+        'You reached the limit for withdrawals to other networks. Try again later.',
+        '[PostHog.js] This capture call is ignored due to client rate limiting.',
+    ])('ignores %s', (message) => {
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: message }))).toBe(true)
+    })
+
+    it('keeps nearby technical failures', () => {
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Permission SDK missing app ID' }))).toBe(false)
+        expect(
+            shouldIgnoreError(eventWith({ type: 'Error', value: 'Permission blocked by invalid OneSignal config' }))
+        ).toBe(false)
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Rain request failed with HTTP 500' }))).toBe(false)
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'PostHog capture transport failed' }))).toBe(false)
+    })
 })
 
 describe('beforeSendHandler — OneSignal op-failure fingerprint', () => {

--- a/sentry.utils.test.ts
+++ b/sentry.utils.test.ts
@@ -231,10 +231,12 @@ describe('shouldIgnoreError — critical-flow captures', () => {
     it.each([
         ['Error', 'Permission dismissed'],
         ['Error', 'Authentication was not completed'],
-        ['Error', 'Login not verified'],
         ['CardAuthenticationRequiredError', 'Authentication required'],
         ['RainCooldownError', 'A previous withdrawal is still active'],
-        ['ApiError', 'You reached the limit of 10 cross-chain withdrawals per hour.'],
+        [
+            'ApiError',
+            'You reached the limit of 10 cross-chain withdrawals per hour. Try again in about 10 minutes. Arbitrum withdrawals have no limit, or contact support to raise yours.',
+        ],
         ['ApiError', 'Company has exceeded their debt limit'],
     ])('still ignores expected behavior in a critical flow: %s / %s', (type, value) => {
         expect(shouldIgnoreError(eventWith({ type, value, tags }))).toBe(true)
@@ -258,9 +260,8 @@ describe('shouldIgnoreError — expected product and SDK outcomes', () => {
         'Permission dismissed',
         'Permission blocked',
         'Authentication was not completed',
-        'Login not verified',
-        'You reached the limit of 20 cross-chain withdrawals per day.',
-        'You reached the limit of 30 cross-chain withdrawals per 30 days.',
+        'You reached the limit of 20 cross-chain withdrawals per day. Try again in about 3 hours. Arbitrum withdrawals have no limit, or contact support to raise yours.',
+        'You reached the limit of 30 cross-chain transfers per 30 days. Try again in about 2 days, or contact support to raise your limit.',
         'You reached the limit for withdrawals to other networks. Try again later.',
         '[PostHog.js] This capture call is ignored due to client rate limiting.',
     ])('ignores %s', (message) => {
@@ -269,11 +270,25 @@ describe('shouldIgnoreError — expected product and SDK outcomes', () => {
 
     it('keeps nearby technical failures', () => {
         expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Permission SDK missing app ID' }))).toBe(false)
+        expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Login not verified' }))).toBe(false)
+        expect(
+            shouldIgnoreError(
+                eventWith({ type: 'Error', value: 'Login not verified because the auth API returned 500' })
+            )
+        ).toBe(false)
         expect(
             shouldIgnoreError(eventWith({ type: 'Error', value: 'Permission blocked by invalid OneSignal config' }))
         ).toBe(false)
         expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'Rain request failed with HTTP 500' }))).toBe(false)
         expect(shouldIgnoreError(eventWith({ type: 'Error', value: 'PostHog capture transport failed' }))).toBe(false)
+        expect(
+            shouldIgnoreError(
+                eventWith({
+                    type: 'ApiError',
+                    value: 'You reached the limit of 10 cross-chain transfers per hour because the provider returned HTTP 500',
+                })
+            )
+        ).toBe(false)
     })
 })
 

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -109,10 +109,10 @@ const EXPECTED_BEHAVIOR_MESSAGES = [
     /^Permission dismissed\.?$/i,
     /^Permission blocked\.?$/i,
     /^Authentication was not completed\.?$/i,
-    /^Login not verified\.?$/i,
-    /^You reached the limit of 10 cross-chain withdrawals per hour\.?$/i,
-    /^You reached the limit of 20 cross-chain withdrawals per day\.?$/i,
-    /^You reached the limit of 30 cross-chain withdrawals per 30 days\.?$/i,
+    // The API includes a variable cooldown and support hint in these messages.
+    // Match only the complete, known cap contract so a technical failure that
+    // happens to mention a limit still reaches Sentry.
+    /^You reached the limit of (?:10|20|30) cross-chain (?:withdrawals|transfers) per (?:hour|day|30 days)\. Try again in .+$/i,
     /^You reached the limit for withdrawals to other networks(?:\..*)?$/i,
     /^Company has exceeded their debt limit\.?$/i,
     /^\[PostHog\.js\] This capture call is ignored due to client rate limiting\.?$/i,

--- a/sentry.utils.ts
+++ b/sentry.utils.ts
@@ -99,6 +99,31 @@ const IGNORED_ERRORS = {
     ],
 }
 
+// Deliberate product and SDK outcomes. Keep these outside IGNORED_ERRORS' fuzzy
+// substring matcher: a technical error that merely includes similar prose must
+// remain visible. Error classes are exact; messages are anchored to the complete
+// observed outcome, with punctuation/detail allowed only for the variable limit
+// copy we own.
+const EXPECTED_BEHAVIOR_ERROR_TYPES = new Set(['CardAuthenticationRequiredError', 'RainCooldownError'])
+const EXPECTED_BEHAVIOR_MESSAGES = [
+    /^Permission dismissed\.?$/i,
+    /^Permission blocked\.?$/i,
+    /^Authentication was not completed\.?$/i,
+    /^Login not verified\.?$/i,
+    /^You reached the limit of 10 cross-chain withdrawals per hour\.?$/i,
+    /^You reached the limit of 20 cross-chain withdrawals per day\.?$/i,
+    /^You reached the limit of 30 cross-chain withdrawals per 30 days\.?$/i,
+    /^You reached the limit for withdrawals to other networks(?:\..*)?$/i,
+    /^Company has exceeded their debt limit\.?$/i,
+    /^\[PostHog\.js\] This capture call is ignored due to client rate limiting\.?$/i,
+]
+
+function isExpectedBehaviorError(event: ErrorEvent, searchTexts: string[]): boolean {
+    const exceptionTypes = (event.exception?.values ?? []).map((value) => value.type || '')
+    if (exceptionTypes.some((type) => EXPECTED_BEHAVIOR_ERROR_TYPES.has(type))) return true
+    return searchTexts.some((text) => EXPECTED_BEHAVIOR_MESSAGES.some((pattern) => pattern.test(text.trim())))
+}
+
 /**
  * Capgo's background updater logs every transient CDN/network hiccup at error
  * level, and captureConsoleIntegration promotes each one into a Sentry event
@@ -274,6 +299,10 @@ export function shouldIgnoreError(event: ErrorEvent): boolean {
      * third-party SDK.
      */
     if (isFetchSiteMutationFailure(event)) return false
+
+    // Expected outcomes remain expected even in a tagged money flow, but use
+    // exact classes/anchored messages so adjacent technical failures survive.
+    if (isExpectedBehaviorError(event, searchTexts)) return true
 
     // Check all ignore patterns
     for (const [group, patterns] of Object.entries(IGNORED_ERRORS)) {

--- a/src/app/(setup)/setup/__tests__/page.test.tsx
+++ b/src/app/(setup)/setup/__tests__/page.test.tsx
@@ -86,7 +86,11 @@ jest.mock('@/components/Global/UnsupportedBrowserModal', () => ({
 }))
 jest.mock('@/assets/mascot', () => ({ PeanutWavingHello: { src: '' } }))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), addBreadcrumb: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({
+    captureException: jest.fn(),
+    captureMessage: jest.fn(),
+    addBreadcrumb: jest.fn(),
+}))
 
 const landing: ISetupStep = {
     screenId: 'landing',
@@ -174,6 +178,11 @@ it('recovers from an initialization exception', async () => {
     renderWithIntl(<SetupPage />)
     await advance(100)
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        'Setup initialization failed',
+        expect.objectContaining({ level: 'error', tags: { reason: 'initialization_failed' } })
+    )
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
 })
 
 it('ignores an authenticator check that completes after initialization timed out', async () => {
@@ -191,6 +200,11 @@ it('ignores an authenticator check that completes after initialization timed out
     renderWithIntl(<SetupPage />)
     await advance(15000)
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        'Setup initialization failed',
+        expect.objectContaining({ level: 'error', tags: { reason: 'initialization_timeout' } })
+    )
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
     await act(async () => {
         resolveSupport(true)
     })
@@ -437,8 +451,10 @@ it('bounces a completed session home without showing the recovery screen', async
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
     // the initialization bound must not turn the pending bounce into a fault either
     await advance(15000)
     expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
     expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
+    expect(Sentry.captureMessage).not.toHaveBeenCalled()
 })

--- a/src/app/(setup)/setup/__tests__/page.test.tsx
+++ b/src/app/(setup)/setup/__tests__/page.test.tsx
@@ -86,7 +86,7 @@ jest.mock('@/components/Global/UnsupportedBrowserModal', () => ({
 }))
 jest.mock('@/assets/mascot', () => ({ PeanutWavingHello: { src: '' } }))
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
-jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }))
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), addBreadcrumb: jest.fn() }))
 
 const landing: ISetupStep = {
     screenId: 'landing',
@@ -131,7 +131,9 @@ it('shows retry and support when no current setup step can render', async () => 
     expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Contact support' }))
     expect(mockSupport).toHaveBeenCalledWith(true)
-    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1)
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({ category: 'setup.recovery', level: 'info', message: 'Setup recovery required' })
+    )
     expect(useSetupStepAnalytics).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }))
 })
 
@@ -434,9 +436,9 @@ it('bounces a completed session home without showing the recovery screen', async
     expect(mockRouter.replace).toHaveBeenCalledWith('/home')
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
-    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
     // the initialization bound must not turn the pending bounce into a fault either
     await advance(15000)
     expect(screen.queryByRole('button', { name: 'Try again' })).not.toBeInTheDocument()
-    expect(Sentry.captureMessage).not.toHaveBeenCalled()
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled()
 })

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -141,9 +141,11 @@ function SetupPageContent() {
 
     useEffect(() => {
         if (recoveryReason) {
-            Sentry.captureMessage('Setup recovery required', {
-                level: 'warning',
-                tags: { reason: recoveryReason },
+            Sentry.addBreadcrumb({
+                category: 'setup.recovery',
+                level: 'info',
+                message: 'Setup recovery required',
+                data: { reason: recoveryReason },
             })
         }
     }, [recoveryReason])

--- a/src/app/(setup)/setup/page.tsx
+++ b/src/app/(setup)/setup/page.tsx
@@ -140,14 +140,20 @@ function SetupPageContent() {
               : null))
 
     useEffect(() => {
-        if (recoveryReason) {
+        if (!recoveryReason) return
+        if (recoveryReason === 'missing_step') {
             Sentry.addBreadcrumb({
                 category: 'setup.recovery',
                 level: 'info',
                 message: 'Setup recovery required',
                 data: { reason: recoveryReason },
             })
+            return
         }
+        Sentry.captureMessage('Setup initialization failed', {
+            level: 'error',
+            tags: { reason: recoveryReason },
+        })
     }, [recoveryReason])
 
     useEffect(() => {

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -45,7 +45,13 @@ jest.mock('@/utils/migration.utils', () => ({ isPwaSunsetOn: () => mockIsPwaSuns
 jest.mock('@/utils/demo', () => ({ isDemoMode: () => false }))
 jest.mock('@/context/authContext', () => ({ useAuth: () => ({ user: { user: { userId: 'user-1' } } }) }))
 jest.mock('posthog-js', () => ({ capture: jest.fn() }))
-jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }))
+const mockSentryCaptureException = jest.fn()
+const mockSentryAddBreadcrumb = jest.fn()
+jest.mock('@sentry/nextjs', () => ({
+    captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+    captureMessage: jest.fn(),
+    addBreadcrumb: (...args: unknown[]) => mockSentryAddBreadcrumb(...args),
+}))
 
 import { NOTIF_PROMPT_SNOOZE_DAYS } from '@/constants/migration.consts'
 import { useNotifications } from '../useNotifications'
@@ -80,6 +86,7 @@ describe('useNotifications dismissal / snooze logic', () => {
         mockIsPwaSunsetOn.mockReturnValue(false)
         mockAdapter.getPermission.mockResolvedValue('default')
         mockAdapter.isOptedIn.mockResolvedValue(false)
+        mockAdapter.requestPermission.mockResolvedValue('default')
     })
 
     it('shows the modal for a user who never dismissed it', async () => {
@@ -143,5 +150,36 @@ describe('useNotifications dismissal / snooze logic', () => {
         await reEvaluate(rendered)
 
         expect(rendered.result.current.showPermissionModal).toBe(false)
+    })
+
+    it.each(['Permission dismissed', 'Permission blocked'])(
+        'breadcrumbs an expected permission outcome without reporting it: %s',
+        async (message) => {
+            const rendered = await renderWithShowingBaseline()
+            mockAdapter.requestPermission.mockRejectedValueOnce(new Error(message))
+
+            await act(async () => {
+                await expect(rendered.result.current.requestPermission()).resolves.toBe('default')
+            })
+
+            expect(mockSentryCaptureException).not.toHaveBeenCalled()
+            expect(mockSentryAddBreadcrumb).toHaveBeenCalledWith(
+                expect.objectContaining({ category: 'onesignal.permission', level: 'info' })
+            )
+        }
+    )
+
+    it('still reports a technical permission SDK failure', async () => {
+        const rendered = await renderWithShowingBaseline()
+        const failure = new Error('OneSignal SDK transport failed')
+        mockAdapter.requestPermission.mockRejectedValueOnce(failure)
+
+        await act(async () => {
+            await expect(rendered.result.current.requestPermission()).resolves.toBe('default')
+        })
+
+        expect(mockSentryCaptureException).toHaveBeenCalledWith(failure, {
+            tags: { source: 'onesignal_request_permission' },
+        })
     })
 })

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -16,6 +16,14 @@ import { UTM_SOURCES, UTM_MEDIUMS } from '@/utils/utm.utils'
 
 const NOTIF_PROMPT_SNOOZE_MS = NOTIF_PROMPT_SNOOZE_DAYS * 24 * 60 * 60 * 1000
 
+const EXPECTED_PERMISSION_ERRORS = ['permission dismissed', 'permission blocked']
+
+export function isExpectedNotificationPermissionError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error ?? '')
+    const normalized = message.toLowerCase().trim().replace(/\.$/, '')
+    return EXPECTED_PERMISSION_ERRORS.includes(normalized)
+}
+
 /*
  * Notification state lives in a module-level store shared by every
  * useNotifications() consumer. The hook used to keep per-instance useState and
@@ -323,6 +331,14 @@ async function requestPermission(): Promise<NotificationPermissionState> {
         evaluateVisibility()
         return newPermission
     } catch (error) {
+        if (isExpectedNotificationPermissionError(error)) {
+            addBreadcrumb({
+                category: 'onesignal.permission',
+                level: 'info',
+                message: 'notification permission prompt was not accepted',
+            })
+            return 'default'
+        }
         console.warn('Error requesting permission:', error)
         captureException(error, { tags: { source: 'onesignal_request_permission' } })
         return 'default'

--- a/src/services/card.ts
+++ b/src/services/card.ts
@@ -63,6 +63,13 @@ export interface WaitlistStateResponse {
     releasedAt: string | null
 }
 
+export class CardAuthenticationRequiredError extends Error {
+    constructor() {
+        super('Authentication required')
+        this.name = 'CardAuthenticationRequiredError'
+    }
+}
+
 /**
  * Fail fast — loud and local — instead of an opaque 401 from an
  * unauthenticated request. apiFetch itself awaits authReady() and attaches
@@ -79,7 +86,7 @@ export interface WaitlistStateResponse {
 async function assertAuthenticated(): Promise<void> {
     if (isDemoMode() || isCapacitor()) return
     await authReady()
-    if (!getAuthToken()) throw new Error('Authentication required')
+    if (!getAuthToken()) throw new CardAuthenticationRequiredError()
 }
 
 export const cardApi = {


### PR DESCRIPTION
## Summary

- filter exact, expected user and product outcomes before they become Sentry issues: notification denial, passkey cancellation, signed-out card hydration, configured withdrawal/cooldown/debt limits, and PostHog client throttling
- breadcrumb notification denial and expected setup-entry recovery; keep setup initialization failures as actionable Sentry events
- use exact error classes and anchored messages so nearby technical failures still reach Sentry, including in critical money-flow captures

## Sentry audit impact

The 30-day production audit found 22 fully expected UI issue groups (846 events), plus 23 expected `Permission blocked` events inside one mixed issue group. Failed passkey verification and setup initialization failures remain reportable; the mixed group's configuration/origin/retry failures remain reportable.

## Validation

- focused Sentry/notification suites — 143 tests passed
- setup recovery suite — 19 tests passed
- targeted Prettier check — passed
- targeted ESLint — no errors (one pre-existing hook-dependency warning in the setup page)
- `pnpm typecheck` — passed
