### PR TITLE
fix(share): build user-shareable links with shareableUrl

### DIFF
--- a/src/app/(mobile-ui)/qr/[code]/success/page.tsx
+++ b/src/app/(mobile-ui)/qr/[code]/success/page.tsx
@@ -14,7 +14,7 @@ import { useRedirectQrStatus } from '@/hooks/useRedirectQrStatus'
 import QRCodeWrapper from '@/components/Global/QRCodeWrapper'
 import { copyTextToClipboard } from '@/utils/clipboard.utils'
 import { useToast } from '@/components/0_Bruddle/Toast'
-import { BASE_URL } from '@/constants/general.consts'
+import { shareableUrl } from '@/utils/url.utils'
 
 export default function RedirectQrSuccessPage() {
     const t = useTranslations('qrPay')
@@ -27,7 +27,7 @@ export default function RedirectQrSuccessPage() {
 
     const { data: redirectQrData, isLoading } = useRedirectQrStatus(code)
 
-    const qrUrl = `${BASE_URL}/qr/${code}`
+    const qrUrl = shareableUrl(`/qr/${code}`)
 
     useEffect(() => {
         const timer = setTimeout(() => {

--- a/src/components/Create/useCreateLink.tsx
+++ b/src/components/Create/useCreateLink.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { getNextDepositIndex } from '@/app/actions/claimLinks'
-import { BASE_URL } from '@/constants/general.consts'
 import { loadingStateContext } from '@/context/loadingStates.context'
 import { saveToLocalStorage } from '@/utils/general.utils'
 import { generateKeysFromString, getLinkFromParams } from '@/utils/peanut-link.utils'
+import { shareableUrl } from '@/utils/url.utils'
 import {
     getContractAbi,
     getContractAddress,
@@ -120,7 +120,7 @@ export const useCreateLink = () => {
                         contractVersion,
                         depositIdx,
                         password,
-                        `${BASE_URL}/claim`,
+                        shareableUrl('/claim'),
                         undefined
                     )
                     return {

--- a/src/components/Global/QRScannerOverlay/index.tsx
+++ b/src/components/Global/QRScannerOverlay/index.tsx
@@ -13,7 +13,7 @@ import { EQrType, NAME_BY_QR_TYPE, parseEip681, recognizeQr } from '@/components
 import { useAuth } from '@/context/authContext'
 import { useModalsContext } from '@/context/ModalsContext'
 import { ANALYTICS_EVENTS } from '@/constants/analytics.consts'
-import { BASE_URL } from '@/constants/general.consts'
+import { payLinkUrl } from '@/utils/url.utils'
 import { serverFetch } from '@/utils/api-fetch'
 import { openExternalUrl } from '@/utils/capacitor'
 import { pixKeyToQrPayUrl } from '@/utils/pix.utils'
@@ -215,7 +215,7 @@ export default function QRScannerOverlay() {
     const searchParams = useSearchParams()
     const toast = useToast()
     const { user } = useAuth()
-    const payUserUrl = user?.user.username ? `${BASE_URL}/pay/${user.user.username}` : ''
+    const payUserUrl = user?.user.username ? payLinkUrl(`/${user.user.username}`) : ''
     const { triggerHaptic } = useAppHaptic()
     const { isQRScannerOpen, setIsQRScannerOpen } = useModalsContext()
     const isChainRolledOut = useChainRollout()

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -10,7 +10,7 @@ import { serverFetch } from '@/utils/api-fetch'
 import * as peanutInterfaces from '@/interfaces/peanut-sdk-types'
 import { chargesApi } from './charges'
 import { type TCharge } from './services.types'
-import { BASE_URL } from '@/constants/general.consts'
+import { appBaseUrl } from '@/utils/url.utils'
 
 type ApiAccount = {
     identifier: string
@@ -87,7 +87,7 @@ export const usersApi = {
         return chargesApi.create({
             pricing_type: 'fixed_price',
             local_price: { amount, currency: 'USD' },
-            baseUrl: BASE_URL,
+            baseUrl: appBaseUrl(),
             requestId: undefined,
             requestProps: {
                 chainId: PEANUT_WALLET_CHAIN.id.toString(),


### PR DESCRIPTION
## Summary

- `useCreateLink` builds the `/claim` base through `shareableUrl('/claim')` instead of the build-time `BASE_URL`
- the redirect QR success page builds its `/qr/<code>` target the same way, so the rendered QR, the copy button and the web share all carry the current origin
- the scanner overlay's own receive QR goes through `payLinkUrl()`, which already existed for that exact shape
- `usersApi.requestByUsername` sends `appBaseUrl()` as the `baseUrl` of the charge it creates, matching the sibling `chargesApi.create` call in the crypto withdraw flow

## Why

Closes #2011, the sweep scoped out of #2010.

A link built from `BASE_URL` falls back to `https://peanut.me` whenever `NEXT_PUBLIC_BASE_URL` is unset, so a link copied on staging or on a preview deployment silently points at production. Every call site here is user-shareable and runs in the client, which is what `shareableUrl` is for. The claim link also lines up with `history.utils.ts`, which has been re-sharing the same link shape through `shareableUrl` since #2010.

The six call sites on the issue checklist that are not in this diff no longer need the change. `ProfileHeader`, `SemanticRequestReceiptView`, `PaymentSuccessView` and `useCreateRequestLink` already go through `shareableUrl` or `payLinkUrl`, and `BadgeStatusDrawer` and `DirectSendQR` no longer build a URL at all. The scanner overlay and `usersApi` were not on the list but are the same bug class, so they are in.

## Verification

- `pnpm exec jest src/components/Global/QRScannerOverlay/__tests__ src/services/__tests__/users.test.ts src/utils/__tests__/url.utils.test.ts src/features/qr-code src/components/Send/link/views/__tests__/Initial.link.send.view.test.tsx`: 64 tests in 7 suites passed
- `pnpm exec eslint` on the four changed files: clean
- `pnpm exec prettier --check` on the four changed files: clean
- `pnpm typecheck`: no new errors. The 5 that fail also fail on an untouched `dev`, in `SEOFooter.tsx` and `tweets.consts.ts`, which read generated content from the `src/content` submodule I have no access to
- no manual QA on a deployed environment

## A known gap this does not close

`recognizeQr` treats a scanned URL as a Peanut URL only when it starts with that build's `BASE_URL` or with the literal `peanut.me/`. Native builds bake `NEXT_PUBLIC_BASE_URL=https://peanut.me`, so a QR generated on staging and scanned with the staging app falls through to the generic URL branch instead of the `/qr/` claim branch. Before this change the same QR carried a production URL whose code does not exist there, so neither shape works today. Widening that check to any `*.peanut.me` host is a scanner change and belongs in its own PR.

